### PR TITLE
Fix saving locale in Word documents

### DIFF
--- a/chrome/content/zotero/bibliography.js
+++ b/chrome/content/zotero/bibliography.js
@@ -33,8 +33,11 @@
 // Used by rtfScan.xul, integrationDocPrefs.xul, and bibliography.xul
 
 var Zotero_File_Interface_Bibliography = new function() {
-	var _io, _saveStyle;
-	var lastSelectedLocale; // Only changes when explicitly selected
+	var _io;
+	
+	// Only changes when explicitly selected
+	var lastSelectedStyle,
+		lastSelectedLocale;
 	
 	/*
 	 * Initialize some variables and prepare event listeners for when chrome is done
@@ -60,7 +63,6 @@ var Zotero_File_Interface_Bibliography = new function() {
 		// if no style is requested, get the last style used
 		if(!_io.style) {
 			_io.style = Zotero.Prefs.get("export.lastStyle");
-			_saveStyle = true;
 		}
 		
 		// add styles to list
@@ -175,8 +177,8 @@ var Zotero_File_Interface_Bibliography = new function() {
 	 */
 	this.styleChanged = function () {
 		var selectedItem = document.getElementById("style-listbox").selectedItem;
-		var selectedStyle = selectedItem.getAttribute('value');
-		var selectedStyleObj = Zotero.Styles.get(selectedStyle);
+		lastSelectedStyle = selectedItem.getAttribute('value');
+		var selectedStyleObj = Zotero.Styles.get(lastSelectedStyle);
 		
 		updateLocaleMenu(selectedStyleObj);
 		
@@ -210,7 +212,7 @@ var Zotero_File_Interface_Bibliography = new function() {
 		// Change label to "Citation" or "Note" depending on style class
 		if(document.getElementById("citations")) {
 			let label = "";
-			if(Zotero.Styles.get(selectedStyle).class == "note") {
+			if(Zotero.Styles.get(lastSelectedStyle).class == "note") {
 				label = Zotero.getString('citation.notes');
 			} else {
 				label = Zotero.getString('citation.citations');
@@ -252,7 +254,7 @@ var Zotero_File_Interface_Bibliography = new function() {
 		if(document.getElementById("displayAs")) {
 			var automaticJournalAbbreviationsEl = document.getElementById("automaticJournalAbbreviations-checkbox");
 			_io.automaticJournalAbbreviations = automaticJournalAbbreviationsEl.checked;
-			if(!automaticJournalAbbreviationsEl.hidden && _saveStyle) {
+			if(!automaticJournalAbbreviationsEl.hidden && lastSelectedStyle) {
 				Zotero.Prefs.set("cite.automaticJournalAbbreviations", _io.automaticJournalAbbreviations);
 			}
 			_io.useEndnotes = document.getElementById("displayAs").selectedIndex;
@@ -260,13 +262,11 @@ var Zotero_File_Interface_Bibliography = new function() {
 			_io.storeReferences = document.getElementById("storeReferences").checked;
 		}
 		
-		// save style (this happens only for "Export Bibliography," or Word
-		// integration when no bibliography style was previously selected)
-		if(_saveStyle) {
+		// remember style and locale if user selected these explicitly
+		if(lastSelectedStyle) {
 			Zotero.Prefs.set("export.lastStyle", _io.style);
 		}
 		
-		// save locale
 		if (lastSelectedLocale) {
 			Zotero.Prefs.set("export.lastLocale", lastSelectedLocale);
 		}

--- a/chrome/content/zotero/bibliography.js
+++ b/chrome/content/zotero/bibliography.js
@@ -235,7 +235,10 @@ var Zotero_File_Interface_Bibliography = new function() {
 	this.acceptSelection = function () {
 		// collect code
 		_io.style = document.getElementById("style-listbox").value;
-		_io.locale = document.getElementById("locale-menu").value;
+		
+		let localeMenu = document.getElementById("locale-menu");
+		_io.locale = localeMenu.disabled ? undefined : localeMenu.value;
+		
 		if(document.getElementById("output-method-radio")) {
 			// collect settings
 			_io.mode = document.getElementById("output-mode-radio").selectedItem.id;

--- a/chrome/content/zotero/xpcom/integration.js
+++ b/chrome/content/zotero/xpcom/integration.js
@@ -2029,7 +2029,7 @@ Zotero.Integration.Session.prototype.resetRequest = function(doc) {
  * @param data {Zotero.Integration.DocumentData}
  * @param resetStyle {Boolean} Whether to force the style to be reset
  *     regardless of whether it has changed. This is desirable if the
- *     automaticJournalAbbreviations has changed.
+ *     automaticJournalAbbreviations or locale has changed.
  */
 Zotero.Integration.Session.prototype.setData = function(data, resetStyle) {
 	var oldStyle = (this.data && this.data.style ? this.data.style : false);
@@ -2039,7 +2039,7 @@ Zotero.Integration.Session.prototype.setData = function(data, resetStyle) {
 		try {
 			var getStyle = Zotero.Styles.get(data.style.styleID);
 			data.style.hasBibliography = getStyle.hasBibliography;
-			this.style = getStyle.getCiteProc(data.locale, data.prefs.automaticJournalAbbreviations);
+			this.style = getStyle.getCiteProc(data.style.locale, data.prefs.automaticJournalAbbreviations);
 			this.style.setOutputFormat("rtf");
 			this.styleClass = getStyle.class;
 			this.dateModified = new Object();
@@ -2069,7 +2069,7 @@ Zotero.Integration.Session.prototype.setDocPrefs = function(doc, primaryFieldTyp
 	
 	if(this.data) {
 		io.style = this.data.style.styleID;
-		io.locale = this.data.locale;
+		io.locale = this.data.style.locale;
 		io.useEndnotes = this.data.prefs.noteType == 0 ? 0 : this.data.prefs.noteType-1;
 		io.fieldType = this.data.prefs.fieldType;
 		io.primaryFieldType = primaryFieldType;
@@ -2092,19 +2092,17 @@ Zotero.Integration.Session.prototype.setDocPrefs = function(doc, primaryFieldTyp
 		var data = new Zotero.Integration.DocumentData();
 		data.sessionID = oldData.sessionID;
 		data.style.styleID = io.style;
-		data.locale = io.locale;
+		data.style.locale = io.locale;
 		data.prefs.fieldType = io.fieldType;
 		data.prefs.storeReferences = io.storeReferences;
 		data.prefs.automaticJournalAbbreviations = io.automaticJournalAbbreviations;
-
-		var localeChanged = false;
-		if (!oldData.locale || (oldData.locale != io.locale)) {
-			localeChanged = true;
-		}
-
-		me.setData(data, oldData && 
-		(oldData.prefs.automaticJournalAbbreviations !=
-		data.prefs.automaticJournalAbbreviations || localeChanged));
+		
+		var forceStyleReset = oldData
+			&& (
+				oldData.prefs.automaticJournalAbbreviations != data.prefs.automaticJournalAbbreviations
+				|| oldData.style.locale != io.locale
+			);
+		me.setData(data, forceStyleReset);
 
 		// need to do this after setting the data so that we know if it's a note style
 		me.data.prefs.noteType = me.style && me.styleClass == "note" ? io.useEndnotes+1 : 0;
@@ -2983,6 +2981,7 @@ Zotero.Integration.DocumentData.prototype.serializeXML = function() {
 		'zotero-version="'+Zotero.Utilities.htmlSpecialChars(Zotero.version)+'">'+
 			'<session id="'+Zotero.Utilities.htmlSpecialChars(this.sessionID)+'"/>'+
 		'<style id="'+Zotero.Utilities.htmlSpecialChars(this.style.styleID)+'" '+
+			(this.style.locale ? 'locale="' + Zotero.Utilities.htmlSpecialChars(this.style.locale) + '" ': '') +
 			'hasBibliography="'+(this.style.hasBibliography ? "1" : "0")+'" '+
 			'bibliographyStyleHasBeenSet="'+(this.style.bibliographyStyleHasBeenSet ? "1" : "0")+'"/>'+
 		(prefs ? '<prefs>'+prefs+'</prefs>' : '<prefs/>')+'</data>';
@@ -2998,6 +2997,7 @@ Zotero.Integration.DocumentData.prototype.unserializeXML = function(xmlData) {
 	
 	this.sessionID = Zotero.Utilities.xpathText(doc, '/data/session[1]/@id');
 	this.style = {"styleID":Zotero.Utilities.xpathText(doc, '/data/style[1]/@id'),
+		"locale":Zotero.Utilities.xpathText(doc, '/data/style[1]/@locale'),
 		"hasBibliography":(Zotero.Utilities.xpathText(doc, '/data/style[1]/@hasBibliography') == 1),
 		"bibliographyStyleHasBeenSet":(Zotero.Utilities.xpathText(doc, '/data/style[1]/@bibliographyStyleHasBeenSet') == 1)};
 	this.prefs = {};


### PR DESCRIPTION
Seems like we forgot to do this properly.

Also fixes some logic with remembering last-used style/locale. Should now remember all explicit user selections.