### PR TITLE
Update itembox.xml

### DIFF
--- a/chrome/content/zotero/bindings/itembox.xml
+++ b/chrome/content/zotero/bindings/itembox.xml
@@ -1334,7 +1334,7 @@
 						var elems = this._dynamicFields.getElementsByAttribute('value', '+');
 						var button = elems[elems.length-1];
 						var creatorFields = this.getCreatorFields(Zotero.getAncestorByTagName(button, 'row'));
-						this._enablePlusButton(button, creatorFields.typeID, creatorFields.fieldMode);
+						this._enablePlusButton(button, creatorFields.creatorTypeID, creatorFields.fieldMode);
 						
 						this._creatorCount--;
 						return;


### PR DESCRIPTION
Corrects a tiny bug where pressing minus button to remove an unsaved creator row creates incorrect behaviour in the plus button in preceding row. Done in preparation for a fix I have locally for issue #251.  Please advise if I have your preferred workflow wrong.
