### PR TITLE
Update install.rdf

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -29,5 +29,14 @@
       </Description>
     </em:targetApplication>
     
+    <!-- Palemoon -->
+    <em:targetApplication>
+      <Description>
+        <em:id>{8de7fcbb-c55c-4fbe-bfc5-fc555c87dbc4}</em:id>
+        <em:minVersion>25</em:minVersion>
+        <em:maxVersion>25.*</em:maxVersion>
+      </Description>
+    </em:targetApplication>
+    
   </Description>
 </RDF>


### PR DESCRIPTION
Add support for Palemoon 25.x browser which got a own GUID from version 25.x.

Other changes for full support might me needed, but this got zotero running for me again.

Changes to Zotero.dot for the Microsoft Word plugin are also needed, :
http://www.consumingexperience.com/2014/06/zotero-pale-moon-solve-word.html
https://forums.zotero.org/discussion/32334/word-2010-cant-find-zotero-4012-for-firefox-in-palemoon-2402x64/
