### PR TITLE
Allow meta redirects when running web translator tests

### DIFF
--- a/chrome/content/zotero/tools/testTranslators/translatorTester.js
+++ b/chrome/content/zotero/tools/testTranslators/translatorTester.js
@@ -319,7 +319,7 @@ Zotero_TranslatorTester.prototype._runTestsRecursively = function(testDoneCallba
 	var testNumber = this.tests.length-this.pending.length;
 	var me = this;
 	
-	this._debug(this, "\nTranslatorTester: Running "+this.translator.label+" Test "+testNumber);
+	this._debug(this, "TranslatorTester: Running "+this.translator.label+" Test "+testNumber);
 	
 	var executedCallback = false;
 	var callback = function(obj, test, status, message) {

--- a/chrome/content/zotero/tools/testTranslators/translatorTester.js
+++ b/chrome/content/zotero/tools/testTranslators/translatorTester.js
@@ -195,6 +195,8 @@ Zotero_TranslatorTester = function(translator, type, debugCallback) {
 	}
 };
 
+Zotero_TranslatorTester.DEFER_DELAY = 30000; // Delay for deferred tests
+
 /**
  * Removes document objects, which contain cyclic references, and other fields to be ignored from items
  * @param {Object} Item, in the format returned by Zotero.Item.serialize()
@@ -374,7 +376,14 @@ Zotero_TranslatorTester.prototype.fetchPageAndRunTest = function(test, testDoneC
 	var hiddenBrowser = Zotero.HTTP.processDocuments(test.url,
 		function(doc) {
 			if(test.defer) {
-				Zotero.setTimeout(function() { runTest(doc) }, 30000, true);
+				me._debug(this, "TranslatorTesting: Waiting "
+					+ (Zotero_TranslatorTester.DEFER_DELAY/1000)
+					+ " second(s) for page content to settle"
+				);
+				Zotero.setTimeout(
+					function() {runTest(hiddenBrowser.contentDocument) },
+					Zotero_TranslatorTester.DEFER_DELAY, true
+				);
 			} else {
 				runTest(doc);
 			}
@@ -385,6 +394,8 @@ Zotero_TranslatorTester.prototype.fetchPageAndRunTest = function(test, testDoneC
 		},
 		true
 	);
+	
+	hiddenBrowser.docShell.allowMetaRedirects = true;
 };
 
 /**


### PR DESCRIPTION
This is necessary to have functional tests for websites that redirect where a URL-based session ID has expired. E.g. http://www.bdsl-online.de/BDSL-DB/suche/Titelaufnahme.xml?vid={D620881E-7697-40A8-BF2C-4E898FD12362}&erg=0&Anzeige=10&Sprache=de&contenttype=text/html&Skript=titelaufnahme&Publikation_ID=028514998

See zotero/translators#821