### PR TITLE
Fix dropping of creators in CSL JSON export

### DIFF
--- a/chrome/content/zotero/xpcom/utilities.js
+++ b/chrome/content/zotero/xpcom/utilities.js
@@ -1464,13 +1464,14 @@ Zotero.Utilities = {
 		}
 		
 		// separate name variables
-		var authorID = Zotero.CreatorTypes.getPrimaryIDForType(item.itemType);
+		var authorID = Zotero.CreatorTypes.getPrimaryIDForType(itemTypeID);
+		var authorFieldName = Zotero.CreatorTypes.getName(authorID);
 		var creators = item.creators;
 		if(creators) {
 			for(var i=0, n=creators.length; i<n; i++) {
 				var creator = creators[i];
 				
-				if(creator.creatorTypeID == authorID) {
+				if(creator.creatorType == authorFieldName) {
 					var creatorType = "author";
 				} else {
 					var creatorType = CSL_NAMES_MAPPINGS[creator.creatorType]


### PR DESCRIPTION
Use ID rather than name on getPrimaryIDForType()
Use creator name for comparison (creatorTypeID does not exist on array-form creators)
