### PR TITLE
Allow right-click on multiple items in duplicate view. Closes #53

### DIFF
--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -2538,14 +2538,8 @@ var ZoteroPane = new function()
 			else if (tree.id == 'zotero-items-tree') {
 				let itemGroup = ZoteroPane_Local.getItemGroup();
 				if (itemGroup.isDuplicates()) {
-					if (event.button == 0 && (event.metaKey || event.shiftKey
-						|| event.altKey || event.ctrlKey)) {
-						return;
-					}
-					
-					// Allow right-click on single items/attachments
-					var items = ZoteroPane_Local.getSelectedItems();
-					if (event.button != 0 && items.length == 1) {
+					if (event.button != 0 || event.metaKey || event.shiftKey
+						|| event.altKey || event.ctrlKey) {
 						return;
 					}
 					


### PR DESCRIPTION
Originally I thought this was intentional behavior so I left it in, but now I found issue #53

I suspect that the reason this was "windows-only" bug is that right-click on mac (which IIRC historically has been Ctrl (i.e. meta) +click) triggers event.metaKey. Otherwise, the code pretty much suggests that right-click was not meant to be in duplicate view (which is why I thought it was intentional). I think it was probably also a problem on Ubuntu, but it seems that adamsmith suggests otherwise. I could be wrong though. Just my theory.
