### PR TITLE
Discard redundant tags in translator tester

### DIFF
--- a/chrome/content/zotero/tools/testTranslators/translatorTester.js
+++ b/chrome/content/zotero/tools/testTranslators/translatorTester.js
@@ -257,7 +257,9 @@ Zotero_TranslatorTester._sanitizeItem = function(item, testItem, keepValidFields
 	if(!keepValidFields && "accessDate" in item) delete item.accessDate;
 
 	//sort tags, if they're still there
-	if(item.tags && typeof item.tags === "object" && "sort" in item.tags) item.tags.sort();
+	if(item.tags && typeof item.tags === "object" && "sort" in item.tags) {
+		item.tags = Zotero.Utilities.arrayUnique(item.tags).sort();
+	}
 	
 	return item;
 };


### PR DESCRIPTION
Zotero would discard these anyway when writing to DB. So this makes for more appropriate test cases