### PR TITLE
Resolve symbolic links when importing attachments

### DIFF
--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -3114,8 +3114,8 @@ Zotero.Item.prototype.relinkAttachmentFile = function(file, skipItemUpdate) {
 		throw('Cannot relink linked URL in Zotero.Items.relinkAttachmentFile()');
 	}
 	
-	if (file.leafName.endsWith(".lnk")) {
-		throw new Error("Cannot relink to Windows shortcut");
+	if (file.isSymlink()) {
+		file = Zotero.File.getTargetFile(file);
 	}
 	
 	var newName = Zotero.File.getValidFileName(file.leafName);

--- a/chrome/content/zotero/xpcom/file.js
+++ b/chrome/content/zotero/xpcom/file.js
@@ -693,4 +693,24 @@ Zotero.File = new function(){
 		
 		throw (e);
 	}
+	
+	/**
+	 * Get reference to file pointed to by shortcut/symbolic link
+	 * @param {nsILocalFile} file
+	 * @return {nsILocalFile} Target file
+	 */
+	this.getTargetFile = function(file) {
+		if (!file.isSymlink()) return file;
+		
+		var followLinks = file.followLinks; // So we can restore it
+		var newFile = Components.classes["@mozilla.org/file/local;1"]
+			.createInstance(Components.interfaces.nsILocalFile);
+		
+		file.followLinks = true;
+		newFile.initWithPath(file.target);
+		
+		newFile.followLinks = file.followLinks = followLinks;
+		
+		return newFile;
+	}
 }

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -3117,16 +3117,10 @@ var ZoteroPane = new function()
 				var file = files.getNext();
 				file.QueryInterface(Components.interfaces.nsILocalFile);
 				var attachmentID;
-				if(link)
+				if(link) {
 					attachmentID = Zotero.Attachments.linkFromFile(file, id);
+				}
 				else {
-					if (file.leafName.endsWith(".lnk")) {
-						let wm = Components.classes["@mozilla.org/appshell/window-mediator;1"]
-						.getService(Components.interfaces.nsIWindowMediator);
-						let win = wm.getMostRecentWindow("navigator:browser");
-						win.ZoteroPane.displayCannotAddShortcutMessage(file.path);
-						continue;
-					}
 					attachmentID = Zotero.Attachments.importFromFile(file, id, libraryID);
 				}
 			
@@ -3768,17 +3762,6 @@ var ZoteroPane = new function()
 		ps.alert(null, "", Zotero.getString('save.error.cannotAddFilesToCollection'));
 	}
 	
-	
-	// TODO: Figure out a functioning way to get the original path and just copy the real file
-	this.displayCannotAddShortcutMessage = function (path) {
-		Zotero.alert(
-			null,
-			Zotero.getString("general.error"),
-			Zotero.getString("file.error.cannotAddShortcut") + (path ? "\n\n" + path : "")
-		);
-	}
-	
-	
 	function showAttachmentNotFoundDialog(itemID, noLocate) {
 		var ps = Components.classes["@mozilla.org/embedcomp/prompt-service;1"].
 				createInstance(Components.interfaces.nsIPromptService);
@@ -3996,12 +3979,6 @@ var ZoteroPane = new function()
 				// Disallow hidden files
 				// TODO: Display a message
 				if (file.leafName.startsWith('.')) {
-					continue;
-				}
-				
-				// Disallow Windows shortcuts
-				if (file.leafName.endsWith(".lnk")) {
-					this.displayCannotAddShortcutMessage(file.path);
 					continue;
 				}
 				

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -594,6 +594,8 @@ zotero.preferences.advanced.debug.error = An error occurred sending debug output
 
 dragAndDrop.existingFiles = The following files already existed in the destination directory and were not copied:
 dragAndDrop.filesNotFound = The following files were not found and could not be copied:
+dragAndDrop.invalidLink.title = File Not Found
+dragAndDrop.invalidLink.text = The following file shortcut points to a non-existent file and cannot be imported: \n\n%S
 
 fileInterface.itemsImported		= Importing items…
 fileInterface.itemsExported		= Exporting items…

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -967,7 +967,6 @@ file.accessError.message.windows	= Check that the file is not currently in use, 
 file.accessError.message.other		= Check that the file is not currently in use and that its permissions allow write access.
 file.accessError.restart			= Restarting your computer or disabling security software may also help.
 file.accessError.showParentDir		= Show Parent Directory
-file.error.cannotAddShortcut       = Shortcut files cannot be added directly. Please select the original file.
 
 lookup.failure.title				= Lookup Failed
 lookup.failure.description			= Zotero could not find a record for the specified identifier. Please verify the identifier and try again.


### PR DESCRIPTION
Follow-up to dfb28ff3f675157b7ef2a6c4fe92320f2f81cc38

The trick to getting `.target` to work was setting `.followLinks` to `true`, which is somewhat silly given the purpose of `.target`
