### PR TITLE
Forbid "Attachments" column to be resized

### DIFF
--- a/chrome/content/zotero/zoteroPane.xul
+++ b/chrome/content/zotero/zoteroPane.xul
@@ -517,7 +517,8 @@
 									class="treecol-image"
 									label="&zotero.tabs.attachments.label;"
 									src="chrome://zotero/skin/attach-small.png"
-									zotero-persist="width ordinal hidden sortActive sortDirection"/>
+									fixed="true"
+									zotero-persist="ordinal hidden sortActive sortDirection"/>
 								<splitter class="tree-splitter"/>
 								<treecol
 									id="zotero-items-column-numNotes" hidden="true"


### PR DESCRIPTION
You might be reluctant to forbid the user to resize it, but in this case (a graphic column, no text), I think this is better. Each time I resize one column, this one is widened and I never want that, who does?