### PR TITLE
Use documentURI/URL instead of location.href.

### DIFF
--- a/chrome/content/zotero/xpcom/translation/translate.js
+++ b/chrome/content/zotero/xpcom/translation/translate.js
@@ -132,7 +132,7 @@ Zotero.Translate.Sandbox = {
 				var nAttachments = attachments.length;
 				for(var j=0; j<nAttachments; j++) {
 					if(attachments[j].document) {
-						attachments[j].url = attachments[j].document.location.href;
+						attachments[j].url = attachments[j].document.documentURI || attachments[j].document.URL;
 						attachments[j].mimeType = "text/html";
 						delete attachments[j].document;
 					}


### PR DESCRIPTION
document.location is null after the document is detached from its parent window (e.g. after we navigate to a different page in the same hidden browser)

I'm not sure if there's a good reason to include document.URL. I included it just in case.

Addresses https://forums.zotero.org/discussion/34211/save-multiple-items-from-wiley/ and probably quite a few of other translation errors 
