### PR TITLE
Set each extraData object on event queue under its respective itemID

### DIFF
--- a/chrome/content/zotero/xpcom/notifier.js
+++ b/chrome/content/zotero/xpcom/notifier.js
@@ -135,8 +135,19 @@ Zotero.Notifier = new function(){
 			
 			// Merge extraData keys
 			if (extraData) {
-				for (var dataID in extraData) {
-					_queue[type][event].data[dataID] = extraData[dataID];
+				for each(var id in ids) {
+					if (!_queue[type][event].data[id]) {
+						_queue[type][event].data[id] = {};
+					}
+					if (extraData[id]) {
+						for (var dataID in extraData[id]) {
+							_queue[type][event].data[id][dataID] = extraData[id][dataID];
+						}
+					} else {
+						for (var dataID in extraData) {
+							_queue[type][event].data[id][dataID] = extraData[dataID];
+						}
+					}
 				}
 			}
 			


### PR DESCRIPTION
This relates to the following discussion on zotero-dev:

https://groups.google.com/forum/#!msg/zotero-dev/UF7BIjVqaJw/6HtDEQlU4isJ

From the code in notifier.js, it appears that modify events are meant to carry the old data of objects being modified in their extraData object. A key mismatch was causing the object always to be empty. This change should pass the data through, for both single-item and multiple-item modify events.

(Pull request refiled. The original pointed at a much earlier point in branch development for some reason.)
