### PR TITLE
Assume local time for accessDate. Don't display time if not set

### DIFF
--- a/chrome/content/zotero/xpcom/itemTreeView.js
+++ b/chrome/content/zotero/xpcom/itemTreeView.js
@@ -971,7 +971,9 @@ Zotero.ItemTreeView.prototype.getCellText = function(row, column)
 					order = 'YMD';
 					var join = '-';
 				}
-				var date = Zotero.Date.sqlToDate(val, true);
+				
+				var isUTC = column.id != 'zotero-items-column-accessDate';
+				var date = Zotero.Date.sqlToDate(val, isUTC);
 				var parts = [];
 				for (var i=0; i<3; i++) {
 					switch (order[i]) {
@@ -1001,7 +1003,18 @@ Zotero.ItemTreeView.prototype.getCellText = function(row, column)
 					}
 					
 					val = parts.join(join);
-					val += ' ' + date.toLocaleTimeString();
+					
+					var hasTime;
+					//check if time was set (most likely)
+					if(!isUTC) {
+						hasTime = date.getHours() || date.getMinutes() || date.getSeconds();
+					} else {
+						hasTime = date.getUTCHours() || date.getUTCMinutes() || date.getUTCSeconds();
+					}
+					
+					if(hasTime) {
+						val += ' ' + date.toLocaleTimeString();
+					}
 				}
 			}
 	}


### PR DESCRIPTION
I think we should assume local time for all dates that can be entered by the user.

Also, how come we're not using [Date.prototype.toLocaleDateString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString) (and related) to generate localized dates?

Edit: Alternatively, convert all entered dates to UTC on write?
