### PR TITLE
Fix/sync auth form

### DIFF
--- a/chrome/content/zotero/preferences/preferences_sync.js
+++ b/chrome/content/zotero/preferences/preferences_sync.js
@@ -30,7 +30,7 @@ Zotero_Preferences.Sync = {
 	init: Zotero.Promise.coroutine(function* () {
 		this.updateStorageSettingsUI();
 
-		var username = Zotero.Users.getCurrentUsername() || "";
+		var username = Zotero.Users.getCurrentUsername() || Zotero.Prefs.get('sync.server.username') || " ";
 		var apiKey = Zotero.Sync.Data.Local.getAPIKey();
 		this.displayFields(apiKey ? username : "");
 		
@@ -46,6 +46,7 @@ Zotero_Preferences.Sync = {
 					{timeout: 5000}
 				);
 				this.displayFields(keyInfo.username);
+				Zotero.Users.setCurrentUsername(keyInfo.username);
 			}
 			catch (e) {
 				// API key wrong/invalid

--- a/chrome/content/zotero/xpcom/data/library.js
+++ b/chrome/content/zotero/xpcom/data/library.js
@@ -567,6 +567,15 @@ Zotero.Library.prototype.updateSearches = Zotero.Promise.coroutine(function* () 
 	this._hasSearches = !!(yield Zotero.DB.valueQueryAsync(sql, this.libraryID));
 });
 
+Zotero.Library.prototype.hasItems = Zotero.Promise.coroutine(function* () {
+	if (!this.id) {
+		throw new Error("Library is not saved yet");
+	}
+	let sql = 'SELECT COUNT(*)>0 FROM items WHERE libraryID=?';
+
+	return Zotero.DB.valueQueryAsync(sql, this.libraryID);
+});
+
 Zotero.Library.prototype.hasItem = function (item) {
 	if (!(item instanceof Zotero.Item)) {
 		throw new Error("item must be a Zotero.Item");

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -112,6 +112,7 @@ dataDir.notFound						= The Zotero data directory could not be found.
 dataDir.previousDir					= Previous directory:
 dataDir.useProfileDir				= Use %S profile directory
 dataDir.selectDir					= Select a Zotero data directory
+dataDir.changeDataDirectory 		= Change Data Directory…
 dataDir.unsafeLocation.selected.dropbox = Choosing a data directory within Dropbox may corrupt your database.
 dataDir.unsafeLocation.selected.useAnyway = Use this directory anyway?
 dataDir.unsafeLocation.existing.dropbox = Your Zotero data directory is within Dropbox, which may lead to data corruption.
@@ -828,6 +829,8 @@ sync.localDataWillBeCombined		= If you continue, local Zotero data will be combi
 sync.localGroupsWillBeRemoved1		= Local groups, including any with changed items, will also be removed from this computer.
 sync.avoidCombiningData				= To avoid combining data, revert to the '%S' account or use the Reset options in the Sync pane of the Zotero preferences.
 sync.unlinkWarning					= Are you sure you want to unlink this account?\n\n%S will no longer sync your data, but your data will remain locally.
+sync.warning.emptyLibrary			= You are about to sync the ‘%1$S’ account to an empty %2$S database. This could happen if you removed your previous %2$S database or if the location of your data directory changed.
+sync.warning.existingDataElsewhere  = If your %S data exists elsewhere on your computer, you should move it to your current data directory or change your data directory location to point to the existing data.
 
 sync.conflict.autoChange.alert			= One or more locally deleted Zotero %S have been modified remotely since the last sync.
 sync.conflict.autoChange.log			= A Zotero %S has changed both locally and remotely since the last sync:

--- a/test/tests/libraryTest.js
+++ b/test/tests/libraryTest.js
@@ -256,6 +256,39 @@ describe("Zotero.Library", function() {
 			assert.isFalse(library.hasSearches());
 		})
 	});
+	describe("#hasItems()", function() {
+		it("should throw if called before saving a library", function* () {
+			let library = new Zotero.Library();
+			try {
+				yield library.hasItems();
+				assert.isFalse(true, "Library#hasItems did not throw an error");
+			} catch (e) {
+				assert.ok(e);
+			}
+		});
+		it("should stay up to date as items are added and removed", function* () {
+			let library = yield createGroup({ editable: true });
+			let libraryID = library.libraryID;
+			var hasItems = yield library.hasItems();
+			assert.isFalse(hasItems);
+
+			let i1 = yield createDataObject('item', { libraryID });
+			hasItems = yield library.hasItems();
+			assert.isTrue(hasItems);
+
+			let i2 = yield createDataObject('item', { libraryID });
+			hasItems = yield library.hasItems();
+			assert.isTrue(hasItems);
+
+			yield i1.eraseTx();
+			hasItems = yield library.hasItems();
+			assert.isTrue(hasItems);
+
+			yield i2.eraseTx();
+			hasItems = yield library.hasItems();
+			assert.isFalse(hasItems);
+		});
+	});
 	describe("#updateLastSyncTime()", function() {
 		it("should set sync time to current time", function* () {
 			let group = yield createGroup();


### PR DESCRIPTION
Closes #886 
Closes #833 

Did not really require `Zotero.Library.hasItems` method, but I had implemented it before (my idea was to check for absence of items in current library and presence of items on the sync server), so we may as well keep it - might come in handy.