### PR TITLE
Show expected style extensions in "Add Style" file browser window

### DIFF
--- a/chrome/content/zotero/tools/cslpreview.xul
+++ b/chrome/content/zotero/tools/cslpreview.xul
@@ -45,14 +45,13 @@
 			this.generateBibliography = generateBibliography;
 
 			function init() { 
-				var iframe = document.getElementById('zotero-csl-preview-box');
-				iframe.contentDocument.documentElement.innerHTML = '<html><head><title></title></head><body><p>The <b>Zotero Preview pane</b> renders citations and bibliographies for items selected in Zotero for all installed styles.</p></body></html>';
+				//refresh(); 
 			}
 			function refresh() {
 				var iframe = document.getElementById('zotero-csl-preview-box');
 				var items = Zotero.getActiveZoteroPane().getSelectedItems();
 				if (items.length == 0) {
-					iframe.contentDocument.documentElement.innerHTML = '<html><head><title></title></head><body><p style="color: red">No items selected in Zotero.</p></body></html>';
+					iframe.contentDocument.documentElement.innerHTML = '<html><head><title></title></head><body><p style="color: red">No references selected in Zotero.</p></body></html>';
 					return;
 				}
 				var progressWin = new Zotero.ProgressWindow();
@@ -65,7 +64,7 @@
 				var f = function() {
 					var styles = Zotero.Styles.getAll();
 					// XXX needs its own string really for the title!
-					var str = '<html><head><title></title></head><body><h2>Citation/Bibliography list<h2>';
+					var str = '<html><head><title></title></head><body><h1>Citation/Bibliography list<h1>';
 					for each(var style in styles) {
 						if (style.source) {
 							continue;
@@ -73,7 +72,7 @@
 						Zotero.debug("Generate Bib for " + style.title);
 						var cite = generateBibliography(style);
 						if (cite) {
-							str += '<hr><h3>' + style.title + '</h3>';
+							str += '<hr><h2>' + style.title + '</h2>';
 							str += cite;
 						}
 					}
@@ -94,9 +93,28 @@
 					return '';
 				}
 				
-				var citationFormat = document.getElementById("citation-format").selectedItem.value;
-				if (citationFormat != "all" && citationFormat != style.categories) {
-					Zotero.debug("CSL IGNORE: citation format is " + style.categories);
+				var authordate = document.getElementById("format-author-date");
+				var numeric = document.getElementById("format-numeric");
+				Zotero.debug("style class is " + style.class);
+				if (document.getElementById("format-note").checked == false && style.class == "note") {
+					Zotero.debug("CSL IGNORE NOTE one");
+					return '';
+				}
+				if (document.getElementById("format-in-text").checked == false && style.class == "in-text") {
+					Zotero.debug("CSL IGNORE IN-TEXT one");
+					return '';
+				}
+				var terms = new Object();
+				for each(var cat in style.categories) {
+					Zotero.debug("TERM is " + cat.toString());
+					terms[cat.toString()] = true;
+				}
+				if (!numeric.checked && terms["numeric"]) {
+					Zotero.debug("CSL IGNORE this numeric");
+					return '';
+				}
+				if (!authordate.checked && terms["author-date"]) {
+					Zotero.debug("CSL IGNORE this AD");
 					return '';
 				}
 				var styleEngine = style.csl;
@@ -124,24 +142,22 @@
 	</script>
 	<!-- NEEDS LOCALISING -->
 	<vbox flex="1">
-	   <hbox style="border-bottom: 1px solid grey;">
+	   <hbox >
 		<hbox align="center">
 			<button id="preview-refresh-button" label="Refresh" oncommand="Zotero_CSL_Preview.refresh()"/>
 			<groupbox orient="horizontal" align="center">
-				<label value="Citation format:" />
-				<menulist id="citation-format" oncommand="Zotero_CSL_Preview.refresh()">
-					<menupopup>
-						<menuitem label="all" value="all"/>
-						<menuitem label="author" value="author"/>
-						<menuitem label="author-date" value="author-date"/>
-						<menuitem label="label" value="label"/>
-						<menuitem label="note" value="note"/>
-						<menuitem label="numeric" value="numeric"/>
-					</menupopup>
-				</menulist>
+				<label value="Class:"/>
+				<checkbox id="format-in-text" label="In-Text" checked="true"/>
+				<checkbox id="format-note" label="Notes" checked="true"/>
+			</groupbox>
+			<groupbox orient="horizontal" align="center">
+				<label value="Citation form:"/>
+				<checkbox id="format-author-date" label="Author Date" checked="true"/>
+				<checkbox id="format-numeric" label="Numeric" checked="true"/>
 			</groupbox>
 		</hbox>
 	   </hbox>
+	   <splitter/>
 	   <iframe id="zotero-csl-preview-box" flex="1" style="padding: 0 1em; background:white;" overflow="auto" type="content"/>
 	</vbox>
 	

--- a/chrome/content/zotero/xpcom/style.js
+++ b/chrome/content/zotero/xpcom/style.js
@@ -390,14 +390,11 @@ Zotero.Style = function(arg) {
 		this.styleID = xml.info.id.toString();
 		this.title = xml.info.title.toString();
 		this.updated = xml.info.updated.toString().replace(/(.+)T([^\+]+)\+?.*/, "$1 $2");
+		this.categories = [category.@term.toString() for each(category in xml.info) if(category.@term.length())];
 		this._class = xml.@class.toString();
 		this._hasBibliography = !!xml.bibliography.length();
 		this._version = xml.@version.toString();
-		if(this._version == "") {
-			this._version = "0.8";
-		} else {
-			this.categories = xml.info.category.attribute("citation-format").toString();
-		}
+		if(this._version == "") this._version = "0.8";
 		
 		this.source = null;
 		for each(var link in xml.info.link) {


### PR DESCRIPTION
Applications like MS Word show the file extension of the selected file types that are shown in the file browser window (e.g., "WordPerfect 5.x (*.doc)"). Zotero should probably do the same.
