### PR TITLE
Don't proxify proxied hosts

### DIFF
--- a/chrome/content/zotero/xpcom/connector/translator.js
+++ b/chrome/content/zotero/xpcom/connector/translator.js
@@ -203,7 +203,7 @@ Zotero.Translators = new function() {
 					} else {
 						// in Firefox, push the converterFunction
 						converterFunctions.push(new function() {
-							var re = new RegExp('^https?://(?:[^/]\\.)?'+Zotero.Utilities.quotemeta(properHosts[j-1]), "gi");
+							var re = new RegExp('^https?://(?:[^/]\\.)?'+Zotero.Utilities.quotemeta(properHosts[j-1])+'/', "gi");
 							var proxyHost = proxyHosts[j-1].replace(/\$/g, "$$$$");
 							return function(uri) { return uri.replace(re, "$&."+proxyHost) };
 						});


### PR DESCRIPTION
Re https://forums.zotero.org/discussion/45778/bug-isi-web-of-knowledge-records-are-not-saved-but-refs-citing-them-are/

Proxied URIs in Firefox in connector mode  were getting double-proxied.