### PR TITLE
Disable expand/collapse shortcuts in coll. tree when in-line editing

### DIFF
--- a/chrome/content/zotero/xpcom/collectionTreeView.js
+++ b/chrome/content/zotero/xpcom/collectionTreeView.js
@@ -73,6 +73,8 @@ Zotero.CollectionTreeView.prototype.setTree = function(treebox)
 	var self = this;
 	
 	tree.addEventListener('keypress', function(event) {
+		if (tree.editingRow != -1) return; // In-line editing active
+		
 		var key = String.fromCharCode(event.which);
 		
 		if (key == '+' && !(event.ctrlKey || event.altKey || event.metaKey)) {


### PR DESCRIPTION
Re https://forums.zotero.org/discussion/46259/report-id-295014583/ and I think some others