### PR TITLE
Ignore order when comparing arrays in translatorTester

### DIFF
--- a/chrome/content/zotero/tools/testTranslators/translatorTester.js
+++ b/chrome/content/zotero/tools/testTranslators/translatorTester.js
@@ -221,9 +221,6 @@ Zotero_TranslatorTester._sanitizeItem = function(item, forSave) {
 						"itemType", "complete", "creators"];
 	for(var field in item) {
 		if(skipFields.indexOf(field) !== -1) {
-			if(field == 'tags') {
-				item[field].sort();
-			}
 			continue;
 		}
 		
@@ -246,6 +243,9 @@ Zotero_TranslatorTester._sanitizeItem = function(item, forSave) {
 	
 	// remove fields to be ignored
 	if("accessDate" in item) delete item.accessDate;
+
+	//sort tags, if they're still there
+	if(item.tags) item.tags.sort();
 	
 	return item;
 };


### PR DESCRIPTION
Time.com keeps changing the order of their keywords, which causes tests to break. I don't think tags need to be compared in any particular order, as long as they are all there.

This patch seems very primitive, but I think it should work fine.
