### PR TITLE
Fixes a bug in getFileBaseNameFromItem

### DIFF
--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -891,7 +891,7 @@ Zotero.Attachments = new function(){
 				break;
 				
 				default:
-					var value = item.getField(field, false, true);
+					var value = '' + item.getField(field, false, true);
 			}
 			
 			var re = new RegExp("\{?([^%\{\}]*)" + rpl + "(\{[0-9]+\})?" + "([^%\{\}]*)\}?");


### PR DESCRIPTION
Reported at http://forums.zotero.org/discussion/23508/jstor-parsing/

Since the title for that article referenced in the report is a number, str.replace was failing. The odd thing is that the exception never made it to the debug log (at least on my machine). Any ideas why?
