### PR TITLE
Allow QuickSearch to search for civil law cases

### DIFF
--- a/chrome/content/zotero/xpcom/search.js
+++ b/chrome/content/zotero/xpcom/search.js
@@ -420,6 +420,8 @@ Zotero.Search.prototype.addCondition = function(condition, operator, value, requ
 			if (condition == 'quicksearch-titleCreatorYear') {
 				this.addCondition('title', operator, part.text, false);
 				this.addCondition('publicationTitle', operator, part.text, false);
+				this.addCondition('shortTitle', operator, part.text, false);
+				this.addCondition('court', operator, part.text, false);
 				this.addCondition('year', operator, part.text, false);
 			}
 			else {


### PR DESCRIPTION
Civil law cases in Zotero have no author or title... so, you can't cite them from the QuickFormat search box! (see issue https://github.com/zotero/zotero/issues/501).

Therefore, QuickFormat should be able to search into `court`and `shortTitle` to find such items.
The commit add these two in the "quicksearch-titleCreatorYear" filter.

(Actually, it was proposed by @gracile-fr in #501; successfully implemented and tested on my dev profile.)
