### PR TITLE
Consider type-specific "title" alternatives for validating web translations

### DIFF
--- a/chrome/content/zotero/xpcom/translation/translate.js
+++ b/chrome/content/zotero/xpcom/translation/translate.js
@@ -578,6 +578,10 @@ Zotero.Translate.Sandbox = {
 					item.accessDate = "CURRENT_TIMESTAMP";
 				}
 				
+				//consider type-specific "title" alternatives
+				var altTitle = Zotero.ItemFields.getName(Zotero.ItemFields.getFieldIDFromTypeAndBase(item.itemType, 'title'));
+				if(altTitle && item[altTitle]) item.title = item[altTitle];
+				
 				if(!item.title) {
 					translate.complete(false, new Error("No title specified for item"));
 					return;


### PR DESCRIPTION
e.g. item.subject should pass for item.title for emails

This would also mean that item-specific title fields would override `item.title`, but I think that's somewhat expected anyway.
