### PR TITLE
Add possibility to save as webpage also when translators are available

### DIFF
--- a/chrome/content/zotero/browser.js
+++ b/chrome/content/zotero/browser.js
@@ -537,6 +537,16 @@ var Zotero_Browser = new function() {
 				_constructLookupFunction(tab, function(e, obj) {
 					Zotero_LocateMenu.locateItem(e, obj.newItems);
 				}), true);
+				
+			menuitem = document.createElement("menuitem");
+			menuitem.setAttribute("label", "Save to Zotero as Web Page (with snapshot)");
+			menuitem.setAttribute("class", "menuitem-iconic");
+			menuitem.addEventListener("command", function (event) {
+				ZoteroPane.addItemFromPage('temporaryPDFHack', !Zotero.Prefs.get('automaticSnapshots') );
+				event.stopPropagation();
+			}); 
+			popup.appendChild(menuitem);
+			
 		}
 		else {
 			let webPageIcon = tab.getCaptureIcon(Zotero.hiDPI);


### PR DESCRIPTION
This is an attempt to resolve #644 

![zotero-web-page-save](https://cloud.githubusercontent.com/assets/5199995/8398057/fd539826-1de1-11e5-908a-7d925b14f7e8.jpg)
