### PR TITLE
Allows the replacement of multiple spaces in the platform name

### DIFF
--- a/chrome/content/zotero/xpcom/fulltext.js
+++ b/chrome/content/zotero/xpcom/fulltext.js
@@ -109,7 +109,7 @@ Zotero.Fulltext = new function(){
 		this.decoder = Components.classes["@mozilla.org/intl/utf8converterservice;1"].
 			getService(Components.interfaces.nsIUTF8ConverterService);
 
-		var platform = Zotero.platform.replace(' ', '-');
+		var platform = Zotero.platform.split(' ').join('-');
 		_pdfConverterFileName = this.pdfConverterName + '-' + platform;
 		_pdfInfoFileName = this.pdfInfoName + '-' + platform;
 		if (Zotero.isWin) {


### PR DESCRIPTION
On linux 64bit with a 32bit version of firefox:
 ```javascript
Zotero.platform.replace(" ", "-")
```

replaces only the first occurence of " ", which makes zotero unable to detect the presence of PDFtools installed manually.

With:

 ```javascript
Zotero.platform.split(' ').join('-')
``` 

all spaces are replaced and Zotero can detect the presence of PDFtools.