### PR TITLE
Normalize all user and translator input to NFC

### DIFF
--- a/chrome/content/zotero/bindings/tagselector.xml
+++ b/chrome/content/zotero/bindings/tagselector.xml
@@ -107,7 +107,9 @@
 				<parameter name="skipRefresh"/>
 				<body>
 				<![CDATA[
-					this._search = val ? val.toLowerCase() : false;
+					this._search = val
+						? val.toLowerCase().normalize()
+						: false;
 					
 					if (!skipRefresh) {
 						this.refresh();

--- a/chrome/content/zotero/xpcom/data/collection.js
+++ b/chrome/content/zotero/xpcom/data/collection.js
@@ -113,7 +113,7 @@ Zotero.Collection.prototype._set = function (field, val) {
 			return;
 		
 		case 'name':
-			val = Zotero.Utilities.trim(val);
+			val = Zotero.Utilities.trim(val).normalize();
 			break;
 	}
 	

--- a/chrome/content/zotero/xpcom/data/creator.js
+++ b/chrome/content/zotero/xpcom/data/creator.js
@@ -104,7 +104,7 @@ Zotero.Creator.prototype._set = function (field, val) {
 		case 'lastName':
 		case 'shortName':
 			if (val) {
-				val = Zotero.Utilities.trim(val);
+				val = Zotero.Utilities.trim(val).normalize();
 			}
 			else {
 				val = '';

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -691,7 +691,7 @@ Zotero.Item.prototype.inCollection = function(collectionID) {
  */
 Zotero.Item.prototype.setField = function(field, value, loadIn) {
 	if (typeof value == 'string') {
-		value = value.trim();
+		value = value.trim().normalize();
 	}
 	
 	this._disabledCheck();

--- a/chrome/content/zotero/xpcom/data/tag.js
+++ b/chrome/content/zotero/xpcom/data/tag.js
@@ -98,7 +98,7 @@ Zotero.Tag.prototype._set = function (field, val) {
 			return;
 		
 		case 'name':
-			val = Zotero.Utilities.trim(val);
+			val = Zotero.Utilities.trim(val).normalize();
 			break;
 	}
 	

--- a/chrome/content/zotero/xpcom/search.js
+++ b/chrome/content/zotero/xpcom/search.js
@@ -114,7 +114,7 @@ Zotero.Search.prototype._set = function (field, val) {
 			return;
 		
 		case 'name':
-			val = Zotero.Utilities.trim(val);
+			val = Zotero.Utilities.trim(val).normalize();
 			break;
 	}
 	
@@ -481,6 +481,8 @@ Zotero.Search.prototype.addCondition = function(condition, operator, value, requ
 	
 	var [condition, mode] = Zotero.SearchConditions.parseCondition(condition);
 	
+	if (typeof value == 'string') value = value.normalize();
+	
 	this._conditions[searchConditionID] = {
 		id: searchConditionID,
 		condition: condition,
@@ -519,6 +521,8 @@ Zotero.Search.prototype.updateCondition = function(searchConditionID, condition,
 	}
 	
 	var [condition, mode] = Zotero.SearchConditions.parseCondition(condition);
+	
+	if (typeof value == 'string') value = value.normalize();
 	
 	this._conditions[searchConditionID] = {
 		id: parseInt(searchConditionID),


### PR DESCRIPTION
This includes storing values into DB and performing searches.

Note that export/display of existing data is not normalized. We can try to capture all access points to the database and normalize on output, but that seems like a lot of unnecessary normalization happening all the time. Would probably be best to just normalize existing data.

I'm not sure what this will do to sync if existing data gets normalized when it syncs down. I'm actually not sure what we _want_ it to do. Should it trigger an upload of the normalized data? Should data coming from server not get normalized? (I think the latter sounds like the best option for now)
