### PR TITLE
Fix the issue that attachment can not be saved when using firefox nightly

### DIFF
--- a/chrome/content/zotero/preferences/preferences_search.js
+++ b/chrome/content/zotero/preferences/preferences_search.js
@@ -392,12 +392,19 @@ Zotero_Preferences.Search = {
 		
 		wbp.progressListener = progressListener;
 		Zotero.debug("Saving " + uri.spec + " to " + fileURL.spec);
-		try {
-			wbp.saveURI(uri, null, null, null, null, fileURL);
-		} catch(e if e.name === "NS_ERROR_XPC_NOT_ENOUGH_ARGS") {
-			// https://bugzilla.mozilla.org/show_bug.cgi?id=794602
-			// XXX Always use when we no longer support Firefox < 18
-			wbp.saveURI(uri, null, null, null, null, fileURL, null);
+		try
+		{
+			try {
+				wbp.saveURI(nsIURL, null, null, null, null, file);
+			} catch(e if e.name === "NS_ERROR_XPC_NOT_ENOUGH_ARGS") {
+				// https://bugzilla.mozilla.org/show_bug.cgi?id=794602
+				// XXX Always use when we no longer support Firefox < 18
+						wbp.saveURI(nsIURL, null, null, null, null, file, null);
+			}
+		}catch(e if e.name === "NS_ERROR_XPC_NOT_ENOUGH_ARGS") {
+			// https://bugzilla.mozilla.org/show_bug.cgi?id=704320
+			// One more parameter
+			wbp.saveURI(nsIURL, null, null, null, null, null, file, null);
 		}
 	},
 	

--- a/chrome/content/zotero/preferences/preferences_search.js
+++ b/chrome/content/zotero/preferences/preferences_search.js
@@ -392,7 +392,7 @@ Zotero_Preferences.Search = {
 		
 		wbp.progressListener = progressListener;
 		Zotero.debug("Saving " + uri.spec + " to " + fileURL.spec);
-		Zotero.Utilities.saveURI(wbp, nsIURL, file);
+		Zotero.Utilities.Internal.saveURI(wbp, nsIURL, file);
 	},
 	
 	

--- a/chrome/content/zotero/preferences/preferences_search.js
+++ b/chrome/content/zotero/preferences/preferences_search.js
@@ -392,20 +392,7 @@ Zotero_Preferences.Search = {
 		
 		wbp.progressListener = progressListener;
 		Zotero.debug("Saving " + uri.spec + " to " + fileURL.spec);
-		try
-		{
-			try {
-				wbp.saveURI(nsIURL, null, null, null, null, file);
-			} catch(e if e.name === "NS_ERROR_XPC_NOT_ENOUGH_ARGS") {
-				// https://bugzilla.mozilla.org/show_bug.cgi?id=794602
-				// XXX Always use when we no longer support Firefox < 18
-						wbp.saveURI(nsIURL, null, null, null, null, file, null);
-			}
-		}catch(e if e.name === "NS_ERROR_XPC_NOT_ENOUGH_ARGS") {
-			// https://bugzilla.mozilla.org/show_bug.cgi?id=704320
-			// One more parameter
-			wbp.saveURI(nsIURL, null, null, null, null, null, file, null);
-		}
+		Zotero.Utilities.saveURI(wbp, nsIURL, file);
 	},
 	
 	

--- a/chrome/content/zotero/webpagedump/common.js
+++ b/chrome/content/zotero/webpagedump/common.js
@@ -672,20 +672,7 @@ var wpdCommon = {
 
 			// has the url the same filetype like the file extension?
 			//save file to target
-			try
-			{
-				try {
-					wbp.saveURI(nsIURL, null, null, null, null, file);
-				} catch(e if e.name === "NS_ERROR_XPC_NOT_ENOUGH_ARGS") {
-					// https://bugzilla.mozilla.org/show_bug.cgi?id=794602
-					// XXX Always use when we no longer support Firefox < 18
-					wbp.saveURI(nsIURL, null, null, null, null, file, null);
-				}
-			}catch(e if e.name === "NS_ERROR_XPC_NOT_ENOUGH_ARGS") {
-				// https://bugzilla.mozilla.org/show_bug.cgi?id=704320
-				// One more parameter
-				wbp.saveURI(nsIURL, null, null, null, null, null, file, null);
-			}
+			Zotero.Utilities.saveURI(wbp, nsIURL, file);
 
 			return true;
 

--- a/chrome/content/zotero/webpagedump/common.js
+++ b/chrome/content/zotero/webpagedump/common.js
@@ -672,7 +672,7 @@ var wpdCommon = {
 
 			// has the url the same filetype like the file extension?
 			//save file to target
-			Zotero.Utilities.saveURI(wbp, nsIURL, file);
+			Zotero.Utilities.Internal.saveURI(wbp, nsIURL, file);
 
 			return true;
 

--- a/chrome/content/zotero/webpagedump/common.js
+++ b/chrome/content/zotero/webpagedump/common.js
@@ -672,12 +672,19 @@ var wpdCommon = {
 
 			// has the url the same filetype like the file extension?
 			//save file to target
-			try {
-				obj_Persist.saveURI(obj_URI, null, null, null, null, obj_TargetFile);
-			} catch(e if e.name === "NS_ERROR_XPC_NOT_ENOUGH_ARGS") {
-				// https://bugzilla.mozilla.org/show_bug.cgi?id=794602
-				// XXX Always use when we no longer support Firefox < 18
-				obj_Persist.saveURI(obj_URI, null, null, null, null, obj_TargetFile, null);
+			try
+			{
+				try {
+					wbp.saveURI(nsIURL, null, null, null, null, file);
+				} catch(e if e.name === "NS_ERROR_XPC_NOT_ENOUGH_ARGS") {
+					// https://bugzilla.mozilla.org/show_bug.cgi?id=794602
+					// XXX Always use when we no longer support Firefox < 18
+					wbp.saveURI(nsIURL, null, null, null, null, file, null);
+				}
+			}catch(e if e.name === "NS_ERROR_XPC_NOT_ENOUGH_ARGS") {
+				// https://bugzilla.mozilla.org/show_bug.cgi?id=704320
+				// One more parameter
+				wbp.saveURI(nsIURL, null, null, null, null, null, file, null);
 			}
 
 			return true;

--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -347,13 +347,21 @@ Zotero.Attachments = new function(){
 				var nsIURL = Components.classes["@mozilla.org/network/standard-url;1"]
 							.createInstance(Components.interfaces.nsIURL);
 				nsIURL.spec = url;
-				try {
-					wbp.saveURI(nsIURL, null, null, null, null, file);
-				} catch(e if e.name === "NS_ERROR_XPC_NOT_ENOUGH_ARGS") {
-					// https://bugzilla.mozilla.org/show_bug.cgi?id=794602
-					// XXX Always use when we no longer support Firefox < 18
-					wbp.saveURI(nsIURL, null, null, null, null, file, null);
+				try
+				{
+					try {
+						wbp.saveURI(nsIURL, null, null, null, null, file);
+					} catch(e if e.name === "NS_ERROR_XPC_NOT_ENOUGH_ARGS") {
+						// https://bugzilla.mozilla.org/show_bug.cgi?id=794602
+						// XXX Always use when we no longer support Firefox < 18
+						wbp.saveURI(nsIURL, null, null, null, null, file, null);
+					}
+				}catch(e if e.name === "NS_ERROR_XPC_NOT_ENOUGH_ARGS") {
+					// https://bugzilla.mozilla.org/show_bug.cgi?id=704320
+					// One more parameter
+					wbp.saveURI(nsIURL, null, null, null, null, null, file, null);
 				}
+
 				
 				return attachmentItem;
 			}
@@ -663,12 +671,19 @@ Zotero.Attachments = new function(){
 						throw (e);
 					}
 				});
-				try {
-					wbp.saveURI(nsIURL, null, null, null, null, file);
-				} catch(e if e.name === "NS_ERROR_XPC_NOT_ENOUGH_ARGS") {
-					// https://bugzilla.mozilla.org/show_bug.cgi?id=794602
-					// XXX Always use when we no longer support Firefox < 18
-					wbp.saveURI(nsIURL, null, null, null, null, file, null);
+				try
+				{
+					try {
+						wbp.saveURI(nsIURL, null, null, null, null, file);
+					} catch(e if e.name === "NS_ERROR_XPC_NOT_ENOUGH_ARGS") {
+						// https://bugzilla.mozilla.org/show_bug.cgi?id=794602
+						// XXX Always use when we no longer support Firefox < 18
+						wbp.saveURI(nsIURL, null, null, null, null, file, null);
+					}
+				}catch(e if e.name === "NS_ERROR_XPC_NOT_ENOUGH_ARGS") {
+					// https://bugzilla.mozilla.org/show_bug.cgi?id=704320
+					// One more parameter
+					wbp.saveURI(nsIURL, null, null, null, null, null, file, null);
 				}
 			}
 			

--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -658,7 +658,7 @@ Zotero.Attachments = new function(){
 						throw (e);
 					}
 				});
-				Zotero.Utilities.saveURI(wbp, nsIURL, file);
+				Zotero.Utilities.Internal.saveURI(wbp, nsIURL, file);
 			}
 			
 			// Add to collections

--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -347,20 +347,7 @@ Zotero.Attachments = new function(){
 				var nsIURL = Components.classes["@mozilla.org/network/standard-url;1"]
 							.createInstance(Components.interfaces.nsIURL);
 				nsIURL.spec = url;
-				try
-				{
-					try {
-						wbp.saveURI(nsIURL, null, null, null, null, file);
-					} catch(e if e.name === "NS_ERROR_XPC_NOT_ENOUGH_ARGS") {
-						// https://bugzilla.mozilla.org/show_bug.cgi?id=794602
-						// XXX Always use when we no longer support Firefox < 18
-						wbp.saveURI(nsIURL, null, null, null, null, file, null);
-					}
-				}catch(e if e.name === "NS_ERROR_XPC_NOT_ENOUGH_ARGS") {
-					// https://bugzilla.mozilla.org/show_bug.cgi?id=704320
-					// One more parameter
-					wbp.saveURI(nsIURL, null, null, null, null, null, file, null);
-				}
+				Zotero.Utilities.saveURI(wbp, nsIURL, file);
 
 				
 				return attachmentItem;
@@ -671,20 +658,7 @@ Zotero.Attachments = new function(){
 						throw (e);
 					}
 				});
