### PR TITLE
[RDF] Encode > in content when serializing to XML

### DIFF
--- a/chrome/content/zotero/xpcom/rdf/serialize.js
+++ b/chrome/content/zotero/xpcom/rdf/serialize.js
@@ -678,7 +678,10 @@ $rdf.Serializer = function () {
 
     function escapeForXML(str) {
       if(typeof str == 'undefined') return '@@@undefined@@@@';
-      return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
+      return str.replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
     }
 
     function relURI(term) {


### PR DESCRIPTION
This avoids the invalid combination "]]>" from appearing in the output

Re https://forums.zotero.org/discussion/36391/2/tips-for-speeding-up-duplicate-merging/#Item_15
