### PR TITLE
Add "Check for Update" button to error alert when DB version is newer

### DIFF
--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -653,7 +653,10 @@ Components.utils.import("resource://gre/modules/Services.jsm");
 						// "Check for updates" button
 						if(index === 0) {
 							if(Zotero.isStandalone) {
-								ZoteroStandalone.checkForUpdates();
+								Components.classes["@mozilla.org/embedcomp/window-watcher;1"]
+									.getService(Components.interfaces.nsIWindowWatcher)
+									.openWindow(null, 'chrome://mozapps/content/update/updates.xul',
+										'updateChecker', 'chrome,centerscreen', null);
 							} else {
 								// In Firefox, show the add-on manager
 								Components.utils.import("resource://gre/modules/AddonManager.jsm");


### PR DESCRIPTION
This adds a "Check for Update" button to the "Your database is newer...." error alert that will either
- launch the ZSA updater (haven't tested this actually)
- launch an update check for Zotero add-on and open up the Add-ons -> Available Updates tab in Firefox .

It works quite nicely IMO, but for some reason update checks this morning have been quite slow (~15 seconds). It's not just via this method - through the add-on manager as well. If this is temporary then I guess it's not a big deal, but otherwise we may want to add a progress indicator.
