### PR TITLE
Allow re-using file names when saving translators

### DIFF
--- a/test/tests/translateTest.js
+++ b/test/tests/translateTest.js
@@ -14,7 +14,7 @@ function buildDummyTranslator(translatorType, code) {
 		"priority":100,
 		"browserSupport":"g",
 		"inRepository":false,
-		"lastUpdated":"0000-00-00 00:00:00",
+		"lastUpdated":"0000-00-00 00:00:00"
 	};
 	let translator = new Zotero.Translator(info);
 	translator.code = code;
@@ -47,7 +47,7 @@ function saveItemsThroughTranslator(translatorType, items) {
 	translate.setTranslator(buildDummyTranslator(translatorType == "web" ? 4 : 1,
 		"function detectWeb() {}\n"+
 		"function do"+tyname+"() {\n"+
-		"	var json = JSON.parse('"+JSON.stringify(items).replace(/'/g, "\'")+"');\n"+
+		"	var json = JSON.parse('"+JSON.stringify(items).replace(/'/g, "\\'")+"');\n"+
 		"	for (var i=0; i<json.length; i++) {"+
 		"		var item = new Zotero.Item;\n"+
 		"		for (var field in json[i]) { item[field] = json[i][field]; }\n"+

--- a/test/tests/translateTest.js
+++ b/test/tests/translateTest.js
@@ -47,7 +47,7 @@ function saveItemsThroughTranslator(translatorType, items) {
 	translate.setTranslator(buildDummyTranslator(translatorType == "web" ? 4 : 1,
 		"function detectWeb() {}\n"+
 		"function do"+tyname+"() {\n"+
-		"	var json = JSON.parse('"+JSON.stringify(items).replace(/'/g, "\\'")+"');\n"+
+		"	var json = JSON.parse('"+JSON.stringify(items).replace(/['\\]/g, "\\$&")+"');\n"+
 		"	for (var i=0; i<json.length; i++) {"+
 		"		var item = new Zotero.Item;\n"+
 		"		for (var field in json[i]) { item[field] = json[i][field]; }\n"+


### PR DESCRIPTION
This is mostly for Scaffold, where saving a translator where the label doesn't match file name (e.g. some cyrillic names) would instead create a new file.

Also fixes some translator saving logic in general and some escaping issues in Zotero.Translate tests.

If the general idea of this PR is ok, I'll add unit tests.
