### PR TITLE
Allow to use empty string as delimiter in xpathText

### DIFF
--- a/chrome/content/zotero/xpcom/utilities.js
+++ b/chrome/content/zotero/xpcom/utilities.js
@@ -971,8 +971,12 @@ Zotero.Utilities = {
 		for(var i=0, n=elements.length; i<n; i++) {
 			strings[i] = elements[i].textContent;
 		}
-		
-		return strings.join(delimiter ? delimiter : ", ");
+
+		if( typeof(delimiter) == 'undefined' ) {
+			delimiter = ', ';
+		}
+
+		return strings.join(delimiter);
 	},
 	
 	/**


### PR DESCRIPTION
Currently passing an empty string to xpathText as a delimiter does not work as expected. This should allow to use empty string as well as other strings that evaluate to false as delimiters. I don't think it should break any compatibility, but please double check.
