### PR TITLE
Fix searching for non-existing attachments with relative paths

### DIFF
--- a/chrome/content/zotero/xpcom/translation/translate_item.js
+++ b/chrome/content/zotero/xpcom/translation/translate_item.js
@@ -239,7 +239,7 @@ Zotero.Translate.ItemSaver.prototype = {
 			var newItem = Zotero.Items.get(myID);
 		} else {
 			var file = this._parsePath(attachment.path);
-			if(!file || !file.exists()) return;
+			if(!file) return;
 			
 			if (attachment.url) {
 				var myID = Zotero.Attachments.importSnapshotFromFile(file,
@@ -297,13 +297,15 @@ Zotero.Translate.ItemSaver.prototype = {
 			return false;
 		}
 		
-		if(!file.exists() && path[0] !== "/" && path.substr(0, 5).toLowerCase() !== "file:") {
+		if(file.exists()) {
+			return file;
+		} else if(path[0] !== "/" && path.substr(0, 5).toLowerCase() !== "file:") {
 			// This looks like a relative path, but it might actually be an absolute path, because
 			// some people are not quite there.
 			var newFile = this._parsePath("/"+path);
-			if(newFile.exists()) return newFile;
+			if(newFile && newFile.exists()) return newFile;
 		}
-		return file;
+		return false;
 	},
 	
 	"_saveAttachmentDownload":function(attachment, parentID) {


### PR DESCRIPTION
This used to fail with `newFile.exists is not a function` when trying to find attachments that did not exist using relative paths.

I think this was probably causing most of the EndNote import failures.
