### PR TITLE
Don't try to clean up underscore-prefixed properties in items

### DIFF
--- a/chrome/content/zotero/xpcom/translation/translate.js
+++ b/chrome/content/zotero/xpcom/translation/translate.js
@@ -92,6 +92,9 @@ Zotero.Translate.Sandbox = {
 			
 			delete item.complete;
 			for(var i in item) {
+				// don't touch underscore-prefixed properties used internally
+				if(i.charAt(0) == '_') continue;
+				
 				var val = item[i];
 				if(!val && val !== 0) {
 					// remove null, undefined, and false properties, and convert objects to strings


### PR DESCRIPTION
Allows objects to be passed as item properties between translators. For search translators, for example, it would be very useful to be able to pass back the query, which can be an object, along with the resulting item.
