### PR TITLE
Clear cached file sync credentials/URLs when changing settings

### DIFF
--- a/chrome/content/zotero/preferences/preferences_sync.js
+++ b/chrome/content/zotero/preferences/preferences_sync.js
@@ -151,6 +151,7 @@ Zotero_Preferences.Sync = {
 	
 	unverifyStorageServer: function () {
 		Zotero.Prefs.set('sync.storage.verified', false);
+		Zotero.Sync.Storage.WebDAV.clearCachedCredentials();
 		Zotero.Sync.Storage.resetAllSyncStates(null, true, false);
 	},
 	

--- a/chrome/content/zotero/xpcom/storage/webdav.js
+++ b/chrome/content/zotero/xpcom/storage/webdav.js
@@ -827,6 +827,11 @@ Zotero.Sync.Storage.WebDAV = (function () {
 		_rootURI = uri;
 	};
 	
+		
+	obj.clearCachedCredentials = function() {
+		_rootURI = _parentURI = undefined;
+		_cachedCredentials = false;
+	};
 	
 	/**
 	 * Begin download process for individual file

--- a/chrome/content/zotero/xpcom/storage/zfs.js
+++ b/chrome/content/zotero/xpcom/storage/zfs.js
@@ -675,7 +675,7 @@ Zotero.Sync.Storage.ZFS = (function () {
 	});
 	
 	
-	obj._init = function (url, username, password) {
+	obj._init = function () {
 		_rootURI = false;
 		_userURI = false;
 		
@@ -695,6 +695,10 @@ Zotero.Sync.Storage.ZFS = (function () {
 		_userURI = uri;
 	};
 	
+	obj.clearCachedCredentials = function() {
+		_rootURI = _userURI = undefined;
+		_cachedCredentials = false;
+	};
 	
 	/**
 	 * Begin download process for individual file

--- a/chrome/content/zotero/xpcom/sync.js
+++ b/chrome/content/zotero/xpcom/sync.js
@@ -1277,6 +1277,9 @@ Zotero.Sync.Server = new function () {
 			break;
 		}
 		
+		// Clear password for file sync
+		Zotero.Sync.Storage.ZFS.clearCachedCredentials();
+		
 		_cachedCredentials = {};
 		
 		var username = this.username;


### PR DESCRIPTION
Re https://forums.zotero.org/discussion/36142/password-change-requires-firefox-iceweasel-restart/
