### PR TITLE
Closes #adomasven/zotero/10. Adds a menu option to add feeds found on the current page.

### DIFF
--- a/chrome/content/zotero/feedSettings.js
+++ b/chrome/content/zotero/feedSettings.js
@@ -116,12 +116,12 @@ var Zotero_Feed_Settings = new function() {
 			if (feedReader !== fr || urlTainted) return;
 			
 			let title = document.getElementById('feed-title');
-			if (!data.url && feed.title) {
+			if (feed.title && (!data.url || data.unsaved)) {
 				title.value = feed.title;
 			}
 			
 			let ttl = document.getElementById('feed-ttl');
-			if (!data.url && feed.ttl) {
+			if (feed.ttl && (!data.url || data.unsaved)) {
 				ttl.value = Math.floor(feed.ttl / 60) || 1;
 			}
 			

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -861,7 +861,27 @@ var ZoteroPane = new function()
 		return collection.saveTx();
 	});
 	
-	this.newFeed = Zotero.Promise.coroutine(function* () {
+	this.newFeedFromPage = Zotero.Promise.coroutine(function* (event) {
+		let data = {unsaved: true};
+		if (event) {
+			data.url = event.target.getAttribute('feed');
+		} else {
+			data.url = gBrowser.selectedBrowser.feeds[0].href;
+		}
+		window.openDialog('chrome://zotero/content/feedSettings.xul', 
+			null, 'centerscreen, modal', data);
+		if (!data.cancelled) {
+			let feed = new Zotero.Feed();
+			feed.url = data.url;
+			feed.name = data.title;
+			feed.refreshInterval = data.ttl;
+			feed.cleanupAfter = data.cleanupAfter;
+			yield feed.saveTx();
+			yield feed.updateFeed();
+		}
+	});
+	
+	this.newFeedFromURL = Zotero.Promise.coroutine(function* () {
 		let data = {};
 		window.openDialog('chrome://zotero/content/feedSettings.xul', 
 			null, 'centerscreen, modal', data);

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -113,6 +113,11 @@ var ZoteroPane = new function()
 			document.getElementById('zotero-pane-stack').setAttribute('oldsearchfield', 'true')
 		}
 		
+		if (Zotero.isStandalone) {
+			document.getElementById('zotero-tb-feed-add-fromPage').hidden = true;
+			document.getElementById('zotero-tb-feed-add-fromPage-menu').hidden = true;
+		}
+		
 		// register an observer for Zotero reload
 		observerService = Components.classes["@mozilla.org/observer-service;1"]
 					  .getService(Components.interfaces.nsIObserverService);

--- a/chrome/content/zotero/zoteroPane.xul
+++ b/chrome/content/zotero/zoteroPane.xul
@@ -36,8 +36,7 @@
 
 <overlay id="zotero"
 	xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
-
-	<script src="feedSettings.js"/>
+	
 	<script src="include.js"/>
 	<script src="zoteroPane.js" type="application/javascript;version=1.8"/>
 	<script src="fileInterface.js"/>
@@ -107,13 +106,13 @@
 					<toolbarbutton id="zotero-tb-library-add-menu" class="zotero-tb-button" tooltiptext="&zotero.toolbar.newLibrary.label;" type="menu">
 						<menupopup id="zotero-tb-library-add-popup">
 							<menuitem id="zotero-tb-group-add" label="&zotero.toolbar.newGroup;" oncommand="ZoteroPane_Local.newGroup()"/>
-							<menu label="&zotero.toolbar.feeds.new;">
-								<menupopup id="zotero-tb-feed-add-more">
+							<menu id="zotero-tb-feed-add-menu" label="&zotero.toolbar.feeds.new;">
+								<menupopup>
 									<menuitem id="zotero-tb-feed-add-fromURL" label="&zotero.toolbar.feeds.new.fromURL;" 
 										command="cmd_zotero_newFeed_fromURL"/>
-									<menuitem id="zotero-tb-feed-add-fromPage" label="&zotero.toolbar.feeds.new.fromPage.menu;"
+									<menuitem id="zotero-tb-feed-add-fromPage" label="&zotero.toolbar.feeds.new.fromPage;"
 										oncommand="ZoteroPane_Local.newFeedFromPage()" observes="singleFeedMenuitemState"/>
-									<menu id="zotero-tb-feed-add-fromPage-menu" label="&zotero.toolbar.feeds.new.fromPage.menu;"
+									<menu id="zotero-tb-feed-add-fromPage-menu" label="&zotero.toolbar.feeds.new.fromPage;"
 										observes="multipleFeedsMenuState">
 											<menupopup oncommand="ZoteroPane_Local.newFeedFromPage(event)" 
 												onpopupshowing="FeedHandler.buildFeedList(event.target)"/>
@@ -258,7 +257,6 @@
 					<menuitem class="menuitem-iconic zotero-menuitem-new-collection" label="&zotero.toolbar.newCollection.label;" command="cmd_zotero_newCollection"/>
 					<menuitem class="menuitem-iconic zotero-menuitem-new-saved-search" label="&zotero.toolbar.newSavedSearch.label;" command="cmd_zotero_newSavedSearch"/>
 					<menuitem class="menuitem-iconic zotero-menuitem-new-collection" label="&zotero.toolbar.newSubcollection.label;" oncommand="ZoteroPane_Local.newCollection(ZoteroPane_Local.getSelectedCollection().key)"/>
-					<menuitem class="menuitem-iconic zotero-menuitem-new-feed" label="&zotero.toolbar.feeds.new;" command="cmd_zotero_newFeed_fromURL"/>
 					<menuitem class="menuitem-iconic zotero-menuitem-refresh-feed" label="&zotero.toolbar.feeds.refresh;" oncommand="ZoteroPane_Local.refreshFeed();"/>
 					<menuseparator/>
 					<menuitem class="menuitem-iconic zotero-menuitem-show-duplicates" label="&zotero.toolbar.duplicate.label;" oncommand="ZoteroPane_Local.setVirtual(ZoteroPane_Local.getSelectedLibraryID(), 'duplicates', true)"/>

--- a/chrome/content/zotero/zoteroPane.xul
+++ b/chrome/content/zotero/zoteroPane.xul
@@ -36,7 +36,8 @@
 
 <overlay id="zotero"
 	xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
-	
+
+	<script src="feedSettings.js"/>
 	<script src="include.js"/>
 	<script src="zoteroPane.js" type="application/javascript;version=1.8"/>
 	<script src="fileInterface.js"/>
@@ -58,7 +59,7 @@
 		<command id="cmd_zotero_createTimeline" oncommand="Zotero_Timeline_Interface.loadTimeline();"/>
 		<command id="cmd_zotero_rtfScan" oncommand="window.openDialog('chrome://zotero/content/rtfScan.xul', 'rtfScan', 'chrome,centerscreen')"/>
 		<command id="cmd_zotero_newCollection" oncommand="ZoteroPane_Local.newCollection()"/>
-		<command id="cmd_zotero_newFeed" oncommand="ZoteroPane_Local.newFeed()"/>
+		<command id="cmd_zotero_newFeed_fromURL" oncommand="ZoteroPane_Local.newFeedFromURL()"/>
 		<command id="cmd_zotero_newSavedSearch" oncommand="ZoteroPane_Local.newSearch()"/>
 		<command id="cmd_zotero_newStandaloneNote" oncommand="ZoteroPane_Local.newNote(event.shiftKey);"/>
 		<command id="cmd_zotero_newChildNote" oncommand="ZoteroPane_Local.newChildNote(event.shiftKey);"/>
@@ -106,7 +107,19 @@
 					<toolbarbutton id="zotero-tb-library-add-menu" class="zotero-tb-button" tooltiptext="&zotero.toolbar.newLibrary.label;" type="menu">
 						<menupopup id="zotero-tb-library-add-popup">
 							<menuitem id="zotero-tb-group-add" label="&zotero.toolbar.newGroup;" oncommand="ZoteroPane_Local.newGroup()"/>
-							<menuitem id="zotero-tb-feed-add" label="&zotero.toolbar.newFeed.label;" command="cmd_zotero_newFeed"/>
+							<menu label="&zotero.toolbar.feeds.new;">
+								<menupopup id="zotero-tb-feed-add-more">
+									<menuitem id="zotero-tb-feed-add-fromURL" label="&zotero.toolbar.feeds.new.fromURL;" 
+										command="cmd_zotero_newFeed_fromURL"/>
+									<menuitem id="zotero-tb-feed-add-fromPage" label="&zotero.toolbar.feeds.new.fromPage.menu;"
+										oncommand="ZoteroPane_Local.newFeedFromPage()" observes="singleFeedMenuitemState"/>
+									<menu id="zotero-tb-feed-add-fromPage-menu" label="&zotero.toolbar.feeds.new.fromPage.menu;"
+										observes="multipleFeedsMenuState">
+											<menupopup oncommand="ZoteroPane_Local.newFeedFromPage(event)" 
+												onpopupshowing="FeedHandler.buildFeedList(event.target)"/>
+									</menu>
+								</menupopup>
+							</menu>
 						</menupopup>
 					</toolbarbutton>
 					<spacer flex="1"/>
@@ -245,14 +258,14 @@
 					<menuitem class="menuitem-iconic zotero-menuitem-new-collection" label="&zotero.toolbar.newCollection.label;" command="cmd_zotero_newCollection"/>
 					<menuitem class="menuitem-iconic zotero-menuitem-new-saved-search" label="&zotero.toolbar.newSavedSearch.label;" command="cmd_zotero_newSavedSearch"/>
 					<menuitem class="menuitem-iconic zotero-menuitem-new-collection" label="&zotero.toolbar.newSubcollection.label;" oncommand="ZoteroPane_Local.newCollection(ZoteroPane_Local.getSelectedCollection().key)"/>
-					<menuitem class="menuitem-iconic zotero-menuitem-new-feed" label="&zotero.toolbar.newFeed.label;" command="cmd_zotero_newFeed"/>
-					<menuitem class="menuitem-iconic zotero-menuitem-refresh-feed" label="&zotero.toolbar.refreshFeed.label;" oncommand="ZoteroPane_Local.refreshFeed();"/>
+					<menuitem class="menuitem-iconic zotero-menuitem-new-feed" label="&zotero.toolbar.feeds.new;" command="cmd_zotero_newFeed_fromURL"/>
+					<menuitem class="menuitem-iconic zotero-menuitem-refresh-feed" label="&zotero.toolbar.feeds.refresh;" oncommand="ZoteroPane_Local.refreshFeed();"/>
 					<menuseparator/>
 					<menuitem class="menuitem-iconic zotero-menuitem-show-duplicates" label="&zotero.toolbar.duplicate.label;" oncommand="ZoteroPane_Local.setVirtual(ZoteroPane_Local.getSelectedLibraryID(), 'duplicates', true)"/>
 					<menuitem class="menuitem-iconic zotero-menuitem-show-unfiled" label="&zotero.collections.showUnfiledItems;" oncommand="ZoteroPane_Local.setVirtual(ZoteroPane_Local.getSelectedLibraryID(), 'unfiled', true)"/>
 					<menuitem class="menuitem-iconic zotero-menuitem-edit-collection" oncommand="ZoteroPane_Local.editSelectedCollection();"/>
 					<menuitem class="menuitem-iconic zotero-menuitem-mark-read-feed" label="&zotero.toolbar.markFeedRead.label;" oncommand="ZoteroPane_Local.markFeedRead();"/>
-					<menuitem class="menuitem-iconic zotero-menuitem-edit-feed" label="&zotero.toolbar.editFeed.label;" oncommand="ZoteroPane_Local.editSelectedFeed();"/>
+					<menuitem class="menuitem-iconic zotero-menuitem-edit-feed" label="&zotero.toolbar.feeds.edit;" oncommand="ZoteroPane_Local.editSelectedFeed();"/>
 					<menuitem class="menuitem-iconic zotero-menuitem-delete-collection" oncommand="ZoteroPane_Local.deleteSelectedCollection();"/>
 					<menuitem class="menuitem-iconic zotero-menuitem-move-to-trash" oncommand="ZoteroPane_Local.deleteSelectedCollection(true);"/>
 					<menuseparator/>

--- a/chrome/locale/en-US/zotero/zotero.dtd
+++ b/chrome/locale/en-US/zotero/zotero.dtd
@@ -105,9 +105,6 @@
 <!ENTITY zotero.toolbar.removeItem.label				"Remove Item…">
 <!ENTITY zotero.toolbar.newLibrary.label			"New Library…">
 <!ENTITY zotero.toolbar.newCollection.label			"New Collection…">
-<!ENTITY zotero.toolbar.newFeed.label				"New Feed…">
-<!ENTITY zotero.toolbar.refreshFeed.label			"Refresh Feed">
-<!ENTITY zotero.toolbar.editFeed.label				"Edit Feed…">
 <!ENTITY zotero.toolbar.markFeedRead.label				"Mark Feed As Read">
 <!ENTITY zotero.toolbar.newGroup						"New Group…">
 <!ENTITY zotero.toolbar.newSubcollection.label			"New Subcollection…">
@@ -127,6 +124,13 @@
 <!ENTITY zotero.toolbar.tab.tooltip					"Toggle Tab Mode">
 <!ENTITY zotero.toolbar.openURL.label					"Locate">
 <!ENTITY zotero.toolbar.openURL.tooltip				"Find through your local library">
+
+<!ENTITY zotero.toolbar.feeds.new					"New Feed…">
+<!ENTITY zotero.toolbar.feeds.new.fromURL			"From URL…">
+<!ENTITY zotero.toolbar.feeds.new.fromPage			"From Page">
+<!ENTITY zotero.toolbar.feeds.new.fromPage.menu		"From Page…">
+<!ENTITY zotero.toolbar.feeds.refresh				"Refresh Feed">
+<!ENTITY zotero.toolbar.feeds.edit					"Edit Feed…">
 
 <!ENTITY zotero.item.add								"Add">
 <!ENTITY zotero.item.attachment.file.show				"Show File">

--- a/chrome/locale/en-US/zotero/zotero.dtd
+++ b/chrome/locale/en-US/zotero/zotero.dtd
@@ -127,8 +127,7 @@
 
 <!ENTITY zotero.toolbar.feeds.new					"New Feed…">
 <!ENTITY zotero.toolbar.feeds.new.fromURL			"From URL…">
-<!ENTITY zotero.toolbar.feeds.new.fromPage			"From Page">
-<!ENTITY zotero.toolbar.feeds.new.fromPage.menu		"From Page…">
+<!ENTITY zotero.toolbar.feeds.new.fromPage		"From Page…">
 <!ENTITY zotero.toolbar.feeds.refresh				"Refresh Feed">
 <!ENTITY zotero.toolbar.feeds.edit					"Edit Feed…">
 


### PR DESCRIPTION
Abuses the same API firefox uses to build its feed menus.