### PR TITLE
[Utilities] Deep copy `null` as `null`. Display object type in varDump

### DIFF
--- a/chrome/content/zotero/xpcom/utilities.js
+++ b/chrome/content/zotero/xpcom/utilities.js
@@ -914,7 +914,7 @@ Zotero.Utilities = {
 		for(var i in obj) {
 			if(!obj.hasOwnProperty(i)) continue;
 			
-			if(typeof obj[i] === "object") {
+			if(typeof obj[i] === "object" && obj[i] !== null) {
 				obj2[i] = Zotero.Utilities.deepCopy(obj[i]);
 			} else {
 				obj2[i] = obj[i];
@@ -1139,7 +1139,7 @@ Zotero.Utilities = {
 						closeBrace = ']';
 					}
 
-					dumped_text += level_padding + "'" + item + "' => " + openBrace;
+					dumped_text += level_padding + "'" + item + "' => " + type + ' ' + openBrace;
 					//only recurse if there's anything in the object, purely cosmetical
 					try {
 						for(var i in value) {


### PR DESCRIPTION
Some minor tweaks to Zotero.Utilities.

I don't think the change to deepCopy should break anything. At least this seems like the more correct behavior. I guess it's a bit odd to single out `null` from all the other possible objects, but `null` is quite special :-)
