### PR TITLE
Localization of hardcoded "Quick Format Citation" dialog title

### DIFF
--- a/chrome/content/zotero/integration/quickFormat.xul
+++ b/chrome/content/zotero/integration/quickFormat.xul
@@ -33,7 +33,7 @@
 <window
 	id="quick-format-dialog"
 	orient="vertical"
-	title="Quick Format Citation"
+	title="&zotero.integration.quickFormatDialog.title;"
 	width="600" 
 	xmlns:html="http://www.w3.org/1999/xhtml"
 	xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"

--- a/chrome/locale/af-ZA/zotero/zotero.dtd
+++ b/chrome/locale/af-ZA/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "Dokumentvoorkeure">
 <!ENTITY zotero.integration.addEditCitation.title "Voeg by/redigeer aanhaling">
 <!ENTITY zotero.integration.editBibliography.title "Redigeer bronnelys">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "Vordering">
 

--- a/chrome/locale/ar/zotero/zotero.dtd
+++ b/chrome/locale/ar/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "تفضيلات المستند">
 <!ENTITY zotero.integration.addEditCitation.title "اضافة/تحرير استشهاد مرجعي">
 <!ENTITY zotero.integration.editBibliography.title "تحرير ببليوجرافية">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "التقدم">
 

--- a/chrome/locale/bg-BG/zotero/zotero.dtd
+++ b/chrome/locale/bg-BG/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "Настройки на докумета">
 <!ENTITY zotero.integration.addEditCitation.title "Добавя/редактира на цитат">
 <!ENTITY zotero.integration.editBibliography.title "Редактира на библиографията">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "Напредък">
 

--- a/chrome/locale/ca-AD/zotero/zotero.dtd
+++ b/chrome/locale/ca-AD/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "Preferències del document">
 <!ENTITY zotero.integration.addEditCitation.title "Afegeix/Edita cita">
 <!ENTITY zotero.integration.editBibliography.title "Edita bibliografia">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "Progrés">
 

--- a/chrome/locale/cs-CZ/zotero/zotero.dtd
+++ b/chrome/locale/cs-CZ/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "Vlastnosti dokumentu">
 <!ENTITY zotero.integration.addEditCitation.title "Přidat/Upravit citaci">
 <!ENTITY zotero.integration.editBibliography.title "Upravit bibliografii">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "Postup">
 

--- a/chrome/locale/da-DK/zotero/zotero.dtd
+++ b/chrome/locale/da-DK/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "Dokumentindstillinger">
 <!ENTITY zotero.integration.addEditCitation.title "Tilføj/rediger reference">
 <!ENTITY zotero.integration.editBibliography.title "Rediger referenceliste">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "Fremgang">
 

--- a/chrome/locale/de/zotero/zotero.dtd
+++ b/chrome/locale/de/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "Dokument-Eigenschaften">
 <!ENTITY zotero.integration.addEditCitation.title "Zitation hinzufügen/ändern">
 <!ENTITY zotero.integration.editBibliography.title "Literaturverzeichnis editieren">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "Fortschritt">
 

--- a/chrome/locale/el-GR/zotero/zotero.dtd
+++ b/chrome/locale/el-GR/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "Document Preferences">
 <!ENTITY zotero.integration.addEditCitation.title "Add/Edit Citation">
 <!ENTITY zotero.integration.editBibliography.title "Edit Bibliography">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "Progress">
 

--- a/chrome/locale/en-US/zotero/zotero.dtd
+++ b/chrome/locale/en-US/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title				"Document Preferences">
 <!ENTITY zotero.integration.addEditCitation.title		"Add/Edit Citation">
 <!ENTITY zotero.integration.editBibliography.title		"Edit Bibliography">
+<!ENTITY zotero.integration.quickFormatDialog.title		"Quick Format Citation">
 
 <!ENTITY zotero.progress.title							"Progress">
 

--- a/chrome/locale/es-ES/zotero/zotero.dtd
+++ b/chrome/locale/es-ES/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "Ajustes de documento">
 <!ENTITY zotero.integration.addEditCitation.title "Añadir o modificar cita">
 <!ENTITY zotero.integration.editBibliography.title "Modificar bibliografía">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "Progreso">
 

