### PR TITLE
Include dateDecided, dateEnacted, issueDate in "Title, Creator, Year"

### DIFF
--- a/chrome/content/zotero/xpcom/search.js
+++ b/chrome/content/zotero/xpcom/search.js
@@ -1197,8 +1197,20 @@ Zotero.Search.prototype._buildQuery = function(){
 						break;
 					
 					case 'year':
-						condSQL += 'fieldID IN (?) AND ';
 						condSQLParams.push(Zotero.ItemFields.getID('date'));
+						//Add base field
+						var dateFields = Zotero.ItemFields.getTypeFieldsFromBase('date');
+						if (dateFields) {
+							condSQL += 'fieldID IN (?,';																
+							// Add type-specific date fields (dateEnacted, dateDecided, issueDate)
+							for each(var fieldID in dateFields) {
+								condSQL += '?,';
+								condSQLParams.push(fieldID);
+							}
+							condSQL = condSQL.substr(0, condSQL.length - 1);
+							condSQL += ') AND ';
+						}
+					
 						condSQL += "valueID IN (SELECT valueID FROM "
 							+ "itemDataValues WHERE ";
 						


### PR DESCRIPTION
Allow searching for dateDecided (case), dateEnacted (statute), issueDate (patent) in the "Title, Creator, Year" quicksearch mode. It's also very useful in the Quick Format Citation dialog.

http://forums.zotero.org/discussion/23597/ yes, that's my own ~~bug report~~ request ;-)

(I added a <code>if</code> without <code>else</code> -copied from the preceding twenty lines- and I don't know if it's a good practice (?)... but the condition should always be met.)