-				try
-				{
-					try {
-						wbp.saveURI(nsIURL, null, null, null, null, file);
-					} catch(e if e.name === "NS_ERROR_XPC_NOT_ENOUGH_ARGS") {
-						// https://bugzilla.mozilla.org/show_bug.cgi?id=794602
-						// XXX Always use when we no longer support Firefox < 18
-						wbp.saveURI(nsIURL, null, null, null, null, file, null);
-					}
-				}catch(e if e.name === "NS_ERROR_XPC_NOT_ENOUGH_ARGS") {
-					// https://bugzilla.mozilla.org/show_bug.cgi?id=704320
-					// One more parameter
-					wbp.saveURI(nsIURL, null, null, null, null, null, file, null);
-				}
+				Zotero.Utilities.saveURI(wbp, nsIURL, file);
 			}
 			
 			// Add to collections

--- a/chrome/content/zotero/xpcom/storage/webdav.js
+++ b/chrome/content/zotero/xpcom/storage/webdav.js
@@ -963,7 +963,7 @@ Zotero.Sync.Storage.WebDAV = (function () {
 					.createInstance(nsIWBP);
 				wbp.persistFlags = nsIWBP.PERSIST_FLAGS_BYPASS_CACHE;
 				wbp.progressListener = listener;
-				Zotero.Utilities.saveURI(wbp, nsIURL, file);
+				Zotero.Utilities.Internal.saveURI(wbp, nsIURL, file);
 				
 				return deferred.promise;
 			});

