### PR TITLE
Fixed Integration Preferences dialog, which was giant with French locale

### DIFF
--- a/chrome/content/zotero/integration/integrationDocPrefs.xul
+++ b/chrome/content/zotero/integration/integrationDocPrefs.xul
@@ -64,7 +64,7 @@
 				<label class="radioDescription" id="fields-caption"/>
 				<label class="radioDescription" id="fields-file-format-notice"/>
 				<radio id="bookmarks" label="&zotero.integration.prefs.bookmarks.label;"/>
-				<description class="radioDescription" id="bookmarks-caption" style="white-space: pre;">&zotero.integration.prefs.bookmarks.caption;</description>
+				<description class="radioDescription" id="bookmarks-caption">&zotero.integration.prefs.bookmarks.caption;</description>
 				<description class="radioDescription" id="bookmarks-file-format-notice"/>
 			</radiogroup>
 			


### PR DESCRIPTION
To understand the bug, look at this:

![Screenshot of giant dialog](http://dl.dropbox.com/u/1389551/capture-bug-Zotero.png)

While this bug has already been partly fixed by commit 10cef4c06fdfca4d758996b3255711fa293534fc, it survives with the French locale, which doesn't include an explicit line break (unlike, say, the English or German locales).

While I could have added a line break to the French locale, I think it is better to let the text flow freely in the dialog. This way, the dialog can be more easily resized in all languages.
