### PR TITLE
value of variable in Zotero.Date.getMonths was not set.

### DIFF
--- a/chrome/content/zotero/xpcom/date.js
+++ b/chrome/content/zotero/xpcom/date.js
@@ -342,7 +342,7 @@ Zotero.Date = new function(){
 				'aug', 'sep', 'oct', 'nov', 'dec'];
 			// If using a non-English bibliography locale, try those too
 			if (Zotero.locale != 'en-US') {
-				Zotero.Date.getMonths();
+				_months = Zotero.Date.getMonths();
 				months = months.concat(_months['short']).concat(_months['long']);
 				for(var i=0, n=months.length; i<n; i++) months[i] = months[i].toLowerCase();
 			}


### PR DESCRIPTION
this fixes the three exporters TEI.js BibTeX.js RIS.js that use strToDate

these exporters run into exceptions when using the strToDate function. It worked in zotero2 but is broken in zotero3. My patch fixes this behaviour as it uses the return value of the Zotero.Date.getMonths function instead of relying on a global variable.

cheers,
Stefan
