### PR TITLE
Don't double-encode file paths

### DIFF
--- a/chrome/content/zotero/xpcom/file.js
+++ b/chrome/content/zotero/xpcom/file.js
@@ -54,7 +54,8 @@ Zotero.File = new function(){
 		var parts = path.split(/([\\\/:]+)/);
 		// Every other item is the separator
 		for (var i=0, n=parts.length; i<n; i+=2) {
-			parts[i] = encodeURIComponent(parts[i]);
+			//decode before re-encoding so we don't double-encode
+			parts[i] = encodeURIComponent(decodeURIComponent(parts[i]));
 		}
 		return parts.join('');
 	}


### PR DESCRIPTION
Broken by https://github.com/zotero/zotero/commit/82448c4a4d367e4e17382ae0c458bdaef3e59d45. Sorry about that.

This also voids https://github.com/aurimasv/translators/commit/b931e43b0229792190704a48dc6944aca729a06a
