### PR TITLE
Tweaks to collections on import

### DIFF
--- a/chrome/content/zotero/fileInterface.js
+++ b/chrome/content/zotero/fileInterface.js
@@ -316,7 +316,16 @@ var Zotero_File_Interface = new function() {
 			translation.setHandler("done", function(obj, worked) {
 				// add items to import collection
 				if(importCollection) {
-					importCollection.addItems([item.id for each(item in obj.newItems)]);
+					//only add items to the base collection that would otherwise go unfiled
+					var itemsWihtoutCollections = [];
+					for(var i=0, n=obj.newItems.length; i<n; i++) {
+						if(!obj.newItems[i].getCollections().length) {
+							itemsWihtoutCollections.push(obj.newItems[i].id);
+						}
+					}
+					
+					if(itemsWihtoutCollections.length)
+						importCollection.addItems(itemsWihtoutCollections);
 				}
 				
 				Zotero.DB.commitTransaction();

--- a/chrome/content/zotero/xpcom/translation/translate_item.js
+++ b/chrome/content/zotero/xpcom/translation/translate_item.js
@@ -199,8 +199,9 @@ Zotero.Translate.ItemSaver.prototype = {
 					parentIDs.push(newCollection.id);
 				} else {
 					// add mapped items to collection
-					if(this._IDMap[child.id]) {
-						toAdd.push(this._IDMap[child.id]);
+					var id = this._IDMap[child.id] || this._IDMap[child.itemID];
+					if(id) {
+						toAdd.push(id);
 					} else {
 						Zotero.debug("Translate: Could not map "+child.id+" to an imported item", 2);
 					}


### PR DESCRIPTION
- Use itemID for mapping items to collections on import
  Not entirely sure why there was such an implicit distinction between itemID for items and id when adding collections. For an example, see http://www.zotero.org/support/dev/translators/coding#creating_collections
  
  This would now be:

``` javascript
    var item = new Zotero.Item("book");
    item.itemID = "my-item-id"; // any string or number
    item.complete();

    var collection = new Zotero.Collection();
    collection.name = "Test Collection";
    collection.type = "collection"; //it's also not clear to me why this is not set automatically in the Zotero.Collections constructor
    collection.children = [item];
    collection.complete();
```
- Don't add all items to base collection on import
  I never really noticed the problem here, because I always use recursive collections. But basically, if somebody's organization strategy involves having uncatergorized items in the root of the library (or a collection that is being exported), when importing those items would be mixed in with the items in subcollections.
  
  I don't particularly like the idea of performing and additional DB lookup for every single item that's being imported, but I don't currently have a better solution. I was going to keep track of items that are being assigned to collections in the "collectionDone" handler, but unfortunately there is no way to map items between those passed to `collection.complete` and those that are in the translator object passed to the "done" handler. My initial attempt was to use itemID, but itemID is not preserved when the item is saved and is actually internally redirected to `item.id`.
