### PR TITLE
Add more debug logging for RecognizePDF

### DIFF
--- a/chrome/content/zotero/recognizePDF.js
+++ b/chrome/content/zotero/recognizePDF.js
@@ -724,7 +724,10 @@ var Zotero_RecognizePDF = new function() {
 				throw new Zotero.Exception.Alert('recognizePDF.stopped');
 			}
 			
+			Zotero.debug("RecognizePDF: (" + xmlhttp.status + ") Got page with title " + xmlhttp.response.title);
+			
 			if(Zotero.Utilities.xpath(xmlhttp.response, "//form[@action='Captcha']").length) {
+				Zotero.debug("RecognizePDF: Found CAPTCHA on page.");
 				return _solveCaptcha(xmlhttp, tries);
 			}
 			return xmlhttp;
@@ -744,19 +747,24 @@ var Zotero_RecognizePDF = new function() {
 				throw new Zotero.Exception.Alert('recognizePDF.stopped');
 			}
 			
+			Zotero.debug("RecognizePDF: Checking for CAPTCHA on Google Scholar error page (" + e.status + ")");
+			
 			// Check for captcha on error page
 			if(e instanceof Zotero.HTTP.UnexpectedStatusException
 				&& (e.status == 403 || e.status == 503) && e.xmlhttp.response) {
 				if(_extractCaptchaFormData(e.xmlhttp.response)) {
+					Zotero.debug("RecognizePDF: CAPTCHA found");
 					return _solveCaptcha(e.xmlhttp, tries);
 				} else if(!dontClearCookies && e.xmlhttp.channel) { // Make sure we can obtain original URL
 					// AFAICT, for 403 errors, GS just says "sorry, try later",
 					// but if you clear cookies, you get a CAPTCHA
+					Zotero.debug("RecognizePDF: No CAPTCHA detected on page. Clearing cookies.");
 					if(!_clearGSCookies(e.xmlhttp.channel.originalURI.host)) {
 						//user said no or no cookies removed
 						throw new Zotero.Exception.Alert('recognizePDF.limit');
 					}
 					// Redo GET request
+					Zotero.debug("RecognizePDF: Reloading page after clearing cookies.");
 					return Zotero.HTTP.promise("GET", e.xmlhttp.channel.originalURI.spec, {"responseType":"document"})
 						.then(function(xmlhttp) {
 							return _checkCaptchaOK(xmlhttp, tries);
@@ -811,6 +819,7 @@ var Zotero_RecognizePDF = new function() {
 				throw new Zotero.Exception.Alert('recognizePDF.limit');
 			}
 			
+			Zotero.debug('RecognizePDF: User entered "' + io.dataOut.captcha + '" for CAPTCHA');
 			formData.input.captcha = io.dataOut.captcha;
 			var url = '', prop;
 			for(prop in formData.input) {


### PR DESCRIPTION
Should be helpful to track down why users get locked out.

So far, I've seen that clearing all cookies presents you with a new sort of CAPTCHA, which we don't account for. That should result in "No metadata found" messages. I forgot to look at the DOM the first time I got it and I haven't been able to reproduce it since, but I'll keep playing around.