### PR TITLE
Fix typo

### DIFF
--- a/chrome/content/zotero/xpcom/utilities.js
+++ b/chrome/content/zotero/xpcom/utilities.js
@@ -65,7 +65,7 @@ const CSL_TEXT_MAPPINGS = {
 	"section":["section"],
 	"genre":["type"],
 	"source":["libraryCatalog"],
-	"dimension": ["artworkSize", "runningTime"], 
+	"dimensions": ["artworkSize", "runningTime"], 
 	"medium":["medium", "system"],
 	"scale":["scale"],
 	"archive":["archive"],


### PR DESCRIPTION
http://forums.zotero.org/discussion/26312/csl-variables-used-in-zotero-but-not-in-documentation/#Item_3
