### PR TITLE
Disable ZSA ping from bookmarklet in non-IE browsers

### DIFF
--- a/chrome/content/zotero/xpcom/connector/connector.js
+++ b/chrome/content/zotero/xpcom/connector/connector.js
@@ -35,8 +35,20 @@ Zotero.Connector = new function() {
 	 * @param {Function} callback
 	 */
 	this.checkIsOnline = function(callback) {
+		// As of Chrome 38 (and corresponding Opera version 24?) pages loaded over
+		// https (i.e. the zotero bookmarklet iframe) can not send requests over
+		// http, so pinging Standalone at http://127.0.0.1 fails.
+		// Disable for all browsers, except IE, which may be used frequently with ZSA
+		if(Zotero.isBookmarklet && !Zotero.isIE) {
+			callback(false);
+			return;
+		}
+		
 		// Only check once in bookmarklet
-		if(Zotero.isBookmarklet && this.isOnline !== null) callback(this.isOnline);
+		if(Zotero.isBookmarklet && this.isOnline !== null) {
+			callback(this.isOnline);
+			return;
+		}
 		
 		if(Zotero.isIE) {
 			if(window.location.protocol !== "http:") {


### PR DESCRIPTION
This means that bookmarklet will only save to server.
