### PR TITLE
Return citation preview as HTML in integration.js

### DIFF
--- a/chrome/content/zotero/xpcom/integration.js
+++ b/chrome/content/zotero/xpcom/integration.js
@@ -2824,7 +2824,7 @@ Zotero.Integration.Session.prototype.previewCitation = function(citation) {
 	var citationsPre, citationsPost, citationIndices;
 	[citationsPre, citationsPost, citationIndices] = this._getPrePost(citation.properties.zoteroIndex);
 	try {
-		return this.style.previewCitationCluster(citation, citationsPre, citationsPost, "rtf");
+		return this.style.previewCitationCluster(citation, citationsPre, citationsPost, "html");
 	} catch(e) {
 		throw e;
 	}


### PR DESCRIPTION
  Aims to address reports of raw RTF code in the Classic View citation editor.

  * [problems-with-last-update-firefox-word-2010-not-starter-edition](https://forums.zotero.org/discussion/50595/problems-with-last-update-firefox-word-2010-not-starter-edition)
  * [trouble-editing-citations-in-word-2008](https://forums.zotero.org/discussion/24306/trouble-editing-citations-in-word-2008)
  * [utilizing-show-editor-adds-a-i-in-my-footnote](https://forums.zotero.org/discussion/51037/utilizing-show-editor-adds-a-i-in-my-footnote)

I may not fully understand the code, but it looks like the editor object in styled-textbox.xml is set to deliver either RTF or HTML from HTML source. With this patch, the citeproc-js preview (used for the source) is delivered in HTML, which seems to bring things right.
    
If there are no obvious problems with this, it probably wants some torture testing before it's fully trusted. (For what it's worth, I've been running a copy of Juris-M with this change for a couple of weeks with no apparent problems.)
