### PR TITLE
Recognize Windows network shares on file attachment import

### DIFF
--- a/chrome/content/zotero/xpcom/translation/translate_item.js
+++ b/chrome/content/zotero/xpcom/translation/translate_item.js
@@ -329,11 +329,16 @@ Zotero.Translate.ItemSaver.prototype = {
 		var file;
 
 		// First, try to parse as absolute path
-		if(((/^[a-zA-Z]:\\|^\\\\/.test(path) && Zotero.isWin) // Paths starting with drive letter or network shares starting with \\
-			|| (path[0] === "/" && !Zotero.isWin))
-				&& (file = this._parseAbsolutePath(path))) {
-			Zotero.debug("Translate: Got file "+path+" as absolute path");
-			return file;
+		if((/^[a-zA-Z]:[\\\/]|^\\\\/.test(path) && Zotero.isWin) // Paths starting with drive letter or network shares starting with \\
+			|| (path[0] === "/" && !Zotero.isWin)) {
+			// Forward slashes on Windows are not allowed in filenames, so we can
+			// assume they're meant to be backslashes. Backslashes are technically
+			// allowed on Linux, so the reverse cannot be done reliably.
+			var nativePath = Zotero.isWin ? path.replace('/', '\\', 'g') : path;
+			if (file = this._parseAbsolutePath(nativePath)) {
+				Zotero.debug("Translate: Got file "+nativePath+" as absolute path");
+				return file;
+			}
 		}
 
 		// Next, try to parse as URI


### PR DESCRIPTION
E.g. in bibtex `file = {Test:\\\\HOST\\share\\test.pdf:application/pdf}`

Related to zotero/translators#735 and we've seen a bibtex file like this [posted on the forums](https://forums.zotero.org/discussion/25145/problem-importing-pdfs/) before.

Also, anchor drive letter to beginning of string (though I don't think a colon could be anywhere else anyway)
