### PR TITLE
Fix bug in Create Bibliography from Item w/Notes

### DIFF
--- a/chrome/content/zotero/xpcom/cite.js
+++ b/chrome/content/zotero/xpcom/cite.js
@@ -81,8 +81,15 @@ Zotero.Cite = {
 		}
 		
 		var styleClass = cslEngine.opt.class;
-		var citations = [cslEngine.appendCitationCluster({"citationItems":[{"id":item.id}], "properties":{}}, true)[0][1]
-			for each(item in items)];
+		var citations=[];
+		for (var i=0, ilen=items.length; i<ilen; i++) {
+			var item = items[i];
+			var outList = cslEngine.appendCitationCluster({"citationItems":[{"id":item.id}], "properties":{}}, true);
+			for (var j=0, jlen=outList.length; j<jlen; j++) {
+				var citationPos = outList[j][0];
+				citations[citationPos] = outList[j][1];
+			}
+		}
 		
 		if(styleClass == "note") {
 			if(format == "html") {


### PR DESCRIPTION
When the user selects "Create Bibliography from Item(s)" with the "Notes" option, some entries come out incorrectly, when the input items require disambiguation in the selected style.

[HTML export of Presentation items with same author a](https://forums.zotero.org/discussion/51346/html-export-of-presentation-items-with-same-author-and-title-creates-duplicates/#Item_4)

In this case, Zotero is iterating over appendCitationCluster() to build the citations list. The lack of documentation on appendCitationCluster() is the root source of the issue - what the function does is a little more complex than its name implies.

Under the hood, appendCitationCluster() invokes processCitationCluster() to generate citations to be added, and just strips off the error segment from the return. What is not obvious is that processCitationCluster() function returns multiple citations when disambiguation is required. In Zotero code, the first-listed citation in the return from appendCitationCluster() is always picked. When input does not require disambiguation, this will always be correct. When disambiguation is performed, it will be wrong.

With this patch, all items returned from appendCitationCluster() are inserted in the appropriate locations of the formatted citation list, so that disambiguation operations are fully reflected in the return.
