### PR TITLE
[Standalone] Pass url to detect function from savePages

### DIFF
--- a/chrome/content/zotero/xpcom/server_connector.js
+++ b/chrome/content/zotero/xpcom/server_connector.js
@@ -187,9 +187,9 @@ Zotero.Server.Connector.SavePage.prototype = {
 	 * @param {Object} data POST data or GET query string
 	 * @param {Function} sendResponseCallback function to send HTTP response
 	 */
-	"init":function(data, sendResponseCallback) {
+	"init":function(url, data, sendResponseCallback) {
 		this.sendResponse = sendResponseCallback;
-		Zotero.Server.Connector.Detect.prototype.init.apply(this, [data, sendResponseCallback])
+		Zotero.Server.Connector.Detect.prototype.init.apply(this, [url, data, sendResponseCallback])
 	},
 
 	/**


### PR DESCRIPTION
Re http://forums.zotero.org/discussion/26591/cannot-get-the-data-from-springer/

I'm guessing this has not been picked up before because most translators are marked as compatible with Chrome. Springer Link should probably be marked that way too. I didn't mark it initially though, since I know you guys prefer to run the tests first.
