### PR TITLE
Always save snapshots in UTF-8 encoding

### DIFF
--- a/chrome/content/zotero/webpagedump/domsaver.js
+++ b/chrome/content/zotero/webpagedump/domsaver.js
@@ -199,7 +199,7 @@ var wpdDOMSaver = {
 			// Changed by Dan for Zotero
 			"script": true, // no scripts
 
-			"encodeUTF8": false, // write the DOM Tree as UTF-8 and change the charset entry of the document
+			"encodeUTF8": true, // write the DOM Tree as UTF-8 and change the charset entry of the document
 			"metainfo": true, // include meta tags with URL and date/time information
 			"metacharset": false // if the meta charset is defined inside html override document charset
 			//"xtagging"    : true      // include a x tag around each word

--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -540,7 +540,7 @@ Zotero.Attachments = new function(){
 			mimeType = "application/pdf";
 		}
 		
-		var charsetID = Zotero.CharacterSets.getID(document.characterSet);
+		var charsetID = Zotero.CharacterSets.getID('utf-8'); // WPD will output UTF-8
 		
 		if (!forceTitle) {
 			// Remove e.g. " - Scaled (-17%)" from end of images saved from links,


### PR DESCRIPTION
Re https://forums.zotero.org/discussion/49897/thecreate-web-page-item-from-current-pageis-sometimes-not-working-correctly/

There is something wrong with the way `nsIScriptableUnicodeConverter` converts to gbk (maybe other formats too). The HTML of http://www.cmiw.cn/forum.php is truncated in the middle of an em tag. In general, `ConvertFromUnicode` is supposed to return an `ACString` (not `AString`), which is not something that JavaScript can handle well.