### PR TITLE
Prevent empty window and tab appearance with zotero://select links

### DIFF
--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -2787,11 +2787,11 @@ var ZoteroPane = new function()
 			}
 			
 			//Special treatment for zotero links
-			if (uri.match(/(^zotero\:\/\/)((open-pdf)|(select))/)) {
-				var ioservice = Components.classes["@mozilla.org/network/io-service;1"]
+			if (uri.match(/^zotero\:\/\/(open-pdf|select)/)) {
+				let ioservice = Components.classes["@mozilla.org/network/io-service;1"]
 					  .getService(Components.interfaces.nsIIOService);
-				var zoteroLink = ioservice.newURI(uri, null, null);
-				var openZoteroLink = Components.classes["@mozilla.org/network/protocol;1?name=zotero"]
+				let zoteroLink = ioservice.newURI(uri, null, null);
+				openZoteroLink = Components.classes["@mozilla.org/network/protocol;1?name=zotero"]
 						.getService(Components.interfaces.nsIProtocolHandler).newChannel(zoteroLink);
 				return;
 			}

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -2786,6 +2786,16 @@ var ZoteroPane = new function()
 				return;
 			}
 			
+			//Special treatment for zotero links
+			if (uri.match(/(^zotero\:\/\/)((open-pdf)|(select))/)) {
+				var ioservice = Components.classes["@mozilla.org/network/io-service;1"]
+					  .getService(Components.interfaces.nsIIOService);
+				var zoteroLink = ioservice.newURI(uri, null, null);
+				var openZoteroLink = Components.classes["@mozilla.org/network/protocol;1?name=zotero"]
+						.getService(Components.interfaces.nsIProtocolHandler).newChannel(zoteroLink);
+				return;
+			}
+			
 			if (Zotero.isStandalone) {
 				if(uri.match(/^https?/)) {
 					this.launchURL(uri);


### PR DESCRIPTION
A proposed solution for issue #498 - it prevents a blank window or tab from appearing after a zotero://select or zotero://open-pdf link is opened
