### PR TITLE
add "Save" button and "Near Note" position to CSL Preview

### DIFF
--- a/chrome/content/zotero/tools/csledit.xul
+++ b/chrome/content/zotero/tools/csledit.xul
@@ -42,7 +42,6 @@
 			this.loadCSL = loadCSL;
 			this.generateBibliography = generateBibliography;
 			this.refresh = refresh;
-			
 			function init() {
 				var cslList = document.getElementById('zotero-csl-list');
 				if (cslList.getAttribute('initialized') == 'true') {
@@ -71,6 +70,30 @@
 				var editor = document.getElementById('zotero-csl-editor')
 				generateBibliography(editor.value);
 
+			}
+			this.save = function() {
+				var editor = document.getElementById('zotero-csl-editor')
+				var style = editor.value;
+				const nsIFilePicker = Components.interfaces.nsIFilePicker;
+				var fp = Components.classes["@mozilla.org/filepicker;1"]
+					.createInstance(nsIFilePicker);
+				fp.init(window, "Save Citation Style", nsIFilePicker.modeSave);
+				//get the filename from the id; we could consider doing even more here like creating the id from filename. 
+				var parser = new DOMParser();
+				var doc = parser.parseFromString(style, 'text/xml');
+				var filename = doc.getElementsByTagName("id");
+				if (filename) {
+					filename = filename[0].textContent;
+					fp.defaultString = filename.replace(/.+\//, "") + ".csl";
+				}
+				else {
+					fp.defaultString = "untitled.csl";
+				}
+				var rv = fp.show();
+				if (rv == nsIFilePicker.returnOK || rv == nsIFilePicker.returnReplace) {				
+					var outputFile = fp.file;
+					Zotero.File.putContents(outputFile, style);
+				}
 			}
 			
 			function handleKeyPress(event) {
@@ -145,7 +168,14 @@
 						citation.citationItems[i].locator = search.value;
 						citation.citationItems[i].label = loc.selectedItem.value;
 					}
-					citation.citationItems[i].position = parseInt(pos, 10);
+					if (pos == 4) {
+						//near note is a subsequent citation with near note set to true;
+						citation.citationItems[i].position = 1;
+						citation.citationItems[i]["near-note"] = true;
+					}
+					else {
+						citation.citationItems[i].position = parseInt(pos, 10);
+					{
 					var subcitation = [citation.citationItems[i]];
 					citations += styleEngine.makeCitationCluster(subcitation) + '<br />';
 				}
@@ -189,6 +219,7 @@
 	
 	<vbox flex="1">
 		<hbox align="center">
+		    <button id="zotero-csl-save" label="Save" oncommand="Zotero_CSL_Editor.save()"/>
 		    <button id="preview-refresh-button" label="Refresh" oncommand="Zotero_CSL_Editor.refresh()"/>
 		    <menulist id="zotero-csl-page-type" style="min-height: 1.6em; min-width: 50px" oncommand="Zotero_CSL_Editor.refresh()" />
 		    <label value=":" />
@@ -201,6 +232,7 @@
 		    	    <menuitem label="Subsequent" value="1"/>
 		    	    <menuitem label="Ibid" value="2"/>
 		    	    <menuitem label="Ibid+Locator" value="3"/>
+		    	    <menuitem label="Near Note" value="4"/>
 		    	</menupopup>
 		    </menulist>
 		    <menulist id="zotero-csl-list" style="min-height: 1.6em; min-width: 100px" initialized="false" flex="1" oncommand="Zotero_CSL_Editor.loadCSL(this.selectedItem.value)"/>


### PR DESCRIPTION
related to: https://github.com/zotero/zotero/issues/120
I think having this would be nice even without direct installation, we get a fair amount of confusion from people saving the entire webpage and I don't like having to copy this over into emacs every time, either. (For me personally, save is actually more useful then direct install)

But if you really don't like the save button let me know and I'll put up just the near-note position as a separate pull request.
