### PR TITLE
Expose sync server in preferences

### DIFF
--- a/chrome/content/zotero/preferences/preferences_sync.xul
+++ b/chrome/content/zotero/preferences/preferences_sync.xul
@@ -31,6 +31,7 @@
 			helpTopic="sync">
 		<preferences>
 			<preference id="pref-sync-autosync" name="extensions.zotero.sync.autoSync" type="bool"/>
+			<preference id="pref-sync-url" name="extensions.zotero.sync.server.url" type="string" instantApply="true"/>
 			<preference id="pref-sync-username" name="extensions.zotero.sync.server.username" type="unichar" instantApply="true"/>
 			<preference id="pref-sync-fulltext-enabled" name="extensions.zotero.sync.fulltext.enabled" type="bool"/>
 			<preference id="pref-storage-enabled" name="extensions.zotero.sync.storage.enabled" type="bool"/>
@@ -64,6 +65,11 @@
 								
 								<rows>
 									<row>
+										<label value="&zotero.preferences.sync.url;"/>
+										<textbox preference="pref-sync-url"
+											onchange="this.value = this.value.trim().replace(/\/+$/, ''); Zotero.Prefs.set('sync.server.url', this.value)"/>
+									 </row>
+									 <row>
 										<label value="&zotero.preferences.sync.username;"/>
 										<textbox preference="pref-sync-username"
 											onchange="this.value = this.value.trim(); Zotero.Prefs.set('sync.server.username', this.value); var pass = document.getElementById('sync-password'); if (pass.value) { Zotero.Sync.Server.password = pass.value; }"/>

--- a/chrome/content/zotero/preferences/preferences_sync.xul
+++ b/chrome/content/zotero/preferences/preferences_sync.xul
@@ -31,6 +31,7 @@
 			helpTopic="sync">
 		<preferences>
 			<preference id="pref-sync-autosync" name="extensions.zotero.sync.autoSync" type="bool"/>
+			<preference id="pref-sync-scheme" name="extensions.zotero.sync.server.scheme" type="string" instantApply="true"/>
 			<preference id="pref-sync-url" name="extensions.zotero.sync.server.url" type="string" instantApply="true"/>
 			<preference id="pref-sync-username" name="extensions.zotero.sync.server.username" type="unichar" instantApply="true"/>
 			<preference id="pref-sync-fulltext-enabled" name="extensions.zotero.sync.fulltext.enabled" type="bool"/>
@@ -66,8 +67,19 @@
 								<rows>
 									<row>
 										<label value="&zotero.preferences.sync.url;"/>
-										<textbox preference="pref-sync-url"
-											onchange="this.value = this.value.trim().replace(/\/+$/, ''); Zotero.Prefs.set('sync.server.url', this.value)"/>
+										<hbox>
+											<menulist id="sync-url-prefix"
+													preference="pref-sync-scheme"
+													style="padding: 0; width: 7em">
+												<menupopup>
+													<menuitem label="https" value="https" style="padding: 0"/>
+													<menuitem label="http" value="http" style="padding: 0"/>
+												</menupopup>
+											</menulist>
+											<label value="://"/>
+											<textbox preference="pref-sync-url" flex="1"
+												onchange="this.value = this.value.trim().replace(/^https?:\/\/|\/+$/, ''); Zotero.Prefs.set('sync.server.url', this.value)"/>
+										</hbox>
 									 </row>
 									 <row>
 										<label value="&zotero.preferences.sync.username;"/>

