### PR TITLE
Add an option to not show the proxy redirection notification

### DIFF
--- a/chrome/content/zotero/preferences/preferences_firefox.xul
+++ b/chrome/content/zotero/preferences/preferences_firefox.xul
@@ -50,6 +50,8 @@
 			<vbox style="margin-left: 1em">
 				<checkbox id="zotero-proxies-autoRecognize" label="&zotero.preferences.proxies.autoRecognize;"
 					command="zotero-proxies-update"/>
+				<checkbox id="zotero-proxies-showRedirectNotification" label="&zotero.preferences.proxies.showRedirectNotification;"
+					command="zotero-proxies-update"/>
 				<hbox style="display: block; line-height: 1.75em">
 					<checkbox id="zotero-proxies-disableByDomain-checkbox"
 						label="&zotero.preferences.proxies.disableByDomain;"

--- a/chrome/content/zotero/preferences/preferences_proxies.js
+++ b/chrome/content/zotero/preferences/preferences_proxies.js
@@ -40,6 +40,7 @@ Zotero_Preferences.Proxies = {
 		var transparent = document.getElementById('zotero-proxies-transparent').checked;
 		Zotero.Prefs.set("proxies.transparent", transparent);
 		Zotero.Prefs.set("proxies.autoRecognize", document.getElementById('zotero-proxies-autoRecognize').checked);	
+		Zotero.Prefs.set("proxies.showRedirectNotification", document.getElementById('zotero-proxies-showRedirectNotification').checked);
 		Zotero.Prefs.set("proxies.disableByDomainString", document.getElementById('zotero-proxies-disableByDomain-textbox').value);
 		Zotero.Prefs.set("proxies.disableByDomain", document.getElementById('zotero-proxies-disableByDomain-checkbox').checked &&
 				document.getElementById('zotero-proxies-disableByDomain-textbox').value != "");
@@ -50,8 +51,10 @@ Zotero_Preferences.Proxies = {
 			document.getElementById('proxyTree-delete').disabled =
 			document.getElementById('proxyTree').disabled = 
 			document.getElementById('zotero-proxies-autoRecognize').disabled = 
+			document.getElementById('zotero-proxies-showRedirectNotification').disabled = 
 			document.getElementById('zotero-proxies-disableByDomain-checkbox').disabled = 
-			document.getElementById('zotero-proxies-disableByDomain-textbox').disabled = !transparent;
+			document.getElementById('zotero-proxies-disableByDomain-textbox').disabled = 
+			!transparent;
 	},
 	
 	
@@ -141,6 +144,7 @@ Zotero_Preferences.Proxies = {
 		document.getElementById('proxyTree-delete').disabled = true;
 		document.getElementById('zotero-proxies-transparent').checked = Zotero.Prefs.get("proxies.transparent");
 		document.getElementById('zotero-proxies-autoRecognize').checked = Zotero.Prefs.get("proxies.autoRecognize");
+		document.getElementById('zotero-proxies-showRedirectNotification').checked = Zotero.Prefs.get("proxies.showRedirectNotification");
 		document.getElementById('zotero-proxies-disableByDomain-checkbox').checked = Zotero.Prefs.get("proxies.disableByDomain");
 		document.getElementById('zotero-proxies-disableByDomain-textbox').value = Zotero.Prefs.get("proxies.disableByDomainString");
 	}

--- a/chrome/locale/en-US/zotero/preferences.dtd
+++ b/chrome/locale/en-US/zotero/preferences.dtd
@@ -144,6 +144,7 @@
 <!ENTITY zotero.preferences.proxies.desc_after_link 		"for more information.">
 <!ENTITY zotero.preferences.proxies.transparent				"Enable proxy redirection">
 <!ENTITY zotero.preferences.proxies.autoRecognize			"Automatically recognize proxied resources">
+<!ENTITY zotero.preferences.proxies.showRedirectNotification			"Show notification when redirecting through a proxy">
 <!ENTITY zotero.preferences.proxies.disableByDomain			"Disable proxy redirection when my domain name contains ">
 <!ENTITY zotero.preferences.proxies.configured				"Configured Proxies">
 <!ENTITY zotero.preferences.proxies.hostname				"Hostname">

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -55,6 +55,7 @@ general.numMore                    = %S more…
 general.openPreferences				= Open Preferences
 general.keys.ctrlShift				= Ctrl+Shift+
 general.keys.cmdShift				= Cmd+Shift+
+general.dontShowAgain = Don’t Show Again
 
 general.operationInProgress = A Zotero operation is currently in progress.
 general.operationInProgress.waitUntilFinished = Please wait until it has finished.

--- a/defaults/preferences/zotero.js
+++ b/defaults/preferences/zotero.js
@@ -154,6 +154,7 @@ pref("extensions.zotero.proxies.autoRecognize", true);
 pref("extensions.zotero.proxies.transparent", true);
 pref("extensions.zotero.proxies.disableByDomain", false);
 pref("extensions.zotero.proxies.disableByDomainString", ".edu");
+pref("extensions.zotero.proxies.showRedirectNotification", true);
 
 // Data layer purging
 pref("extensions.zotero.purge.creators", false);


### PR DESCRIPTION
I find that the notification you get when Zotero automatically redirects you through a proxy to get a little annoying, especially when I'm opening a bunch of tabs from Google Scholar or the like. 

Unfortunately, I only speak English, so locale translations are a bit lacking in variety. 