### PR TITLE
[WebPageDump] Don't crash when @import stylesheets are null

### DIFF
--- a/chrome/content/zotero/webpagedump/domsaver.js
+++ b/chrome/content/zotero/webpagedump/domsaver.js
@@ -633,7 +633,7 @@ var wpdDOMSaver = {
 	// FONT_FACE_RULE = 5,
 	// PAGE_RULE = 6
 	processCSSRecursively: function (aCSS) {
-		if (aCSS.disabled) return "";
+		if (!aCSS || aCSS.disabled) return "";
 		var content = "";
 		var medium = aCSS.media.mediaText;
 		if (medium != "" && medium.indexOf("screen") < 0 && medium.indexOf("all") < 0) {
@@ -966,8 +966,9 @@ var wpdDOMSaver = {
 		if (this.option["format"]) {
 			var myStyleSheets = aDocument.styleSheets;
 			// get all style sheets to "CSSText"
-			for (var i = 0; i < myStyleSheets.length; i++)
-			CSSText += this.processCSSRecursively(myStyleSheets[i]);
+			for (var i = 0; i < myStyleSheets.length; i++) {
+				CSSText += this.processCSSRecursively(myStyleSheets[i]);
+			}
 			if (CSSText) {
 				// don't forget to convert the CSS String to the document charset..
 				// (necessary for e.g. font-family)


### PR DESCRIPTION
For whatever reason, sometimes stylesheets specified via @import rules are null when adblock blocks them.

http://forums.zotero.org/discussion/19871/snapshot-the-attached-file-could-not-be-found/
http://forums.zotero.org/discussion/26778/file-not-found/

closes #10
