### PR TITLE
Restore unchanged field from known value

### DIFF
--- a/chrome/content/zotero/bindings/itembox.xml
+++ b/chrome/content/zotero/bindings/itembox.xml
@@ -1885,7 +1885,7 @@
 					// a refresh), close it manually
 					if (textbox && textbox.parentNode) {
 						elem = this.createValueElement(
-							this.item.getField(fieldName),
+							newVal,
 							fieldName,
 							tabindex
 						);


### PR DESCRIPTION
It looks like the intention is to use newVal to restore an unchanged value in hideEditor()?

While working up the item panel interface for Juris-M, I noticed that family names were lost when tabbing across two-field creator entries. I had been puzzled by the var-setting of newVal for creator and ordinary fields in the hideEditor() function, since it wasn't used further down in the function. Then I realized that the code needed to restore the field value is exactly that used for the declarations of newVal.