### PR TITLE
Add Firefox Beta for Travis-CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,22 @@ language: cpp
 compiler:
     - gcc
 env:
-    matrix:
-        - FIREFOXVERSION="36.0.1"
-        - FIREFOXVERSION="31.5.0esr"
+    - FX_PATH_SUFFIX=""
+    - FX_PATH_SUFFIX="-esr"
+    - FX_PATH_SUFFIX="-beta"
+#    - FX_PATH_SUFFIX="-prior-esr"
+matrix:
+    fast_finish: true
+    allow_failures:
+        - env: FX_PATH_SUFFIX="-beta"
+        - env: FX_PATH_SUFFIX="-prior-esr"
 notifications:
     email: false
-before_install:
+install:
+    - wget -r -l1 -np -nd -R "index.html*" "http://ftp.mozilla.org/pub/mozilla.org/firefox/releases/latest${FX_PATH_SUFFIX}/linux-x86_64/en-US/?F=0&P=*.tar.*"
+    - tar -xf firefox-*.tar.*
+before_script:
     - export DISPLAY=:99.0
     - sh -e /etc/init.d/xvfb start
-    - wget http://ftp.mozilla.org/pub/firefox/releases/${FIREFOXVERSION}/linux-x86_64/en-US/firefox-${FIREFOXVERSION}.tar.bz2
-    - tar -xjf firefox-${FIREFOXVERSION}.tar.bz2
 script:
     - test/runtests.sh -x firefox/firefox

--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -210,6 +210,7 @@ Components.utils.import("resource://gre/modules/Services.jsm");
 		
 		if (options) {
 			if (options.openPane) this.openPane = true;
+			if (options.noUserInput) this.noUserInput = true;
 		}
 		
 		this.mainThread = Components.classes["@mozilla.org/thread-manager;1"].getService().mainThread;

--- a/components/zotero-service.js
+++ b/components/zotero-service.js
@@ -447,6 +447,10 @@ ZoteroCommandLineHandler.prototype = {
 				}
 			}
 		}
+		
+		if (cmdLine.handleFlag("ZoteroNoUserInput", false)) {
+			zInitOptions.noUserInput = true;
+		}
 	},
 	
 	contractID: "@mozilla.org/commandlinehandler/general-startup;1?type=zotero",

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -77,9 +77,13 @@ user_pref("extensions.zotero.firstRunGuidance", false);
 user_pref("extensions.zotero.firstRun2", false);
 EOF
 
-
+# -v flag on Windows makes Firefox process hang
 if [ -z $IS_CYGWIN ]; then
 	echo "`MOZ_NO_REMOTE=1 NO_EM_RESTART=1 \"$FX_EXECUTABLE\" -v`"
+fi
+
+if [ "$TRAVIS" = true ]; then
+	FX_ARGS="$FX_ARGS --ZoteroNoUserInput"
 fi
 
 makePath FX_PROFILE "$PROFILE"

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -77,6 +77,11 @@ user_pref("extensions.zotero.firstRunGuidance", false);
 user_pref("extensions.zotero.firstRun2", false);
 EOF
 
+
+if [ -z $IS_CYGWIN ]; then
+	echo "`MOZ_NO_REMOTE=1 NO_EM_RESTART=1 \"$FX_EXECUTABLE\" -v`"
+fi
+
 makePath FX_PROFILE "$PROFILE"
 MOZ_NO_REMOTE=1 NO_EM_RESTART=1 "$FX_EXECUTABLE" -profile "$FX_PROFILE" \
     -chrome chrome://zotero-unit/content/runtests.html -test "$TESTS" $FX_ARGS

--- a/test/tests/recognizePDF.js
+++ b/test/tests/recognizePDF.js
@@ -38,6 +38,8 @@ describe("PDF Recognition", function() {
 	});
 
 	it("should recognize a PDF without a DOI", function() {
+		if (Zotero.noUserInput) this.skip(); // CAPTCHAs make this fail
+		
 		this.timeout(30000);
 		// Import the PDF
 		var testdir = getTestDataDirectory();


### PR DESCRIPTION
Also makes it unnecessary to adjust Firefox version numbers for each release

Disables recognizePDF test for PDFs with no DOIs, because I think they start failing due to GS captcha. It probably clears up once there are no recent commits.