### PR TITLE
Use rebuildProcessorState() in RTF Scan. Fixes AGM SIG-CHI Proceedings.

### DIFF
--- a/chrome/content/zotero/rtfScan.js
+++ b/chrome/content/zotero/rtfScan.js
@@ -529,7 +529,6 @@ var Zotero_RTFScan = new function() {
 		
 		itemIDs = [itemID for(itemID in itemIDs)];
 		Zotero.debug(itemIDs);
-		style.updateItems(itemIDs);
 		
 		// prepare the list of rendered citations
 		var citationResults = style.rebuildProcessorState(cslCitations, "rtf");


### PR DESCRIPTION
RTF Scan is currently iterating over the document citation data using appendCitationCluster(), discarding updates to already-rendered citations. The AGM SIG-CHI Proceedings style uses numbered references drawn from a bibliography sorted by author. The numbering in the bibliography changes as items are added, with the result that the numbers fall out of line with the bibliography in the scanned document. This has been reported in the forums:

  https://forums.zotero.org/discussion/28971/rtf-scan-numbering-incorrect/

This changeset uses the (new) rebuildProcessorState() function to build the citation/bibliography data completely before inserting citations. It has been tested against a simple document, and works. Test before deploying, but the rebuildProcessorState() function has been well tested in other contexts, and this should just work.
