### PR TITLE
Fix bug in item.complete()

### DIFF
--- a/chrome/content/zotero/xpcom/translation/translate.js
+++ b/chrome/content/zotero/xpcom/translation/translate.js
@@ -1371,7 +1371,7 @@ Zotero.Translate.Base.prototype = {
 					"for(var key in this) {"+
 					"if("+createArrays+".indexOf(key) !== -1) {"+
 						"for each(var item in this[key]) {"+
-							"for(var key2 in item[key2]) {"+
+							"for(var key2 in item) {"+
 								"if(typeof item[key2] === 'xml') {"+
 									"item[key2] = item[key2].toString();"+
 								"}"+


### PR DESCRIPTION
I believe this was the intended code. It came up during my RIS translator testing.
