### PR TITLE
Prevent duplicate items when copying citations to clipboard

### DIFF
--- a/chrome/content/zotero/fileInterface.js
+++ b/chrome/content/zotero/fileInterface.js
@@ -439,6 +439,7 @@ var Zotero_File_Interface = new function() {
 		
 		// add text (or HTML source)
 		if(!asHTML) {
+			cslEngine = style.getCiteProc(locale);
 			var bibliography = Zotero.Cite.makeFormattedBibliographyOrCitationList(cslEngine, items, "text", asCitations);
 		}
 		var str = Components.classes["@mozilla.org/supports-string;1"].

--- a/chrome/content/zotero/xpcom/quickCopy.js
+++ b/chrome/content/zotero/xpcom/quickCopy.js
@@ -375,6 +375,7 @@ Zotero.QuickCopy = new function() {
 				var style = Zotero.Styles.get(format.id);
 				var cslEngine = style.getCiteProc(locale);
  				var html = Zotero.Cite.makeFormattedBibliographyOrCitationList(cslEngine, items, "html");
+				cslEngine = style.getCiteProc(locale);
 				var text = Zotero.Cite.makeFormattedBibliographyOrCitationList(cslEngine, items, "text");
 			}
 			


### PR DESCRIPTION
This is a followup to #834, which turned out to be a little less than the "straightforward bug fix" I declared it to be.

This PR addresses the duplicate-cite issue reported [on the Zotero forums](https://forums.zotero.org/discussion/52886/).

As per discussion under #834, this fix will be specific to the 4.0 branch. In 5.0, the plan will be to reduce clutter by changing the signature of `makeFormattedBibliographyOrCitationList()` to receive the locale (plus the style), and instantiate the processor in that function.
