### PR TITLE
generate secure DOI links

### DIFF
--- a/chrome/content/zotero/bindings/itembox.xml
+++ b/chrome/content/zotero/bindings/itembox.xml
@@ -409,7 +409,7 @@
 							// Pull out DOI, in case there's a prefix
 							var doi = Zotero.Utilities.cleanDOI(val);
 							if (doi) {
-								doi = "https://dx.doi.org/" + encodeURIComponent(doi);
+								doi = "https://doi.org/" + encodeURIComponent(doi);
 								label.setAttribute("isButton", true);
 								label.setAttribute("onclick", "ZoteroPane_Local.loadURI('" + doi + "', event)");
 								label.setAttribute("tooltiptext", Zotero.getString('locate.online.tooltip'));

--- a/chrome/content/zotero/bindings/itembox.xml
+++ b/chrome/content/zotero/bindings/itembox.xml
@@ -409,7 +409,7 @@
 							// Pull out DOI, in case there's a prefix
 							var doi = Zotero.Utilities.cleanDOI(val);
 							if (doi) {
-								doi = "http://dx.doi.org/" + encodeURIComponent(doi);
+								doi = "https://dx.doi.org/" + encodeURIComponent(doi);
 								label.setAttribute("isButton", true);
 								label.setAttribute("onclick", "ZoteroPane_Local.loadURI('" + doi + "', event)");
 								label.setAttribute("tooltiptext", Zotero.getString('locate.online.tooltip'));

--- a/chrome/content/zotero/locateMenu.js
+++ b/chrome/content/zotero/locateMenu.js
@@ -410,7 +410,7 @@ var Zotero_LocateMenu = new function() {
 			if(doi && typeof doi === "string") {
 				doi = Zotero.Utilities.cleanDOI(doi);
 				if(doi) {
-					return "http://dx.doi.org/" + encodeURIComponent(doi);
+					return "https://dx.doi.org/" + encodeURIComponent(doi);
 				}
 			}
 			

--- a/chrome/content/zotero/locateMenu.js
+++ b/chrome/content/zotero/locateMenu.js
@@ -410,7 +410,7 @@ var Zotero_LocateMenu = new function() {
 			if(doi && typeof doi === "string") {
 				doi = Zotero.Utilities.cleanDOI(doi);
 				if(doi) {
-					return "https://dx.doi.org/" + encodeURIComponent(doi);
+					return "https://doi.org/" + encodeURIComponent(doi);
 				}
 			}
 			

--- a/chrome/content/zotero/xpcom/citeproc.js
+++ b/chrome/content/zotero/xpcom/citeproc.js
@@ -13227,7 +13227,7 @@ CSL.Output.Formats.prototype.html = {
         return "<a href=\"" + str + "\">" + str + "</a>";
     },
     "@DOI/true": function (state, str) {
-        return "<a href=\"https://dx.doi.org/" + str + "\">" + str + "</a>";
+        return "<a href=\"http://dx.doi.org/" + str + "\">" + str + "</a>";
     }
 };
 CSL.Output.Formats.prototype.text = {

--- a/chrome/content/zotero/xpcom/citeproc.js
+++ b/chrome/content/zotero/xpcom/citeproc.js
@@ -13227,7 +13227,7 @@ CSL.Output.Formats.prototype.html = {
         return "<a href=\"" + str + "\">" + str + "</a>";
     },
     "@DOI/true": function (state, str) {
-        return "<a href=\"http://dx.doi.org/" + str + "\">" + str + "</a>";
+        return "<a href=\"https://dx.doi.org/" + str + "\">" + str + "</a>";
     }
 };
 CSL.Output.Formats.prototype.text = {

--- a/chrome/content/zotero/xpcom/utilities.js
+++ b/chrome/content/zotero/xpcom/utilities.js
@@ -506,7 +506,7 @@ Zotero.Utilities = {
 		str = str.replace(/([^">])(https?:\/\/[^\s]+)(\s|$)/g, '$1<a href="$2">$2</a>$3');
 		
 		// DOI
-		str = str.replace(/(doi:[ ]*)(10\.[^\s]+[0-9a-zA-Z])/g, '$1<a href="https://dx.doi.org/$2">$2</a>');
+		str = str.replace(/(doi:[ ]*)(10\.[^\s]+[0-9a-zA-Z])/g, '$1<a href="https://doi.org/$2">$2</a>');
 		return str;
 	},
 	

--- a/chrome/content/zotero/xpcom/utilities.js
+++ b/chrome/content/zotero/xpcom/utilities.js
@@ -506,7 +506,7 @@ Zotero.Utilities = {
 		str = str.replace(/([^">])(https?:\/\/[^\s]+)(\s|$)/g, '$1<a href="$2">$2</a>$3');
 		
 		// DOI
-		str = str.replace(/(doi:[ ]*)(10\.[^\s]+[0-9a-zA-Z])/g, '$1<a href="http://dx.doi.org/$2">$2</a>');
+		str = str.replace(/(doi:[ ]*)(10\.[^\s]+[0-9a-zA-Z])/g, '$1<a href="https://dx.doi.org/$2">$2</a>');
 		return str;
 	},
 	


### PR DESCRIPTION
Because https-support for dx.doi.org was recently [upgraded](https://www.ssllabs.com/ssltest/analyze.html?d=dx.doi.org&latest), and to bumb privacy & security for researches up a bit, I suggest to stop generating plain http links where possible.

Because Zotero's server apparently enforces https, the next commit in this PR could be to change all zotero.org URLs as well. More ideas? Would doing the same to the namespaces containing a mozilla.org URL be a problem?
