### PR TITLE
Don't break when stringifying item fields

### DIFF
--- a/chrome/content/zotero/xpcom/translation/translate.js
+++ b/chrome/content/zotero/xpcom/translation/translate.js
@@ -98,8 +98,9 @@ Zotero.Translate.Sandbox = {
 					delete item[i];
 					continue;
 				}
-
-				var isObject = typeof val === "object" || typeof val === "xml" || typeof val === "function",
+				
+				var type = typeof val;
+				var isObject = type === "object" || type === "xml" || type === "function",
 					shouldBeObject = allowedObjects.indexOf(i) !== -1;
 				if(isObject && !shouldBeObject) {
 					// Convert things that shouldn't be objects to objects
@@ -108,7 +109,7 @@ Zotero.Translate.Sandbox = {
 				} else if(shouldBeObject && !isObject) {
 					translate._debug("Translate: WARNING: typeof "+i+" is "+type+"; converting to array");
 					item[i] = [val];
-				} else if(typeof val === "string") {
+				} else if(type === "string") {
 					// trim strings
 					item[i] = val.trim();
 				}


### PR DESCRIPTION
Broken by 2f8f18c Currently breaks RDF import.

It's either this, or use `typeof val` in the warning message
