### PR TITLE
make items tree column focused when select a item by running zotero://select/items/xxx.

### DIFF
--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -1983,7 +1983,9 @@ var ZoteroPane = new function()
 			Zotero.debug("Told to select in library; switching to library");
 			this.collectionsView.selectLibrary(item.libraryID);
 		}
-		
+		// Focus the items column before selecting the item.
+		document.getElementById('zotero-items-tree').focus();
+
 		var selected = this.itemsView.selectItem(itemID, expand);
 		if (!selected) {
 			if (item.deleted) {


### PR DESCRIPTION
It's really convenient to find an item using ZotQuery on Mac. 
But there's a minor issue is that when the original focus is not on item tree column, select item will not focus the item tree column. So I have to use my cursor to make it focused to operate on the item. 
The expected behavior is that when select item, the item tree column should always be focused. 
This is the reasoning behind this commit. 