--- a/chrome/content/zotero/xpcom/sync.js
+++ b/chrome/content/zotero/xpcom/sync.js
@@ -1363,8 +1363,6 @@ Zotero.Sync.Server = new function () {
 	var _loginManagerHost = 'chrome://zotero';
 	var _loginManagerRealm = 'Zotero Sync Server';
 	
-	var _serverURL = ZOTERO_CONFIG.SYNC_URL;
-	
 	var _apiVersionComponent = "version=" + this.apiVersion;
 	var _cachedCredentials = {};
 	var _syncInProgress;
@@ -1389,7 +1387,7 @@ Zotero.Sync.Server = new function () {
 	};
 	
 	function login() {
-		var url = _serverURL + "login";
+		var url = Zotero.Prefs.get('sync.server.url') + "/login";
 		
 		var username = Zotero.Sync.Server.username;
 		if (!username) {
@@ -1516,7 +1514,7 @@ Zotero.Sync.Server = new function () {
 		}
 		
 		// Get updated data
-		var url = _serverURL + 'updated';
+		var url = Zotero.Prefs.get('sync.server.url') + '/updated';
 		var lastsync = Zotero.Sync.Server.lastRemoteSyncTime;
 		if (!lastsync) {
 			lastsync = 1;
@@ -1707,7 +1705,7 @@ Zotero.Sync.Server = new function () {
 						
 						Zotero.Sync.Runner.setSyncStatus(Zotero.getString('sync.status.uploadingData'));
 						
-						var url = _serverURL + 'upload';
+						var url = Zotero.Prefs.get('sync.server.url') + '/upload';
 						var body = _apiVersionComponent
 									+ '&' + Zotero.Sync.Server.sessionIDComponent
 									+ '&updateKey=' + updateKey
@@ -1737,7 +1735,7 @@ Zotero.Sync.Server = new function () {
 									case 'queued':
 										Zotero.Sync.Runner.setSyncStatus(Zotero.getString('sync.status.uploadAccepted'));
 										
-										var url = _serverURL + 'uploadstatus';
+										var url = Zotero.Prefs.get('sync.server.url') + '/uploadstatus';
 										var body = _apiVersionComponent
 													+ '&' + Zotero.Sync.Server.sessionIDComponent;
 										Zotero.HTTP.doPost(url, body, function (xmlhttp) {
@@ -1902,7 +1900,7 @@ Zotero.Sync.Server = new function () {
 			return;
 		}
 		
-		var url = _serverURL + "clear";
+		var url = Zotero.Prefs.get('sync.server.url') + "/clear";
 		var body = _apiVersionComponent
 					+ '&' + Zotero.Sync.Server.sessionIDComponent;
 		
@@ -1966,7 +1964,7 @@ Zotero.Sync.Server = new function () {
 	
 	
 	function logout(callback) {
-		var url = _serverURL + "logout";
+		var url = Zotero.Prefs.get('sync.server.url') + "/logout";
 		var body = _apiVersionComponent
 					+ '&' + Zotero.Sync.Server.sessionIDComponent;
 		

--- a/chrome/content/zotero/xpcom/sync.js
+++ b/chrome/content/zotero/xpcom/sync.js
@@ -1387,7 +1387,7 @@ Zotero.Sync.Server = new function () {
 	};
 	
 	function login() {
-		var url = Zotero.Prefs.get('sync.server.url') + "/login";
+		var url = Zotero.Prefs.get('sync.server.scheme') + "://" + Zotero.Prefs.get('sync.server.url') + "/login";
 		
 		var username = Zotero.Sync.Server.username;
 		if (!username) {
@@ -1514,7 +1514,7 @@ Zotero.Sync.Server = new function () {
 		}
 		
 		// Get updated data
-		var url = Zotero.Prefs.get('sync.server.url') + '/updated';
+		var url = Zotero.Prefs.get('sync.server.scheme') + "://" + Zotero.Prefs.get('sync.server.url') + '/updated';
 		var lastsync = Zotero.Sync.Server.lastRemoteSyncTime;
 		if (!lastsync) {
 			lastsync = 1;
@@ -1705,7 +1705,7 @@ Zotero.Sync.Server = new function () {
 						
 						Zotero.Sync.Runner.setSyncStatus(Zotero.getString('sync.status.uploadingData'));
 						
-						var url = Zotero.Prefs.get('sync.server.url') + '/upload';
+						var url = Zotero.Prefs.get('sync.server.scheme') + "://" + Zotero.Prefs.get('sync.server.url') + '/upload';
 						var body = _apiVersionComponent
 									+ '&' + Zotero.Sync.Server.sessionIDComponent
 									+ '&updateKey=' + updateKey
@@ -1735,7 +1735,7 @@ Zotero.Sync.Server = new function () {
 									case 'queued':
 										Zotero.Sync.Runner.setSyncStatus(Zotero.getString('sync.status.uploadAccepted'));
 										
-										var url = Zotero.Prefs.get('sync.server.url') + '/uploadstatus';
+										var url = Zotero.Prefs.get('sync.server.scheme') + "://" + Zotero.Prefs.get('sync.server.url') + '/uploadstatus';
 										var body = _apiVersionComponent
 													+ '&' + Zotero.Sync.Server.sessionIDComponent;
 										Zotero.HTTP.doPost(url, body, function (xmlhttp) {
@@ -1900,7 +1900,7 @@ Zotero.Sync.Server = new function () {
 			return;
 		}
 		
-		var url = Zotero.Prefs.get('sync.server.url') + "/clear";
+		var url = Zotero.Prefs.get('sync.server.scheme') + "://" + Zotero.Prefs.get('sync.server.url') + "/clear";
 		var body = _apiVersionComponent
 					+ '&' + Zotero.Sync.Server.sessionIDComponent;
 		
@@ -1964,7 +1964,7 @@ Zotero.Sync.Server = new function () {
 	
 	
 	function logout(callback) {
-		var url = Zotero.Prefs.get('sync.server.url') + "/logout";
+		var url = Zotero.Prefs.get('sync.server.scheme') + "://" + Zotero.Prefs.get('sync.server.url') + "/logout";
 		var body = _apiVersionComponent
 					+ '&' + Zotero.Sync.Server.sessionIDComponent;
 		

--- a/chrome/locale/de/zotero/preferences.dtd
+++ b/chrome/locale/de/zotero/preferences.dtd
@@ -47,6 +47,7 @@
 <!ENTITY zotero.preferences.openurl.version "Version:">
 
 <!ENTITY zotero.preferences.prefpane.sync "Sync">
+<!ENTITY zotero.preferences.sync.url "URL:">
 <!ENTITY zotero.preferences.sync.username "Benutzername:">
 <!ENTITY zotero.preferences.sync.password "Passwort:">
 <!ENTITY zotero.preferences.sync.syncServer "Zotero Sync Server">

--- a/chrome/locale/en-US/zotero/preferences.dtd
+++ b/chrome/locale/en-US/zotero/preferences.dtd
@@ -47,6 +47,7 @@
 <!ENTITY zotero.preferences.openurl.version				"Version:">
 
 <!ENTITY zotero.preferences.prefpane.sync							"Sync">
+<!ENTITY zotero.preferences.sync.url								"URL:">
 <!ENTITY zotero.preferences.sync.username							"Username:">
 <!ENTITY zotero.preferences.sync.password							"Password:">
 <!ENTITY zotero.preferences.sync.syncServer						"Zotero Sync Server">

--- a/defaults/preferences/zotero.js
+++ b/defaults/preferences/zotero.js
@@ -132,7 +132,8 @@ pref("extensions.zotero.annotations.warnOnClose", true);
 
 // Sync
 pref("extensions.zotero.sync.autoSync", true);
-pref("extensions.zotero.sync.server.url", "https://sync.zotero.org");
+pref("extensions.zotero.sync.server.scheme", "https");
+pref("extensions.zotero.sync.server.url", "sync.zotero.org");
 pref("extensions.zotero.sync.server.username", '');
 pref("extensions.zotero.sync.server.compressData", true);
 pref("extensions.zotero.sync.storage.enabled", true);

--- a/defaults/preferences/zotero.js
+++ b/defaults/preferences/zotero.js
@@ -132,6 +132,7 @@ pref("extensions.zotero.annotations.warnOnClose", true);
 
 // Sync
 pref("extensions.zotero.sync.autoSync", true);
+pref("extensions.zotero.sync.server.url", "https://sync.zotero.org");
 pref("extensions.zotero.sync.server.username", '');
 pref("extensions.zotero.sync.server.compressData", true);
 pref("extensions.zotero.sync.storage.enabled", true);

--- a/resource/config.js
+++ b/resource/config.js
@@ -7,7 +7,6 @@ var ZOTERO_CONFIG = {
 	BASE_URI: 'http://zotero.org/',
 	WWW_BASE_URL: 'https://www.zotero.org/',
 	PROXY_AUTH_URL: 'https://s3.amazonaws.com/zotero.org/proxy-auth',
-	SYNC_URL: 'https://sync.zotero.org/',
 	API_URL: 'https://api.zotero.org/',
 	API_VERSION: 2,
 	PREF_BRANCH: 'extensions.zotero.',


### PR DESCRIPTION
Expose SYNC_URL by creating inputs for the sync server URL to make it easier to use a custom dataserver. At the moment, changing the server URL requires a patched Zotero Firefox add-on, which is particularly inconvenient considering forced extensions signing (see issue #849).
