### PR TITLE
Add "Save to Zotero" submenu to the Firefox content area context menu.  ...

### DIFF
--- a/chrome/content/zotero/browser.js
+++ b/chrome/content/zotero/browser.js
@@ -411,7 +411,8 @@ var Zotero_Browser = new function() {
 	}
 	
 	/**
-	 * Called when status bar icon is right-clicked
+	 * Called when status bar icon is right-clicked or the "Save to Zotero" submenu
+	 * of the contentAreaContextMenu is shown
 	 */
 	this.onStatusPopupShowing = function(e) {
 		var popup = e.target;

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -2864,6 +2864,17 @@ var ZoteroPane = new function()
 			}
 		}
 		
+		var menu = document.getElementById("zotero-context-save-page-menu");
+		if (menu) {
+			// statusImage.hidden is updated on pageshow to reflect scrapability of
+			// current page
+			if (Zotero_Browser.statusImage.hidden) {
+				menu.hidden = true;
+			} else {
+				menu.hidden = false;
+			}
+		}
+		
 		// If Zotero is locked or library is read-only, disable menu items
 		var menu = document.getElementById('zotero-content-area-context-menu');
 		var disabled = Zotero.locked;

--- a/chrome/content/zotero/zoteroPane.xul
+++ b/chrome/content/zotero/zoteroPane.xul
@@ -81,6 +81,10 @@
 				<menuitem id="zotero-context-save-image-as-item" class="menu-iconic"
 					label="&zotero.contextMenu.saveImageAsItem;" hidden="true"
 					oncommand="ZoteroPane.addItemFromURL(window.gContextMenu.onImage ? (window.gContextMenu.mediaURL ? window.gContextMenu.mediaURL : window.gContextMenu.imageURL) : window.gContextMenu.bgImageURL, 'artwork')"/>
+				<menu id="zotero-context-save-page-menu" label="&zotero.contextMenu.saveToZotero;"
+					hidden="true">
+					<menupopup id="zotero-context-save-page-menupopup" onpopupshowing="Zotero_Browser.onStatusPopupShowing(event)"/>
+				</menu>
 			</menupopup>
 		</menu>
 	</popup>

--- a/chrome/locale/en-US/zotero/zotero.dtd
+++ b/chrome/locale/en-US/zotero/zotero.dtd
@@ -31,6 +31,7 @@
 <!ENTITY zotero.contextMenu.addTextToNewNote			"Create Zotero Item and Note from Selection">
 <!ENTITY zotero.contextMenu.saveLinkAsItem			"Save Link As Zotero Item">
 <!ENTITY zotero.contextMenu.saveImageAsItem		"Save Image As Zotero Item">
+<!ENTITY zotero.contextMenu.saveToZotero		"Save to Zotero">
 
 <!ENTITY zotero.tabs.info.label						"Info">
 <!ENTITY zotero.tabs.notes.label						"Notes">


### PR DESCRIPTION
...Use the same menupopup as used for the status bar icon for the submenu.  This addresses zotero/zotero#356 .

A couple comments:
- I used the same context menu generating function used by the status bar icon for the content area context menu.  I think this is fine, but in the future it could be confusing development-wise that the `onStatusPopupShowing` function is also used for the content area context menu.  I added a comment to `onStatusPopupShowing` to point this out.
- I set the hidden status of the submenu of the content area context menu based on the hidden status of `statusImage.hidden`.  I think this is okay because it should always be set before the context menu can be shown, but again the name could be confusing.
- I only added the context menu.  A "Save to Zotero" menuitem equivalent to clicking on the status bar icon could also be added directly to the Zotero submenu but maybe it's simpler just to have the "Save to Zotero" options in the separate submenu of the Zotero submenu.
