### PR TITLE
Allow file paths to be specified in attachment.url

### DIFF
--- a/chrome/content/zotero/xpcom/translation/translate.js
+++ b/chrome/content/zotero/xpcom/translation/translate.js
@@ -631,6 +631,13 @@ Zotero.Translate.Sandbox = {
 				
 				for(var i=0; i<item.attachments.length; i++) {
 					var attachment = item.attachments[i];
+					
+					// Web translators are not allowed to use attachment.path
+					if (attachment.path) {
+						if (!attachment.url) attachment.url = attachment.path;
+						delete attachment.path;
+					}
+					
 					if(attachment.url) {
 						// Remap attachment (but not link) URLs
 						attachment.url = translate.resolveURL(attachment.url, attachment.snapshot === false);

--- a/chrome/content/zotero/xpcom/translation/translate_item.js
+++ b/chrome/content/zotero/xpcom/translation/translate_item.js
@@ -229,25 +229,25 @@ Zotero.Translate.ItemSaver.prototype = {
 		if(!attachment.path) {
 			let url = Zotero.Attachments.cleanAttachmentURI(attachment.url);
 			if (!url) {
-				let e = "Translate: Invalid attachment URL specified <" + attachment.url + ">";
-				Zotero.debug(e, 2);
-				attachmentCallback(attachment, false, e);
-				return false;
-			}
-			attachment.url = url;
-			url = Components.classes["@mozilla.org/network/io-service;1"]
-				.getService(Components.interfaces.nsIIOService)
-				.newURI(url, null, null); // This cannot fail, since we check above
-			
-			// see if this is actually a file URL
-			if(url.scheme == "file") {
+				Zotero.debug("Translate: Invalid attachment.url specified <" + attachment.url + "> Will attempt to treat it as path.");
 				attachment.path = attachment.url;
 				attachment.url = false;
-			} else if(url.scheme != "http" && url.scheme != "https") {
-				let e = "Translate: " + url.scheme + " protocol is not allowed for attachments from translators.";
-				Zotero.debug(e, 2);
-				attachmentCallback(attachment, false, e);
-				return false;
+			} else {
+				attachment.url = url;
+				url = Components.classes["@mozilla.org/network/io-service;1"]
+					.getService(Components.interfaces.nsIIOService)
+					.newURI(url, null, null); // This cannot fail, since we check above
+				
+				// see if this is actually a file URL
+				if(url.scheme == "file") {
+					attachment.path = attachment.url;
+					attachment.url = false;
+				} else if(url.scheme != "http" && url.scheme != "https") {
+					let e = "Translate: " + url.scheme + " protocol is not allowed for attachments from translators.";
+					Zotero.debug(e, 2);
+					attachmentCallback(attachment, false, e);
+					return false;
+				}
 			}
 		}
 		
@@ -268,7 +268,12 @@ Zotero.Translate.ItemSaver.prototype = {
 			var newItem = Zotero.Items.get(myID);
 		} else {
 			var file = this._parsePath(attachment.path);
-			if(!file) return;
+			if(!file) {
+				let e = "Translate: Could not parse attachment path <" + attachment.path + ">";
+				Zotero.debug(e, 2);
+				attachmentCallback(attachment, false, e);
+				return false;
+			}
 			
 			if (attachment.url) {
 				attachment.linkMode = "imported_url";


### PR DESCRIPTION
In import translators, it may not always be clear whether the given URI is a URL or a local file path. I'm a little concerned that this may open up some security hole (by, hypothetically, allowing web translators and, thus, web pages to attach files located throughout the file system) since we use `attachment.url` in a lot of translators and we would pay more attention to translators using `attachment.path`, but (1) translators can already use file: protocol via URL (2) I'm not really sure how useful such attack would be since Zotero copies files and whether there is really any vulnerability here. Maybe we should limit attachment.path use to import translators called directly (not by web translators)

Regression from 849803473a0386aacc86745466d56f0ff3463f48 (that piece of code was introduced by me)

Re https://forums.zotero.org/discussion/45710/ris-import-from-endnote-mac-yosemite-to-zotero-standalone/