### PR TITLE
Allow relative file attachment import. Fix some bugs in _parsePath.

### DIFF
--- a/chrome/content/zotero/xpcom/translation/translate_item.js
+++ b/chrome/content/zotero/xpcom/translation/translate_item.js
@@ -215,8 +215,8 @@ Zotero.Translate.ItemSaver.prototype = {
 		if(!attachment.path) {
 			// see if this is actually a file URL
 			var m = urlRe.exec(attachment.url);
-			var protocol = m ? m[2].toLowerCase() : "";
-			if(protocol == "file" || protocol == "") {
+			var protocol = m ? m[2].toLowerCase() : "file";
+			if(protocol == "file") {
 				attachment.path = attachment.url;
 				attachment.url = false;
 			} else if(protocol != "http" && protocol != "https") {


### PR DESCRIPTION
First, the `attachment.path` code must have been left over from before. There is no `attachment` variable declared inside that function or anywhere in the scope.

Secondly, the `protocol == ""` is an attempt to allow relative file imports from translators.

From the research that I did, I don't think `file://`protocol allows relative referencing, though I could not find a definitive statement on that. Zotero RDF exports attachments with paths that look like `files/8/exporting_from_endnote_with_pdfs.html` and the RDF translator manages to import them just fine. I did some poking around, but I could not figure out how the RDF translator manages to resolve the complete URI from the relative path. Whatever RDF translator does, I think might be a better way to go. It seems to me, though I'm not sure (it's more of hunch), that this may be a security concern.

Either way, I would really like to get this sorted out. This would allow us to significantly simplify EndNote library imports with attachments. I can import attachments with the changes in this patch, but I don't know if this has potential of breaking anything else.

The regex just caught my eye so I simplified it.
