### PR TITLE
Set default handlers if they are not set

### DIFF
--- a/chrome/content/zotero/xpcom/translation/translate.js
+++ b/chrome/content/zotero/xpcom/translation/translate.js
@@ -179,12 +179,13 @@ Zotero.Translate.Sandbox = {
 		 */	 
 		"loadTranslator":function(translate, type) {
 			const setDefaultHandlers = function(translate, translation) {
-				if(Zotero.Utilities.isEmpty(translation._handlers)) {
-					if(type !== "export") {
-						translation.setHandler("itemDone", function(obj, item) {
-							translate.Sandbox._itemDone(translate, item);
-						});
-					}
+				if(type !== "export"
+					&& (!translation._handlers['itemDone'] || !translation._handlers['itemDone'].length)) {
+					translation.setHandler("itemDone", function(obj, item) {
+						translate.Sandbox._itemDone(translate, item);
+					});
+				}
+				if(!translation._handlers['selectItems'] || !translation._handlers['selectItems'].length) {
 					translation.setHandler("selectItems", translate._handlers["selectItems"]);
 				}
 			}


### PR DESCRIPTION
 (even if some other handlers are set). Sometimes you just want to dedicate translation to another translator without doing anything in the "itemDone" handler.

See https://groups.google.com/d/msg/zotero-dev/25r1PwRNspg/v_GdPSQqL7UJ

Could this break anything?
