### PR TITLE
Allow translators to define translator-specific hidden preferences.

### DIFF
--- a/chrome/content/zotero/xpcom/connector/translator.js
+++ b/chrome/content/zotero/xpcom/connector/translator.js
@@ -367,7 +367,7 @@ Zotero.Translators.CodeGetter.prototype.getCodeFor = function(i) {
 const TRANSLATOR_REQUIRED_PROPERTIES = ["translatorID", "translatorType", "label", "creator", "target",
 		"priority", "lastUpdated"];
 var TRANSLATOR_PASSING_PROPERTIES = TRANSLATOR_REQUIRED_PROPERTIES.concat(["displayOptions", "configOptions",
-		"browserSupport", "code", "runMode"]);
+		"hiddenPrefs", "browserSupport", "code", "runMode"]);
 var TRANSLATOR_SAVE_PROPERTIES = TRANSLATOR_REQUIRED_PROPERTIES.concat(["browserSupport"]);
 /**
  * @class Represents an individual translator
@@ -385,8 +385,11 @@ var TRANSLATOR_SAVE_PROPERTIES = TRANSLATOR_REQUIRED_PROPERTIES.concat(["browser
  *     c = Google Chrome (WebKit & V8)
  *     s = Safari (WebKit & Nitro/Squirrelfish Extreme)
  *     i = Internet Explorer
+ *     b = Bookmarklet
+ *     v = Server (requires server translation when using a bookmarklet)
  * @property {Object} configOptions Configuration options for import/export
  * @property {Object} displayOptions Display options for export
+ * @property {Object} hiddenPrefs Hidden preferences configurable through about:config
  * @property {Boolean} inRepository Whether the translator may be found in the repository
  * @property {String} lastUpdated SQL-style date and time of translator's last update
  * @property {String} code The executable JavaScript for the translator
@@ -421,6 +424,7 @@ Zotero.Translator.prototype.init = function(info) {
 	
 	this._configOptions = info["configOptions"] ? info["configOptions"] : {};
 	this._displayOptions = info["displayOptions"] ? info["displayOptions"] : {};
+	this._hiddenPrefs = info["hiddenPrefs"] ? info["hiddenPrefs"] : {};
 	
 	if(this.translatorType & TRANSLATOR_TYPES["import"]) {
 		// compile import regexp to match only file extension
@@ -467,6 +471,9 @@ Zotero.Translator.prototype.__defineGetter__("displayOptions", function() {
 });
 Zotero.Translator.prototype.__defineGetter__("configOptions", function() {
 	return Zotero.Utilities.deepCopy(this._configOptions);
+});
+Zotero.Translator.prototype.__defineGetter__("hiddenPrefs", function() {
+	return Zotero.Utilities.deepCopy(this._hiddenPrefs);
 });
 
 /**

--- a/chrome/content/zotero/xpcom/schema.js
+++ b/chrome/content/zotero/xpcom/schema.js
@@ -1677,7 +1677,7 @@ Zotero.Schema = new function(){
 			metadata.browserSupport = browserSupport;
 		}
 		
-		for each(var attr in ["configOptions", "displayOptions"]) {
+		for each(var attr in ["configOptions", "displayOptions", "hiddenPrefs"]) {
 			try {
 				var tags = xmlnode.getElementsByTagName(attr);
 				if(tags.length && tags[0].firstChild) {

--- a/chrome/content/zotero/xpcom/server_connector.js
+++ b/chrome/content/zotero/xpcom/server_connector.js
@@ -66,7 +66,7 @@ Zotero.Server.Connector.GetTranslators.prototype = {
 		for each(var translator in translators) {
 			let serializableTranslator = {};
 			for each(var key in ["translatorID", "translatorType", "label", "creator", "target",
-					"minVersion", "maxVersion", "configOptions", "displayOptions", "priority", 
+					"minVersion", "maxVersion", "configOptions", "displayOptions", "hiddenPrefs", "priority", 
 					"browserSupport", "inRepository", "lastUpdated"]) {
 				serializableTranslator[key] = translator[key];
 			}

--- a/chrome/content/zotero/xpcom/translation/translate.js
+++ b/chrome/content/zotero/xpcom/translation/translate.js
@@ -171,6 +171,27 @@ Zotero.Translate.Sandbox = {
 		},
 		
 		/**
+		 * Gets a hidden preference that can be defined by hiddenPrefs in translator header
+		 *
+		 * @param {Zotero.Translate} translate
+		 * @param {String} pref Prefernce to be retrieved
+		 */
+		"getHiddenPref":function(translate, pref) {
+			if(typeof(pref) != "string") {
+				throw(new Error("getPref: preference must be a string"));
+			}
+
+			var hp = translate._hiddenPrefs || {};	//_hiddenPrefs should already be {} if undefined
+
+			var value;
+			try {
+				value = Zotero.Prefs.get('translators.' + pref);
+			} catch(e) {}
+
+			return (value !== undefined ? value : hp[pref]);
+		},
+		
+		/**
 		 * For loading other translators and accessing their methods
 		 * 
 		 * @param {Zotero.Translate} translate
@@ -1331,6 +1352,7 @@ Zotero.Translate.Base.prototype = {
 		this._runningAsyncProcesses = 0;
 		this._returnValue = undefined;
 		this._aborted = false;
+		this._hiddenPrefs = translator.hiddenPrefs;
 		this.saveQueue = [];
 		
 		Zotero.debug("Translate: Parsing code for "+translator.label, 4);

--- a/chrome/content/zotero/xpcom/translation/translator.js
+++ b/chrome/content/zotero/xpcom/translation/translator.js
@@ -425,8 +425,11 @@ Zotero.Translators = new function() {
  *     c = Google Chrome (WebKit & V8)
  *     s = Safari (WebKit & Nitro/Squirrelfish Extreme)
  *     i = Internet Explorer
+ *     b = Bookmarklet
+ *     v = Server (requires server translation when using a bookmarklet)
  * @property {Object} configOptions Configuration options for import/export
  * @property {Object} displayOptions Display options for export
+ * @property {Object} hiddenPrefs Hidden preferences configurable through about:config
  * @property {Boolean} inRepository Whether the translator may be found in the repository
  * @property {String} lastUpdated SQL-style date and time of translator's last update
  * @property {String} code The executable JavaScript for the translator
@@ -490,6 +493,8 @@ Zotero.Translator = function(file, json, code) {
 	
 	this._configOptions = info["configOptions"] ? info["configOptions"] : {};
 	this._displayOptions = info["displayOptions"] ? info["displayOptions"] : {};
+	this._hiddenPrefs = info["hiddenPrefs"] ? info["hiddenPrefs"] : {};
+	
 	this.browserSupport = info["browserSupport"] ? info["browserSupport"] : "g";
 	this.runMode = Zotero.Translator.RUN_MODE_IN_BROWSER;
 	
@@ -542,6 +547,9 @@ Zotero.Translator.prototype.__defineGetter__("displayOptions", function() {
 });
 Zotero.Translator.prototype.__defineGetter__("configOptions", function() {
 	return Zotero.Utilities.deepCopy(this._configOptions);
+});
+Zotero.Translator.prototype.__defineGetter__("hiddenPrefs", function() {
+	return Zotero.Utilities.deepCopy(this._hiddenPrefs);
 });
 
 /**


### PR DESCRIPTION
This applies to several use-cases, but one of the more recent discussions is here: https://github.com/zotero/translators/pull/477

Translators can now include the following in the translator info header

```
hiddenPrefs: {
    key: 'someTranslator',
    prefs: { test: 'hello', myPref: null }},
```

(due to the way the header is currently parsed, it is important that the closing braces for both the `hiddenPrefs` and the `prefs` properties do not match `/}\s*?[\r\n]/`. i.e. they cannot end with new line)

Furthermore, the user can define these hidden properties in about:config under `extensions.zotero.translators`. E.g. with the above setup, you can define `extensions.zotero.translators.someTranslator.myPref` to be `bye`. The user-defined property takes precedence over the default.

From the translator, hidden preferences can be access using `Zotero.getPref("someProp")`. If the property is not defined for this translator, `undefined` is returned. Otherwise, user supplied value or the default value are returned.

E.g. for the above, `Zotero.getPref("test")` returns "hello" and `Zotero.getPref("myPref")` returns "bye".

I hope all the functions are in the right places. I will also commit any changes necessary to connectors/bookmarklet/translation server.

Hopefully I didn't miss anything
