### PR TITLE
Don't return incomplete documents for HTTP.processDocuments

### DIFF
--- a/chrome/content/zotero/xpcom/progressWindow.js
+++ b/chrome/content/zotero/xpcom/progressWindow.js
@@ -138,7 +138,7 @@ Zotero.ProgressWindow = function(_window){
 		
 		if (_window) {
 			_progressWindow = _window.openDialog("chrome://zotero/content/progressWindow.xul",
-				"", "chrome,dialog=no,titlebar=no,popup=yes");
+				"", "chrome,dialog=no,titlebar=no,popup=yes,dependent=yes");
 		}
 		else {
 			_progressWindow = ww.openWindow(null, "chrome://zotero/content/progressWindow.xul",


### PR DESCRIPTION
@adam3smith emailed me about an issue with Aleph translator. On https://aleph.univie.ac.at a `ZU.processDocuments` call to retrieve MARC metadata was returning an incomplete page (only a few META elements from the HEAD). The processDocuments call was accompanied by the following message in the Browser console:

> The page was reloaded, because the character encoding declaration of the HTML document was not found when prescanning the first 1024 bytes of the file. The encoding declaration needs to be moved to be within the first 1024 bytes of the file.

So, what was happening was that the page was being loaded, the loading was stopped (firing a `pageshow` event, but not the `load` event), and Zotero was returning the incomplete document to translator (just past the META element with charset declaration).

This patch takes advantage to the `load` event not being fired in these cases to detect incomplete page loads. However, as commented [here](https://bugzilla.mozilla.org/show_bug.cgi?id=420025#c31) the same behavior is obtained for network errors (don't think these were being handled anyway), so we introduce some additional checks for those cases.
