### PR TITLE
Allow \n and \r as delimiters for entering tags

### DIFF
--- a/chrome/content/zotero/bindings/tagsbox.xml
+++ b/chrome/content/zotero/bindings/tagsbox.xml
@@ -293,6 +293,7 @@
 					t.setAttribute('fieldname', fieldName);
 					t.setAttribute('ztabindex', tabindex);
 					t.setAttribute('flex', '1');
+                    t.setAttribute('newlines','pasteintact');
 					
 					// Add auto-complete
 					t.setAttribute('type', 'autocomplete');

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -3351,6 +3351,17 @@ Zotero.Item.prototype.addTag = function(name, type) {
 	if (!this.id) {
 		throw ('Cannot add tag to unsaved item in Item.addTag()');
 	}
+    
+    //Check for newlines or carriage returns used as delimiters
+    //in a series of tags added at once.  Add each tag
+    //separately.
+    if (name.search('\r') > -1 || name.search('\n') > -1) {
+        name = name.replace('\r\n','\n');
+        name = name.replace('\r','\n');
+        var nameArray = name.split('\n');
+        this.addTags(nameArray,type);
+        return false;
+    }
 	
 	name = Zotero.Utilities.trim(name);
 	


### PR DESCRIPTION
These changes allow you to enter multiple tags at once by separating them with \n, \r, or \r\n.  To prevent newlines from being stripped, the tag textbox's newline property was set to pasteintact, but pressing enter when the tag editor is active still calls addTag, so there should be no change to the previous functionality of the tags editor.  The delimited tags are recognized at the beginning of addTag() and added by a call to addTags().  The one thing I was not sure about was what value to return when multiple delimited tags are added by addTag().  Right now, addTag() just returns false.  Perhaps it should return an array of tagID's?  I am not sure that this return value is used anywhere currently.
