### PR TITLE
Map from baseID to item type fieldID in itemToCSLJSON

### DIFF
--- a/chrome/content/zotero/xpcom/utilities.js
+++ b/chrome/content/zotero/xpcom/utilities.js
@@ -1549,10 +1549,10 @@ Zotero.Utilities = {
 					value = zoteroItem[field];
 				} else {
 					var fieldID = Zotero.ItemFields.getID(field),
-						baseMapping;
-					if(Zotero.ItemFields.isValidForType(fieldID, itemTypeID)
-							&& (baseMapping = Zotero.ItemFields.getBaseIDFromTypeAndField(itemTypeID, fieldID))) {
-						value = zoteroItem[Zotero.ItemTypes.getName(baseMapping)];
+						fieldMapping;
+					if((fieldMapping = Zotero.ItemFields.getFieldIDFromTypeAndBase(itemTypeID, fieldID))
+							&& Zotero.ItemFields.isValidForType(fieldMapping, itemTypeID)){
+						value = zoteroItem[Zotero.ItemFields.getName(fieldMapping)];
 					}
 				}
 				


### PR DESCRIPTION
While testing new code for legal support in MLZ in a branch based on current 4.0, I found that base-named fields (caseName, reporterVolume, firstPage) were not coming through to the processor. On inspection, it seems that are a couple of problems in `itemToCSLJSON()`.

**`ItemFields.getName()`**

The call to `getName()` at line 1555 should be from `Zotero.ItemFields` to get a fieldID.

**`getFieldIDFromTypeAndBase()`**

* From `item.toArray()`, we get a JS object with the item-specific mapped field names as keys.
* In `CSL_TEXT_MAPPINGS`, base names are used for the Zotero-side field mappings.

To use `CSL_TEXT_MAPPINGS` against the object we get from `item.toArray()`, we need to map from the base name to the item type's field name, not the other way around. This pull request runs the mapping in that direction, and the base-named fields come through.

I haven't tested in Zotero proper, and if I've missed something please forgive the traffic; but from reading the code, this looks right.