### PR TITLE
Add DOI-field context-menu

### DIFF
--- a/chrome/content/zotero/bindings/itembox.xml
+++ b/chrome/content/zotero/bindings/itembox.xml
@@ -413,6 +413,13 @@
 								label.setAttribute("isButton", true);
 								label.setAttribute("onclick", "ZoteroPane_Local.loadURI('" + doi + "', event)");
 								label.setAttribute("tooltiptext", Zotero.getString('locate.online.tooltip'));
+								valueElement.setAttribute('contextmenu', 'zotero-doi-menu');
+								
+								var openURLMenuItem = document.getElementById('zotero-doi-menu-view-online');
+								openURLMenuItem.setAttribute("oncommand", "ZoteroPane_Local.loadURI('" + doi + "', event)");
+								
+								var copyMenuItem = document.getElementById('zotero-doi-menu-copy');
+								copyMenuItem.setAttribute("oncommand", "Zotero.Utilities.Internal.copyTextToClipboard('" + doi + "')");
 							}
 						}
 						else if (fieldName == 'abstractNote') {
@@ -2478,6 +2485,10 @@
 							return !hideTransforms;">
 						<menuitem label="&zotero.item.creatorTransform.nameSwap;"
 							oncommand="document.getBindingParent(this).swapNames();"/>
+					</menupopup>
+					<menupopup id="zotero-doi-menu">
+						<menuitem id="zotero-doi-menu-view-online" label="&zotero.item.viewOnline;"/>
+						<menuitem id="zotero-doi-menu-copy" label="&zotero.item.copyAsURL;"/>
 					</menupopup>
 					<zoteroguidancepanel id="zotero-author-guidance" about="authorMenu" position="after_end" x="-25"/>
 				</popupset>

--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -30,6 +30,16 @@
  * @class Utility functions not made available to translators
  */
 Zotero.Utilities.Internal = {
+	
+	/**
+	 * Unicode normalization
+	 */
+	"copyTextToClipboard":function(str) {
+		Components.classes["@mozilla.org/widget/clipboardhelper;1"]
+			.getService(Components.interfaces.nsIClipboardHelper)
+			.copyString(str);
+	},
+	
 	 /*
 	 * Adapted from http://developer.mozilla.org/en/docs/nsICryptoHash
 	 *

--- a/chrome/locale/en-US/zotero/zotero.dtd
+++ b/chrome/locale/en-US/zotero/zotero.dtd
@@ -126,6 +126,8 @@
 <!ENTITY zotero.item.textTransform.titlecase			"Title Case">
 <!ENTITY zotero.item.textTransform.sentencecase			"Sentence case">
 <!ENTITY zotero.item.creatorTransform.nameSwap      	"Swap First/Last Names">
+<!ENTITY zotero.item.viewOnline							"View Online">
+<!ENTITY zotero.item.copyAsURL							"Copy as URL">
 
 <!ENTITY zotero.toolbar.newNote				"New Note">
 <!ENTITY zotero.toolbar.note.standalone				"New Standalone Note">


### PR DESCRIPTION
I tried my hand at https://github.com/zotero/zotero/issues/295.

The "Open in Browser" function works, but my attempt to add a "Copy" function failed, and I was wondering if I could get some help. I found the incantation:

```
Components.classes["@mozilla.org/widget/clipboardhelper;1"]
                      .getService(Components.interfaces.nsIClipboardHelper)
                      .copyString("testString");
```

in fileInterface.js, but using it directly via my menuitem's `oncommand` breaks the code. Anything I'm missing?