### PR TITLE
Add an option for page breaks between items in report

### DIFF
--- a/chrome/content/zotero/xpcom/report.js
+++ b/chrome/content/zotero/xpcom/report.js
@@ -46,12 +46,12 @@ Zotero.Report = new function() {
 		content += '</head>\n\n<body>\n';
 		
 		// Add an option for page breaks between items in report
-		content += '<form class="noprint" name="breakForm">\n<input type="checkbox" name="checkbox" onClick="pageBreak()">Check this box if you want to print each item on a separate page.</form>\n';
+		content += '<form class="noprint" name="breakForm">\n<input type="checkbox" name="checkbox" onClick="pageBreak()">' + Zotero.getString('report.option.pageBreak') + '</form>\n';
 		content += '<script type="text/javascript">function pageBreak(){divs=document.getElementsByClassName("endItem");for(i=0;i<divs.length;i++){divs[i].style.pageBreakAfter=(document.forms.breakForm.checkbox.checked)?"always":""}}</script>\n';
 		
 		content += '<ul class="report' + (combineChildItems ? ' combineChildItems' : '') + '">\n';
 		for each(var arr in items) {
-			content += '\n<li id="i' + arr.itemID + '" class="item ' + arr.itemType + '">\n';
+			content += '\n<li id="i' + arr.itemID + '" class="item ' + arr.itemType + ' endItem">\n';
 			
 			if (arr.title) {
 				// Top-level item matched search, so display title
@@ -130,7 +130,7 @@ Zotero.Report = new function() {
 			}
 			
 			
-			content += '</li><div class="endItem"></div>\n\n';
+			content += '</li>\n\n';
 		}
 		content += '</ul>\n';
 		content += '</body>\n</html>';

--- a/chrome/content/zotero/xpcom/report.js
+++ b/chrome/content/zotero/xpcom/report.js
@@ -45,6 +45,7 @@ Zotero.Report = new function() {
 		content += '<link rel="stylesheet" type="text/css" media="print" href="zotero://report/detail_print.css"/>\n';
 		content += '</head>\n\n<body>\n';
 		
+		// Add an option for page breaks between items in report
 		content += '<form class="noprint" name="breakForm">\n<input type="checkbox" name="checkbox" onClick="pageBreak()">Check this box if you want to print each item on a separate page.</form>\n';
 		content += '<script type="text/javascript">function pageBreak(){divs=document.getElementsByClassName("endItem");for(i=0;i<divs.length;i++){divs[i].style.pageBreakAfter=(document.forms.breakForm.checkbox.checked)?"always":""}}</script>\n';
 		

--- a/chrome/content/zotero/xpcom/report.js
+++ b/chrome/content/zotero/xpcom/report.js
@@ -45,6 +45,9 @@ Zotero.Report = new function() {
 		content += '<link rel="stylesheet" type="text/css" media="print" href="zotero://report/detail_print.css"/>\n';
 		content += '</head>\n\n<body>\n';
 		
+		content += '<form class="noprint" name="breakForm">\n<input type="checkbox" name="checkbox" onClick="pageBreak()">Check this box if you want to print each item on a separate page.</form>\n';
+		content += '<script type="text/javascript">function pageBreak(){divs=document.getElementsByClassName("endItem");for(i=0;i<divs.length;i++){divs[i].style.pageBreakAfter=(document.forms.breakForm.checkbox.checked)?"always":""}}</script>\n';
+		
 		content += '<ul class="report' + (combineChildItems ? ' combineChildItems' : '') + '">\n';
 		for each(var arr in items) {
 			content += '\n<li id="i' + arr.itemID + '" class="item ' + arr.itemType + '">\n';
@@ -126,7 +129,7 @@ Zotero.Report = new function() {
 			}
 			
 			
-			content += '</li>\n\n';
+			content += '</li><div class="endItem"></div>\n\n';
 		}
 		content += '</ul>\n';
 		content += '</body>\n</html>';
@@ -302,4 +305,6 @@ Zotero.Report = new function() {
 		}
 		return content;
 	}
+	
+
 }

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -563,6 +563,7 @@ citation.showEditor				= Show Editor…
 citation.hideEditor				= Hide Editor…
 
 report.title.default				= Zotero Report
+report.option.pageBreak				= Check this box if you want to print each item on a separate page.
 report.parentItem					= Parent Item:
 report.notes						= Notes:
 report.tags							= Tags:

--- a/chrome/skin/default/zotero/report/detail_print.css
+++ b/chrome/skin/default/zotero/report/detail_print.css
@@ -24,3 +24,7 @@ a {
 	color: #000;
 	text-decoration: none;
 }
+
+.noprint {
+	display: none;
+}


### PR DESCRIPTION
The patch adds a checkbox in the report.html file, generated by Zotero.
When checked, the report is printed (not automatically: the user has still to click print/ ctrl-p) with page breaks.
The checkbox and its message are not printed (css: "display:none").

I've added the function into the generateHTMLDetails function since I don't know how to do it differently. As I've compressed the code, you may consider that this is not enough human readable despite the explicit comment (?).

@simonster: I took inspiration from this script: http://www.javascriptkit.com/dhtmltutors/pagebreak.shtml .

---

Old trac ticket: https://www.zotero.org/trac/ticket/1608
Zotero forum: http://forums.zotero.org/discussion/9452/
