### PR TITLE
Fix for OpenURL 0.1 resolver detection

### DIFF
--- a/chrome/content/zotero/xpcom/openurl.js
+++ b/chrome/content/zotero/xpcom/openurl.js
@@ -74,7 +74,7 @@ Zotero.OpenURL = new function() {
 			
 			if(resolver.getElementsByTagName("Z39.88-2004").length > 0) {
 				var version = "1.0";
-			} else if(resolver.getElementsByTagName("OpenUrl 0.1").length > 0) {
+			} else if(resolver.getElementsByTagName("OpenURL_0.1").length > 0) {
 				var version = "0.1";
 			} else {
 				continue;


### PR DESCRIPTION
The discoverResolvers function was looking for the wrong XML tag name representing OpenURL version 0.1 in the response from the WorldCat Registry