### PR TITLE
Attachment proxy fixes

### DIFF
--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -201,7 +201,7 @@ Zotero.Attachments = new function(){
 	
 	function importFromURL(url, sourceItemID, forceTitle, forceFileBaseName, parentCollectionIDs,
 			mimeType, libraryID, callback, cookieSandbox) {
-		Zotero.debug('Importing attachment from URL');
+		Zotero.debug('Importing attachment from URL ' + url);
 		
 		if (sourceItemID && parentCollectionIDs) {
 			var msg = "parentCollectionIDs is ignored when sourceItemID is set in Zotero.Attachments.importFromURL()";

--- a/chrome/content/zotero/xpcom/translation/translator.js
+++ b/chrome/content/zotero/xpcom/translation/translator.js
@@ -254,7 +254,7 @@ Zotero.Translators = new function() {
 						}
 					} else {
 						converterFunctions.push(new function() {
-							var re = new RegExp('^https?://(?:[^/]\\.)?'+Zotero.Utilities.quotemeta(properHosts[j-1]), "gi");
+							var re = new RegExp('^https?://(?:[^/]+\\.)?'+Zotero.Utilities.quotemeta(properHosts[j-1]+'/'), "gi");
 							var proxyHost = proxyHosts[j-1].replace(/\$/g, "$$$$");
 							return function(uri) { return uri.replace(re, "$&."+proxyHost) };
 						});


### PR DESCRIPTION
Seems like this should have been detected much earlier. It appears that attachment downloads from proxied pages in Firefox should have been broken since 7f7fe90ad5fc21502fb1ab2e84f793628cd9892d

The second commit doesn't really have much impact, so we can remove it for now, until #578 (probably for 5.0 release)