### PR TITLE
Enable Abbreviation Filter plugin in csledit.xul

### DIFF
--- a/chrome/content/zotero/tools/csledit.js
+++ b/chrome/content/zotero/tools/csledit.js
@@ -138,6 +138,7 @@ var Zotero_CSL_Editor = new function() {
 			iframe.contentDocument.documentElement.innerHTML = '<div>' + Zotero.getString('styles.editor.warning.parseError') + '</div><div>'+e+'</div>';
 			throw e;
 		}
+		editor.styleEngine = styleEngine;
 		
 		var itemIds = [items[i].id for (i in items)];
 


### PR DESCRIPTION
This change enables access to the Abbreviation Filter via the csledit.xul editor, making it fully functional in Zotero as well as MLZ.

The plugin allows the user to edit the abbreviations used with a particular style, to import and export abbreviation lists, and it enables some transforms that are needed for legal citation styles. The Filter has been a clunky proof-of-concept thing, but some changes I put up yesterday, described in the [release announcement](http://citationstylist.org/2014/05/11/improvements-to-the-abbreviation-filter-for-multilingual-zotero/), should make it more inviting to people with work to do.