### PR TITLE
[cleanDOI] Don't allow periods or commas at the end of DOIs

### DIFF
--- a/chrome/content/zotero/xpcom/utilities.js
+++ b/chrome/content/zotero/xpcom/utilities.js
@@ -262,7 +262,7 @@ Zotero.Utilities = {
 			throw "cleanDOI: argument must be a string";
 		}
 		
-		return x.match(/10\.[^\s\/]+\/[^\s]*[^\s\.,]/);
+		return x.match(/10\.[0-9]{4,}\/[^\s]*[^\s\.,]/);
 	},
 
 	/**


### PR DESCRIPTION
Related to discussion at https://groups.google.com/d/topic/zotero-dev/0MuxjDOpz-U/discussion but this one doesn't have to be as stringent. It's would still be pretty common to see periods and commas immediately after DOIs.
