### PR TITLE
Instantate CSL processor once on drag, changing output mode on the fly

### DIFF
--- a/chrome/content/zotero/fileInterface.js
+++ b/chrome/content/zotero/fileInterface.js
@@ -419,9 +419,10 @@ var Zotero_File_Interface = new function() {
 		var clipboardService = Components.classes["@mozilla.org/widget/clipboard;1"].
 							   getService(Components.interfaces.nsIClipboard);
 		var style = Zotero.Styles.get(style);
-		
+		var cslEngine = style.getCiteProc();
+        
 		// add HTML
-		var bibliography = Zotero.Cite.makeFormattedBibliographyOrCitationList(style, items, "html", asCitations);
+ 		var bibliography = Zotero.Cite.makeFormattedBibliographyOrCitationList(cslEngine, items, "html", asCitations);
 		var str = Components.classes["@mozilla.org/supports-string;1"].
 				  createInstance(Components.interfaces.nsISupportsString);
 		str.data = bibliography;
@@ -430,7 +431,7 @@ var Zotero_File_Interface = new function() {
 		
 		// add text (or HTML source)
 		if(!asHTML) {
-			var bibliography = Zotero.Cite.makeFormattedBibliographyOrCitationList(style, items, "text", asCitations);
+			var bibliography = Zotero.Cite.makeFormattedBibliographyOrCitationList(cslEngine, items, "text", asCitations);
 		}
 		var str = Components.classes["@mozilla.org/supports-string;1"].
 				  createInstance(Components.interfaces.nsISupportsString);
@@ -516,7 +517,8 @@ var Zotero_File_Interface = new function() {
 			}
 			else {
 				var style = Zotero.Styles.get(io.style);
-				var bibliography = Zotero.Cite.makeFormattedBibliographyOrCitationList(style,
+				var cslEngine = style.getCiteProc();
+				var bibliography = Zotero.Cite.makeFormattedBibliographyOrCitationList(cslEngine,
 					items, format, io.mode === "citations");
 			}
 		} catch(e) {

--- a/chrome/content/zotero/xpcom/cite.js
+++ b/chrome/content/zotero/xpcom/cite.js
@@ -71,11 +71,10 @@ Zotero.Cite = {
 	 * @param {String} format The format of the output (html, text, or rtf)
 	 * @return {String} Bibliography or item list in specified format
 	 */
-	"makeFormattedBibliographyOrCitationList":function(style, items, format, asCitationList) {
-		var cslEngine = style.getCiteProc();
+	"makeFormattedBibliographyOrCitationList":function(cslEngine, items, format, asCitationList) {
 		cslEngine.setOutputFormat(format);
 		cslEngine.updateItems([item.id for each(item in items)]);
-				
+		 		
 		if(!asCitationList) {
 			var bibliography = Zotero.Cite.makeFormattedBibliography(cslEngine, format);
 			if(bibliography) return bibliography;

--- a/chrome/content/zotero/xpcom/quickCopy.js
+++ b/chrome/content/zotero/xpcom/quickCopy.js
@@ -337,8 +337,9 @@ Zotero.QuickCopy = new function() {
 				var text = csl.previewCitationCluster(citation, [], [], "text"); 
 			} else {
 				var style = Zotero.Styles.get(format);
-				var html = Zotero.Cite.makeFormattedBibliographyOrCitationList(style, items, "html");
-				var text = Zotero.Cite.makeFormattedBibliographyOrCitationList(style, items, "text");
+				var cslEngine = style.getCiteProc();
+ 				var html = Zotero.Cite.makeFormattedBibliographyOrCitationList(cslEngine, items, "html");
+				var text = Zotero.Cite.makeFormattedBibliographyOrCitationList(cslEngine, items, "text");
 			}
 			
 			return {text:(contentType == "html" ? html : text), html:html};


### PR DESCRIPTION
The processor is currently instantiated twice on a drag operation (or unmodified quick-copy): once for the HTML and once for the text version of the cite. With a heavy style, there can be a significant delay between the start of the drag and the highlight signalling ready-to-drop state. With this change, the processor is instantiated just once, reducing the potential delay.
