### PR TITLE
[Don't merge] Fix for TinyMCE image embedding

### DIFF
--- a/chrome/content/zotero/tinymce/plugins/paste/editor_plugin.js
+++ b/chrome/content/zotero/tinymce/plugins/paste/editor_plugin.js
@@ -522,6 +522,14 @@
 		_postProcess : function(pl, o) {
 			var t = this, ed = t.editor, dom = ed.dom, styleProps;
 
+			/* Save local images */
+			each(dom.select('img', o.node), function (img) {
+				if (a.alt && a.alt.indexOf('zotero://') === 0) {
+					a.setAttribute('href', a.alt);
+					a.setAttribute('mce_href', a.alt);
+				}
+			});
+
 			if (o.wordContent) {
 				// Remove named anchors or TOC links
 				each(dom.select('a', o.node), function(a) {


### PR DESCRIPTION
I think I did about all we need on the TinyMCE side to restore the insertion of local attachments into notes (see attached; it depends on a quirk that happens to put the original path in the `alt` attribute); now we're running into a new security error:

```
Security Error: Content at jar:file:///home/ajlyon/.mozilla/firefox/jlm2qjtg.Demo/extensions/zotero@chnm.gmu.edu/chrome/zotero.jar!/content/zotero/tinymce/note.html may not load or link to zotero://attachment/7749/.
```

As I understand it, `note.html` is unprivileged (the big switch for 84f59ab451c2cfd38ab4955c609580fe1630524a), so this error is somewhat surprising-- is it really the case that all local attachments are opened in the chrome context? I don't know much about the privileging model of XUL, but it seems like the privileges of notes and of user attachments should be the same.

It used to be possible to make the images appear by editing the HTML or using TinyMCE's image editor, but that also triggers the error above now.

This is a quite valuable, albeit little-known, feature of Zotero, and I'd like to see it working again.
