### PR TITLE
Remove tags on shift-drag

### DIFF
--- a/chrome/content/zotero/bindings/tagselector.xml
+++ b/chrome/content/zotero/bindings/tagselector.xml
@@ -934,13 +934,16 @@
 							}
 						}
 						*/
-						
+
+						// Store the event, because drop event does not have shiftKey attribute set
+						Zotero.DragDrop.currentEvent = event;
 						event.target.setAttribute('draggedOver', true);
 						event.preventDefault();
-						event.effectAllowed = event.dropEffect = "link";
+						event.dataTransfer.dropEffect = "copy";
 					}
 					
 					this.onDragExit = function (event) {
+						Zotero.DragDrop.currentEvent = null;
 						event.target.setAttribute('draggedOver', false);
 					}
 					
@@ -962,7 +965,11 @@
 							
 							for (let i=0; i<items.length; i++) {
 								let item = items[i];
-								item.addTag(value);
+								if (Zotero.DragDrop.currentEvent.shiftKey) {
+									item.removeTag(value);
+								} else {
+									item.addTag(value);
+								}
 								yield item.save();
 							}
 						}.bind(this));


### PR DESCRIPTION
Closes #852

Currently shows a *+* icon for adding a tag and
a *link* icon for removing it.

There does not appear to be any way to have a custom mouse cursor,
which makes this interaction extremely unintuitive. It might be
possible to hack this in, but the issue does not really warrant the effort.
E.g. `window.setCursor` does not respond whilst dragging.