### PR TITLE
Update item.js for display of case law title

### DIFF
--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -956,7 +956,7 @@ Zotero.Item.prototype.getDisplayTitle = function (includeAuthorAndDate) {
 					title = title + ' (' + court + ');
 				}
 			}
-		} 
+		}
 		else { // civil law cases have only shortTitle as case name
 			var strParts = [];
 			var caseinfo = "";


### PR DESCRIPTION
This is a request from several Canadian and European lawyers using Zotero.
- Common law citation:
  In case of "neutral reference" (now commonly used as first reference for case law in Canada and EU), there is no report... Zotero should then display the court official code.
- Civil law citation:
  Zotero should display shortTitle; because, actually, cases are also known by name in civil law jurisdictions.
