### PR TITLE
Add server JSON representation to drag events

### DIFF
--- a/chrome/content/zotero/xpcom/itemTreeView.js
+++ b/chrome/content/zotero/xpcom/itemTreeView.js
@@ -2438,8 +2438,16 @@ Zotero.ItemTreeView.prototype.onDragStart = function (event) {
 	
 	var itemIDs = this.saveSelection();
 	var items = Zotero.Items.get(itemIDs);
+	var serverJSONObjs = [];
 	
 	event.dataTransfer.setData("zotero/item", itemIDs.join());
+
+	for (var i=0; i<items.length; i++) {
+		serverJSONObjs.push(Zotero.Utilities.itemToServerJSON(items[i].toArray()));
+	}
+	event.dataTransfer.setData('zotero/server-json', JSON.stringify({
+		items: serverJSONObjs
+	}));
 	
 	// Multi-file drag
 	//  - Doesn't work on Windows


### PR DESCRIPTION
I believe something like this would help web applications to better interact with users' Zotero libraries. These sorts of interactions are already possible through using the server API, but I think it would be useful for both users and developers to allow them without requiring the server as an intermediary.

This would enable:
- more sophisticated interactions via drag-and-drop to browsers
- use of Zotero data in offline applications
- use of Zotero data not synced to the server for whatever reason
- use of Zotero data synced to servers other than the one located at api.zotero.org without needing to manage multiple API keys/authorizations
