### PR TITLE
Store username and url inside correct preference keys

### DIFF
--- a/chrome/content/zotero/preferences/preferences.xul
+++ b/chrome/content/zotero/preferences/preferences.xul
@@ -268,7 +268,7 @@ To add a new preference:
 										<textbox id="storage-url" flex="1"
 											preference="pref-storage-url"
 											onkeypress="if (Zotero.isMac &amp;&amp; event.keyCode == 13) { this.blur(); setTimeout(verifyStorageServer, 1); }"
-											onchange="unverifyStorageServer(); this.value = this.value.replace(/(^https?:\/\/|\/zotero\/?$|\/$)/g, ''); Zotero.Prefs.set('extensions.zotero.sync.storage.url', this.value)"/>
+											onchange="unverifyStorageServer(); this.value = this.value.replace(/(^https?:\/\/|\/zotero\/?$|\/$)/g, ''); Zotero.Prefs.set('sync.storage.url', this.value)"/>
 										<label value="/zotero/"/>
 									</hbox>
 								</row>
@@ -278,7 +278,7 @@ To add a new preference:
 										<textbox id="storage-username"
 											preference="pref-storage-username"
 											onkeypress="if (Zotero.isMac &amp;&amp; event.keyCode == 13) { this.blur(); setTimeout(verifyStorageServer, 1); }"
-											onchange="unverifyStorageServer(); Zotero.Prefs.set('extensions.zotero.sync.storage.username', this.value); var pass = document.getElementById('storage-password'); if (pass.value) { Zotero.Sync.Storage.Session.WebDAV.prototype.password = pass.value; }"/>
+											onchange="unverifyStorageServer(); Zotero.Prefs.set('sync.storage.username', this.value); var pass = document.getElementById('storage-password'); if (pass.value) { Zotero.Sync.Storage.Session.WebDAV.prototype.password = pass.value; }"/>
 									</hbox>
 								</row>
 								<row>


### PR DESCRIPTION
I'm not sure how this happened. When I was testing, it worked for me, but perhaps I just ended up using an old value stored in the correct key. Sorry about that.

I noticed another problem. After "Verifying server" with correct username and password, I changed my password to something that is incorrect and tried verifying again. To my surprise, the verification passed. Looking at the debug output, I see (after disabling password obfuscation; also, actual email has been removed):

```
(3)(+0000007): HTTP OPTIONS for https://myEmail:wrongPassword@www.box.net/dav/test/zotero/

(3)(+0000397): Server: nginx
Date: Sun, 10 Feb 2013 09:24:01 GMT
Content-Type: httpd/unix-directory
Connection: keep-alive
X-Robots-Tag: noindex, nofollow
DAV: 1,2
Allow: GET, PUT, DELETE, MKCOL, OPTIONS, COPY, MOVE, PROPFIND, PROPPATCH, LOCK, UNLOCK, HEAD
MS-Author-Via: DAV
Content-Length: 0


(3)(+0000000): 

(3)(+0000000): ===>200<===(number)
```

It seems like it might be sending cookies with the OPTIONS request and what's worse is that the server essentially ignores the username and password if it gets a cookie (so I guess this is more of a box.net problem). It's a bit difficult to say for sure, since even if I try to go HTTP route, I get redirected to an HTTPS page, but I can see that cookies are in fact sent to the HTTP address. My quick search did not turn up any way to easily block these cookies. 
