### PR TITLE
Add Edit button for site-specific Quick Copy settings

### DIFF
--- a/chrome/content/zotero/preferences/preferences_export.js
+++ b/chrome/content/zotero/preferences/preferences_export.js
@@ -145,6 +145,21 @@ Zotero_Preferences.Export = {
 		checkbox.disabled = mode != 'bibliography';
 	},
 	
+	/**
+	 * Disables UI buttons when no site-specific quick copy entries are selected
+	 */
+	disableQuickCopySiteButtons: function () {
+		document.getElementById('quickCopy-edit').disabled = true;
+		document.getElementById('quickCopy-delete').disabled = true;
+	},
+	
+	/**
+	 * Enables UI buttons when a site-specific quick copy entry is selected
+	 */
+	enableQuickCopySiteButtons: function () {
+		document.getElementById('quickCopy-edit').disabled = false;
+		document.getElementById('quickCopy-delete').disabled = false;
+	},
 	
 	showQuickCopySiteEditor: function (index) {
 		var treechildren = document.getElementById('quickCopy-siteSettings-rows');
@@ -212,6 +227,8 @@ Zotero_Preferences.Export = {
 			treeitem.appendChild(treerow);
 			treechildren.appendChild(treeitem);
 		}
+		
+		this.disableQuickCopySiteButtons();
 	},
 	
 	

--- a/chrome/content/zotero/preferences/preferences_export_firefox.xul
+++ b/chrome/content/zotero/preferences/preferences_export_firefox.xul
@@ -23,7 +23,10 @@
     
     ***** END LICENSE BLOCK *****
 -->
-<!DOCTYPE prefwindow SYSTEM "chrome://zotero/locale/preferences.dtd">
+<!DOCTYPE prefwindow [
+	<!ENTITY % preferencesDTD SYSTEM "chrome://zotero/locale/preferences.dtd"> %preferencesDTD;
+	<!ENTITY % zoteroDTD SYSTEM "chrome://zotero/locale/zotero.dtd"> %zoteroDTD;
+]>
 
 <overlay xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
 	<prefpane id="zotero-prefpane-export">
@@ -34,6 +37,7 @@
 				<label value="&zotero.preferences.quickCopy.siteEditor.setings;" control="quickCopy-siteSettings"/>
 				<tree flex="1" id="quickCopy-siteSettings" hidecolumnpicker="true" rows="6" seltype="single"
 						ondblclick="Zotero_Preferences.Export.showQuickCopySiteEditor(this.currentIndex)"
+						onselect="Zotero_Preferences.Export.enableQuickCopySiteButtons()"
 						onkeypress="if (event.keyCode == event.DOM_VK_DELETE) { Zotero_Preferences.Export.deleteSelectedQuickCopySite(); }">
 					<treecols>
 						<treecol id="quickCopy-urlColumn" label="&zotero.preferences.quickCopy.siteEditor.domainPath;" flex="1"/>
@@ -43,9 +47,13 @@
 					<treechildren id="quickCopy-siteSettings-rows"/>
 				</tree>
 				<separator class="thin"/>
-				<hbox pack="end">
-					<button label="-" onclick="Zotero_Preferences.Export.deleteSelectedQuickCopySite()"/>
-					<button label="+" onclick="Zotero_Preferences.Export.showQuickCopySiteEditor()"/>
+				<hbox>
+					<button disabled="true" id="quickCopy-edit" label="&zotero.general.edit;"
+						onclick="Zotero_Preferences.Export.showQuickCopySiteEditor(document.getElementById('quickCopy-siteSettings').currentIndex)"/>
+					<spacer flex="1"/>
+					<button disabled="true" id="quickCopy-delete" label="-" onclick="Zotero_Preferences.Export.deleteSelectedQuickCopySite()"/>
+					<button label="+"
+						onclick="Zotero_Preferences.Export.showQuickCopySiteEditor()"/>
 				</hbox>
 			</vbox>
 		</groupbox>


### PR DESCRIPTION
Adds an Edit button to the site-specific Quick Copy settings, and adds enabling/disabling logic for the Edit button and the existing "minus"/delete button.

Similar to #715 (would also close #265).