### PR TITLE
Prefer higher priority translators even if they don't target the top frame

### DIFF
--- a/chrome/content/zotero/browser.js
+++ b/chrome/content/zotero/browser.js
@@ -812,11 +812,14 @@ Zotero_Browser.Tab.prototype._translatorsAvailable = function(translate, transla
 			//this set of translators is not targeting the same URL as a previous set of translators,
 			// because otherwise we want to use the newer set
 			&& this.page.document.location.href != translate.document.location.href
-			//the previous set of translators targets the top frame or the current one does not either
-			&& (this.page.document.defaultView == this.page.document.defaultView.top
-				|| translate.document.defaultView !== this.page.document.defaultView.top)
-			//the best translator we had was of higher priority than the new set
-			&& this.page.translators[0].priority <= translators[0].priority
+				//the best translator we had was of higher priority than the new set
+			&& (this.page.translators[0].priority < translators[0].priority
+				//or the priority was the same, but...
+				|| (this.page.translators[0].priority == translators[0].priority
+					//the previous set of translators targets the top frame or the current one does not either
+					&& (this.page.document.defaultView == this.page.document.defaultView.top
+						|| translate.document.defaultView !== this.page.document.defaultView.top)
+			))
 		) {
 			return; //keep what we had
 		} else {


### PR DESCRIPTION
E.g. pdf+html pages for HighWire 2.0 (http://www.plantcell.org/content/25/4/1213.full.pdf+html?with-ds=yes)

I might be overlooking something, but I don't think this is currently possible (oversight on my part with the previous patch of course). The HighWire 2.0 translator is designed to attach to the sidebar frame and will return "`false`" for all other frames. Unfortunately, there is Embedded Metadata in the top frame, so EM takes over with the current selection criteria.
