### PR TITLE
varDump with parent object tracking

### DIFF
--- a/chrome/content/zotero/xpcom/utilities.js
+++ b/chrome/content/zotero/xpcom/utilities.js
@@ -1064,7 +1064,7 @@ Zotero.Utilities = {
 					dumped_text += level_padding + "'" + item + "' => " + openBrace;
 					//only recurse if there's anything in the object, purely cosmetical
 					for(var i in value) {
-						dumped_text += "\n" + arguments.callee(value,level+1,maxLevel,parentObjects.concat([value]),path.concat([item])) + level_padding;
+						dumped_text += "\n" + varDump(value,level+1,maxLevel,parentObjects.concat([value]),path.concat([item])) + level_padding;
 						break;
 					}
 					dumped_text += closeBrace + "\n";


### PR DESCRIPTION
And some formatting tweaks. You guys might think this is overkill, and it probably is.

For something like

``` javascript
    var a = {
        b: 'hi',
        c: [ 1, 2, 3, 4 ],
        e: { f: {g: {h: {i: {j: 5}}}}},
        f: {},
        g: 6
    };
    a.d = a;
    Z.debug(ZU.varDump(a));
```

Outputs

``` javascript
             'b' => "hi"
             'c' => [
                 '0' => 1
                 '1' => 2
                 '2' => 3
                 '3' => 4
             ]
             'e' => {
                 'f' => {
                     'g' => {
                         'h' => {
                             'i' => {
                                 <<Maximum depth reached>>...
                             }
                         }
                     }
                 }
             }
             'f' => {}
             'g' => 6
             'd' => <<Reference to parent object ROOT >>
```

EDIT: Had the wrong code/output posted. Updated.
