### PR TITLE
Add callback to importFromURL for drag-dropped PDFs instead of setTimeout

### DIFF
--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -3283,16 +3283,12 @@ var ZoteroPane = new function()
 							var collectionID = false;
 						}
 						
-						var attachmentItem = Zotero.Attachments.importFromURL(url, false, false, false, collectionID, mimeType, libraryID);
-						
-						// importFromURL() doesn't trigger the notifier until
-						// after download is complete
-						//
-						// TODO: add a callback to importFromURL()
-						setTimeout(function () {
-							self.selectItem(attachmentItem.id);
-						}, 1001);
-						
+						var attachmentItem = Zotero.Attachments.importFromURL(url, false,
+							false, false, collectionID, mimeType, libraryID,
+							function(attachmentItem) {
+								self.selectItem(attachmentItem.id);
+							});
+							
 						return;
 					}
 				}


### PR DESCRIPTION
Re https://forums.zotero.org/discussion/29606/any-crtl-key-to-go-back-automatically/

Should we also be doing something about cookieSandbox there (the argument right after callback)?

Edit: The downloads are pretty slow from that server + there's a redirect, so that's why this was manifesting.

Edit 2: But now there's a bit of an awkward wait between drag-and-dropping and when the download is done. I think eventually it would be good to add some sort of progress bar. It doesn't have to be blocking interface. Or just use the popup notification in the corner (do we have that for Standalone?)
