### PR TITLE
Parse author names

### DIFF
--- a/chrome/content/zotero/xpcom/style.js
+++ b/chrome/content/zotero/xpcom/style.js
@@ -664,12 +664,17 @@ Zotero.Style.prototype.getCiteProc = function(locale, automaticJournalAbbreviati
 	}
 	
 	try {
-		return new Zotero.CiteProc.CSL.Engine(
+		var citeproc = new Zotero.CiteProc.CSL.Engine(
 			new Zotero.Cite.System(automaticJournalAbbreviations),
 			xml,
 			locale,
 			overrideLocale
 		);
+		
+		// Don't try to parse author names. We parse them in itemToCSLJSON
+		citeproc.opt.development_extensions.parse_names = false;
+		
+		return citeproc;
 	} catch(e) {
 		Zotero.logError(e);
 		throw e;

--- a/chrome/content/zotero/xpcom/utilities.js
+++ b/chrome/content/zotero/xpcom/utilities.js
@@ -1555,7 +1555,25 @@ Zotero.Utilities = {
 			
 			var nameObj;
 			if (creator.lastName || creator.firstName) {
-				nameObj = {'family': creator.lastName, 'given': creator.firstName};
+				nameObj = {
+					family: creator.lastName || '',
+					given: creator.firstName || ''
+				};
+				
+				// Parse name particles
+				// Replicate citeproc-js logic for what should be parsed so we don't
+				// break current behavior.
+				if (nameObj.family && nameObj.given) {
+					// Don't parse if last name is quoted
+					if (nameObj.family.length > 1
+						&& nameObj.family.charAt(0) == '"'
+						&& nameObj.family.charAt(nameObj.family.length - 1) == '"'
+					) {
+						nameObj.family = nameObj.family.substr(1, nameObj.family.length - 2);
+					} else {
+						Zotero.CiteProc.CSL.parseParticles(nameObj, true);
+					}
+				}
 			} else if (creator.name) {
 				nameObj = {'literal': creator.name};
 			}


### PR DESCRIPTION
Currently non-dropping particle parsing is being done automatically in CiteProc. This patch disables automatic parsing and moves it to `itemToCSLJSON`, which means that names are parsed when exporting to CSL JSON.

Also fixes the non-dropping particle handling reported [here](https://forums.zotero.org/discussion/30974/1/any-idea-why-an-a-author-comes-last-in-the-bibliography/) via citeproc update