### PR TITLE
Export fixes

### DIFF
--- a/chrome/content/zotero/charsetMenu.js
+++ b/chrome/content/zotero/charsetMenu.js
@@ -46,13 +46,8 @@ var Zotero_Charset_Menu = new function() {
 		if (Zotero.platformMajorVersion >= 32) {
 			Components.utils.import("resource://gre/modules/CharsetMenu.jsm");
 			var cmData = CharsetMenu.getData();
-			let pinned = true;
-			for each(var charsetList in [cmData.pinnedCharsets, false, cmData.otherCharsets]) {
-				if (charsetList === false) {
-					// Done with pinned list
-					pinned = false;
-					continue;
-				}
+			for each(var charsetList in [cmData.pinnedCharsets, cmData.otherCharsets]) {
+				let pinned = charsetList === cmData.pinnedCharsets;
 				
 				for each(var charsetInfo in charsetList) {
 					if (charsetInfo.value == "UTF-8") {

--- a/chrome/content/zotero/exportOptions.js
+++ b/chrome/content/zotero/exportOptions.js
@@ -162,20 +162,46 @@ var Zotero_File_Interface_Export = new function() {
 		}
 		
 		// handle charset popup
-		if(_charsets && translatorOptions.exportCharset) {
-			optionsBox.hidden = undefined;
-			document.getElementById("charset-box").hidden = undefined;
-			var charsetMenu = document.getElementById(OPTION_PREFIX+"exportCharset");
-			var charset = "UTF-8";
-			if(options && options.exportCharset && _charsets[options.exportCharset]) {
-				charset = options.exportCharset;
-			} else if(translatorOptions.exportCharset && _charsets[translatorOptions.exportCharset]) {
-				charset = translatorOptions.exportCharset;
+		if(_charsets) {
+			//Clear recommended option and hidden charset
+			let charsetPopup = document.getElementById(OPTION_PREFIX+"exportCharset").lastChild;
+			let recommended = charsetPopup.getElementsByClassName('zotero-recommended')[0];
+			if (recommended) {
+				charsetPopup.removeChild(recommended);
 			}
 			
-			charsetMenu.selectedItem = _charsets[charset];
-		} else {
-			document.getElementById("charset-box").hidden = true;
+			let hidden = charsetPopup.getElementsByClassName('zotero-hidden');
+			for (let i=0; i<hidden.length; i++) {
+				hidden[i].classList.remove('zotero-hidden');
+			}
+			
+			if (translatorOptions.exportCharset) {
+				optionsBox.hidden = undefined;
+				document.getElementById("charset-box").hidden = undefined;
+				var charsetMenu = document.getElementById(OPTION_PREFIX+"exportCharset");
+				var charset = "UTF-8";
+				if(options && options.exportCharset && _charsets[options.exportCharset]) {
+					charset = options.exportCharset;
+				} else if(translatorOptions.exportCharset && _charsets[translatorOptions.exportCharset]) {
+					charset = translatorOptions.exportCharset;
+				}
+				
+				// Display recommended option at the top
+				if (translatorOptions.exportCharset && _charsets[translatorOptions.exportCharset]) {
+					let recommended = _charsets[translatorOptions.exportCharset];
+					let newNode = recommended.cloneNode();
+					newNode.setAttribute("label", Zotero.getString("charset.recommended", [recommended.getAttribute("label")]));
+					
+					newNode.classList.add('zotero-recommended');
+					recommended.classList.add('zotero-hidden');
+					
+					charsetPopup.insertBefore(newNode, charsetPopup.firstChild);
+				}
+				
+				charsetMenu.selectedItem = _charsets[charset];
+			} else {
+				document.getElementById("charset-box").hidden = true;
+			}
 		}
 		
 		window.sizeToContent();

--- a/chrome/content/zotero/exportOptions.js
+++ b/chrome/content/zotero/exportOptions.js
@@ -57,8 +57,7 @@ var Zotero_File_Interface_Export = new function() {
 		// get format popup
 		var formatPopup = document.getElementById("format-popup");
 		var formatMenu = document.getElementById("format-menu");
-		var optionsBox = document.getElementById("translator-options");
-		var charsetBox = document.getElementById("charset-box");
+		var regularOptions = document.getElementById("regular-options");
 		
 		var selectedTranslator = Zotero.Prefs.get("export.lastTranslator");
 		
@@ -85,7 +84,7 @@ var Zotero_File_Interface_Export = new function() {
 						var checkbox = document.createElement("checkbox");
 						checkbox.setAttribute("id", OPTION_PREFIX+option);
 						checkbox.setAttribute("label", optionLabel);
-						optionsBox.insertBefore(checkbox, charsetBox);
+						regularOptions.appendChild(checkbox);
 					}
 					
 					addedOptions[option] = true;
@@ -108,6 +107,7 @@ var Zotero_File_Interface_Export = new function() {
 			_charsets = Zotero_Charset_Menu.populate(document.getElementById(OPTION_PREFIX+"exportCharset"), true);
 		}
 		
+		this.toggleAdvancedOptions(false);
 		updateOptions(Zotero.Prefs.get("export.translatorSettings"));
 	}
 	
@@ -126,11 +126,12 @@ var Zotero_File_Interface_Export = new function() {
 		}
 		
 		var optionsBox = document.getElementById("translator-options");
+		var regularOptions = document.getElementById("regular-options");
 		optionsBox.hidden = true;
 		var haveOption = false;
-		for(var i=0; i<optionsBox.childNodes.length; i++) {
+		for(var i=0; i<regularOptions.childNodes.length; i++) {
 			// loop through options to see which should be enabled
-			var node = optionsBox.childNodes[i];
+			var node = regularOptions.childNodes[i];
 			// skip non-options
 			if(node.id.length <= OPTION_PREFIX.length
 					|| node.id.substr(0, OPTION_PREFIX.length) != OPTION_PREFIX) {
@@ -204,6 +205,18 @@ var Zotero_File_Interface_Export = new function() {
 			}
 		}
 		
+		// See if we need to hide advanced options
+		var hasVisible = false,
+			advOption = document.getElementById("advanced-options-togglable").firstChild;
+		while (advOption) {
+			if (!advOption.hidden) {
+				hasVisible = true;
+				break;
+			}
+			advOption = advOption.nextSibling;
+		}
+		document.getElementById("advanced-options").hidden = !hasVisible;
+		
 		window.sizeToContent();
 	}
 	
@@ -247,4 +260,17 @@ var Zotero_File_Interface_Export = new function() {
 	function cancel() {
 		window.arguments[0].selectedTranslator = false;
 	}
+	
+	/*
+	 * Show/hide advanced options
+	 * @param {Boolean} [show] If set, indicates whether the advanced
+	 *   options should be shown or not. If omitted, the options toggle
+	 */
+	this.toggleAdvancedOptions = function(show) {
+		var opts = document.getElementById("advanced-options-togglable");
+		opts.hidden = show !== undefined ? !show : !opts.hidden;
+		document.getElementById("advanced-options")
+			.setAttribute("state", opts.hidden ? "closed" : "open");
+		window.sizeToContent();
+	};
 }

--- a/chrome/content/zotero/exportOptions.xul
+++ b/chrome/content/zotero/exportOptions.xul
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
+<?xml-stylesheet href="chrome://zotero/skin/zotero.css" type="text/css"?>
 <!DOCTYPE window [
 <!ENTITY % zoteroDTD SYSTEM "chrome://zotero/locale/zotero.dtd" >
 %zoteroDTD;

--- a/chrome/content/zotero/exportOptions.xul
+++ b/chrome/content/zotero/exportOptions.xul
@@ -33,11 +33,20 @@
 		</hbox>
 		<groupbox id="translator-options">
 			<caption id="translator-options-label" label="&zotero.exportOptions.translatorOptions.label;"/>
-			
-			<vbox id="charset-box" hidden="true">
-				<separator class="thin"/>
-				<label value="&zotero.charset.label;:" control="charset-menu"/>
-				<menulist id="export-option-exportCharset"/>
+			<vbox id="regular-options">
+			</vbox>
+			<vbox id="advanced-options" class="zotero-advanced-options">
+				<hbox onclick="Zotero_File_Interface_Export.toggleAdvancedOptions()"  class="zotero-advanced-options-label">
+					<dropmarker/>
+					<label value="&zotero.exportOptions.advancedOptions.label;"/>
+				</hbox>
+				<vbox id="advanced-options-togglable">
+					<vbox id="charset-box" hidden="true">
+						<separator class="thin"/>
+						<label value="&zotero.charset.label;:" control="charset-menu"/>
+						<menulist id="export-option-exportCharset"/>
+					</vbox>
+				</vbox>
 			</vbox>
 		</groupbox>
 	</vbox>

--- a/chrome/content/zotero/preferences/preferences_export.xul
+++ b/chrome/content/zotero/preferences/preferences_export.xul
@@ -33,7 +33,6 @@
 		<preferences>
 			<preference id="pref-quickCopy-setting" name="extensions.zotero.export.quickCopy.setting" type="string"/>
 			<preference id="pref-quickCopy-dragLimit" name="extensions.zotero.export.quickCopy.dragLimit" type="int"/>
-			<preference id="pref-export-displayCharsetOption" name="extensions.zotero.export.displayCharsetOption" type="bool"/>
 			<preference id="pref-import-charset" name="extensions.zotero.import.charset" type="string"/>
 		</preferences>
 		
@@ -65,9 +64,6 @@
 		
 		<groupbox>
 			<caption label="&zotero.preferences.charset;"/>
-			
-			<checkbox id="zotero-export-displayCharsetOption" label="&zotero.preferences.charset.displayExportOption;"
-				preference="pref-export-displayCharsetOption"/>
 			
 			<hbox align="center">
 				<label value="&zotero.preferences.charset.importCharset;:" control="zotero-import-charsetMenu"/>

--- a/chrome/content/zotero/xpcom/translation/translate.js
+++ b/chrome/content/zotero/xpcom/translation/translate.js
@@ -2292,7 +2292,8 @@ Zotero.Translate.IO = {
 		}
 		
 		if(nodes.getElementsByTagName("parsererror").length) {
-			throw "DOMParser error: loading data into data store failed";
+			throw "DOMParser error: loading data into data store failed:\n"
+				+ nodes.getElementsByTagName("parsererror")[0].firstChild.textContent;
 		}
 		
 		if("normalize" in nodes) nodes.normalize();
@@ -2332,7 +2333,7 @@ Zotero.Translate.IO.String.prototype = {
 	},
 	
 	"_initRDF":function(callback) {
-		Zotero.debug("Translate: Initializing RDF data store");
+		Zotero.debug("Translate: Initializing RDF data store from string.");
 		this._dataStore = new Zotero.RDF.AJAW.IndexedFormula();
 		this.RDF = new Zotero.Translate.IO._RDFSandbox(this._dataStore);
 		

--- a/chrome/content/zotero/xpcom/translation/translate_firefox.js
+++ b/chrome/content/zotero/xpcom/translation/translate_firefox.js
@@ -746,7 +746,7 @@ Zotero.Translate.IO.Read.prototype = {
 						  .QueryInterface(Components.interfaces.nsIFileProtocolHandler);
 		var baseURI = fileHandler.getURLSpecFromFile(this.file);
 		
-		Zotero.debug("Translate: Initializing RDF data store");
+		Zotero.debug("Translate: Initializing RDF data store from file. (Character encoding: " + this._charset + ")");
 		this._dataStore = new Zotero.RDF.AJAW.IndexedFormula();
 		var parser = new Zotero.RDF.AJAW.RDFParser(this._dataStore);
 		try {
@@ -756,7 +756,7 @@ Zotero.Translate.IO.Read.prototype = {
 			this.RDF = new Zotero.Translate.IO._RDFSandbox(this._dataStore);
 		} catch(e) {
 			this.close();
-			throw "Translate: No RDF found";
+			throw "Translate: No RDF found.\n" + e;
 		}
 	},
 	

--- a/chrome/locale/en-US/zotero/preferences.dtd
+++ b/chrome/locale/en-US/zotero/preferences.dtd
@@ -175,7 +175,6 @@
 
 <!ENTITY zotero.preferences.charset							"Character Encoding">
 <!ENTITY zotero.preferences.charset.importCharset			"Import Character Encoding">
-<!ENTITY zotero.preferences.charset.displayExportOption		"Display character encoding option on export">
 
 <!ENTITY zotero.preferences.dataDir						"Data Directory Location">
 <!ENTITY zotero.preferences.dataDir.useProfile			"Use profile directory">

--- a/chrome/locale/en-US/zotero/zotero.dtd
+++ b/chrome/locale/en-US/zotero/zotero.dtd
@@ -179,6 +179,7 @@
 <!ENTITY zotero.exportOptions.title						"Export…">
 <!ENTITY zotero.exportOptions.format.label				"Format:">
 <!ENTITY zotero.exportOptions.translatorOptions.label	"Translator Options">
+<!ENTITY zotero.exportOptions.advancedOptions.label				"Advanced Options">
 
 <!ENTITY zotero.charset.label							"Character Encoding">
 <!ENTITY zotero.moreEncodings.label						"More Encodings">

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -644,8 +644,11 @@ fulltext.indexState.partial								= Partial
 exportOptions.exportNotes       = Export Notes
 exportOptions.exportFileData    = Export Files
 exportOptions.useJournalAbbreviation = Use Journal Abbreviation
-charset.UTF8withoutBOM			= Unicode (UTF-8 without BOM)
-charset.autoDetect				= (auto detect)
+charset.unicode                 = Unicode (%S)
+charset.western                 = Western (%S)
+charset.withBOM                 = %S with BOM
+charset.recommended             = %S [recommended]
+charset.autoDetect              = (auto detect)
 
 date.daySuffixes                = st, nd, rd, th
 date.abbreviation.year          = y

--- a/chrome/skin/default/zotero/zotero.css
+++ b/chrome/skin/default/zotero/zotero.css
@@ -355,3 +355,11 @@ label.zotero-text-link {
 {
 	margin: 3px 0;
 }
+
+.zotero-hidden {
+	visibility: collapse;
+}
+
+.zotero-recommended {
+	font-style: italic;
+}

--- a/chrome/skin/default/zotero/zotero.css
+++ b/chrome/skin/default/zotero/zotero.css
@@ -363,3 +363,12 @@ label.zotero-text-link {
 .zotero-recommended {
 	font-style: italic;
 }
+
+.zotero-advanced-options>.zotero-advanced-options-label>dropmarker {
+	list-style-image: url("chrome://browser/skin/toolbarbutton-dropdown-arrow.png");
+	transform: rotate(270deg);
+}
+
+.zotero-advanced-options[state=open]>.zotero-advanced-options-label>dropmarker {
+	transform: none;
+}

--- a/defaults/preferences/zotero.js
+++ b/defaults/preferences/zotero.js
@@ -100,7 +100,6 @@ pref("extensions.zotero.export.translatorSettings", 'true,false');
 pref("extensions.zotero.export.lastStyle", 'http://www.zotero.org/styles/chicago-note-bibliography');
 pref("extensions.zotero.export.bibliographySettings", 'save-as-rtf');
 pref("extensions.zotero.export.bibliographyLocale", '');
-pref("extensions.zotero.export.displayCharsetOption", false);
 pref("extensions.zotero.export.citePaperJournalArticleURL", false);
 pref("extensions.zotero.cite.automaticJournalAbbreviations", true);
 pref("extensions.zotero.import.charset", "auto");


### PR DESCRIPTION
See commits, but...
- Fixes BOM on export. There was no way to export with BOM (sort of needed for zotero/translators#742)
- Always show character encoding options in the Export dialog, but collapse them under Advanced Options
- Show the character encoding option that is recommended by the translator (e.g. CSV is better exported as UTF-8 with BOM) in case user switches to another encoding and wants to got back to default.

Here's what this looks like (no, RIS is not normally with BOM):
![Recommended character encoding](http://i.imgur.com/M4CVkbx.png)

(having second thoughts on the italics though, maybe it's too much)

Also, why aren't we showing character encoding options for all exports, even if the translator does not specify anything explicitly?
