### PR TITLE
Add "Create Web Page Item from Current Page" keyboard shortcut, followin...

### DIFF
--- a/chrome/content/zotero/overlay.xul
+++ b/chrome/content/zotero/overlay.xul
@@ -98,5 +98,9 @@
 			 key="S"
 			 oncommand="Zotero_Browser.scrapeThisPage();"
 			 modifiers="accel shift" />
+		 <key id="key_newItemFromPage"
+		 	 key="I"
+		 	 oncommand="ZoteroPane.addItemFromPage();"
+		 	 modifiers="accel shift" />
 	</keyset>
 </overlay>

--- a/chrome/content/zotero/preferences/preferences_keys.xul
+++ b/chrome/content/zotero/preferences/preferences_keys.xul
@@ -32,6 +32,7 @@
 		<preferences>
 			<preference id="pref-keys-openZotero" name="extensions.zotero.keys.openZotero" type="string"/>
 			<preference id="pref-keys-saveToZotero" name="extensions.zotero.keys.saveToZotero" type="string"/>
+			<preference id="pref-keys-newItemFromPage" name="extensions.zotero.keys.newItemFromPage" type="string"/>
 			<preference id="pref-keys-toggleFullscreen" name="extensions.zotero.keys.toggleFullscreen" type="string"/>
 			<preference id="pref-keys-library" name="extensions.zotero.keys.library" type="string"/>
 			<preference id="pref-keys-quicksearch" name="extensions.zotero.keys.quicksearch" type="string"/>

--- a/chrome/content/zotero/preferences/preferences_keys_firefox.xul
+++ b/chrome/content/zotero/preferences/preferences_keys_firefox.xul
@@ -46,6 +46,12 @@
 					<label/>
 					<textbox id="textbox-saveToZotero" maxlength="1" size="1" preference="pref-keys-saveToZotero"/>
 				</row>
+				
+				<row insertbefore="zotero-keys-new-item">
+					<label value="&zotero.preferences.keys.newItemFromPage;" control="key-textbox-newItemFromPage"/>
+					<label/>
+					<textbox id="textbox-newItemFromPage" maxlength="1" size="1" preference="pref-keys-newItemFromPage"/>
+				</row>
 			</rows>
 		</grid>
 	</prefpane>

--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -2324,6 +2324,10 @@ Zotero.Keys = new function() {
 			{
 				name: 'saveToZotero',
 				defaultKey: 'S'
+			},
+			{
+				name: 'newItemFromPage',
+				defaultKey: 'I'
 			}
 		];
 		

--- a/chrome/locale/en-US/zotero/preferences.dtd
+++ b/chrome/locale/en-US/zotero/preferences.dtd
@@ -127,6 +127,7 @@
 
 <!ENTITY zotero.preferences.keys.openZotero				"Open/Close Zotero Pane">
 <!ENTITY zotero.preferences.keys.saveToZotero "Save to Zotero (address bar icon)">
+<!ENTITY zotero.preferences.keys.newItemFromPage "Create Web Page Item from Current Page">
 <!ENTITY zotero.preferences.keys.toggleFullscreen			"Toggle Fullscreen Mode">
 <!ENTITY zotero.preferences.keys.focusLibrariesPane		"Focus Libraries Pane">
 <!ENTITY zotero.preferences.keys.quicksearch				"Quick Search">

--- a/defaults/preferences/zotero.js
+++ b/defaults/preferences/zotero.js
@@ -66,6 +66,7 @@ pref("extensions.zotero.tagCloud", false);
 pref("extensions.zotero.keys.openZotero", 'Z');
 pref("extensions.zotero.keys.toggleFullscreen", 'F');
 pref("extensions.zotero.keys.saveToZotero", 'S');
+pref("extensions.zotero.keys.newItemFromPage", 'I');
 pref("extensions.zotero.keys.newItem", 'N');
 pref("extensions.zotero.keys.newNote", 'O');
 pref("extensions.zotero.keys.importFromClipboard", 'V');


### PR DESCRIPTION
...g the example of the "Save to Zotero" shortcut.  Address zotero/zotero#178

A few comments:

* I tried to follow the style of `key_saveToZotero`, so I think this should be easy to review.
* I was not sure what to choose for a good default key.  The best choices mnemonically are taken (`C` and `N` by Zotero, `W` and `P` by Firefox).  I went with `I` for now.
* I did not add a case to `handleKeyPress()` of ZoteroPane.js because `key_saveToZotero` does not currently have one.  So, like `key_saveToZotero`, `key_newItemFromPage` can not be called when Zotero is focused.  I was not sure if this was the intended behavior for `key_saveToZotero` or an oversight.