### PR TITLE
More informative error messages for failed file loads

### DIFF
--- a/components/zotero-service.js
+++ b/components/zotero-service.js
@@ -328,8 +328,10 @@ function ZoteroService() {
 		
 		zContext.Zotero.debug("Initialized in "+(Date.now() - start)+" ms");
 	} catch(e) {
-		var msg = typeof e == 'string' ? e : e.name;
-		dump(e + "\n\n");
+		var msg = e instanceof Error
+			? e.name + ': ' + e.message + '\n' + e.fileName + ':' + e.lineNumber + '\n' + e.stack
+			: '' + e;
+		dump(msg + '\n');
 		Components.utils.reportError(e);
 		throw e;
 	}


### PR DESCRIPTION
This is the format that's being output on Mac already when `dump`ing Error objects
```
SyntaxError: expected expression, got '}'
chrome://zotero/content/xpcom/http.js:982
makeZoteroContext@file:///C:/Users/Aurimas/Desktop/dev/zotero/components/zotero-service.js:254:4
ZoteroService@file:///C:/Users/Aurimas/Desktop/dev/zotero/components/zotero-service.js:311:4
XPCOMUtils__getFactory/factory.createInstance@resource://gre/modules/XPCOMUtils.jsm:292:19
@chrome://zotero/content/include.js:1:14
```