### PR TITLE
Preselect default Export style in csledit.xul

### DIFF
--- a/chrome/content/zotero/tools/csledit.xul
+++ b/chrome/content/zotero/tools/csledit.xul
@@ -45,15 +45,33 @@
 			function init() {
 				var cslList = document.getElementById('zotero-csl-list');
 				if (cslList.getAttribute('initialized') == 'true') {
+					if (currentStyle) {
+						loadCSL(currentStyle);
+						refresh();
+					}
 					return;
 				}
 				
+				var rawDefaultStyle = Zotero.Prefs.get('export.quickCopy.setting');
+				var defaultStyle = Zotero.QuickCopy.stripContentType(rawDefaultStyle);
+				
 				var styles = Zotero.Styles.getAll();
+				var currentStyle = null;
+				var listPos = 0;
 				for each(var style in styles) {
 					if (style.source) {
 						continue;
 					}
 					var item = cslList.appendItem(style.title, style.styleID);
+					if (!currentStyle || defaultStyle == ('bibliography=' + style.styleID)) {
+						currentStyle = style.styleID;
+						cslList.selectedIndex = listPos;
+					}
+					listPos += 1;
+				}
+				if (currentStyle) {
+					loadCSL(currentStyle);
+					refresh();
 				}
 				var pageList = document.getElementById('zotero-csl-page-type');
 				var locators = Zotero.Cite.labels;


### PR DESCRIPTION
This is a little cosmetic fix.

When the user opens csledit.xul from advanced preferences, the pane is empty, and the style selection dropdown presents an empty button. For a user arriving at the editor for the first time, it may not be immediately apparent how to proceed; and a user who returns to the pane repeatedly during a session must select the style each time the pane is reopened.

This preselects the default Export style when csledit.xul is opened, and renders the pane content for any item(s) selected in the Zotero center pane.
