### PR TITLE
Fixes the finish button on my publication wizard on linux

### DIFF
--- a/chrome/content/zotero-platform/unix/publicationsDialog.css
+++ b/chrome/content/zotero-platform/unix/publicationsDialog.css
@@ -1,0 +1,4 @@
+/* There's an ugly horizontal scrollbar on linux in some steps of the wizard, which this fixes */
+.wizard-page-box {
+  margin: 10px 40px;
+}

--- a/chrome/content/zotero/publicationsDialog.js
+++ b/chrome/content/zotero/publicationsDialog.js
@@ -129,9 +129,7 @@ var Zotero_Publications_Dialog = new function () {
 		var wizard = document.getElementById('zotero-publications-wizard');
 		var currentPage = wizard.currentPage;
 		var nextPage = wizard.wizardPages[wizard.pageIndex + 1];
-		var pageid = wizard.currentPage.pageid;
 		var nextButton = wizard.getButton('next');
-		var finishButton = wizard.getButton('finish');
 		
 		// Require authorship checkbox on first page to be checked to advance
 		wizard.canAdvance = document.getElementById('confirm-authorship-checkbox').checked;
@@ -147,8 +145,6 @@ var Zotero_Publications_Dialog = new function () {
 					&& _shareSettings.sharing == 'cc'
 					&& !(_hasRights == 'all' && _keepRights))) {
 			this.lastPage = false;
-			finishButton.hidden = true;
-			nextButton.hidden = false;
 			nextButton.label = Zotero.getString(
 				'publications.buttons.next',
 				Zotero.getString('publications.buttons.' + nextPage.pageid)
@@ -157,8 +153,10 @@ var Zotero_Publications_Dialog = new function () {
 		// Otherwise this is the last page
 		else {
 			this.lastPage = true;
-			nextButton.hidden = true;
-			finishButton.hidden = false;
+			// Due to issues with linux not handling finish button hiding correctly
+			// we just set the next button label to be the one for the finish button
+			// and leave visibility handling up to mr wizard
+			nextButton.label = Zotero.getString('publications.buttons.addToMyPublications');
 		}
 	}
 	

--- a/chrome/content/zotero/publicationsDialog.xul
+++ b/chrome/content/zotero/publicationsDialog.xul
@@ -31,6 +31,7 @@
 <?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
 <?xml-stylesheet href="chrome://zotero/skin/zotero.css" type="text/css"?>
 <?xml-stylesheet href="chrome://zotero/skin/publicationsDialog.css" type="text/css"?>
+<?xml-stylesheet href="chrome://zotero-platform/content/publicationsDialog.css"?>
 
 <wizard id="zotero-publications-wizard" title="&zotero.publications.my_publications;"
 		width="600"


### PR DESCRIPTION
Linux seems to not be happy with hiding and restoring the *finish* button, so we just change the label of the *next* button instead. Closes #738 
Also a tiny fix which closes #740