### PR TITLE
Simplification of stableStringify()

### DIFF
--- a/test/content/support.js
+++ b/test/content/support.js
@@ -202,39 +202,18 @@ function resetDB() {
  * Equivalent to JSON.stringify, except that object properties are stringified
  * in a sorted order.
  */
-function stableStringify(obj, level, label) {
-	if (!level) level = 0;
-	let indent = '\t'.repeat(level);
-	
-	if (label) label = JSON.stringify('' + label) + ': ';
-	else label = '';
-	
-	if (typeof obj == 'function' || obj === undefined) return null;
-	
-	if (typeof obj != 'object' || obj === null) return indent + label + JSON.stringify(obj);
-	
-	if (Array.isArray(obj)) {
-		let str = indent + label + '[';
-		for (let i=0; i<obj.length; i++) {
-			let json = stableStringify(obj[i], level + 1);
-			if (json === null) json = indent + '\tnull'; // function
-			str += '\n' + json + (i < obj.length-1 ? ',' : '');
+function stableStringify(obj) {
+	return JSON.stringify(obj, function(k, v) {
+		if (v && typeof v == "object" && !Array.isArray(v)) {
+			let o = {},
+			    keys = Object.keys(v).sort();
+			for (let i = 0; i < keys.length; i++) {
+				o[keys[i]] = v[keys[i]];
+			}
+			return o;
 		}
-		return str + (obj.length ? '\n' + indent : '') + ']';
-	}
-	
-	let keys = Object.keys(obj).sort(),
-		empty = true,
-		str = indent + label + '{';
-	for (let i=0; i<keys.length; i++) {
-		let json = stableStringify(obj[keys[i]], level + 1, keys[i]);
-		if (json === null) continue; // function
-		
-		empty = false;
-		str += '\n' + json + (i < keys.length-1 ? ',' : '');
-	}
-	
-	return str + (!empty ? '\n' + indent : '') + '}';
+		return v;
+	}, "\t");
 }
 
 /**


### PR DESCRIPTION
I wrote this for MLZ debugging before I noticed that a `stableStringify()` function was already in place. It uses a replacer function on `JSON.stringify()` itself, and produces the same output. Upside is that it's easier to read, and guaranteed to track the behavior of the native stringifier. Downside is that it touches the object itself; but as far as I can tell, the refactored object is identical in JS terms.

(I posted a caution on this earlier, but it was a false alarm - nothing is lost in the refactored object.)