### PR TITLE
Don't drop access date from CSL JSON if "cite URL" pref is unchecked

### DIFF
--- a/chrome/content/zotero/xpcom/cite.js
+++ b/chrome/content/zotero/xpcom/cite.js
@@ -529,13 +529,11 @@ Zotero.Cite.System.prototype = {
 		
 		if (!Zotero.Prefs.get("export.citePaperJournalArticleURL")) {
 			var itemType = Zotero.ItemTypes.getName(zoteroItem.itemTypeID);
-			// don't return URL or accessed information for journal articles if a
-			// pages field exists
+			// don't return URL for journal articles if a pages field exists
 			if (["journalArticle", "newspaperArticle", "magazineArticle"].indexOf(itemType) !== -1
 				&& zoteroItem.getField("pages")
 			) {
 				delete cslItem.URL;
-				delete cslItem.accessed;
 			}
 		}
 		

--- a/test/tests/citeTest.js
+++ b/test/tests/citeTest.js
@@ -1,0 +1,48 @@
+describe("Zotero.Cite.System", function() {
+	describe("#retrieveItem()", function() {
+		let article, citeSystem;
+		before(function() {
+			// Load sample item into DB
+			let data = populateDBWithSampleData(loadSampleData('journalArticle'));
+			article = Zotero.Items.get(data.journalArticle.id);
+			
+			// instantiate Zotero.Cite.System object
+			citeSystem = new Zotero.Cite.System();
+		});
+		
+		it('should retrieve item given a Zotero.Item', function() {
+			let cslItem = citeSystem.retrieveItem(article);
+			assert.ok(cslItem);
+			assert.equal(cslItem.id, article.id);
+		});
+		
+		it.skip('should retrieve item given an item URI', function() {
+			let cslItem = citeSystem.retrieveItem(Zotero.URI.getItemURI(article));
+			assert.ok(cslItem);
+			assert.equal(cslItem.id, article.id);
+		});
+		
+		it('should retrieve item given a local DB ID', function() {
+			let cslItem = citeSystem.retrieveItem(article.id);
+			assert.ok(cslItem);
+			assert.equal(cslItem.id, article.id);
+		});
+		
+		it('should exclude URL if preference is selected', function() {
+			let originalPref = Zotero.Prefs.get("export.citePaperJournalArticleURL");
+			
+			Zotero.Prefs.set("export.citePaperJournalArticleURL", true);
+			let withURL = citeSystem.retrieveItem(article);
+			assert.ok(withURL.URL, "URL is set when preference is true");
+			
+			Zotero.Prefs.set("export.citePaperJournalArticleURL", false);
+			let withoutURL = citeSystem.retrieveItem(article);
+			assert.isUndefined(withoutURL.URL, "URL is undefined when preference is false");
+			
+			delete withURL.URL;
+			assert.deepEqual(withURL, withoutURL, "objects are the same except for the URL");
+			
+			Zotero.Prefs.set("export.citePaperJournalArticleURL", originalPref);
+		});
+	});
+});


### PR DESCRIPTION
Regression from f0bd1e77ffab6dbc7fbd600dc1acc11844aa2e02
Re https://forums.zotero.org/discussion/50652/date-accessed-no-longer-appearing-in-bibliography/
