### PR TITLE
Check if attempting to use a legacy generator function in Mocha tests

### DIFF
--- a/test/content/runtests.js
+++ b/test/content/runtests.js
@@ -138,7 +138,7 @@ function Reporter(runner) {
 	});
 }
 
-// Monkey-patch Mocha to check instanceof Error using compartent-local
+// Monkey-patch Mocha to check instanceof Error using compartment-local
 // Error object
 Mocha.Runner.prototype.fail = function(test, err){
 	++this.failures;
@@ -168,6 +168,8 @@ mocha.setup({
 	Runnable.prototype.run = function (fn) {
 		if (this.fn.constructor.name === 'GeneratorFunction') {
 			this.fn = Zotero.Promise.coroutine(this.fn);
+		} else if (typeof this.fn == 'function' && this.fn.isGenerator()) {
+			throw new Error("Attempting to use a legacy generator in Mocha test");
 		}
 		return run.call(this, fn);
 	};

--- a/test/tests/itemTest.js
+++ b/test/tests/itemTest.js
@@ -1,17 +1,17 @@
 describe("Zotero.Item", function () {
 	describe("#getField()", function () {
-		it("should return false for valid unset fields on unsaved items", function* () {
+		it("should return false for valid unset fields on unsaved items", function () {
 			var item = new Zotero.Item('book');
 			assert.equal(item.getField('rights'), false);
 		});
 		
-		it("should return false for valid unset fields on unsaved items after setting on another field", function* () {
+		it("should return false for valid unset fields on unsaved items after setting on another field", function () {
 			var item = new Zotero.Item('book');
 			item.setField('title', 'foo');
 			assert.equal(item.getField('rights'), false);
 		});
 		
-		it("should return false for invalid unset fields on unsaved items after setting on another field", function* () {
+		it("should return false for invalid unset fields on unsaved items after setting on another field", function () {
 			var item = new Zotero.Item('book');
 			item.setField('title', 'foo');
 			assert.equal(item.getField('invalid'), false);
@@ -19,7 +19,7 @@ describe("Zotero.Item", function () {
 	});
 	
 	describe("#setField", function () {
-		it("should throw an error if item type isn't set", function* () {
+		it("should throw an error if item type isn't set", function () {
 			var item = new Zotero.Item;
 			assert.throws(item.setField.bind(item, 'title', 'test'), "Item type must be set before setting field data");
 		})
@@ -31,7 +31,7 @@ describe("Zotero.Item", function () {
 			assert.ok(item.hasChanged());
 		})
 		
-		it("should clear an existing field set to a falsy value", function () {
+		it("should clear an existing field set to a falsy value", function* () {
 			var field = 'title';
 			var fieldID = Zotero.ItemFields.getID(field);
 			var item = new Zotero.Item('book');
@@ -76,7 +76,7 @@ describe("Zotero.Item", function () {
 			assert.equal(item.version, 1);
 		});
 		
-		it("should save versionNumber for computerProgram", function () {
+		it("should save versionNumber for computerProgram", function* () {
 			var item = new Zotero.Item('computerProgram');
 			item.setField("versionNumber", "1.0");
 			var id = yield item.saveTx();


### PR DESCRIPTION
Since we don't wrap those in `Zotero.Promise.coroutine`, which means that they never end up running. Alternatively we could wrap them, but there's no reason we should be using these (and no one uses them on purpose)

I'm thinking that there should also be a way to throw or warn if `assert` is never invoked during a test, but I haven't figured out how to do that yet.