### PR TITLE
Allow translators to re-trigger detectWeb on DOM changes

### DIFF
--- a/chrome/content/zotero/xpcom/translation/translate.js
+++ b/chrome/content/zotero/xpcom/translation/translate.js
@@ -635,6 +635,52 @@ Zotero.Translate.Sandbox = {
 			
 			// call super
 			Zotero.Translate.Sandbox.Base._itemDone(translate, item);
+		},
+		
+		/**
+		 * Tells Zotero to monitor changes to the DOM and re-trigger detectWeb
+		 * Can only be set during the detectWeb call
+		 * @param {DOMNode} target Document node to monitor for changes
+		 * @param {MutationObserverInit} [config] specifies which DOM mutations should be reported
+		 */
+		"monitorDOMChanges":function(translate, target, config) {
+			if(translate._currentState != "detect") {
+				Zotero.debug("Translate: monitorDOMChanges can only be called during the 'detect' stage");
+				return;
+			}
+
+			var window = translate.document.defaultView
+			var mutationObserver = window && ( window.MutationObserver || window.WebKitMutationObserver || window.MozMutationObserver );
+			if(!mutationObserver) {
+				Zotero.debug("Translate: This browser does not support mutation observers.");
+				return;
+			}
+
+			var translator = translate._potentialTranslators[0];
+			if(!translate._registeredDOMObservers[translator.translatorID])
+				translate._registeredDOMObservers[translator.translatorID] = [];
+			var obs = translate._registeredDOMObservers[translator.translatorID];
+
+			//do not re-register observer by the same translator for the same node
+			if(obs.indexOf(target) != -1) {
+				Zotero.debug("Translate: Already monitoring this node");
+				return;
+			}
+
+			obs.push(target);
+
+			var observer = new mutationObserver(function(mutations, observer) {
+				obs.splice(obs.indexOf(target),1);
+				observer.disconnect();
+				
+				Zotero.debug("Translate: Page modified.");
+				//we don't really care what got updated
+				var doc = mutations[0].target.ownerDocument;
+				translate._runHandler("pageModified", doc);
+			});
+
+			observer.observe(target, config || {childList: true, subtree: true});
+			Zotero.debug("Translate: Mutation observer registered on <" + target.nodeName + "> node");
 		}
 	},
 
@@ -843,6 +889,11 @@ Zotero.Translate.Base.prototype = {
 	 *           complete
 	 *   passed: an array of appropriate translators
 	 *   returns: N/A
+	 * pageModified
+	 *   valid: web
+	 *   called: when a web page has been modified
+	 *   passed: the document object for the modified page
+	 *   returns: N/A
 	 * @param {Function} handler Callback function. All handlers will be passed the current
 	 * translate instance as the first argument. The second argument is dependent on the handler.
 	 */
@@ -909,7 +960,7 @@ Zotero.Translate.Base.prototype = {
 		if(this._handlers[type]) {
 			// compile list of arguments
 			if(this._parentTranslator) {
-				// if there is a parent translator, make sure we don't the Zotero.Translate
+				// if there is a parent translator, make sure we don't pass the Zotero.Translate
 				// object, since it could open a security hole
 				var args = [null];
 			} else {
@@ -1528,6 +1579,7 @@ Zotero.Translate.Base.prototype = {
  *     this Translate instance.
  */
 Zotero.Translate.Web = function() {
+	this._registeredDOMObservers = {}
 	this.init();
 }
 Zotero.Translate.Web.prototype = new Zotero.Translate.Base();


### PR DESCRIPTION
This is in regards to websites that update their pages without triggering a pageLoad event. Since monitoring all DOM changes on all websites would be too much, I figured that each translator should be able to tell Zotero to monitor certain DOM nodes for changes and redo detectWeb.

E.g. the ARTstor translator is currently more or less broken because of heavy use of JavaScript on their website. Using this patch, you could do something like:

```
function detectWeb(doc, url) {
    if(doc.body.id == "canvas") {
        Zotero.monitorDOMChanges(doc.body);
    }

    ...
}
```

At least that's how it should work in theory.

I am currently running into one problem that I cannot wrap my head around: `MutationObserver` is undefined inside `monitorDOMChanges`.

It is running inside a sandbox, so it kind of makes sense (though I'm still not sure how to figure out if an object will be defined inside a sandbox or not.... E.g. `Math` is defined, so why not `MutationObserver`??). I was looking at some code used to expose `DOMParser` to translators and I think I could use the same method, but the thing is that I don't want/need `MutationObserver` to be accessible by the translators themselves, just the `monitorDOMChanges` function. Should I be defining `monitorDOMChanges` as `Zotero.Translate.Web.prototype.monitorDOMChanges` instead of inside `Zotero.Translate.Sandbox`? But I don't think that's an appropriate place for it in terms of the conditions that the function is used under (i.e. it is only ever called from translators)

So what are my options here? (Also, is this an OK approach to the bigger problem?)
