### PR TITLE
Item list column width tweaks

### DIFF
--- a/chrome/content/zotero/xpcom/itemTreeView.js
+++ b/chrome/content/zotero/xpcom/itemTreeView.js
@@ -922,6 +922,8 @@ Zotero.ItemTreeView.prototype.unregister = function()
 
 Zotero.ItemTreeView.prototype.getCellText = function(row, column)
 {
+	if(column.element.getAttribute('ignore') == 'true') return;
+
 	var obj = this._getItemAtRow(row);
 	
 	var val;
@@ -2328,7 +2330,7 @@ Zotero.ItemTreeView.prototype.getVisibleFields = function() {
 	var columns = [];
 	for (var i=0, len=this._treebox.columns.count; i<len; i++) {
 		var col = this._treebox.columns.getColumnAt(i);
-		if (col.element.getAttribute('hidden') != 'true') {
+		if (col.element.getAttribute('ignore') != 'true' && col.element.getAttribute('hidden') != 'true') {
 			columns.push(col.id.substring(20));
 		}
 	}

--- a/chrome/content/zotero/zoteroPane.xul
+++ b/chrome/content/zotero/zoteroPane.xul
@@ -349,12 +349,14 @@
 									id="zotero-items-column-title" primary="true"
 									label="&zotero.items.title_column;"
 									minwidth="100"
+									width="300"
 									zotero-persist="width ordinal hidden sortActive sortDirection"/>
 								<splitter class="tree-splitter" resizeafter="grow"/>
 								<treecol
 									id="zotero-items-column-firstCreator"
 									label="&zotero.items.creator_column;"
 									minwidth="50"
+									width="100"
 									zotero-persist="width ordinal hidden sortActive sortDirection"/>
 								<splitter class="tree-splitter" resizeafter="grow"/>
 								<treecol
@@ -541,6 +543,7 @@
 									src="chrome://zotero/skin/attach-small.png"
 									fixed="true"
 									zotero-persist="ordinal hidden sortActive sortDirection"/>
+								<splitter class="tree-splitter" resizeafter="grow"/>
 								<treecol
 									id="zotero-items-column-numNotes" hidden="true"
 									class="treecol-image"
@@ -548,6 +551,12 @@
 									src="chrome://zotero/skin/treeitem-note-small.png"
 									fixed="true"
 									zotero-persist="ordinal hidden sortActive sortDirection"/>
+								<splitter class="tree-splitter" resizeafter="grow"/>
+								<treecol
+									id="zotero-items-column-filler"
+									ignore="true"
+									flex="1"
+									ignoreincolumnpicker="true"/>
 							</treecols>
 							<treechildren/>
 						</tree>

--- a/chrome/content/zotero/zoteroPane.xul
+++ b/chrome/content/zotero/zoteroPane.xul
@@ -348,176 +348,206 @@
 								<treecol
 									id="zotero-items-column-title" primary="true"
 									label="&zotero.items.title_column;"
-									flex="4" zotero-persist="width ordinal hidden sortActive sortDirection"/>
-								<splitter class="tree-splitter"/>
+									minwidth="100"
+									zotero-persist="width ordinal hidden sortActive sortDirection"/>
+								<splitter class="tree-splitter" resizeafter="grow"/>
 								<treecol
 									id="zotero-items-column-firstCreator"
 									label="&zotero.items.creator_column;"
-									flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
-								<splitter class="tree-splitter"/>
+									minwidth="50"
+									zotero-persist="width ordinal hidden sortActive sortDirection"/>
+								<splitter class="tree-splitter" resizeafter="grow"/>
 								<treecol
 									id="zotero-items-column-type" hidden="true"
 									label="&zotero.items.type_column;"
-									width="40" zotero-persist="width ordinal hidden sortActive sortDirection"/>
-								<splitter class="tree-splitter"/>
+									minwidth="50"
+									zotero-persist="width ordinal hidden sortActive sortDirection"/>
+								<splitter class="tree-splitter" resizeafter="grow"/>
 								<treecol
 									id="zotero-items-column-date" hidden="true"
 									label="&zotero.items.date_column;"
-									flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
-								<splitter class="tree-splitter"/>
+									minwidth="60"
+									zotero-persist="width ordinal hidden sortActive sortDirection"/>
+								<splitter class="tree-splitter" resizeafter="grow"/>
 								<treecol
 									id="zotero-items-column-year" hidden="true"
 									label="&zotero.items.year_column;"
-									flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
-								<splitter class="tree-splitter"/>
+									minwidth="35"
+									zotero-persist="width ordinal hidden sortActive sortDirection"/>
+								<splitter class="tree-splitter" resizeafter="grow"/>
 								<treecol
 									id="zotero-items-column-publisher" hidden="true"
 									label="&zotero.items.publisher_column;"
-									flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
-								<splitter class="tree-splitter"/>
+									minwidth="50"
+									zotero-persist="width ordinal hidden sortActive sortDirection"/>
+								<splitter class="tree-splitter" resizeafter="grow"/>
 								<treecol
 									id="zotero-items-column-publicationTitle" hidden="true"
 									label="&zotero.items.publication_column;"
-									flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
-								<splitter class="tree-splitter"/>
+									minwidth="50"
+									zotero-persist="width ordinal hidden sortActive sortDirection"/>
+								<splitter class="tree-splitter" resizeafter="grow"/>
 								<treecol
 									id="zotero-items-column-journalAbbreviation" hidden="true"
 									label="&zotero.items.journalAbbr_column;"
-									flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
-								<splitter class="tree-splitter"/>
+									minwidth="50"
+									zotero-persist="width ordinal hidden sortActive sortDirection"/>
+								<splitter class="tree-splitter" resizeafter="grow"/>
 								<treecol
 									id="zotero-items-column-language" hidden="true"
 									label="&zotero.items.language_column;"
-									flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
-								<splitter class="tree-splitter"/>
+									minwidth="40"
+									zotero-persist="width ordinal hidden sortActive sortDirection"/>
+								<splitter class="tree-splitter" resizeafter="grow"/>
 								<treecol
 									id="zotero-items-column-accessDate" hidden="true"
 									label="&zotero.items.accessDate_column;"
-									flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
-								<splitter class="tree-splitter"/>
+									minwidth="60"
+									zotero-persist="width ordinal hidden sortActive sortDirection"/>
+								<splitter class="tree-splitter" resizeafter="grow"/>
 								<treecol
 									id="zotero-items-column-libraryCatalog" hidden="true"
 									label="&zotero.items.libraryCatalog_column;"
-									flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
-								<splitter class="tree-splitter"/>
+									minwidth="50"
+									zotero-persist="width ordinal hidden sortActive sortDirection"/>
+								<splitter class="tree-splitter" resizeafter="grow"/>
 								<treecol
 									id="zotero-items-column-callNumber" hidden="true"
 									submenu="true"
 									label="&zotero.items.callNumber_column;"
-									flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
-								<splitter class="tree-splitter"/>
+									minwidth="50"
+									zotero-persist="width ordinal hidden sortActive sortDirection"/>
+								<splitter class="tree-splitter" resizeafter="grow"/>
 								<treecol
 									id="zotero-items-column-rights" hidden="true"
 									submenu="true"
 									label="&zotero.items.rights_column;"
-									flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
-								<splitter class="tree-splitter"/>
+									minwidth="50"
+									zotero-persist="width ordinal hidden sortActive sortDirection"/>
+								<splitter class="tree-splitter" resizeafter="grow"/>
 								<treecol
 									id="zotero-items-column-dateAdded" hidden="true"
 									label="&zotero.items.dateAdded_column;"
-									flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
-								<splitter class="tree-splitter"/>
+									minwidth="60"
+									zotero-persist="width ordinal hidden sortActive sortDirection"/>
+								<splitter class="tree-splitter" resizeafter="grow"/>
 								<treecol
 									id="zotero-items-column-dateModified" hidden="true"
 									label="&zotero.items.dateModified_column;"
-									flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
-								<splitter class="tree-splitter"/>
+									minwidth="60"
+									zotero-persist="width ordinal hidden sortActive sortDirection"/>
+								<splitter class="tree-splitter" resizeafter="grow"/>
 								<treecol
 									id="zotero-items-column-archive" hidden="true"
 									submenu="true"
 									label="&zotero.items.archive_column;"
-									flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
-								<splitter class="tree-splitter"/>								
+									minwidth="50"
+									zotero-persist="width ordinal hidden sortActive sortDirection"/>
+								<splitter class="tree-splitter" resizeafter="grow"/>
 								<treecol
 									id="zotero-items-column-archiveLocation" hidden="true"
 									submenu="true"
 									label="&zotero.items.archiveLocation_column;"
-									flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
-								<splitter class="tree-splitter"/>
+									minwidth="50"
+									zotero-persist="width ordinal hidden sortActive sortDirection"/>
+								<splitter class="tree-splitter" resizeafter="grow"/>
 								<treecol
 									id="zotero-items-column-place" hidden="true"
 									submenu="true"
 									label="&zotero.items.place_column;"
-									flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
-								<splitter class="tree-splitter"/>
+									minwidth="50"
+									zotero-persist="width ordinal hidden sortActive sortDirection"/>
+								<splitter class="tree-splitter" resizeafter="grow"/>
 								<treecol
 									id="zotero-items-column-volume" hidden="true"
 									submenu="true"
 									label="&zotero.items.volume_column;"
-									flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
-								<splitter class="tree-splitter"/>
+									minwidth="50"
+									zotero-persist="width ordinal hidden sortActive sortDirection"/>
+								<splitter class="tree-splitter" resizeafter="grow"/>
 								<treecol
 									id="zotero-items-column-edition" hidden="true"
 									submenu="true"
 									label="&zotero.items.edition_column;"
-									flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
-								<splitter class="tree-splitter"/>
+									minwidth="50"
+									zotero-persist="width ordinal hidden sortActive sortDirection"/>
+								<splitter class="tree-splitter" resizeafter="grow"/>
 								<treecol
 									id="zotero-items-column-pages" hidden="true"
 									submenu="true"
 									label="&zotero.items.pages_column;"
-									flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
-								<splitter class="tree-splitter"/>
+									minwidth="50"
+									zotero-persist="width ordinal hidden sortActive sortDirection"/>
+								<splitter class="tree-splitter" resizeafter="grow"/>
 								<treecol
 									id="zotero-items-column-issue" hidden="true"
 									submenu="true"
 									label="&zotero.items.issue_column;"
-									flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
-								<splitter class="tree-splitter"/>
+									minwidth="50"
+									zotero-persist="width ordinal hidden sortActive sortDirection"/>
+								<splitter class="tree-splitter" resizeafter="grow"/>
 								<treecol
 									id="zotero-items-column-series" hidden="true"
 									submenu="true"
 									label="&zotero.items.series_column;"
-									flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
-								<splitter class="tree-splitter"/>
+									minwidth="50"
+									zotero-persist="width ordinal hidden sortActive sortDirection"/>
+								<splitter class="tree-splitter" resizeafter="grow"/>
 								<treecol
 									id="zotero-items-column-seriesTitle" hidden="true"
 									submenu="true"
 									label="&zotero.items.seriesTitle_column;"
-									flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
-								<splitter class="tree-splitter"/>
+									minwidth="50"
+									zotero-persist="width ordinal hidden sortActive sortDirection"/>
+								<splitter class="tree-splitter" resizeafter="grow"/>
 								<treecol
 									id="zotero-items-column-court" hidden="true"
 									submenu="true"
 									label="&zotero.items.court_column;"
-									flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
-								<splitter class="tree-splitter"/>
+									minwidth="50"
+									zotero-persist="width ordinal hidden sortActive sortDirection"/>
+								<splitter class="tree-splitter" resizeafter="grow"/>
 								<treecol
 									id="zotero-items-column-medium" hidden="true"
 									submenu="true"
 									label="&zotero.items.medium_column;"
-									flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
-								<splitter class="tree-splitter"/>
+									minwidth="50"
+									zotero-persist="width ordinal hidden sortActive sortDirection"/>
+								<splitter class="tree-splitter" resizeafter="grow"/>
 								<treecol
 									id="zotero-items-column-genre" hidden="true"
 									submenu="true"
 									label="&zotero.items.genre_column;"
-									flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
-								<splitter class="tree-splitter"/>
+									minwidth="50"
+									zotero-persist="width ordinal hidden sortActive sortDirection"/>
+								<splitter class="tree-splitter" resizeafter="grow"/>
 								<treecol
 									id="zotero-items-column-system" hidden="true"
 									submenu="true"
 									label="&zotero.items.system_column;"
-									flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
-								<splitter class="tree-splitter"/>
+									minwidth="50"
+									zotero-persist="width ordinal hidden sortActive sortDirection"/>
+								<splitter class="tree-splitter" resizeafter="grow"/>
 								<treecol
 									id="zotero-items-column-extra" hidden="true"
 									label="&zotero.items.extra_column;"
-									flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
-								<splitter class="tree-splitter"/>
+									minwidth="50"
+									zotero-persist="width ordinal hidden sortActive sortDirection"/>
+								<splitter class="tree-splitter" resizeafter="grow"/>
 								<treecol
 									id="zotero-items-column-hasAttachment"
 									class="treecol-image"
 									label="&zotero.tabs.attachments.label;"
 									src="chrome://zotero/skin/attach-small.png"
-									zotero-persist="width ordinal hidden sortActive sortDirection"/>
-								<splitter class="tree-splitter"/>
+									fixed="true"
+									zotero-persist="ordinal hidden sortActive sortDirection"/>
 								<treecol
 									id="zotero-items-column-numNotes" hidden="true"
 									class="treecol-image"
 									label="&zotero.tabs.notes.label;"
 									src="chrome://zotero/skin/treeitem-note-small.png"
-									zotero-persist="width ordinal hidden sortActive sortDirection"/>
+									fixed="true"
+									zotero-persist="ordinal hidden sortActive sortDirection"/>
 							</treecols>
 							<treechildren/>
 						</tree>


### PR DESCRIPTION
There are a couple issues that I wanted to address with the item list.

1) It does not make sense to me that the Attachment and Notes columns are resizable. All they show is one dot, so I set them to fixed width. Dropping width from `zotero-persist` will allow these columns to forget any previous width settings after second restart.

2) Currently, I feel that adjusting column widths is very awkward. One of the problems is that when I try expanding some columns, the adjacent columns shrink to practically 0 width. It's rather frustrating. I added minwidth to all the columns based mostly on the type of data displayed in the field.

3) The second problem with width adjustment, I think, is that it does shrink adjacent columns. This is probably not a big deal when you have two or three columns, but I don't think this behavior is intuitive or convenient for anything more. By allowing overflow and horizontal scrolling, I think it makes it easier to adjust the columns the way you want to. This way you can adjust each column individually without affecting other columns. I don't know if the horizontal scrolling has a lot of benefit for the final set up though (maybe other people would like it).

There is one issue with this however, which I have not figured out yet. With `resizeafter="grow"` in splitter elements and flex attributes removed from treecol, you can actually resize the columns to where they are narrower than the tree box. This looks quite weird. I think ideally, you should not be able to resize the columns any smaller than the full width. I'm not sure how to implement this though. Maybe someone has an idea how to fix it.
