### PR TITLE
Fix duplicate matching when ISBN is non-sensical

### DIFF
--- a/chrome/content/zotero/xpcom/duplicates.js
+++ b/chrome/content/zotero/xpcom/duplicates.js
@@ -170,7 +170,9 @@ Zotero.Duplicates.prototype._findDuplicates = function () {
 				}
 				// If no comparison function, check for exact match
 				else {
-					if (rows[i].value !== rows[j].value) {
+					if (!rows[i].value || !rows[j].value
+						|| (rows[i].value !== rows[j].value)
+					) {
 						break;
 					}
 				}
@@ -205,8 +207,8 @@ Zotero.Duplicates.prototype._findDuplicates = function () {
 	var isbnCache = {};
 	if (rows) {
 		for each(var row in rows) {
-			row.value = (row.value+'').replace(/[^\dX]+/ig, '').toUpperCase(); //ignore formatting
-			isbnCache[row.itemID] = row.value;
+			row.value = Zotero.Utilities.cleanISBN('' + row.value);
+			if (row.value) isbnCache[row.itemID] = row.value;
 		}
 		rows.sort(sortByValue);
 		processRows();


### PR DESCRIPTION
Re https://forums.zotero.org/discussion/43046/items-mistakenly-identified-as-duplicates/