--- a/chrome/locale/et-EE/zotero/zotero.dtd
+++ b/chrome/locale/et-EE/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "Dokumendi sätted">
 <!ENTITY zotero.integration.addEditCitation.title "Lisa/toimeta viidet">
 <!ENTITY zotero.integration.editBibliography.title "Toimeta bibliograafiat">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "Progress">
 

--- a/chrome/locale/eu-ES/zotero/zotero.dtd
+++ b/chrome/locale/eu-ES/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "Dokumentu honetako ezaugarriak">
 <!ENTITY zotero.integration.addEditCitation.title "Erreferentzia gehitu/editatu">
 <!ENTITY zotero.integration.editBibliography.title "Bibliografia editatu">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "Aurrerapena">
 

--- a/chrome/locale/fa/zotero/zotero.dtd
+++ b/chrome/locale/fa/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "تنظیمات سند">
 <!ENTITY zotero.integration.addEditCitation.title "افزودن/ویرایش یادکرد">
 <!ENTITY zotero.integration.editBibliography.title "ویرایش کتابنامه">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "پیشرفت">
 

--- a/chrome/locale/fi-FI/zotero/zotero.dtd
+++ b/chrome/locale/fi-FI/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "Asiakirjan asetukset">
 <!ENTITY zotero.integration.addEditCitation.title "Lisää/muokkaa sitaatti">
 <!ENTITY zotero.integration.editBibliography.title "Muokkaa lähdeluetteloa">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "Eteneminen">
 

--- a/chrome/locale/fr-FR/zotero/zotero.dtd
+++ b/chrome/locale/fr-FR/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "Préférences du document">
 <!ENTITY zotero.integration.addEditCitation.title "Ajouter/Modifier la citation">
 <!ENTITY zotero.integration.editBibliography.title "Modifier la bibliographie">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "Progression">
 

--- a/chrome/locale/gl-ES/zotero/zotero.dtd
+++ b/chrome/locale/gl-ES/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "Preferencias do Documento">
 <!ENTITY zotero.integration.addEditCitation.title "Engadir/Editar Cita">
 <!ENTITY zotero.integration.editBibliography.title "Editar Bibliografía">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "Progreso">
 

--- a/chrome/locale/he-IL/zotero/zotero.dtd
+++ b/chrome/locale/he-IL/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "Document Preferences">
 <!ENTITY zotero.integration.addEditCitation.title "Add/Edit Citation">
 <!ENTITY zotero.integration.editBibliography.title "ערוך ביבליוגרפיה">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "Progress">
 

--- a/chrome/locale/hr-HR/zotero/zotero.dtd
+++ b/chrome/locale/hr-HR/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "Document Preferences">
 <!ENTITY zotero.integration.addEditCitation.title "Add/Edit Citation">
 <!ENTITY zotero.integration.editBibliography.title "Edit Bibliography">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "Progress">
 

--- a/chrome/locale/hu-HU/zotero/zotero.dtd
+++ b/chrome/locale/hu-HU/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "Dokumentum beállításai">
 <!ENTITY zotero.integration.addEditCitation.title "Hivatkozás hozzáadása/szerkesztése">
 <!ENTITY zotero.integration.editBibliography.title "Bibliográfia szerkesztése">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "Folyamatban">
 

--- a/chrome/locale/is-IS/zotero/zotero.dtd
+++ b/chrome/locale/is-IS/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "Document Preferences">
 <!ENTITY zotero.integration.addEditCitation.title "Add/Edit Citation">
 <!ENTITY zotero.integration.editBibliography.title "Edit Bibliography">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "Progress">
 

--- a/chrome/locale/it-IT/zotero/zotero.dtd
+++ b/chrome/locale/it-IT/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "Impostazioni documento">
 <!ENTITY zotero.integration.addEditCitation.title "Aggiungi o modifica citazione">
 <!ENTITY zotero.integration.editBibliography.title "Modifica bibliografia">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "Avanzamento">
 

