### PR TITLE
Making splitter and grippy more visible if collapsed

### DIFF
--- a/chrome/content/zotero/zoteroPane.xul
+++ b/chrome/content/zotero/zoteroPane.xul
@@ -329,7 +329,7 @@
 				</vbox>
 				
 				<splitter id="zotero-collections-splitter" resizebefore="closest" resizeafter="closest" collapse="before"
-					zotero-persist="state"
+					zotero-persist="state" tooltiptext="Resize left pane"
 					onmousemove="document.getElementById('zotero-items-toolbar').setAttribute('state', this.getAttribute('state'));ZoteroPane_Local.updateToolbarPosition();"
 					oncommand="ZoteroPane_Local.updateToolbarPosition()">
 					<grippy id="zotero-collections-grippy"/>
@@ -538,7 +538,7 @@
 					</deck>
 				</vbox>
 				
-				<splitter id="zotero-items-splitter" resizebefore="closest" resizeafter="closest" collapse="after" zotero-persist="state"
+				<splitter id="zotero-items-splitter" resizebefore="closest" resizeafter="closest" collapse="after" zotero-persist="state" tooltiptext="Resize right pane"
 					onmousemove="ZoteroPane_Local.updateToolbarPosition()"
 					oncommand="ZoteroPane_Local.updateToolbarPosition()">
 					<grippy id="zotero-items-grippy"/>

--- a/chrome/skin/default/zotero/overlay.css
+++ b/chrome/skin/default/zotero/overlay.css
@@ -48,6 +48,17 @@
 	height: .25em;
 }*/
 
+#zotero-pane splitter[state="collapsed"] > grippy
+{
+	width: 14px;
+	background-position: 50% 50%;
+}
+
+#zotero-pane splitter[state="collapsed"]
+{
+	width: 20px;
+}
+
 #zotero-pane splitter
 {
 	border: 0;


### PR DESCRIPTION
I am trying to respond to the frequent question in the forum when the right pane is collapsed. My idea is to 
 * add tooltip on splitters (always showing up)
 * double the size of the splitter if collapsed
 * double the size of the grippy and center it if splitter is collapsed

![splitter-styling](https://cloud.githubusercontent.com/assets/5199995/6698666/f72793ea-ccfa-11e4-9f6e-941e220eb1de.jpg)
Let me know what you think about the approach. I guess the actual coding would need to be improved (different css, use localized strings for tooltips, ...).