### PR TITLE
zotero://select: do not open tab, initialize Zotero pane if needed

### DIFF
--- a/chrome/content/zotero/tools/closeWindow.xul
+++ b/chrome/content/zotero/tools/closeWindow.xul
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<!--
+    ***** BEGIN LICENSE BLOCK *****
+    
+    Copyright © 2009 Center for History and New Media
+                     George Mason University, Fairfax, Virginia, USA
+                     http://zotero.org
+    
+    This file is part of Zotero.
+    
+    Zotero is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    
+    Zotero is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+    
+    You should have received a copy of the GNU Affero General Public License
+    along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
+    
+    ***** END LICENSE BLOCK *****
+-->
+<?xml-stylesheet href="chrome://global/skin/global.css"?>
+
+<window
+	id="zotero-close-window"
+	xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
+	title="This won't happen">
+	
+	<script language="javascript" type="text/javascript">window.close();</script>
+	
+</window>


### PR DESCRIPTION
Users express interest in using the zotero://select protocol to link from external note-taking tools with some regularity. A couple of sample threads:

  http://forums.zotero.org/discussion/20040/using-zoteroselect-for-external-program-links/
  http://forums.zotero.org/discussion/1919/outlining-in-zotero/

Two small glitches make this less attractive than it might be: each zotero://select call opens an empty tab in the browser; and the selection fails unless Zotero is opened at least once in a running Firefox before the call.

With this patch, zotero://select calls open a special dummy page that closes immediately after opening, and Zotero is initialised before the item selection so that the item will be selected even upon Firefox startup.
