### PR TITLE
Don't attach snapshots when option is unchecked and no mimeType is supplied

### DIFF
--- a/chrome/content/zotero/xpcom/mime.js
+++ b/chrome/content/zotero/xpcom/mime.js
@@ -330,8 +330,6 @@ Zotero.MIME = new function(){
 				var mimeType = xmlhttp.channel.contentType;
 			}
 			
-			if(!mimeType) mimeType = 'application/octet-stream';	//unknown item type according to RFC 2046 section 4.5.1
-			
 			var nsIURL = Components.classes["@mozilla.org/network/standard-url;1"]
 						.createInstance(Components.interfaces.nsIURL);
 			nsIURL.spec = url;

--- a/chrome/content/zotero/xpcom/translation/translate_item.js
+++ b/chrome/content/zotero/xpcom/translation/translate_item.js
@@ -405,12 +405,12 @@ Zotero.Translate.ItemSaver.prototype = {
 				// Save attachment if snapshot pref enabled or not HTML
 				// (in which case downloadAssociatedFiles applies)
 				} else {
-					if(!attachment.mimeType && attachment.mimeType !== '') {	//in case '' indicates unknwon mime type at some point
+					if(!attachment.mimeType && attachment.mimeType !== '') {
 						Zotero.debug("Translate: No mimeType specified for a possible snapshot. Trying to determine mimeType.", 4);
 						var me = this;
 						try {
 							Zotero.MIME.getMIMETypeFromURL(attachment.url, function (mimeType, hasNativeHandler) {
-								attachment.mimeType = mimeType;
+								attachment.mimeType = mimeType || '';
 								me._saveAttachmentDownload(attachment, parentID, attachmentCallback);
 							}, this._cookieSandbox);
 						} catch(e) {


### PR DESCRIPTION
When mimeType is not supplied, try to fetch it from server and redo checks for automatic snapshots.

Re http://forums.zotero.org/discussion/28055/zotero-downloads-then-deletes-pdf/#Item_10

> 2) http://jcp.aip.org/resource/1/jcpsa6/v138/i3/p034703_s1
> Webpage snapshot added, which is not expected, because in general preferences the corresponding field are untick

Which stems from the AIP translator https://github.com/zotero/translators/blob/master/AIP.js#L50 indicating mimeType in the type attribute instead of mimeType. However, this is what the Framework documentation recommends http://www.zotero.org/support/dev/translators/framework but in that case Framework should compensate for this and convert type to mimeType.

Either way, when no mimeType was supplied, the attachment would pass the snapshot option check no matter what, but then a mimeType check through a HEAD request would result in 'text/html' mimeType and the attachment would be attached as Snapshot.

This fixes the latter behavior. We should still address the Framework issue to avoid the unnecessary HEAD requests.
