### PR TITLE
Eliminate race condition during processDocuments call with multiple URLs

### DIFF
--- a/chrome/content/zotero/xpcom/http.js
+++ b/chrome/content/zotero/xpcom/http.js
@@ -492,8 +492,7 @@ Zotero.HTTP = new function() {
 		// (Approximately) how many seconds to wait if the document is left in the loading state and
 		// pageshow is called before we call pageshow with an incomplete document
 		const LOADING_STATE_TIMEOUT = 120;
-		var firedLoadEvent = 0,
-			loaded = false;
+		var firedLoadEvent = 0;
 		
 		/**
 		 * Loads the next page
@@ -504,7 +503,6 @@ Zotero.HTTP = new function() {
 				var url = urls[currentURL],
 					hiddenBrowser = hiddenBrowsers[currentURL];
 				firedLoadEvent = 0;
-				loaded = false;
 				currentURL++;
 				try {
 					Zotero.debug("Zotero.HTTP.processDocuments: Loading "+url);
@@ -529,9 +527,9 @@ Zotero.HTTP = new function() {
 		 * @inner
 		 */
 		var onLoad = function(e) {
-			if(loaded) return;
 			var hiddenBrowser = e.currentTarget,
 				doc = hiddenBrowser.contentDocument;
+			if(hiddenBrowser.zotero_loaded) return;
 			if(!doc) return;
 			var url = doc.documentURI;
 			if(url === "about:blank") return;
@@ -543,7 +541,7 @@ Zotero.HTTP = new function() {
 			
 			Zotero.debug("Zotero.HTTP.processDocuments: "+url+" loaded");
 			hiddenBrowser.removeEventListener("pageshow", onLoad, true);
-			loaded = true;
+			hiddenBrowser.zotero_loaded = true;
 			
 			try {
 				processor(doc);


### PR DESCRIPTION
This is in regards to http://forums.zotero.org/discussion/27304/save-multiple-items-to-zotero-on-ieee-xplore-search-results/

Here's what was happening:
1) Queue up two URLs for processDocuments
2) URL one is being processed via `loadURI`, `loaded` is set to false. onLoad is called, but the `doc.readyState` is still loading. 1 second timeout is set to re-run the onLoad function.
3) In the mean time, the page is done loading and another `pageshow` event is fired and onLoad is called. The page loads, `loaded` is set to true, and is passed to the translator. The translator calls doGet/doPost, which results in processDocuments proceeding to the next URL.
4) URL two is processed via `loadURI`, `loaded` is set to false.
5) The 1 second timer from URL one runs out and calls `onLoad` for URL one. `loaded` is set to true and document from URL one is passed back to the translator.
6) URL 2 page loads, but `loaded` is already set to true, so it is discarded.

I'm not entirely sure why we need the 1 second timeout, since it seems that once the page is loaded, a `pageshow` event is fired anyway. I assume @simonster had a good reason for that. So the solution here is to not have a global `loaded` variable, but to use something attached to each browser.

There's still something that puzzles me. I had some debugging code in place that would tell me what the browser ID is for the `e.currentTarget`. Here's a segment of the log from the `loadURI` call of the first URL:

```
(3)(+0000004): Created hidden browser (0)
(3)(+0000004): Created hidden browser (1)
(3)(+0000000): Zotero.HTTP.processDocuments: Loading http://ieeexplore.ieee.org/xpl/articleDetails.jsp?tp=&arnumber=6378758&contentType=Conference+Publications&searchField%3DSearch_All%26queryText%3Delectrode
(3)(+0000001): Entered onLoad
(3)(+0000001): Browser ID: 0
(3)(+0000081): Entered onLoad
(3)(+0000000): Browser ID: 1
(3)(+0003418): Entered onLoad
(3)(+0000000): Browser ID: 0
(3)(+0000000): still loading. Will try again in 1 second.
(3)(+0000205): Entered onLoad
(3)(+0000000): Browser ID: 0
(3)(+0000000): Zotero.HTTP.processDocuments: http://ieeexplore.ieee.org/xpl/articleDetails.jsp?tp=&arnumber=6378758&contentType=Conference+Publications&searchField%3DSearch_All%26queryText%3Delectrode loaded
```

Note the `(3)(+0000000): Browser ID: 1` in there. Why is there a `pageshow` event reaching browser 1 before it has any `loadURI` calls initiated on it?? Do the `pageshow` events just happen randomly??
