### PR TITLE
Add basic tests for fulltext search

### DIFF
--- a/test/content/support.js
+++ b/test/content/support.js
@@ -242,3 +242,16 @@ function resetDB() {
 		return Zotero.Schema.schemaUpdatePromise;
 	});
 }
+
+
+/**
+ * Imports an attachment from a test file.
+ * @param {string} filename - The filename to import (in data directory)
+ * @return {Promise<Zotero.Item>}
+ */
+function importFileAttachment(filename) {
+	let testfile = getTestDataDirectory();
+	filename.split('/').forEach((part) => testfile.append(part));
+	return Zotero.Attachments.importFromFile({file: testfile});
+}
+

--- a/test/tests/data/search/foo.html
+++ b/test/tests/data/search/foo.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>hello</title>
+  </head>
+  <body>
+    <p>foo</p>
+  </body>
+</html>

--- a/test/tests/data/search/foobar.html
+++ b/test/tests/data/search/foobar.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>hello</title>
+  </head>
+  <body>
+    <p>foo bar</p>
+  </body>
+</html>


### PR DESCRIPTION
- also add withImportedAttachmentFromFile support function

I finally got these basics search tests to work with async. I am trying to establish a baseline of search tests so that sqlite fts has something to compare to.