### PR TITLE
Stop monitoring cookies once all sandboxes are done

### DIFF
--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -2679,6 +2679,11 @@ Zotero.Browser = new function() {
 		if(!(myBrowsers instanceof Array)) myBrowsers = [myBrowsers];
 		for(var i=0; i<myBrowsers.length; i++) {
 			var myBrowser = myBrowsers[i];
+			
+			// Browsers take a while to get GC'ed. Drop it from cookie tracking so
+			// we can stop observing cookie-related events faster
+			Zotero.CookieSandbox.Observer.dropBrowser(myBrowser);
+			
 			myBrowser.stop();
 			myBrowser.destroy();
 			myBrowser.parentNode.removeChild(myBrowser);


### PR DESCRIPTION
Currently, after importing from Connectors (into Standalone or Firefox), we never stop monitoring cookie-related events. This shouldn't be a big issue, since we're not supposed to be touching unrelated channels anyway, but there's also no reason to keep doing it. It also pollutes the debug log unnecessarily.