--- a/chrome/locale/ja-JP/zotero/zotero.dtd
+++ b/chrome/locale/ja-JP/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "ドキュメントの設定">
 <!ENTITY zotero.integration.addEditCitation.title "出典表記を追加・編集">
 <!ENTITY zotero.integration.editBibliography.title "参考文献目録を編集">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "進行">
 

--- a/chrome/locale/km/zotero/zotero.dtd
+++ b/chrome/locale/km/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "ជម្រើសរចនាបថសម្រាប់យោងឯកសារ">
 <!ENTITY zotero.integration.addEditCitation.title "បន្ថែម ឬ កែតម្រូវអាគតដ្ឋាន">
 <!ENTITY zotero.integration.editBibliography.title "កែតម្រូវគន្ថនិទេ្ទស">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "កំពុងដំណើរ">
 

--- a/chrome/locale/ko-KR/zotero/zotero.dtd
+++ b/chrome/locale/ko-KR/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "문서 환경설정">
 <!ENTITY zotero.integration.addEditCitation.title "인용 추가/편집">
 <!ENTITY zotero.integration.editBibliography.title "참고문헌 목록 편집">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "진행">
 

--- a/chrome/locale/mn-MN/zotero/zotero.dtd
+++ b/chrome/locale/mn-MN/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "Document Preferences">
 <!ENTITY zotero.integration.addEditCitation.title "Add/Edit Citation">
 <!ENTITY zotero.integration.editBibliography.title "Edit Bibliography">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "Progress">
 

--- a/chrome/locale/nb-NO/zotero/zotero.dtd
+++ b/chrome/locale/nb-NO/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "Dokumentegenskaper">
 <!ENTITY zotero.integration.addEditCitation.title "Legg til/endre henvisning">
 <!ENTITY zotero.integration.editBibliography.title "Rediger bibliografi">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "Framgang">
 

--- a/chrome/locale/nl-NL/zotero/zotero.dtd
+++ b/chrome/locale/nl-NL/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "Documentvoorkeuren">
 <!ENTITY zotero.integration.addEditCitation.title "Verwijzing toevoegen/aanpassen">
 <!ENTITY zotero.integration.editBibliography.title "Bibliografie aanpassen">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "Voortgang">
 

--- a/chrome/locale/nn-NO/zotero/zotero.dtd
+++ b/chrome/locale/nn-NO/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "Dokumenteigenskapar">
 <!ENTITY zotero.integration.addEditCitation.title "Legg til/endra henvisning">
 <!ENTITY zotero.integration.editBibliography.title "Rediger bibliografi">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "Framgang">
 

--- a/chrome/locale/pl-PL/zotero/zotero.dtd
+++ b/chrome/locale/pl-PL/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "Ustawienia dokumentu">
 <!ENTITY zotero.integration.addEditCitation.title "Dodaj/Edytuj odnośnik bibliograficzny">
 <!ENTITY zotero.integration.editBibliography.title "Edytuj bibliografię">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "Postęp">
 

--- a/chrome/locale/pt-BR/zotero/zotero.dtd
+++ b/chrome/locale/pt-BR/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "Preferências do documento">
 <!ENTITY zotero.integration.addEditCitation.title "Adicionar/Modificar citação">
 <!ENTITY zotero.integration.editBibliography.title "Editar bibliografia">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "Progresso">
 

--- a/chrome/locale/pt-PT/zotero/zotero.dtd
+++ b/chrome/locale/pt-PT/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "Preferências do Documento">
 <!ENTITY zotero.integration.addEditCitation.title "Adicionar/Editar Citação">
 <!ENTITY zotero.integration.editBibliography.title "Editar Bibliografia">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "Progresso">
 

--- a/chrome/locale/ro-RO/zotero/zotero.dtd
+++ b/chrome/locale/ro-RO/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "Preferințe document">
 <!ENTITY zotero.integration.addEditCitation.title "Adaugă/Editează citarea">
 <!ENTITY zotero.integration.editBibliography.title "Editează bibliografia">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "Progres">
 

