### PR TITLE
Fixing double encoding of attachments saved in relative path

### DIFF
--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -1546,7 +1546,7 @@ Zotero.Item.prototype.save = function() {
 							let attachmentFile = Components.classes["@mozilla.org/file/local;1"]
 								.createInstance(Components.interfaces.nsILocalFile);
 							try {
-								attachmentFile.initWithPath(path);
+								attachmentFile.persistentDescriptor=path;
 							}
 							catch (e) {
 								Zotero.debug(e, 1);
@@ -1981,7 +1981,7 @@ Zotero.Item.prototype.save = function() {
 							let attachmentFile = Components.classes["@mozilla.org/file/local;1"]
 								.createInstance(Components.interfaces.nsILocalFile);
 							try {
-								attachmentFile.initWithPath(path);
+								attachmentFile.persistentDescriptor=path;
 							}
 							catch (e) {
 								Zotero.debug(e, 1);


### PR DESCRIPTION
When saving attachments in the relative path, the path is double encoded and the file cannot be found again.
This fixes this bug
