### PR TITLE
Small fixes to Export Library

### DIFF
--- a/chrome/content/zotero/xpcom/data/items.js
+++ b/chrome/content/zotero/xpcom/data/items.js
@@ -108,7 +108,7 @@ Zotero.Items = new function() {
 		}
 		
 		// Otherwise, build return array
-		for (i=0; i<ids.length; i++) {
+		for (var i=0; i<ids.length; i++) {
 			if (!this._objectCache[ids[i]]) {
 				Zotero.debug("Item " + ids[i] + " doesn't exist", 2);
 				continue;

--- a/chrome/content/zotero/xpcom/translation/translate_item.js
+++ b/chrome/content/zotero/xpcom/translation/translate_item.js
@@ -909,7 +909,7 @@ Zotero.Translate.ItemGetter.prototype = {
 	 * Retrieves the next available item
 	 */
 	"nextItem":function() {
-		while(this._itemsLeft.length != 0) {
+		while(this._itemsLeft.length) {
 			var returnItem = this._itemsLeft.shift();
 			// export file data for single files
 			if(returnItem.isAttachment()) {		// an independent attachment

--- a/chrome/content/zotero/zoteroPane.xul
+++ b/chrome/content/zotero/zoteroPane.xul
@@ -249,7 +249,7 @@
 					<menuseparator/>
 					<menuitem class="menuitem-iconic zotero-menuitem-export" oncommand="Zotero_File_Interface.exportCollection();"/>
 					<menuitem class="menuitem-iconic zotero-menuitem-create-bibliography" oncommand="Zotero_File_Interface.bibliographyFromCollection();"/>
-					<menuitem class="menuitem-iconic zotero-menuitem-export" label="&zotero.toolbar.export.label;" oncommand="Zotero_File_Interface.exportFile()"/>
+					<menuitem class="menuitem-iconic zotero-menuitem-export" label="&zotero.toolbar.export.label;" command="cmd_zotero_exportLibrary"/>
 					<menuitem class="menuitem-iconic zotero-menuitem-create-report" oncommand="Zotero_Report_Interface.loadCollectionReport(event)"/>
 					<menuitem class="menuitem-iconic zotero-menuitem-delete-from-lib" label="&zotero.toolbar.emptyTrash.label;" oncommand="ZoteroPane_Local.emptyTrash();"/>
 					<menuitem label="&zotero.toolbar.newCollection.label;" oncommand="ZoteroPane_Local.createCommonsBucket();"/><!--TODO localize -->


### PR DESCRIPTION
I can't reproduce the error reported here: https://forums.zotero.org/discussion/29392/cannot-export-library/

But from reading the code, I thought I had figured out how a similar error could happen. If there is only one item in the library `Zotero.Items.get()` should return the item rather than an array (which is fine), but `getAll` would then simply return that value instead of ensuring that it's an array. The error could also happen if get returns false, but then there would be another debug message: `No arguments provided to Items.get()` or `Item {ID} doesn't exist` (Dan, did you maybe miss that message in the log? It may not have been near the thrown exception).

The only problem with this theory is that I cannot get the error to trigger with only one item in the library. This is quite confusing, because it means that I'm misinterpreting something in the code. Any idea what I'm reading incorrectly?
