### PR TITLE
Closes #961. Fixes feed dialogue remove read articles value not saving

### DIFF
--- a/chrome/content/zotero/feedSettings.xul
+++ b/chrome/content/zotero/feedSettings.xul
@@ -7,8 +7,8 @@
 <dialog xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
 	title="&zotero.feedSettings.title;" buttons="cancel,accept"
 	buttonlabelaccept="&zotero.feedSettings.saveButton.label;"
-	ondialogaccept="Zotero_Feed_Settings.accept()"
-	ondialogcancel="Zotero_Feed_Settings.cancel()"
+	ondialogaccept="return Zotero_Feed_Settings.accept()"
+	ondialogcancel="return Zotero_Feed_Settings.cancel()"
 	id="zotero-feed-settings"
 	onload="Zotero_Feed_Settings.init()">
 	
@@ -49,7 +49,7 @@
 		<vbox id="advanced-options-togglable">
 			<hbox align="center">
 				<label value="&zotero.feedSettings.refresh.label1;" control="feed-ttl"/>
-				<textbox id="feed-ttl" type="number" min="0" increment="1" size="3"/>
+				<textbox id="feed-ttl" type="number" min="1" increment="1" size="3"/>
 				<label value="&zotero.feedSettings.refresh.label2;" control="feed-ttl"/>
 			</hbox>
 			<hbox align="center">

--- a/chrome/content/zotero/preferences/preferences_advanced.xul
+++ b/chrome/content/zotero/preferences/preferences_advanced.xul
@@ -312,14 +312,14 @@
 						<hbox>
 							<hbox align="center">
 								<label value="&zotero.feedSettings.refresh.label1;"/>
-								<textbox maxlength="2" size="2" preference="pref-feeds-defaultTTL"/>
+								<textbox type="number" min="1" increment="1" size="3" preference="pref-feeds-defaultTTL"/>
 								<label value="&zotero.feedSettings.refresh.label2;"/>
 							</hbox>
 						</hbox>
 						<hbox>
 							<hbox align="center">
 								<label value="&zotero.feedSettings.cleanupAfter.label1;"/>
-								<textbox maxlength="3" size="3" preference="pref-feeds-defaultCleanupAfter"/>
+								<textbox type="number" min="0" increment="1" size="2" preference="pref-feeds-defaultCleanupAfter"/>
 								<label value="&zotero.feedSettings.cleanupAfter.label2;"/>
 							</hbox>
 						</hbox>

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -2003,7 +2003,7 @@ var ZoteroPane = new function()
 			url: feed.url,
 			title: feed.name,
 			ttl: feed.refreshInterval,
-			cleanAfter: feed.cleanupAfter
+			cleanupAfter: feed.cleanupAfter
 		};
 		
 		window.openDialog('chrome://zotero/content/feedSettings.xul', 
@@ -2012,7 +2012,7 @@ var ZoteroPane = new function()
 		
 		feed.name = data.title;
 		feed.refreshInterval = data.ttl;
-		feed.cleanupAfter = data.cleanAfter;
+		feed.cleanupAfter = data.cleanupAfter;
 		yield feed.saveTx();
 	});
 	

--- a/chrome/locale/en-US/zotero/zotero.dtd
+++ b/chrome/locale/en-US/zotero/zotero.dtd
@@ -266,7 +266,7 @@
 <!ENTITY zotero.feedSettings.saveButton.label           "Save">
 <!ENTITY zotero.feedSettings.url.label                  "URL:">
 <!ENTITY zotero.feedSettings.title.label                "Title:">
-<!ENTITY zotero.feedSettings.refresh.label1             "Refresh Interval:">
+<!ENTITY zotero.feedSettings.refresh.label1             "Update feed every">
 <!ENTITY zotero.feedSettings.refresh.label2             "hour(s)">
 <!ENTITY zotero.feedSettings.cleanupAfter.label1         "Remove read articles after ">
 <!ENTITY zotero.feedSettings.cleanupAfter.label2         "day(s)">


### PR DESCRIPTION
Also addresses the comment:

> (Moreover, I would also expect to receive directly an error if I try to set it to 0.)

We may want to allow deleting articles after 0 days, but 0 hour refresh interval doesn't make any sense, so I changed the minimum value to 1 and made the label more user friendly and consistent with the rest of the dialog.