### PR TITLE
Match more space characters in superCleanString

### DIFF
--- a/chrome/content/zotero/xpcom/utilities.js
+++ b/chrome/content/zotero/xpcom/utilities.js
@@ -215,8 +215,8 @@ Zotero.Utilities = {
 			throw "superCleanString: argument must be a string";
 		}
 		
-		var x = x.replace(/^[\x00-\x27\x29-\x2F\x3A-\x40\x5B-\x60\x7B-\x7F]+/, "");
-		return x.replace(/[\x00-\x28\x2A-\x2F\x3A-\x40\x5B-\x60\x7B-\x7F]+$/, "");
+		var x = x.replace(/^[\x00-\x27\x29-\x2F\x3A-\x40\x5B-\x60\x7B-\x7F\s]+/, "");
+		return x.replace(/[\x00-\x28\x2A-\x2F\x3A-\x40\x5B-\x60\x7B-\x7F\s]+$/, "");
 	},
 	
 	/**


### PR DESCRIPTION
Currently superCleanString does not match non-breaking space (\xA0), which is a pretty common character on web pages. I think \s should be pretty safe to include, since it is Unicode aware.

I have a feeling though that this has come up before (though I couldn't find a reference to it), so I'm interested to hear why this may fail.
