### PR TITLE
[PDF metadata retrieval] Fix broken DOI scanning

### DIFF
--- a/chrome/content/zotero/recognizePDF.js
+++ b/chrome/content/zotero/recognizePDF.js
@@ -310,7 +310,7 @@ Zotero_RecognizePDF.Recognizer.prototype.recognize = function(file, libraryID, c
 	Zotero.debug(allText);
 	var m = Zotero.Utilities.cleanDOI(allText);
 	if(m) {
-		this._DOI = m[0];
+		this._DOI = m;
 	}
 	
 	// Use only first column from multi-column lines


### PR DESCRIPTION
This must have been broken for some time now.

Reported at http://forums.zotero.org/discussion/26561/retrieve-metadata-for-pdf-doesnt-seem-to-work-correctly/
