### PR TITLE
Bug fix progressWindow.js: nArcs undefined

### DIFF
--- a/chrome/content/zotero/xpcom/progressWindow.js
+++ b/chrome/content/zotero/xpcom/progressWindow.js
@@ -332,6 +332,7 @@ Zotero.ProgressWindow = function(_window = null) {
 	this.ItemProgress.prototype.setProgress = _deferUntilWindowLoad(function(percent) {
 		if(percent != 0 && percent != 100) {
 			// Indication of partial progress, so we will use the circular indicator
+			var nArcs = 20;			
 			this._image.style.backgroundImage = "url('chrome://zotero/skin/progress_arcs.png')";
 			this._image.style.backgroundPosition = "-"+(Math.round(percent/100*nArcs)*16)+"px 0";
 			this._hbox.style.opacity = percent/200+.5;


### PR DESCRIPTION
`nArcs` is undefined in `this.ItemProgress.prototype.setProgress()`. This has been the case for a long time but never came up because the progress indicator isn't used in Zotero, I believe. I think it's a nice UI element though and could be used for non-disruptive progress indicators.