--- a/chrome/content/zotero/xpcom/storage/webdav.js
+++ b/chrome/content/zotero/xpcom/storage/webdav.js
@@ -963,12 +963,19 @@ Zotero.Sync.Storage.WebDAV = (function () {
 					.createInstance(nsIWBP);
 				wbp.persistFlags = nsIWBP.PERSIST_FLAGS_BYPASS_CACHE;
 				wbp.progressListener = listener;
-				try {
-					wbp.saveURI(uri, null, null, null, null, destFile);
-				} catch(e if e.name === "NS_ERROR_XPC_NOT_ENOUGH_ARGS") {
-					// https://bugzilla.mozilla.org/show_bug.cgi?id=794602
-					// XXX Always use when we no longer support Firefox < 18
-					wbp.saveURI(uri, null, null, null, null, destFile, null);
+				try
+				{
+					try {
+						wbp.saveURI(nsIURL, null, null, null, null, file);
+					} catch(e if e.name === "NS_ERROR_XPC_NOT_ENOUGH_ARGS") {
+						// https://bugzilla.mozilla.org/show_bug.cgi?id=794602
+						// XXX Always use when we no longer support Firefox < 18
+						wbp.saveURI(nsIURL, null, null, null, null, file, null);
+					}
+				}catch(e if e.name === "NS_ERROR_XPC_NOT_ENOUGH_ARGS") {
+					// https://bugzilla.mozilla.org/show_bug.cgi?id=704320
+					// One more parameter
+					wbp.saveURI(nsIURL, null, null, null, null, null, file, null);
 				}
 				
 				return deferred.promise;

--- a/chrome/content/zotero/xpcom/storage/webdav.js
+++ b/chrome/content/zotero/xpcom/storage/webdav.js
@@ -963,20 +963,7 @@ Zotero.Sync.Storage.WebDAV = (function () {
 					.createInstance(nsIWBP);
 				wbp.persistFlags = nsIWBP.PERSIST_FLAGS_BYPASS_CACHE;
 				wbp.progressListener = listener;
-				try
-				{
-					try {
-						wbp.saveURI(nsIURL, null, null, null, null, file);
-					} catch(e if e.name === "NS_ERROR_XPC_NOT_ENOUGH_ARGS") {
-						// https://bugzilla.mozilla.org/show_bug.cgi?id=794602
-						// XXX Always use when we no longer support Firefox < 18
-						wbp.saveURI(nsIURL, null, null, null, null, file, null);
-					}
-				}catch(e if e.name === "NS_ERROR_XPC_NOT_ENOUGH_ARGS") {
-					// https://bugzilla.mozilla.org/show_bug.cgi?id=704320
-					// One more parameter
-					wbp.saveURI(nsIURL, null, null, null, null, null, file, null);
-				}
+				Zotero.Utilities.saveURI(wbp, nsIURL, file);
 				
 				return deferred.promise;
 			});

--- a/chrome/content/zotero/xpcom/storage/zfs.js
+++ b/chrome/content/zotero/xpcom/storage/zfs.js
@@ -944,12 +944,19 @@ Zotero.Sync.Storage.ZFS = (function () {
 					.createInstance(nsIWBP);
 				wbp.persistFlags = nsIWBP.PERSIST_FLAGS_BYPASS_CACHE;
 				wbp.progressListener = listener;
-				try {
-					wbp.saveURI(uri, null, null, null, null, destFile);
-				} catch(e if e.name === "NS_ERROR_XPC_NOT_ENOUGH_ARGS") {
-					// https://bugzilla.mozilla.org/show_bug.cgi?id=794602
-					// XXX Always use when we no longer support Firefox < 18
-					wbp.saveURI(uri, null, null, null, null, destFile, null);
+				try
+				{
+					try {
+						wbp.saveURI(nsIURL, null, null, null, null, file);
+					} catch(e if e.name === "NS_ERROR_XPC_NOT_ENOUGH_ARGS") {
+						// https://bugzilla.mozilla.org/show_bug.cgi?id=794602
+						// XXX Always use when we no longer support Firefox < 18
+						wbp.saveURI(nsIURL, null, null, null, null, file, null);
+					}
+				}catch(e if e.name === "NS_ERROR_XPC_NOT_ENOUGH_ARGS") {
+					// https://bugzilla.mozilla.org/show_bug.cgi?id=704320
+					// One more parameter
+					wbp.saveURI(nsIURL, null, null, null, null, null, file, null);
 				}
 				
 				return deferred.promise;

--- a/chrome/content/zotero/xpcom/storage/zfs.js
+++ b/chrome/content/zotero/xpcom/storage/zfs.js
@@ -944,7 +944,7 @@ Zotero.Sync.Storage.ZFS = (function () {
 					.createInstance(nsIWBP);
 				wbp.persistFlags = nsIWBP.PERSIST_FLAGS_BYPASS_CACHE;
 				wbp.progressListener = listener;
-				Zotero.Utilities.saveURI(wbp, nsIURL, file);
+				Zotero.Utilities.Internal.saveURI(wbp, nsIURL, file);
 				
 				return deferred.promise;
 			});

--- a/chrome/content/zotero/xpcom/storage/zfs.js
+++ b/chrome/content/zotero/xpcom/storage/zfs.js
@@ -944,20 +944,7 @@ Zotero.Sync.Storage.ZFS = (function () {
 					.createInstance(nsIWBP);
 				wbp.persistFlags = nsIWBP.PERSIST_FLAGS_BYPASS_CACHE;
 				wbp.progressListener = listener;
-				try
-				{
-					try {
-						wbp.saveURI(nsIURL, null, null, null, null, file);
-					} catch(e if e.name === "NS_ERROR_XPC_NOT_ENOUGH_ARGS") {
-						// https://bugzilla.mozilla.org/show_bug.cgi?id=794602
-						// XXX Always use when we no longer support Firefox < 18
-						wbp.saveURI(nsIURL, null, null, null, null, file, null);
-					}
-				}catch(e if e.name === "NS_ERROR_XPC_NOT_ENOUGH_ARGS") {
-					// https://bugzilla.mozilla.org/show_bug.cgi?id=704320
-					// One more parameter
-					wbp.saveURI(nsIURL, null, null, null, null, null, file, null);
-				}
+				Zotero.Utilities.saveURI(wbp, nsIURL, file);
 				
 				return deferred.promise;
 			});

--- a/chrome/content/zotero/xpcom/utilities.js
+++ b/chrome/content/zotero/xpcom/utilities.js
@@ -1783,29 +1783,7 @@ Zotero.Utilities = {
 	 * Provides unicode support and other additional features for regular expressions
 	 * See https://github.com/slevithan/xregexp for usage
 	 */
-	 "XRegExp": XRegExp,
+	 "XRegExp": XRegExp
 
-	 /**
-	 * saveURI wrapper function
-	 * @param {nsIWebBrowserPersist} nsIWebBrowserPersist
-	 * @param {nsIURI} source URL
-	 * @param {nsISupports} target file
-	 */
-	 "saveURI": function(wbp, source, target)
-	 {
-		try
-		{
-			try {
-				wbp.saveURI(source, null, null, null, null, target);
-			} catch(e if e.name === "NS_ERROR_XPC_NOT_ENOUGH_ARGS") {
-				// https://bugzilla.mozilla.org/show_bug.cgi?id=794602
-				// XXX Always use when we no longer support Firefox < 18
-				wbp.saveURI(source, null, null, null, null, target, null);
-			}
-		}catch(e if e.name === "NS_ERROR_XPC_NOT_ENOUGH_ARGS") {
-			// https://bugzilla.mozilla.org/show_bug.cgi?id=704320
-			// One more parameter
-			wbp.saveURI(source, null, null, null, null, null, target, null);
-		}
-	 }
+	 
 }

--- a/chrome/content/zotero/xpcom/utilities.js
+++ b/chrome/content/zotero/xpcom/utilities.js
@@ -1783,5 +1783,29 @@ Zotero.Utilities = {
 	 * Provides unicode support and other additional features for regular expressions
 	 * See https://github.com/slevithan/xregexp for usage
 	 */
-	 "XRegExp": XRegExp
+	 "XRegExp": XRegExp,
+
+	 /**
+	 * saveURI wrapper function
+	 * @param {nsIWebBrowserPersist} nsIWebBrowserPersist
+	 * @param {nsIURI} source URL
+	 * @param {nsISupports} target file
+	 */
+	 "saveURI": function(wbp, source, target)
+	 {
+		try
+		{
+			try {
+				wbp.saveURI(source, null, null, null, null, target);
+			} catch(e if e.name === "NS_ERROR_XPC_NOT_ENOUGH_ARGS") {
+				// https://bugzilla.mozilla.org/show_bug.cgi?id=794602
+				// XXX Always use when we no longer support Firefox < 18
+				wbp.saveURI(source, null, null, null, null, target, null);
+			}
+		}catch(e if e.name === "NS_ERROR_XPC_NOT_ENOUGH_ARGS") {
+			// https://bugzilla.mozilla.org/show_bug.cgi?id=704320
+			// One more parameter
+			wbp.saveURI(source, null, null, null, null, null, target, null);
+		}
+	 }
 }

--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -469,5 +469,21 @@ Zotero.Utilities.Internal.Base64 = {
 		 }
 		 
 		 return string;
-	 }
+	 },
+	/**
+	 * saveURI wrapper function
+	 * @param {nsIWebBrowserPersist} nsIWebBrowserPersist
+	 * @param {nsIURI} source URL
+	 * @param {nsISupports} target file
+	 */
+	saveURI: function (wbp, source, target) {
+   		// Firefox 35 and below
+		try {
+			wbp.saveURI(source, null, null, null, null, target, null);
+		}
+		// Firefox 36+ needs one more parameter
+		catch (e if e.name === "NS_ERROR_XPC_NOT_ENOUGH_ARGS") {
+			wbp.saveURI(source, null, null, null, null, null, target, null);
+		}
+	}
  }


### PR DESCRIPTION
Firefox introduces a new parameter on nsIWebBrowserPersist.saveURI function.
The attach function is broken due to that change.