### PR TITLE
Restore settings (tag colors) to server

### DIFF
--- a/chrome/content/zotero/xpcom/sync.js
+++ b/chrome/content/zotero/xpcom/sync.js
@@ -1924,6 +1924,9 @@ Zotero.Sync.Server = new function () {
 		sql = "INSERT INTO version VALUES ('syncdeletelog', ?)";
 		Zotero.DB.query(sql, Zotero.Date.getUnixTimestamp());
 		
+		var sql = "UPDATE syncedSettings SET synced=0";
+		Zotero.DB.query(sql);
+		
 		Zotero.DB.commitTransaction();
 	}
 	


### PR DESCRIPTION
If the local data is to be resotres to the zotero server,
the settings like tag colors also need to be synced again.