--- a/chrome/locale/ru-RU/zotero/zotero.dtd
+++ b/chrome/locale/ru-RU/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "Параметры документа">
 <!ENTITY zotero.integration.addEditCitation.title "Добавить/редактировать цитату">
 <!ENTITY zotero.integration.editBibliography.title "Редактировать библиографию">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "Ход выполнения">
 

--- a/chrome/locale/sk-SK/zotero/zotero.dtd
+++ b/chrome/locale/sk-SK/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "Vlastnosti dokumentu">
 <!ENTITY zotero.integration.addEditCitation.title "Pridať/Upraviť citáciu">
 <!ENTITY zotero.integration.editBibliography.title "Upraviť bibliografiu">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "Postup">
 

--- a/chrome/locale/sl-SI/zotero/zotero.dtd
+++ b/chrome/locale/sl-SI/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "Lastnosti dokumenta">
 <!ENTITY zotero.integration.addEditCitation.title "Dodaj/uredi navedek">
 <!ENTITY zotero.integration.editBibliography.title "Uredi bibliografijo">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "Napredek">
 

--- a/chrome/locale/sr-RS/zotero/zotero.dtd
+++ b/chrome/locale/sr-RS/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "Поставке документа">
 <!ENTITY zotero.integration.addEditCitation.title "Додај/уреди цитације">
 <!ENTITY zotero.integration.editBibliography.title "Уреди библиографију">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "Напредак">
 

--- a/chrome/locale/sv-SE/zotero/zotero.dtd
+++ b/chrome/locale/sv-SE/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "Dokumentinställningar">
 <!ENTITY zotero.integration.addEditCitation.title "Lägg till/redigera källhänvisning">
 <!ENTITY zotero.integration.editBibliography.title "Redigera källförteckning">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "Förlopp">
 

--- a/chrome/locale/th-TH/zotero/zotero.dtd
+++ b/chrome/locale/th-TH/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "ค่าตั้งพึงใจเกี่ยวกับแฟ้มเอกสาร">
 <!ENTITY zotero.integration.addEditCitation.title "เพิ่ม/แก้ไขการอ้างอิง">
 <!ENTITY zotero.integration.editBibliography.title "แก้ไขบรรณานุกรม">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "ความคืบหน้า">
 

--- a/chrome/locale/tr-TR/zotero/zotero.dtd
+++ b/chrome/locale/tr-TR/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "Döküman Tercihleri">
 <!ENTITY zotero.integration.addEditCitation.title "Gönderme Ekle/Düzenle">
 <!ENTITY zotero.integration.editBibliography.title "Kaynakça Düzenle">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "İşlem">
 

--- a/chrome/locale/vi-VN/zotero/zotero.dtd
+++ b/chrome/locale/vi-VN/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "Các tùy chọn về Tài liệu">
 <!ENTITY zotero.integration.addEditCitation.title "Thêm/Soạn thảo Trích dẫn">
 <!ENTITY zotero.integration.editBibliography.title "Soạn thảo Thư tịch">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "Tiến triển">
 

--- a/chrome/locale/zh-CN/zotero/zotero.dtd
+++ b/chrome/locale/zh-CN/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "文档选项">
 <!ENTITY zotero.integration.addEditCitation.title "添加/编辑引文">
 <!ENTITY zotero.integration.editBibliography.title "编辑文献目录">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "进度">
 

--- a/chrome/locale/zh-TW/zotero/zotero.dtd
+++ b/chrome/locale/zh-TW/zotero/zotero.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.integration.docPrefs.title "文件的偏好設定">
 <!ENTITY zotero.integration.addEditCitation.title "新增／編輯引用文獻">
 <!ENTITY zotero.integration.editBibliography.title "編輯參考書目">
+<!ENTITY zotero.integration.quickFormatDialog.title			"Quick Format Citation">
 
 <!ENTITY zotero.progress.title "進度">
 


### PR DESCRIPTION
I added the string to all .dtd files: should I let you do that in the future?
I didn't even translate it into French (leaving that for Transifex): same question.

Edit: oops, sorry it's against 3.0. Not a big issue for once, though?
