### PR TITLE
Localize Word Processors tab in Preferences

### DIFF
--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -565,6 +565,17 @@ zotero.preferences.export.quickCopy.bibStyles				= Bibliographic Styles
 zotero.preferences.export.quickCopy.exportFormats			= Export Formats
 zotero.preferences.export.quickCopy.instructions			= Quick Copy allows you to copy selected items to the clipboard by pressing %S or dragging items into a text box on a web page.
 zotero.preferences.export.quickCopy.citationInstructions  = For bibliography styles, you can copy citations or footnotes by pressing %S or holding down Shift before dragging items.
+
+zotero.preferences.wordProcessors.installationSuccess		= Installation was successful.
+zotero.preferences.wordProcessors.installationError			= Installation could not be completed because an error occurred. Please ensure that %1$S is closed, and then restart %2$S.
+zotero.preferences.wordProcessors.installed					= The %S add-in is currently installed.
+zotero.preferences.wordProcessors.notInstalled				= The %S add-in is not currently installed.
+zotero.preferences.wordProcessors.install					= Install %S Add-in
+zotero.preferences.wordProcessors.reinstall					= Reinstall %S Add-in
+zotero.preferences.wordProcessors.installing				= Installing %S…
+zotero.preferences.wordProcessors.incompatibleVersions1		= %1$S %2$S is incompatible with versions of %3$S before %4$S. Please remove %3$S, or download the latest version from %5$S.
+zotero.preferences.wordProcessors.incompatibleVersions2		= %1$S %2$S requires %3$S %4$S or later to run. Please download the latest version of %3$S from %5$S.
+
 zotero.preferences.styles.addStyle							= Add Style
 
 zotero.preferences.advanced.resetTranslatorsAndStyles					= Reset Translators and Styles


### PR DESCRIPTION
Fixes #426: this allows the localization of the Word Processors Add-in button and messages displayed in the Prefs, under the "Word Processors" tab. These strings were previously hardcoded in the integration plugins.