### PR TITLE
Use Mozilla's colors for itembox and tagbox background

### DIFF
--- a/chrome/content/zotero-platform/win/overlay.css
+++ b/chrome/content/zotero-platform/win/overlay.css
@@ -90,7 +90,7 @@
 #zotero-view-item {
 	padding: 0 !important;
 	-moz-appearance: none;
-	background-color: white;
+	background-color: -moz-field;
 	border-width: 1px 0 0  1px;
 }
 

--- a/chrome/skin/default/zotero/bindings/tagselector.css
+++ b/chrome/skin/default/zotero/bindings/tagselector.css
@@ -11,7 +11,7 @@ groupbox
 	overflow-x: hidden;
 	overflow-y: auto;
 	display: block; /* allow labels to wrap instead of all being in one line */
-	background-color: white;
+	background-color: -moz-field;
 }
 
 checkbox


### PR DESCRIPTION
This way, the colors play nicely with Windows themes (e.g. high contrast)

Re https://forums.zotero.org/discussion/38870/make-zotero-fully-recognize-windowsff-high-contrast-themes/ and https://twitter.com/stuffilike2know/status/504167872567189504

Much more work to be done for accessibility though.
