### PR TITLE
[DO NOT MERGE] Make Zotero compatible with Firefox 20

### DIFF
--- a/chrome/content/zotero/advancedSearch.js
+++ b/chrome/content/zotero/advancedSearch.js
@@ -62,8 +62,8 @@ var ZoteroAdvancedSearch = new function() {
 				
 				// FIXME: Hack to exclude group libraries for now
 				var groups = Zotero.Groups.getAll();
-				for each(var group in groups) {
-					s2.addCondition('libraryID', 'isNot', group.libraryID);
+				for(var group in groups) {
+					s2.addCondition('libraryID', 'isNot', groups[group].libraryID);
 				}
 				
 				var ids = s2.search();

--- a/chrome/content/zotero/bindings/itembox.xml
+++ b/chrome/content/zotero/bindings/itembox.xml
@@ -309,8 +309,8 @@
 					
 					// Manual field order
 					if (this._fieldOrder.length) {
-						for each(var field in this._fieldOrder) {
-							fieldNames.push(field);
+						for(var field in this._fieldOrder) {
+							fieldNames.push(this._fieldOrder[field]);
 						}
 					}
 					// Get field order from database
@@ -440,7 +440,8 @@
 							
 							var popup = button.appendChild(document.createElement("menupopup"));
 							
-							for each(var v in this._fieldAlternatives[fieldName]) {
+							for(var u in this._fieldAlternatives[fieldName]) {
+								var v = this._fieldAlternatives[fieldName][u];
 								var menuitem = document.createElement("menuitem");
 								var sv = Zotero.Utilities.ellipsize(v, 60);
 								menuitem.setAttribute('label', sv);

--- a/chrome/content/zotero/bindings/merge.xml
+++ b/chrome/content/zotero/bindings/merge.xml
@@ -441,8 +441,8 @@
 						pane.objectbox.clickable = true;
 						var fieldIDs = Zotero.ItemFields.getItemTypeFields(value);
 						var fieldNames = ['itemType'];
-						for each(var field in fieldIDs) {
-							fieldNames.push(Zotero.ItemFields.getName(field));
+						for(var field in fieldIDs) {
+							fieldNames.push(Zotero.ItemFields.getName(fieldIDs[field]));
 						}
 						otherPane.objectbox.clickableFields = fieldNames;
 						otherPane.objectbox.clickable = false;

--- a/chrome/content/zotero/bindings/styled-textbox.xml
+++ b/chrome/content/zotero/bindings/styled-textbox.xml
@@ -204,7 +204,8 @@
 						}
 						
 						// Preserve small caps and underlining
-						for each (var tagspec in this._rtfRexMap){
+						for(var p in this._rtfRexMap){
+							var tagspec = this._rtfRexMap[p];
 							var l = output.split(/(<\/?span[^>]*>)/);
 							var current_level = 0;
 							var tag_level = [];
@@ -227,8 +228,8 @@
 							output = l.join("");
 						}
 						
-						for each(var entry in this._htmlToRtfMap) {
-							output = output.replace(entry[0], entry[1], "g");
+						for(var entry in this._htmlToRtfMap) {
+							output = output.replace(this._htmlToRtfMap[entry][0], this._htmlToRtfMap[entry][1], "g");
 						}
 						
 						output = Zotero.Utilities.unescapeHTML(output.replace(" ", "&nbsp;", "g"))
@@ -295,12 +296,13 @@
 								html = html.replace(this._rtfMap[needle], needle, "g");
 							}
 						}
-						for each (var tagspec in this._rtfRexMap){
+						for(var p in this._rtfRexMap){
+							var tagspec = this._rtfRexMap[p];
 							html = html.replace(tagspec[2], tagspec[0], "g");
 							html = html.replace(tagspec[3], "</span>", "g");
 						}
-						for each(var entry in this._rtfToHtmlMap) {
-							html = html.replace(entry[0], entry[1], "g");
+						for(var entry in this._rtfToHtmlMap) {
+							html = html.replace(this._rtfToHtmlMap[entry][0], this._rtfToHtmlMap[entry][1], "g");
 						}
 						html = '<div style="'+bodyStyle+'"><p>'+html+"</p></div>";
 					}
@@ -371,8 +373,8 @@
 						
 						if (!SJOW.tinyMCE) {
 							var exts = Zotero.getInstalledExtensions(function(exts) {
-								for each(var ext in exts) {
-									if (ext.indexOf('NoScript') != -1) {
+								for(var ext in exts) {
+									if (exts[ext].indexOf('NoScript') != -1) {
 										var warning = win.document.getElementById('noScriptWarning');
 										var str = "The NoScript extension is preventing Zotero "
 											+ "from displaying notes. To use NoScript and Zotero together, "

--- a/chrome/content/zotero/bindings/tagselector.xml
+++ b/chrome/content/zotero/bindings/tagselector.xml
@@ -274,8 +274,8 @@
 						// Check tags against filter
 						if (this._hasFilter) {
 							var inFilter = false;
-							for each(var tagID in tagIDs) {
-								if (this._filter[tagID]) {
+							for(var tagID in tagIDs) {
+								if (this._filter[tagIDs[tagID]]) {
 									inFilter = true;
 									break;
 								}
@@ -285,8 +285,8 @@
 						// Check tags against scope
 						if (this._hasScope) {
 							var inScope = false;
-							for each(var tagID in tagIDs) {
-								if (this._scope[tagID]) {
+							for(var tagID in tagIDs) {
+								if (this._scope[tagIDs[tagID]]) {
 									inScope = true;
 									break;
 								}
@@ -488,8 +488,8 @@
 						this._tags = Zotero.Tags.getAll(this._types, this.libraryID);
 						
 						for (var tag in this.selection) {
-							for each(var tag2 in this._tags) {
-								if (tag == tag2) {
+							for(var tag2 in this._tags) {
+								if (tag == this._tags[tag2]) {
 									var found = true;
 									break;
 								}
@@ -692,9 +692,9 @@
 						
 						// Add other ids with same tag
 						var ids = Zotero.Tags.getIDs(oldName, this.libraryID);
-						for each(var id in ids) {
-							if (tagIDs.indexOf(id) == -1) {
-								tagIDs.push(id);
+						for(var id in ids) {
+							if (tagIDs.indexOf(ids[id]) == -1) {
+								tagIDs.push(ids[id]);
 							}
 						}
 						
@@ -821,12 +821,12 @@
 							var value = node.getAttribute('value');
 						}
 						
-						for each(var item in items) {
+						for(var item in items) {
 							if (tagID) {
-								item.addTagByID(tagID);
+								items[item].addTagByID(tagID);
 							}
 							else {
-								item.addTag(value);
+								items[item].addTag(value);
 							}
 						}
 						

--- a/chrome/content/zotero/bindings/zoterosearch.xml
+++ b/chrome/content/zotero/bindings/zoterosearch.xml
@@ -312,9 +312,9 @@
 								label.setAttribute('value', Zotero.getString('searchConditions.tooltip.fields'));
 								fieldRow.appendChild(label);
 								var vbox = document.createElement('vbox');
-								for each(var str in localized) {
+								for(var str in localized) {
 									var label = document.createElement('label')
-									label.setAttribute('value', str);
+									label.setAttribute('value', localized[str]);
 									vbox.appendChild(label);
 								}
 								fieldRow.appendChild(vbox);

--- a/chrome/content/zotero/browser.js
+++ b/chrome/content/zotero/browser.js
@@ -292,7 +292,8 @@ var Zotero_Browser = new function() {
 			// ignore blacklisted domains
 			try {
 				if(doc.domain) {
-					for each(var blacklistedURL in _blacklist) {
+					for(var p in _blacklist) {
+						var blacklistedURL = _blacklist[p];
 						if(doc.domain.substr(doc.domain.length-blacklistedURL.length) == blacklistedURL) {
 							Zotero.debug("Ignoring blacklisted URL "+doc.location);
 							return;
@@ -526,8 +527,8 @@ var Zotero_Browser = new function() {
 		menuitem.setAttribute("class", "menuitem-iconic");
 		menuitem.addEventListener("command", _constructLookupFunction(tab, function(event, obj) {
 			var urls = [];
-			for each(var item in obj.newItems) {
-				var url = Zotero.OpenURL.resolve(item);
+			for(var item in obj.newItems) {
+				var url = Zotero.OpenURL.resolve(obj.newItems[item]);
 				if(url) urls.push(url);
 			}
 			ZoteroPane.loadURI(urls, event);
@@ -662,7 +663,8 @@ Zotero_Browser.Tab.prototype.detectTranslators = function(rootDoc, doc) {
 Zotero_Browser.Tab.prototype._searchFrames = function(rootDoc, searchDoc) {
 	if(rootDoc == searchDoc) return true;
 	var frames = rootDoc.getElementsByTagName("frame");
-	for each(var frame in frames) {
+	for(var p in frames) {
+		var frame = frames[p];
 		if(frame.contentDocument &&
 				(frame.contentDocument == searchDoc ||
 				this._searchFrames(frame.contentDocument, searchDoc))) {
@@ -671,7 +673,8 @@ Zotero_Browser.Tab.prototype._searchFrames = function(rootDoc, searchDoc) {
 	}
 	
 	var frames = rootDoc.getElementsByTagName("iframe");
-	for each(var frame in frames) {
+	for(var p in frames) {
+		var frame = frames[p];
 		if(frame.contentDocument &&
 				(frame.contentDocument == searchDoc ||
 				this._searchFrames(frame.contentDocument, searchDoc))) {

--- a/chrome/content/zotero/downloadOverlay.js
+++ b/chrome/content/zotero/downloadOverlay.js
@@ -164,7 +164,8 @@ var Zotero_DownloadOverlay = new function() {
 		// Disable for filetypes people probably don't want to save
 		var show = false;
 		var mimeType = dialog.mLauncher.MIMEInfo.MIMEType.toLowerCase();
-		for each(var elem in ALLOW_LIST) {
+		for(var p in ALLOW_LIST) {
+			var elem = ALLOW_LIST[p];
 			if(typeof elem === "string") {
 				if(elem === mimeType) {
 					document.getElementById('zotero-container').hidden = false;

--- a/chrome/content/zotero/duplicatesMerge.js
+++ b/chrome/content/zotero/duplicatesMerge.js
@@ -30,7 +30,8 @@ var Zotero_Duplicates_Pane = new function () {
 	
 	this.setItems = function (items, displayNumItemsOnTypeError) {
 		var itemTypeID, oldestItem, otherItems = [];
-		for each(var item in items) {
+		for(var p in items) {
+			var item = items[p];
 			// Find the oldest item
 			if (!oldestItem) {
 				oldestItem = item;
@@ -96,8 +97,8 @@ var Zotero_Duplicates_Pane = new function () {
 			}
 			
 			var numRows = 0;
-			for each(var item in _items) {
-				var date = Zotero.Date.sqlToDate(item.dateAdded, true);
+			for(var item in _items) {
+				var date = Zotero.Date.sqlToDate(_items[item].dateAdded, true);
 				dateList.appendItem(date.toLocaleString());
 				numRows++;
 			}

--- a/chrome/content/zotero/fileInterface.js
+++ b/chrome/content/zotero/fileInterface.js
@@ -339,7 +339,9 @@ var Zotero_File_Interface = new function() {
 	 */
 	function _importDone(obj, worked) {
 		// add items to import collection
-		_importCollection.addItems([item.id for each(item in obj.newItems)]);
+		var itemIDs = [];
+		for(var p in obj.newItems) itemIDs.push(obj.newItems[p].id);
+		_importCollection.addItems(itemIDs);
 		
 		Zotero.DB.commitTransaction();
 		
@@ -445,7 +447,9 @@ var Zotero_File_Interface = new function() {
 							   getService(Components.interfaces.nsIClipboard);
 		
 		var style = Zotero.Styles.get(style).csl;
-		var citation = {"citationItems":[{id:item.id} for each(item in items)], properties:{}};
+		var itemIDs = [];
+		for(var p in items) itemIDs.push({id: items[p].id});
+		var citation = {"citationItems":itemIDs, properties:{}};
 		
 		// add HTML
 		var bibliography = style.previewCitationCluster(citation, [], [], "html");
@@ -474,8 +478,8 @@ var Zotero_File_Interface = new function() {
 	function _doBibliographyOptions(name, items) {
 		// make sure at least one item is not a standalone note or attachment
 		var haveRegularItem = false;
-		for each(var item in items) {
-			if (item.isRegularItem()) {
+		for(var item in items) {
+			if (items[item].isRegularItem()) {
 				haveRegularItem = true;
 				break;
 			}

--- a/chrome/content/zotero/integration/editBibliographyDialog.js
+++ b/chrome/content/zotero/integration/editBibliographyDialog.js
@@ -72,10 +72,10 @@ var Zotero_Bibliography_Dialog = new function () {
 		var clearListItems = false;
 		var itemsToSelect = [];
 		if(selectedItemIDs.length) {
-			for each(var itemID in selectedItemIDs) {
+			for(var itemID in selectedItemIDs) {
 				var itemIndexToSelect = false;
 				for(var i in bibEditInterface.bibliography[0].entry_ids) {
-					if(bibEditInterface.bibliography[0].entry_ids[i].indexOf(itemID) !== -1) {
+					if(bibEditInterface.bibliography[0].entry_ids[i].indexOf(selectedItemIDs[itemID]) !== -1) {
 						itemIndexToSelect = i;
 						continue;
 					}
@@ -99,7 +99,7 @@ var Zotero_Bibliography_Dialog = new function () {
 			_addButton.disabled = true;
 			_removeButton.disabled = false;
 			_updateRevertButtonStatus();
-			[_itemList.toggleItemSelection(item) for each(item in itemsToSelect)];
+			for(var item in itemsToSelect) _itemList.toggleItemSelection(itemsToSelect[item]);
 			_itemList.ensureIndexIsVisible(itemsToSelect[0]);
 		}
 		_suppressAllSelectEvents = false;
@@ -135,8 +135,9 @@ var Zotero_Bibliography_Dialog = new function () {
 	 * Adds references to the reference list
 	 */
 	this.add = function() {
-		for each(var itemID in itemsView.getSelectedItems(true)) {
-			bibEditInterface.add(itemID);
+		var selectedItems = itemsView.getSelectedItems(true);
+		for(var itemID in selectedItems) {
+			bibEditInterface.add(selectedItems[itemID]);
 		}
 		document.getElementById("add").disabled = true;
 		_loadItems();
@@ -184,8 +185,9 @@ var Zotero_Bibliography_Dialog = new function () {
 		
 		if(regenerate != 0) return;
 		
-		for each(var itemID in _getSelectedListItemIDs()) {
-			bibEditInterface.revert(itemID);
+		var selectedItems = _getSelectedListItemIDs();
+		for(var itemID in selectedItems) {
+			bibEditInterface.revert(selectedItems[selectedItems[itemID]]);
 		}
 		
 		_updatePreview();
@@ -199,8 +201,8 @@ var Zotero_Bibliography_Dialog = new function () {
 		
 		// if cited in bibliography, warn before removing
 		var isCited = false;
-		for each(var itemID in selectedListItemIDs) {
-			isCited |= bibEditInterface.isCited(itemID);
+		for(var itemID in selectedListItemIDs) {
+			isCited |= bibEditInterface.isCited(selectedListItemIDs[itemID]);
 		}
 		if(isCited) {			
 			var promptService = Components.classes["@mozilla.org/embedcomp/prompt-service;1"]
@@ -218,8 +220,8 @@ var Zotero_Bibliography_Dialog = new function () {
 		}
 		
 		// remove
-		for each(var itemID in selectedListItemIDs) {
-			bibEditInterface.remove(itemID);
+		for(var itemID in selectedListItemIDs) {
+			bibEditInterface.remove(selectedListItemIDs[itemID]);
 		}
 		_loadItems();
 	}
@@ -250,8 +252,10 @@ var Zotero_Bibliography_Dialog = new function () {
 	 * Gets selected item IDs from list box on right
 	 */
 	function _getSelectedListItemIDs() {
-		return [bibEditInterface.bibliography[0].entry_ids[item.value][0]
-		        for each(item in _itemList.selectedItems)];
+		var ids = [];
+		for(var item in _itemList.selectedItems)
+			ids.push(bibEditInterface.bibliography[0].entry_ids[_itemList.selectedItems[item].value][0]);
+		return ids;
 	}
 	
 	/**
@@ -260,8 +264,8 @@ var Zotero_Bibliography_Dialog = new function () {
 	function _updateRevertButtonStatus() {
 		_revertButton.disabled = true;
 		var selectedListItemIDs = _getSelectedListItemIDs();
-		for each(var itemID in selectedListItemIDs) {
-			if(bibEditInterface.isEdited(itemID)) {
+		for(var itemID in selectedListItemIDs) {
+			if(bibEditInterface.isEdited(selectedListItemIDs[itemID])) {
 				_revertButton.disabled = false;
 				break;
 			}
@@ -302,7 +306,8 @@ var Zotero_Bibliography_Dialog = new function () {
 	 */
 	function _loadItems() {
 		var itemIDs = bibEditInterface.bibliography[0].entry_ids;
-		var items = [Zotero.Cite.getItem(itemID[0]) for each(itemID in itemIDs)];
+		var items = [];
+		for(var itemID in itemIDs) items.push(Zotero.Cite.getItem(itemIDs[itemID][0]));
 		
 		// delete all existing items from list
 		var itemList = document.getElementById("item-list");

--- a/chrome/content/zotero/integration/quickFormat.js
+++ b/chrome/content/zotero/integration/quickFormat.js
@@ -79,7 +79,8 @@ var Zotero_QuickFormat = new function () {
 			var locators = Zotero.Cite.labels;
 			var menu = document.getElementById("locator-label");
 			var labelList = document.getElementById("locator-label-popup");
-			for each(var locator in locators) {
+			for(var p in locators) {
+				var locator = locators[p];
 				// TODO localize
 				var locatorLabel = locator[0].toUpperCase()+locator.substr(1);
 				
@@ -295,7 +296,12 @@ var Zotero_QuickFormat = new function () {
 					for(var i=0, iCount=citedItems.length; i<iCount; i++) {
 						// Generate a string to search for each item
 						var item = citedItems[i],
-							itemStr = [creator.ref.firstName+" "+creator.ref.lastName for each(creator in item.getCreators())];
+						itemStr = [];
+						var creators = item.getCreators();
+						for(var p in creators) {
+							var creator = creators[p];
+							itemStr.push(creator.ref.firstName+" "+creator.ref.lastName);
+						}
 						itemStr = itemStr.concat([item.getField("title"), item.getField("date", true, true).substr(0, 4)]).join(" ");
 						
 						// See if words match
@@ -388,8 +394,8 @@ var Zotero_QuickFormat = new function () {
 		// Also take into account items cited in this citation. This means that the sorting isn't
 		// exactly by # of items cited from each library, but maybe it's better this way.
 		_updateCitationObject();
-		for each(var citationItem in io.citation.citationItems) {
-			var citedItem = Zotero.Cite.getItem(citationItem.id);
+		for(var citationItem in io.citation.citationItems) {
+			var citedItem = Zotero.Cite.getItem(io.citation.citationItems[citationItem].id);
 			if(!citedItem.cslItemID) {
 				var libraryID = citedItem.libraryID ? citedItem.libraryID : 0;
 				if(libraryID in nCitedItemsFromLibrary) {
@@ -767,8 +773,9 @@ var Zotero_QuickFormat = new function () {
 			if(!panelFrameHeight) {
 				panelFrameHeight = referencePanel.boxObject.height - referencePanel.clientHeight;
 				var computedStyle = window.getComputedStyle(referenceBox, null);
-				for each(var attr in ["border-top-width", "border-bottom-width"]) {
-					var val = computedStyle.getPropertyValue(attr);
+				var ATTRIBUTES = ["border-top-width", "border-bottom-width"];
+				for(var attr in ATTRIBUTES) {
+					var val = computedStyle.getPropertyValue(ATTRIBUTES[attr]);
 					if(val) {
 						var m = pixelRe.exec(val);
 						if(m) panelFrameHeight += parseInt(m[1], 10);

--- a/chrome/content/zotero/locateManager.xul
+++ b/chrome/content/zotero/locateManager.xul
@@ -151,7 +151,8 @@ To add a new preference:
 			// repopulate tree with available engines
 			var engines = Zotero.LocateManager.getEngines();
 			var i = 0;
-			for each(var engine in engines) {
+			for(var p in engines) {
+				var engine = engines[p];
 				var treeitem = document.createElement('treeitem');
 				var treerow = document.createElement('treerow');
 				var checkboxCell = document.createElement('treecell');
@@ -175,7 +176,8 @@ To add a new preference:
 			}
 			
 			// restore ranges
-			for each(var range in ranges) {
+			for(var p in ranges) {
+				var range = ranges[p];
 				if(range[1] <= engines.length-1) {
 					tree.view.selection.rangedSelect(range[0], range[1], true);
 				}
@@ -231,7 +233,8 @@ To add a new preference:
 				hidden = false;
 			}
 			
-			[engine.hidden = hidden for each(engine in Zotero.LocateManager.getEngines())];
+			var engines = Zotero.LocateManager.getEngines();
+			for(var engine in engines) engines[engine].hidden = hidden ;
 
 			refreshLocateEnginesList();
 		}

--- a/chrome/content/zotero/locateMenu.js
+++ b/chrome/content/zotero/locateMenu.js
@@ -72,7 +72,8 @@ var Zotero_LocateMenu = new function() {
 		}
 		
 		if(installableLocateEngines.length) {
-			for each(var locateEngine in installableLocateEngines) {
+			for(var p in installableLocateEngines) {
+				var locateEngine = installableLocateEngines[p];
 				var menuitem = document.createElement("menuitem");
 				menuitem.setAttribute("label", locateEngine.label);
 				menuitem.setAttribute("class", "menuitem-iconic");
@@ -146,10 +147,10 @@ var Zotero_LocateMenu = new function() {
 		var optionsToShow = {};
 		
 		// check which view options are available
-		for each(var item in selectedItems) {
+		for(var item in selectedItems) {
 			for(var viewOption in ViewOptions) {
 				if(!optionsToShow[viewOption]) {
-					optionsToShow[viewOption] = ViewOptions[viewOption].canHandleItem(item);
+					optionsToShow[viewOption] = ViewOptions[viewOption].canHandleItem(selectedItems[item]);
 				}
 			}
 		}
@@ -171,7 +172,7 @@ var Zotero_LocateMenu = new function() {
 		}
 		
 		if(addExtraOptions) {
-			for each(var viewOption in [key for(key in optionsToShow) if(key[0] === "_")]) {
+			for(var viewOption in optionsToShow) {
 				if(viewOption[0] !== "_" || !optionsToShow[viewOption]) continue;
 				locateMenu.insertBefore(_addViewOption(selectedItems, viewOption.substr(1),
 					ViewOptions[viewOption], showIcons), lastNode);
@@ -191,10 +192,11 @@ var Zotero_LocateMenu = new function() {
 		var availableEngines = [];
 		
 		// check which engines can translate an item
-		for each(var engine in customEngines) {
+		for(var p in customEngines) {
+			var engine = customEngines[p];
 			// require a submission for at least one selected item
-			for each(var item in selectedItems) {
-				if(engine.getItemSubmission(item)) {
+			for(var item in selectedItems) {
+				if(engine.getItemSubmission(selectedItems[item])) {
 					availableEngines.push(engine);
 					break;
 				}
@@ -216,7 +218,8 @@ var Zotero_LocateMenu = new function() {
 			locateFn = this.locateItem;
 		}
 		
-		for each(var engine in engines) {
+		for(var p in engines) {
+			var engine = engines[p];
 			var menuitem = _createMenuItem(engine.name, null, engine.description);
 			menuitem.setAttribute("class", "menuitem-iconic");
 			menuitem.setAttribute("image", engine.icon);
@@ -245,7 +248,8 @@ var Zotero_LocateMenu = new function() {
 		if(!window.Zotero_Browser || !window.Zotero_Browser.tabbrowser) return locateEngines;
 		
 		var links = Zotero_Browser.tabbrowser.selectedBrowser.contentDocument.getElementsByTagName("link");
-		for each(var link in links) {
+		for(var p in links) {
+			var link = links[p]
 			if(!link.getAttribute) continue;
 			var rel = link.getAttribute("rel");
 			if(rel && rel === "search") {
@@ -286,8 +290,8 @@ var Zotero_LocateMenu = new function() {
 		
 		var urls = [];
 		var postDatas = [];
-		for each(var item in selectedItems) {
-			var submission = selectedEngine.getItemSubmission(item);
+		for(var item in selectedItems) {
+			var submission = selectedEngine.getItemSubmission(selectedItems[item]);
 			if(submission) {
 				urls.push(submission.uri.spec);
 				postDatas.push(submission.postData);
@@ -346,8 +350,8 @@ var Zotero_LocateMenu = new function() {
 		
 		this.handleItems = function(items, event) {
 			var attachments = [];
-			for each(var item in items) {
-				var attachment = _getFirstAttachmentWithMIMEType(item, this._mimeTypes);
+			for(var item in items) {
+				var attachment = _getFirstAttachmentWithMIMEType(items[item], this._mimeTypes);
 				if(attachment) attachments.push(attachment.id);
 			}
 			
@@ -356,7 +360,8 @@ var Zotero_LocateMenu = new function() {
 		
 		function _getFirstAttachmentWithMIMEType(item, mimeTypes) {
 			var attachments = (item.isAttachment() ? [item] : Zotero.Items.get(item.getBestAttachments()));
-			for each(var attachment in attachments) {
+			for(var p in attachments) {
+				var attachment = attachments[p];
 				if(mimeTypes.indexOf(attachment.attachmentMIMEType) !== -1
 					&& attachment.attachmentLinkMode !== Zotero.Attachments.LINK_MODE_LINKED_URL) return attachment;
 			}
@@ -374,8 +379,12 @@ var Zotero_LocateMenu = new function() {
 		this.canHandleItem = function(item) _getURL(item) !== false;
 		
 		this.handleItems = function(items, event) {
-			var urls = [_getURL(item) for each(item in items)];
-			ZoteroPane_Local.loadURI([url for each(url in urls) if(url)], event);
+			var urls = [];
+			for(var item in items) {
+				var url = _getURL(items[item]);
+				if(url) urls.push(url);
+			}
+			ZoteroPane_Local.loadURI(urls, event);
 		}
 		
 		function _getURL(item) {
@@ -393,7 +402,9 @@ var Zotero_LocateMenu = new function() {
 				var attachments = item.getAttachments();
 				if(attachments) {
 					// look through url fields for non-file:/// attachments
-					for each(var attachment in Zotero.Items.get(attachments)) {
+					attachments = Zotero.Items.get(attachments);
+					for(var p in attachments) {
+						var attachment = attachments[p];
 						var urlField = attachment.getField('url');
 						if(urlField) return urlField;
 					}
@@ -439,8 +450,8 @@ var Zotero_LocateMenu = new function() {
 		
 		this.handleItems = function(items, event) {
 			var attachments = [];
-			for each(var item in items) {
-				var attachment = _getFile(item);
+			for(var item in items) {
+				var attachment = _getFile(items[item]);
 				if(attachment) attachments.push(attachment.id);
 			}
 			
@@ -449,7 +460,8 @@ var Zotero_LocateMenu = new function() {
 		
 		function _getFile(item) {
 			var attachments = (item.isAttachment() ? [item] : Zotero.Items.get(item.getBestAttachments()));
-			for each(var attachment in attachments) {
+			for(var p in attachments) {
+				var attachment = attachments[p];
 				if(!ViewOptions.snapshot.canHandleItem(attachment)
 						&& !ViewOptions.pdf.canHandleItem(attachment)
 						&& attachment.attachmentLinkMode !== Zotero.Attachments.LINK_MODE_LINKED_URL) {
@@ -477,8 +489,8 @@ var Zotero_LocateMenu = new function() {
 		
 		this.handleItems = function(items, event) {
 			var attachments = [];
-			for each(var item in items) {
-				var attachment = _getBestNonNativeAttachment(item);
+			for(var item in items) {
+				var attachment = _getBestNonNativeAttachment(items[item]);
 				if(attachment) attachments.push(attachment.id);
 			}
 			
@@ -487,7 +499,8 @@ var Zotero_LocateMenu = new function() {
 		
 		function _getBestNonNativeAttachment(item) {
 			var attachments = (item.isAttachment() ? [item] : Zotero.Items.get(item.getBestAttachments()));
-			for each(var attachment in attachments) {
+			for(var p in attachments) {
+				var attachment = attachments[p];
 				if(attachment.attachmentLinkMode !== Zotero.Attachments.LINK_MODE_LINKED_URL) {
 					var file = attachment.getFile();
 					if(file) {
@@ -533,8 +546,8 @@ var Zotero_LocateMenu = new function() {
 		}
 		
 		this.handleItems = function(items, event) {
-			for each(var item in items) {
-				var attachment = _getBestFile(item);
+			for(var item in items) {
+				var attachment = _getBestFile(items[item]);
 				if(attachment) {
 					ZoteroPane_Local.showAttachmentInFilesystem(attachment.id);
 				}
@@ -561,7 +574,8 @@ var Zotero_LocateMenu = new function() {
 		this.canHandleItem = function(item) item.isRegularItem();
 		this.handleItems = function(items, event) {
 			var urls = [];
-			for each(var item in items) {
+			for(var p in items) {
+				var item = items[p];
 				if(!item.isRegularItem()) continue;
 				var url = Zotero.OpenURL.resolve(item);
 				if(url) urls.push(url);

--- a/chrome/content/zotero/preferences/preferences.js
+++ b/chrome/content/zotero/preferences/preferences.js
@@ -207,7 +207,8 @@ function populateOpenURLResolvers() {
 	
 	openURLResolvers = Zotero.OpenURL.discoverResolvers();
 	var i = 0;
-	for each(var r in openURLResolvers) {
+	for(var p in openURLResolvers) {
+		var r = openURLResolvers[p];
 		openURLMenu.insertItemAt(i, r.name);
 		if (r.url == Zotero.Prefs.get('openURL.resolver') && r.version == Zotero.Prefs.get('openURL.version')) {
 			openURLMenu.selectedIndex = i;
@@ -624,7 +625,8 @@ function buildQuickCopyFormatDropDown(menulist, contentType, currentFormat) {
 	
 	// add styles to list
 	var styles = Zotero.Styles.getVisible();
-	for each(var style in styles) {
+	for(var p in styles) {
+		var style = styles[p];
 		var baseVal = 'bibliography=' + style.styleID;
 		var val = 'bibliography' + (contentType == 'html' ? '/html' : '') + '=' + style.styleID;
 		var itemNode = document.createElement("menuitem");
@@ -1669,7 +1671,8 @@ function refreshStylesList(cslID) {
 	
 	var selectIndex = false;
 	var i = 0;
-	for each(var style in styles) {
+	for(var p in styles) {
+		var style = styles[p];
 		var treeitem = document.createElement('treeitem');
 		var treerow = document.createElement('treerow');
 		var titleCell = document.createElement('treecell');

--- a/chrome/content/zotero/reportInterface.js
+++ b/chrome/content/zotero/reportInterface.js
@@ -73,8 +73,8 @@ var Zotero_Report_Interface = new function() {
 		}
 		
 		var keyHashes = [];
-		for each(var item in items) {
-			keyHashes.push(Zotero.Items.getLibraryKeyHash(item));
+		for(var item in items) {
+			keyHashes.push(Zotero.Items.getLibraryKeyHash(items[item]));
 		}
 		
 		ZoteroPane_Local.loadURI('zotero://report/items/' + keyHashes.join('-') + '/html/report.html', event);

--- a/chrome/content/zotero/rtfScan.js
+++ b/chrome/content/zotero/rtfScan.js
@@ -341,7 +341,11 @@ var Zotero_RTFScan = new function() {
 				var m = initialRe.exec(firstName);
 				if(m) {
 					var initials = firstName.replace(/[^A-Z]/g, "");
-					var itemInitials = [name[0].toUpperCase() for each (name in itemCreator.ref.firstName.split(/ +/g))].join("");
+					var nameParts = itemCreator.ref.firstName.split(/ +/g);
+					var itemInitials = '';
+					for(var i=0, n=nameParts.length; i<n; i++) {
+						itemInitials += nameParts[i][0].toUpperCase();
+					}
 					if(initials != itemInitials) return false;
 				} else {
 					// not all initials; verify that the first name matches
@@ -457,8 +461,8 @@ var Zotero_RTFScan = new function() {
 	 */
 	function _refreshCanAdvance() {
 		var canAdvance = true;
-		for each(var itemList in citationItemIDs) {
-			if(itemList.length != 1) {
+		for(var itemList in citationItemIDs) {
+			if(citationItemIDs[itemList].length != 1) {
 				canAdvance = false;
 				break;
 			}

--- a/chrome/content/zotero/standalone/standalone.js
+++ b/chrome/content/zotero/standalone/standalone.js
@@ -46,8 +46,9 @@ const ZoteroStandalone = new function() {
 				.getService(Components.interfaces.nsIExternalProtocolService);
 		var hs = Components.classes["@mozilla.org/uriloader/handler-service;1"]
 				.getService(Components.interfaces.nsIHandlerService);
-		for each(var scheme in ["http", "https"]) {
-			var handlerInfo = eps.getProtocolHandlerInfo(scheme);
+		var SCHEMES = ["http", "https"];
+		for(var i=0, n=SCHEMES.length; i<n; i++) {
+			var handlerInfo = eps.getProtocolHandlerInfo(SCHEMES[i]);
 			handlerInfo.preferredAction = Components.interfaces.nsIHandlerInfo.useSystemDefault;
 			handlerInfo.alwaysAskBeforeHandling = false;
 			hs.store(handlerInfo);

--- a/chrome/content/zotero/tinymce/note.html
+++ b/chrome/content/zotero/tinymce/note.html
@@ -26,9 +26,9 @@
 		
 		setup : function (ed) {
 			var commands = ["Cut", "Copy", "Paste"];
-			for each(var command in commands) {
-				let cmd = command;
-				ed.addCommand(command, function (ui, value) {
+			for(var command in commands) {
+				let cmd = commands[command];
+				ed.addCommand(cmd, function (ui, value) {
 					zoteroExecCommand(ed.getDoc(), cmd, ui, value);
 				});
 			}

--- a/chrome/content/zotero/tools/csledit.xul
+++ b/chrome/content/zotero/tools/csledit.xul
@@ -50,7 +50,8 @@
 				}
 				
 				var styles = Zotero.Styles.getAll();
-				for each(var style in styles) {
+				for(var p in styles) {
+					var style = styles[p];
 					if (style.source) {
 						continue;
 					}
@@ -58,7 +59,8 @@
 				}
 				var pageList = document.getElementById('zotero-csl-page-type');
 				var locators = Zotero.Cite.labels;
-				for each(var type in locators) {
+				for(var p in locators) {
+					var type = locators[p];
 					var locator = type;
 					locator = locator[0].toUpperCase()+locator.substr(1);
 					pageList.appendItem(locator, type);

--- a/chrome/content/zotero/tools/cslpreview.xul
+++ b/chrome/content/zotero/tools/cslpreview.xul
@@ -65,7 +65,8 @@
 					var styles = Zotero.Styles.getAll();
 					// XXX needs its own string really for the title!
 					var str = '<html><head><title></title></head><body><h1>Citation/Bibliography list<h1>';
-					for each(var style in styles) {
+					for(var p in styles) {
+						var style = styles[p];
 						if (style.source) {
 							continue;
 						}
@@ -105,7 +106,8 @@
 					return '';
 				}
 				var terms = new Object();
-				for each(var cat in style.categories) {
+				for(var p in style.categories) {
+					var cat = style.categories[p];
 					Zotero.debug("TERM is " + cat.toString());
 					terms[cat.toString()] = true;
 				}
@@ -120,15 +122,19 @@
 				var styleEngine = style.csl;
 				
 				// Generate multiple citations
+				var itemIDs = [];
+				for(var item in items) itemIDs.push({"id":items[item].id});
 				var citations = styleEngine.previewCitationCluster(
-					{"citationItems":[{"id":item.id} for each(item in items)], "properties":{}},
+					{"citationItems":itemIDs, "properties":{}},
 					[], [], "html");
 			
 				// Generate bibliography
 				if(!style.hasBibliography) {
 					var bibliography = '';
 				} else {
-					styleEngine.updateItems([item.id for each(item in items)]);
+					var itemIDs = [];
+					for(var item in items) itemIDs.push(items[item].id);
+					styleEngine.updateItems(itemIDs);
 					var bibliography = '<p>' + Zotero.Cite.makeFormattedBibliography(styleEngine, "html");
 				}
 				

--- a/chrome/content/zotero/xpcom/annotate.js
+++ b/chrome/content/zotero/xpcom/annotate.js
@@ -141,7 +141,8 @@ Zotero.Annotate = new function() {
 			} else {
 				var browsers = win.document.getElementsByTagNameNS(XUL_NAMESPACE, "browser");
 			}
-			for each(var browser in browsers) {
+			for(var p in browsers) {
+				var browser = browsers[p];
 				if(browser.currentURI) {
 					if(browser.currentURI.spec == annotationURL) {
 						if(haveBrowser) {
@@ -364,7 +365,8 @@ Zotero.Annotate.Path.prototype.fromNode = function(node, offset) {
 					// is still part of the first text node
 					if(sibling.getAttribute) {
 						// get offset of all child nodes
-						for each(var child in sibling.childNodes) {
+						for(var p in sibling.childNodes) {
+							var child = sibling.childNodes[p];
 							if(child && child.nodeType == TEXT_TYPE) {
 								this.offset += child.nodeValue.length;
 							}
@@ -711,8 +713,8 @@ Zotero.Annotations.prototype.unhighlight = function(selectedRange) {
  * Refereshes display of annotations (useful if page is reloaded)
  */
 Zotero.Annotations.prototype.refresh = function() {
-	for each(var annotation in this.annotations) {
-		annotation.display();
+	for(var annotation in this.annotations) {
+		this.annotations[annotation].display();
 	}
 }
 
@@ -725,15 +727,16 @@ Zotero.Annotations.prototype.save = function() {
 		Zotero.DB.query("DELETE FROM highlights WHERE itemID = ?", [this.itemID]);
 		
 		// save highlights
-		for each(var highlight in this.highlights) {
+		for(var p in this.highlights) {
+			var highlight = this.highlights[p]
 			if(highlight) highlight.save();
 		}
 		
 		// save annotations
-		for each(var annotation in this.annotations) {
+		for(var annotation in this.annotations) {
 			// Don't drop all annotations if one is broken (due to ~3.0 glitch)
 			try {
-				annotation.save();
+				this.annotations[annotation].save();
 			}
 			catch(e) {
 				Zotero.debug(e);
@@ -754,17 +757,17 @@ Zotero.Annotations.prototype.save = function() {
 Zotero.Annotations.prototype.load = function() {
 	// load annotations
 	var rows = Zotero.DB.query("SELECT * FROM annotations WHERE itemID = ?", [this.itemID]);
-	for each(var row in rows) {
+	for(var row in rows) {
 		var annotation = this.createAnnotation();
-		annotation.initWithDBRow(row);
+		annotation.initWithDBRow(rows[row]);
 	}
 	
 	// load highlights
 	var rows = Zotero.DB.query("SELECT * FROM highlights WHERE itemID = ?", [this.itemID]);
-	for each(var row in rows) {
+	for(var row in rows) {
 		try {
 			var highlight = new Zotero.Highlight(this);
-			highlight.initWithDBRow(row);
+			highlight.initWithDBRow(rows[row]);
 			this.highlights.push(highlight);
 		} catch(e) {
 			Zotero.debug("Annotate: could not load highlight");
@@ -778,16 +781,16 @@ Zotero.Annotations.prototype.load = function() {
 Zotero.Annotations.prototype.toggleCollapsed = function() {
 	// look to see if there are any collapsed annotations
 	var status = true;
-	for each(var annotation in this.annotations) {
-		if(annotation.collapsed) {
+	for(var annotation in this.annotations) {
+		if(this.annotations[annotation].collapsed) {
 			status = false;
 			break;
 		}
 	}
 	
 	// set status on all annotations
-	for each(var annotation in this.annotations) {
-		annotation.setCollapsed(status);
+	for(var annotation in this.annotations) {
+		this.annotations[annotation].setCollapsed(status);
 	}
 }
 
@@ -1621,7 +1624,8 @@ Zotero.Highlight.prototype._highlightSpaceBetween = function(start, end) {
 			node = node.nextSibling;
 		}
 		
-		for each(var textNode in textArray) {
+		for(var p in textArray) {
+			var textNode = textArray[p];
 			if(firstSpan) {
 				this._highlightTextNode(textNode);
 			} else {

--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -279,8 +279,8 @@ Zotero.Attachments = new function(){
 				// Add to collections
 				if (parentCollectionIDs){
 					var ids = Zotero.flattenArguments(parentCollectionIDs);
-					for each(var id in ids){
-						var col = Zotero.Collections.get(id);
+					for(var id in ids){
+						var col = Zotero.Collections.get(ids[id]);
 						col.addItem(itemID);
 					}
 				}
@@ -459,8 +459,8 @@ Zotero.Attachments = new function(){
 		// Add to collections
 		if (parentCollectionIDs){
 			var ids = Zotero.flattenArguments(parentCollectionIDs);
-			for each(var id in ids){
-				var col = Zotero.Collections.get(id);
+			for(var id in ids){
+				var col = Zotero.Collections.get(ids[id]);
 				col.addItem(itemID);
 			}
 		}
@@ -638,8 +638,8 @@ Zotero.Attachments = new function(){
 			// Add to collections
 			if (parentCollectionIDs){
 				var ids = Zotero.flattenArguments(parentCollectionIDs);
-				for each(var id in ids){
-					var col = Zotero.Collections.get(id);
+				for(var id in ids){
+					var col = Zotero.Collections.get(ids[id]);
 					col.addItem(itemID);
 				}
 			}
@@ -757,8 +757,8 @@ Zotero.Attachments = new function(){
 					// Add to collections
 					if (parentCollectionIDs){
 						var ids = Zotero.flattenArguments(parentCollectionIDs);
-						for each(var id in ids){
-							var col = Zotero.Collections.get(id);
+						for(var id in ids){
+							var col = Zotero.Collections.get(ids[id]);
 							col.addItem(itemID);
 						}
 					}

--- a/chrome/content/zotero/xpcom/cite.js
+++ b/chrome/content/zotero/xpcom/cite.js
@@ -55,8 +55,8 @@ Zotero.Cite.System.retrieveItem = function(item) {
 	for(var variable in CSL_TEXT_MAPPINGS) {
 		var fields = CSL_TEXT_MAPPINGS[variable];
 		if(variable == "URL" && ignoreURL) continue;
-		for each(var field in fields) {
-			var value = zoteroItem.getField(field, false, true).toString();
+		for(var field in fields) {
+			var value = zoteroItem.getField(fields[field], false, true).toString();
 			if(value != "") {
 				// Strip enclosing quotes
 				if(value.match(Zotero.Cite.System._quotedRegexp)) {
@@ -71,7 +71,8 @@ Zotero.Cite.System.retrieveItem = function(item) {
 	// separate name variables
 	var authorID = Zotero.CreatorTypes.getPrimaryIDForType(zoteroItem.itemTypeID);
 	var creators = zoteroItem.getCreators();
-	for each(var creator in creators) {
+	for(var p in creators) {
+		var creator = creators[p];
 		if(creator.creatorTypeID == authorID) {
 			var creatorType = "author";
 		} else {
@@ -197,7 +198,13 @@ Zotero.Cite.getBibliographyFormatParameters = function(bib) {
 Zotero.Cite.makeFormattedBibliographyOrCitationList = function(style, items, format, asCitationList) {
 	var cslEngine = style.csl;
 	cslEngine.setOutputFormat(format);
-	cslEngine.updateItems([item.id for each(item in items)]);
+	var itemIDs = [];
+	var itemIdObjs = [];
+	for(var item in items) {
+		itemIDs.push(items[item].id);
+		itemIdObjs.push({"id": items[item].id});
+	}
+	cslEngine.updateItems(itemIDs);
 	
 	if(!asCitationList) {
 		var bibliography = Zotero.Cite.makeFormattedBibliography(cslEngine, format);
@@ -205,8 +212,7 @@ Zotero.Cite.makeFormattedBibliographyOrCitationList = function(style, items, for
 	}
 	
 	var styleClass = style.class;
-	var citations = [cslEngine.appendCitationCluster({"citationItems":[{"id":item.id}], "properties":{}}, true)[0][1]
-		for each(item in items)];
+	var citations = [cslEngine.appendCitationCluster({"citationItems":itemIdObjs, "properties":{}}, true)[0][1]];
 	
 	if(styleClass == "note") {
 		if(format == "html") {
@@ -259,9 +265,9 @@ Zotero.Cite.makeFormattedBibliography = function(cslEngine, format) {
 			output.push(bib[1][i]);
 			
 			// add COinS
-			for each(var itemID in bib[0].entry_ids[i]) {
+			for(var itemID in bib[0].entry_ids[i]) {
 				try {
-					var co = Zotero.OpenURL.createContextObject(Zotero.Items.get(itemID), "1.0");
+					var co = Zotero.OpenURL.createContextObject(Zotero.Items.get(bib[0].entry_ids[i][itemID]), "1.0");
 					if(!co) continue;
 					output.push('  <span class="Z3988" title="'+
 						co.replace("&", "&amp;", "g").replace("<", "&lt;", "g").replace(">", "&gt;", "g")+
@@ -330,7 +336,8 @@ Zotero.Cite.makeFormattedBibliography = function(cslEngine, format) {
 			var divs = xml..div.(@class == "csl-entry");
 			var num = divs.length();
 			var i = 0;
-			for each(var div in divs) {
+			for(var p in divs) {
+				var div = divs[p];
 				var first = i == 0;
 				var last = i == num - 1;
 				
@@ -352,7 +359,8 @@ Zotero.Cite.makeFormattedBibliography = function(cslEngine, format) {
 			var rightPadding = .5;
 			
 			// div.csl-left-margin
-			for each(var div in leftMarginDivs) {
+			for(var p in leftMarginDivs) {
+				var div = leftMarginDivs[p]
 				div.@style = "float: left; padding-right: " + rightPadding + "em;";
 				
 				// Right-align the labels if aligning second line, since it looks
@@ -410,7 +418,9 @@ Zotero.Cite.getItem = function(id) {
 	var slashIndex;
 	
 	if(id instanceof Array) {
-		return [Zotero.Cite.getItem(anId) for each(anId in id)];
+		var items = [];
+		for(var anId in id) items.push(Zotero.Cite.getItem(id[anId]));
+		return items;
 	} else if(typeof id === "string" && (slashIndex = id.indexOf("/")) !== -1) {		
 		var sessionID = id.substr(0, slashIndex),
 			session = Zotero.Integration.sessions[sessionID],


### PR DESCRIPTION
`for each ... in ...` construct has been removed in Firefox 20 (currently Aurora). I've been going through the code and converting these to straight up `for ... in ...`, but I thought I would ask if this is acceptable before I go any further.

Should I keep on going?
