### PR TITLE
Manage cookies received from other hosts.

### DIFF
--- a/chrome/content/zotero/xpcom/connector/connector.js
+++ b/chrome/content/zotero/xpcom/connector/connector.js
@@ -136,7 +136,7 @@ Zotero.Connector = new function() {
 	 * @param	{Object}		data			RPC data. See documentation above.
 	 * @param	{Function}		callback		Function to be called when requests complete.
 	 */
-	this.callMethod = function(method, data, callback) {
+	this.callMethod = function(method, data, callback, tab) {
 		// Don't bother trying if not online in bookmarklet
 		if(Zotero.isBookmarklet && this.isOnline === false) {
 			callback(false, 0);
@@ -204,6 +204,57 @@ Zotero.Connector = new function() {
 					"X-Zotero-Connector-API-Version":CONNECTOR_API_VERSION
 				});
 		}
+	},
+	
+	/**
+	 * Adds detailed cookies to the data before sending "saveItems" request to
+	 *  the server/Standalone
+	 *
+	 * @param	{Object} data RPC data. See documentation above.
+	 * @param	{Function} callback Function to be called when requests complete.
+	 */
+	this.setCookiesThenSaveItems = function(data, callback, tab) {
+		if(Zotero.isFx && !Zotero.isBookmarklet && data.uri) {
+			var host = Services.ios.newURI(data.uri, null, null).host;
+			var cookieEnum = Services.cookies.getCookiesFromHost(host);
+			var cookieHeader = '';
+			while(cookieEnum.hasMoreElements()) {
+				var cookie = cookieEnum.getNext().QueryInterface(Components.interfaces.nsICookie2);
+				cookieHeader += '\n' + cookie.name + '=' + cookie.value
+					+ ';Domain=' + cookie.host
+					+ (cookie.path ? ';Path=' + cookie.path : '')
+					+ (!cookie.isDomain ? ';hostOnly' : '') //not a legit flag, but we have to use it internally
+					+ (cookie.isSecure ? ';secure' : '');
+			}
+			
+			if(cookieHeader) {
+				data.detailedCookies = cookieHeader.substr(1);
+			}
+			
+			this.callMethod("saveItems", data, callback, tab);
+			return;
+		} else if(Zotero.isChrome && !Zotero.isBookmarklet) {
+			var self = this;
+			chrome.cookies.getAll({url: tab.url}, function(cookies) {
+				var cookieHeader = '';
+				for(var i=0, n=cookies.length; i<n; i++) {
+					cookieHeader += '\n' + cookies[i].name + '=' + cookies[i].value
+						+ ';Domain=' + cookies[i].domain
+						+ (cookies[i].path ? ';Path=' + cookies[i].path : '')
+						+ (cookies[i].hostOnly ? ';hostOnly' : '') //not a legit flag, but we have to use it internally
+						+ (cookies[i].secure ? ';secure' : '');
+				}
+				
+				if(cookieHeader) {
+					data.detailedCookies = cookieHeader.substr(1);
+				}
+				
+				self.callMethod("saveItems", data, callback, tab);
+			});
+			return;
+		}
+		
+		this.callMethod("saveItems", data, callback, tab);
 	}
 }
 

--- a/chrome/content/zotero/xpcom/connector/translate_item.js
+++ b/chrome/content/zotero/xpcom/connector/translate_item.js
@@ -80,8 +80,7 @@ Zotero.Translate.ItemSaver.prototype = {
 			payload.uri = this._uri;
 			payload.cookie = this._cookie;
 		}
-		
-		Zotero.Connector.callMethod("saveItems", payload, function(data, status) {
+		Zotero.Connector.setCookiesThenSaveItems(payload, function(data, status) {
 			if(data !== false) {
 				Zotero.debug("Translate: Save via Standalone succeeded");
 				var haveAttachments = false;

--- a/chrome/content/zotero/xpcom/server_connector.js
+++ b/chrome/content/zotero/xpcom/server_connector.js
@@ -339,7 +339,11 @@ Zotero.Server.Connector.SaveItem.prototype = {
 		} catch(e) {}
 		
 		var cookieSandbox = data["uri"] ? new Zotero.CookieSandbox(null, data["uri"],
-			data["cookie"] || "", url.userAgent) : null;
+			data["detailedCookies"] ? "" : data["cookie"] || "", url.userAgent) : null;
+		if(cookieSandbox && data.detailedCookies) {
+			cookieSandbox.addCookiesFromHeader(data.detailedCookies);
+		}
+		
 		for(var i=0; i<data.items.length; i++) {
 			Zotero.Server.Connector.AttachmentProgressManager.add(data.items[i].attachments);
 		}


### PR DESCRIPTION
Currently we ignore any cookies set from other domains while attempting to download attachments (through connector imports) and I'm not entirely sure why.

One issue is downloading attachments when importing via Chrome from cell.com (e.g. http://www.cell.com/abstract/S0092-8674(12)01407-9) Some of their PDFs are hosted on sciencedirect.com so we pass the sciencedirect.com url as attachment url to Zotero Standalone. We don't necessarily need to pass any cookies when fetching these attachments to start with, but sciencedirect does include a redirect (or two) that does set cookies, which end up being required to download the PDF.

This patch allows cookies to be set for different domains during this transaction and it implements domain-level cookie management within the cookie sandbox. It certainly solves the cell.com issue ~~and it may also solve some of the issues mentioned here: https://forums.zotero.org/discussion/32937/pdf-saving-problem/~~