### PR TITLE
Allow MAX_PAGES (for retrieving metadata) to be user-adjustable

### DIFF
--- a/chrome/content/zotero/recognizePDF.js
+++ b/chrome/content/zotero/recognizePDF.js
@@ -70,7 +70,7 @@ var Zotero_RecognizePDF = new function() {
 	 * @return {Promise} A promise resolved when PDF metadata has been retrieved
 	 */
 	this.recognize = function(file, libraryID, stopCheckCallback) {
-		const MAX_PAGES = 7;
+		const MAX_PAGES = 15;
 		var me = this;
 		
 		return _extractText(file, MAX_PAGES).then(function(lines) {


### PR DESCRIPTION
Re https://forums.zotero.org/discussion/45641/error-getting-metadata/#Item_10

I don't really see a reason not to do this. We could also consider bumping the default to 15 right away.