### PR TITLE
Reserve height in div for CSL Editor buttons

### DIFF
--- a/chrome/content/zotero/tools/csledit.xul
+++ b/chrome/content/zotero/tools/csledit.xul
@@ -41,7 +41,7 @@
 	<script src="csledit.js"/>
 	
 	<vbox flex="1">
-		<hbox align="center">
+		<hbox id="zotero-csl-button-bar" align="center">
 			<button id="preview-refresh-button" label="&zotero.general.refresh;" oncommand="Zotero_CSL_Editor.refresh()"/>
 			<button id="zotero-csl-save" label="&zotero.general.saveAs;" oncommand="Zotero_CSL_Editor.save()"/>
 			<menulist id="zotero-csl-page-type" style="min-height: 1.6em; min-width: 50px" oncommand="Zotero_CSL_Editor.refresh()" />

--- a/chrome/skin/default/zotero/zotero.css
+++ b/chrome/skin/default/zotero/zotero.css
@@ -357,3 +357,8 @@ label.zotero-text-link {
 	width: 29.5em;
 	max-width: 29.5em;
 }
+
+#zotero-csl-button-bar
+{
+	min-height: 2.4em;
+}


### PR DESCRIPTION
The new CSL Editor looks great - thanks to @rmzelle for putting it all together.

One tiny nit that I just stumbled across is that (under Linux, at least) the buttons get a bit squashed when the style/preview divider is drawn up to completely obscure the style code. This change reserves space in the hbox containing the buttons so they can retain their natural height.

(I hope I've gotten my branching weirdness sorted out this time!)