### PR TITLE
Add multiple tags/creators as newline delimited list

### DIFF
--- a/chrome/content/zotero/bindings/itembox.xml
+++ b/chrome/content/zotero/bindings/itembox.xml
@@ -1698,12 +1698,9 @@
 						otherFields[creatorField] = value;
 						var lastName = otherFields.lastName;
 						
-						//Handle \n\r delimited entries
-						if (lastName.search('\r') > -1 || lastName.search('\n') > -1) {
-							lastName = lastName.replace('\r\n','\n');
-							lastName = lastName.replace('\r','\n');
-							var rawNameArray = lastName.split('\n');
-							
+						//Handle \n\r and \n delimited entries
+						var rawNameArray = lastName.split(/\r\n?|\n/);
+						if (rawNameArray.length > 1) {
 							//Save tab direction and add creator flags since they are reset in the 
 							//process of adding multiple authors
 							var tabDirectionBuffer = this._tabDirection;
@@ -1713,16 +1710,7 @@
 							this._addCreatorRow = false;
 							
 							//Filter out bad names
-							var nameArray = new Array();
-							var counter = 0;
-							var tempName = '';
-							for each(tempName in rawNameArray) {
-								if (tempName.length > 0) {
-									//Put further error checking of tempName here
-									nameArray[counter] = tempName;
-									counter++;
-								}
-							}
+							var nameArray = [tempName for each(tempName in rawNameArray) if(tempName)];
 							
 							//If not adding names at the end of the creator list, make new creator 
 							//entries and then shift down existing creators.
@@ -1742,25 +1730,25 @@
 							}
 							
 							//Add the creators in lastNameArray one at a time
-							var tempFields=otherFields;
 							for each(tempName in nameArray) {
-								// Check for comma to determine creator name format
-								tempFields.fieldMode = (tempName.indexOf('\t') == -1) ? 1 : 0;
-								if (tempFields.fieldMode == 0) {
-									tempFields.lastName=tempName.split('\t')[0];
-									tempFields.firstName=tempName.split('\t')[1];
+								// Check for tab to determine creator name format
+								otherFields.fieldMode = (tempName.indexOf('\t') == -1) ? 1 : 0;
+								if (otherFields.fieldMode == 0) {
+									otherFields.lastName=tempName.split('\t')[0];
+									otherFields.firstName=tempName.split('\t')[1];
 								} 
 								else {
-									tempFields.lastName=tempName;
+									otherFields.lastName=tempName;
+									otherFields.firstName='';
 								}
-								this.modifyCreator(creatorIndex,tempFields);
+								this.modifyCreator(creatorIndex,otherFields);
 								creatorIndex++;
 							}
 							this._tabDirection = tabDirectionBuffer;
 							this._addCreatorRow = (creatorsToShift==0) ? addCreatorRowBuffer : false;
 							if (this._tabDirection == 1) {
 								this._lastTabIndex = parseInt(tabIndexBuffer,10) + 2*(nameArray.length-1);
-								if (tempFields.fieldMode == 0) {
+								if (otherFields.fieldMode == 0) {
 									this._lastTabIndex++;
 								}
 							}

--- a/chrome/content/zotero/bindings/tagsbox.xml
+++ b/chrome/content/zotero/bindings/tagsbox.xml
@@ -427,10 +427,10 @@
 					// Tag id encoded as 'tag-1234'
 					var id = row.getAttribute('id').split('-')[1];
 					
-					var newlinePresent = (value.search('\r') > -1 || value.search('\n') > -1);
+					var tagArray = value.split(/\r\n?|\n/);
 					
 					if (saveChanges) {
-						if (id && newlinePresent != true) {
+						if (id && (tagArray.length < 2)) {
 							if (value) {
 								var origTagIndex = this.item.getTagIndex(id);
 								var changed = tagsbox.replace(id, value);
@@ -453,16 +453,13 @@
 									}
 								}
 							}
+						}
 						// New tag
 						else {
 							//Check for newlines or carriage returns used as delimiters
 							//in a series of tags added at once.  Add each tag
 							//separately.
-							if (newlinePresent) {
-								value = value.replace('\r\n','\n');
-								value = value.replace('\r','\n');
-								var nameArray = value.split('\n');
-								
+							if (tagArray.length > 1) {
 								var extremeTag = false;
 								var nextTag = false;
 								if (this._tabDirection == -1) {
@@ -479,7 +476,7 @@
 									}
 								}
 								
-								id = this.item.addTags(nameArray);
+								id = this.item.addTags(tagArray);
 								
 								if (extremeTag) {
 									if (this._tabDirection == 1) {

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -1,7 +1,7 @@
 /*
     ***** BEGIN LICENSE BLOCK *****
     
-    Copyright ¬© 2009 Center for History and New Media
+    Copyright © 2009 Center for History and New Media
                      George Mason University, Fairfax, Virginia, USA
                      http://zotero.org
     
@@ -2703,7 +2703,7 @@ Zotero.Item.prototype.getFile = function(row, skipExistsCheck) {
 			// Strip "storage:"
 			var path = row.path.substr(8);
 			// setRelativeDescriptor() silently uses the parent directory on Windows
-			// if the filename contains certain characters, so strip them ‚Äî
+			// if the filename contains certain characters, so strip them —
 			// but don't skip characters outside of XML range, since they may be
 			// correct in the opaque relative descriptor string
 			//
@@ -3541,21 +3541,19 @@ Zotero.Item.prototype.addTag = function(name, type) {
 Zotero.Item.prototype.addTags = function (tags, type) {
 	Zotero.DB.beginTransaction();
 	try {
-		var tagIDarray = [];
-		var counter = 0;
+		var tagIDArray = [];
 		var tempID = false;
 		for (var i = 0; i < tags.length; i++) {
 			tempID = this.addTag(tags[i], type);
 			if (tempID) {
-				tagIDarray[counter] = tempID;
-				counter++;
+				tagIDArray.push(tempID);
 			}
 		}
 		
-		tagIDarray = (tagIDarray.length>0) ? tagIDarray : false;
+		tagIDArray = (tagIDArray.length>0) ? tagIDArray : false;
 		
 		Zotero.DB.commitTransaction();
-		return tagIDarray;
+		return tagIDArray;
 	}
 	catch (e) {
 		Zotero.DB.rollbackTransaction();
@@ -3637,20 +3635,19 @@ Zotero.Item.prototype.getTagIDs = function() {
 	return Zotero.DB.columnQuery(sql, this.id);
 }
 
-//Return the index of tagID in the list of the item's tags
-//sorted in alphabetical order.
+/**
+* Return the index of tagID in the list of the item's tags sorted in alphabetical order.
+*/
 Zotero.Item.prototype.getTagIndex = function(tagID) {
 	var tags = this.getTags();
 	
-	var tagIndex=-1;
 	for (var i=0;i<tags.length;i++) {
 		if (tagID == tags[i].id) {
-			tagIndex=i;
-			break;
+			return i;
 		}
 	}
 	
-	return tagIndex;
+	return false;
 }
 
 Zotero.Item.prototype.replaceTag = function(oldTagID, newTag) {


### PR DESCRIPTION
This is a pull request for adding multiple tags and creators by pasting a newline delimited list into the textbox.  

For creators, names can be entered as lastnname tab firstname or just as a full name.  When pasting a list over an existing entry, that existing entry is not overwritten.  In the case of creators, the list is inserted in front of the existing entry.  I did it this way because it would otherwise be hard to insert a list (you would have to put the entry being overwritten into the pasted list in order to keep it) and the order is important for creator lists.  I made an existing tag also not be overwritten just to be consistent with the way the creators work (though order does not matter for tags since Zotero sorts them alphabetically).

There are three relevant commits.  In commit e10d049428, adding multiple tags/creators works basically the same way adding a tag/creator works currently in Zotero.  If you paste a list of tags over an existing tag, the tags are added but no entry is selected after you hit enter.  In commit 87c47c0615, I changed this so that if you add multiple tags over an existing tag, the tag after that existing tag is selected after you hit enter (or the tag before if you do shift+enter).  For commit 3ef0b63c47, I changed the tagsbox so that if you edit an existing tag (i.e. not pasting a multiple tag list over it) and hit enter/shift+enter, the next/previous tag is selected instead of no tag selected.  This behavior seems intuitive and preferable to me.  Sometimes when I am entering tags, I notice a typo and shift+tab back and fix it.  It is annoying that I then have to move my hand from the keyboard to the mouse and click on the tagsbox again to re-select it.
