### PR TITLE
Use Zotero.Item.fromJSON() for saving from attachments

### DIFF
--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -105,6 +105,7 @@ user_pref("extensions.zotero.debug.time", $DEBUG);
 user_pref("extensions.zotero.firstRunGuidance", false);
 user_pref("extensions.zotero.firstRun2", false);
 user_pref("extensions.zotero.reportTranslationFailure", false);
+user_pref("extensions.zotero.httpServer.enabled", true);
 EOF
 
 # -v flag on Windows makes Firefox process hang

--- a/test/tests/data/snapshot/index.html
+++ b/test/tests/data/snapshot/index.html
@@ -1,0 +1,16 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
+
+
+<meta name="wpd_version" content="0.2">
+<meta name="wpd_baseurl" content="http://209.141.35.188/">
+<meta name="wpd_url" content="http://209.141.35.188/">
+<meta name="wpd_date" content="2015-05-05T00:06Z">
+</head>
+<body><h1>It works!</h1>
+<p>This is the default web page for this server.</p>
+<p>The web server software is running but no content has been added, yet.</p>
+
+</body>
+</html>


### PR DESCRIPTION
Also:
  - Move some canonicalization of items returned by translators to `Zotero.Translate`
  - Make `Zotero.Translate#translate` return a promise
  - Add tests

Fixes #735, #736

Now implemented:
  - [x] Tests for standalone notes
  - [x] Tests for saving attachments
  - [x] Tests for saving collections
  - [x] Tests for appropriate tag behavior when saving from a web translator