### PR TITLE
Fix some for each ... in cases

### DIFF
--- a/chrome/content/zotero/bindings/filesyncstatus.xml
+++ b/chrome/content/zotero/bindings/filesyncstatus.xml
@@ -92,7 +92,7 @@
 					else {
 						// Get ordered list of library names
 						var libraryNames = [];
-						for each(var libraryID in newLibraries) {
+						for (let libraryID of newLibraries) {
 							libraryNames.push({
 								libraryID: libraryID,
 								name: Zotero.Libraries.getName(libraryID)

--- a/chrome/content/zotero/bindings/itembox.xml
+++ b/chrome/content/zotero/bindings/itembox.xml
@@ -325,7 +325,7 @@
 					
 					// Manual field order
 					if (this._fieldOrder.length) {
-						for each(var field in this._fieldOrder) {
+						for (let field of this._fieldOrder) {
 							fieldNames.push(field);
 						}
 					}
@@ -1800,7 +1800,7 @@
 							}
 							
 							//Add the creators in lastNameArray one at a time
-							for each(var tempName in nameArray) {
+							for (let tempName of nameArray) {
 								// Check for tab to determine creator name format
 								otherFields.fieldMode = (tempName.indexOf('\t') == -1) ? 1 : 0;
 								if (otherFields.fieldMode == 0) {

--- a/chrome/content/zotero/bindings/styled-textbox.xml
+++ b/chrome/content/zotero/bindings/styled-textbox.xml
@@ -609,7 +609,7 @@
 						
 						if (!SJOW.tinyMCE) {
 							var exts = Zotero.getInstalledExtensions(function(exts) {
-								for each(var ext in exts) {
+								for (let ext of exts) {
 									if (ext.indexOf('NoScript') != -1 && ext.indexOf('disabled') == -1) {
 										var doc = win.document;
 										var div = doc.getElementById('tinymce');

--- a/chrome/content/zotero/bindings/zoterosearch.xml
+++ b/chrome/content/zotero/bindings/zoterosearch.xml
@@ -369,7 +369,7 @@
 								label.setAttribute('value', Zotero.getString('searchConditions.tooltip.fields'));
 								fieldRow.appendChild(label);
 								var vbox = document.createElement('vbox');
-								for each(var str in localized) {
+								for (let str of localized) {
 									var label = document.createElement('label')
 									label.setAttribute('value', str);
 									vbox.appendChild(label);

--- a/chrome/content/zotero/charsetMenu.js
+++ b/chrome/content/zotero/charsetMenu.js
@@ -47,7 +47,7 @@ var Zotero_Charset_Menu = new function() {
 		if(Zotero.platformMajorVersion >= 32) {
 			Components.utils.import("resource://gre/modules/CharsetMenu.jsm");
 			var cmData = CharsetMenu.getData();
-			for each(var charsetList in [cmData.pinnedCharsets, cmData.otherCharsets]) {
+			for (let charsetList of [cmData.pinnedCharsets, cmData.otherCharsets]) {
 				for each(var charsetInfo in charsetList) {
 					if(charsetInfo.value == "UTF-8") {
 						charsets.push({

--- a/chrome/content/zotero/downloadOverlay.js
+++ b/chrome/content/zotero/downloadOverlay.js
@@ -182,7 +182,7 @@ var Zotero_DownloadOverlay = new function() {
 		// Disable for filetypes people probably don't want to save
 		var show = false;
 		var mimeType = dialog.mLauncher.MIMEInfo.MIMEType.toLowerCase();
-		for (var elem of ALLOW_LIST) {
+		for (let elem of ALLOW_LIST) {
 			if(typeof elem === "string") {
 				if(elem === mimeType) {
 					document.getElementById('zotero-container').hidden = false;

--- a/chrome/content/zotero/downloadOverlay.js
+++ b/chrome/content/zotero/downloadOverlay.js
@@ -182,7 +182,7 @@ var Zotero_DownloadOverlay = new function() {
 		// Disable for filetypes people probably don't want to save
 		var show = false;
 		var mimeType = dialog.mLauncher.MIMEInfo.MIMEType.toLowerCase();
-		for each(var elem in ALLOW_LIST) {
+		for (var elem of ALLOW_LIST) {
 			if(typeof elem === "string") {
 				if(elem === mimeType) {
 					document.getElementById('zotero-container').hidden = false;

--- a/chrome/content/zotero/integration/editBibliographyDialog.js
+++ b/chrome/content/zotero/integration/editBibliographyDialog.js
@@ -72,7 +72,7 @@ var Zotero_Bibliography_Dialog = new function () {
 		var clearListItems = false;
 		var itemsToSelect = [];
 		if(selectedItemIDs.length) {
-			for each(var itemID in selectedItemIDs) {
+			for (let itemID of selectedItemIDs) {
 				var itemIndexToSelect = false;
 				for(var i in bibEditInterface.bibliography[0].entry_ids) {
 					if(bibEditInterface.bibliography[0].entry_ids[i].indexOf(itemID) !== -1) {
@@ -135,7 +135,7 @@ var Zotero_Bibliography_Dialog = new function () {
 	 * Adds references to the reference list
 	 */
 	this.add = function() {
-		for each(var itemID in itemsView.getSelectedItems(true)) {
+		for (let itemID of itemsView.getSelectedItems(true)) {
 			bibEditInterface.add(itemID);
 		}
 		document.getElementById("add").disabled = true;
@@ -184,7 +184,7 @@ var Zotero_Bibliography_Dialog = new function () {
 		
 		if(regenerate != 0) return;
 		
-		for each(var itemID in _getSelectedListItemIDs()) {
+		for (let itemID of _getSelectedListItemIDs()) {
 			bibEditInterface.revert(itemID);
 		}
 		
@@ -199,7 +199,7 @@ var Zotero_Bibliography_Dialog = new function () {
 		
 		// if cited in bibliography, warn before removing
 		var isCited = false;
-		for each(var itemID in selectedListItemIDs) {
+		for (let itemID of selectedListItemIDs) {
 			isCited |= bibEditInterface.isCited(itemID);
 		}
 		if(isCited) {			
@@ -218,7 +218,7 @@ var Zotero_Bibliography_Dialog = new function () {
 		}
 		
 		// remove
-		for each(var itemID in selectedListItemIDs) {
+		for (let itemID of selectedListItemIDs) {
 			bibEditInterface.remove(itemID);
 		}
 		_loadItems();
@@ -263,7 +263,7 @@ var Zotero_Bibliography_Dialog = new function () {
 	function _updateRevertButtonStatus() {
 		_revertButton.disabled = true;
 		var selectedListItemIDs = _getSelectedListItemIDs();
-		for each(var itemID in selectedListItemIDs) {
+		for (let itemID of selectedListItemIDs) {
 			if(bibEditInterface.isEdited(itemID)) {
 				_revertButton.disabled = false;
 				break;

--- a/chrome/content/zotero/locateManager.xul
+++ b/chrome/content/zotero/locateManager.xul
@@ -151,7 +151,7 @@ To add a new preference:
 			// repopulate tree with available engines
 			var engines = Zotero.LocateManager.getEngines();
 			var i = 0;
-			for each(var engine in engines) {
+			for (let engine of engines) {
 				var treeitem = document.createElement('treeitem');
 				var treerow = document.createElement('treerow');
 				var checkboxCell = document.createElement('treecell');

--- a/chrome/content/zotero/locateManager.xul
+++ b/chrome/content/zotero/locateManager.xul
@@ -175,7 +175,7 @@ To add a new preference:
 			}
 			
 			// restore ranges
-			for each(var range in ranges) {
+			for (let range of ranges) {
 				if(range[1] <= engines.length-1) {
 					tree.view.selection.rangedSelect(range[0], range[1], true);
 				}

--- a/chrome/content/zotero/preferences/preferences_advanced.js
+++ b/chrome/content/zotero/preferences/preferences_advanced.js
@@ -247,7 +247,7 @@ Zotero_Preferences.Advanced = {
 		
 		this._openURLResolvers = Zotero.OpenURL.discoverResolvers();
 		var i = 0;
-		for each(var r in this._openURLResolvers) {
+		for (let r of this._openURLResolvers) {
 			openURLMenu.insertItemAt(i, r.name);
 			if (r.url == Zotero.Prefs.get('openURL.resolver') && r.version == Zotero.Prefs.get('openURL.version')) {
 				openURLMenu.selectedIndex = i;

--- a/chrome/content/zotero/preferences/preferences_sync.js
+++ b/chrome/content/zotero/preferences/preferences_sync.js
@@ -213,9 +213,9 @@ Zotero_Preferences.Sync = {
 	updateStorageSettingsGroups: function (enabled) {
 		var storageSettings = document.getElementById('storage-settings');
 		var menulists = storageSettings.getElementsByTagName('menulist');
-		for (let i=0; i<menulists.length; i++) {
-			if (menulists[i].className == 'storage-groups') {
-				menulists[i].disabled = !enabled;
+		for (let menulist of menulists) {
+			if (menulist.className == 'storage-groups') {
+				menulist.disabled = !enabled;
 			}
 		}
 		

--- a/chrome/content/zotero/preferences/preferences_sync.js
+++ b/chrome/content/zotero/preferences/preferences_sync.js
@@ -213,9 +213,9 @@ Zotero_Preferences.Sync = {
 	updateStorageSettingsGroups: function (enabled) {
 		var storageSettings = document.getElementById('storage-settings');
 		var menulists = storageSettings.getElementsByTagName('menulist');
-		for each(var menulist in menulists) {
-			if (menulist.className == 'storage-groups') {
-				menulist.disabled = !enabled;
+		for (let i=0; i<menulists.length; i++) {
+			if (menulists[i].className == 'storage-groups') {
+				menulists[i].disabled = !enabled;
 			}
 		}
 		

--- a/chrome/content/zotero/standalone/standalone.js
+++ b/chrome/content/zotero/standalone/standalone.js
@@ -52,7 +52,7 @@ const ZoteroStandalone = new function() {
 					.getService(Components.interfaces.nsIExternalProtocolService);
 			var hs = Components.classes["@mozilla.org/uriloader/handler-service;1"]
 					.getService(Components.interfaces.nsIHandlerService);
-			for each(var scheme in ["http", "https"]) {
+			for (var scheme of ["http", "https"]) {
 				var handlerInfo = eps.getProtocolHandlerInfo(scheme);
 				handlerInfo.preferredAction = Components.interfaces.nsIHandlerInfo.useSystemDefault;
 				handlerInfo.alwaysAskBeforeHandling = false;

--- a/chrome/content/zotero/standalone/standalone.js
+++ b/chrome/content/zotero/standalone/standalone.js
@@ -52,7 +52,7 @@ const ZoteroStandalone = new function() {
 					.getService(Components.interfaces.nsIExternalProtocolService);
 			var hs = Components.classes["@mozilla.org/uriloader/handler-service;1"]
 					.getService(Components.interfaces.nsIHandlerService);
-			for (var scheme of ["http", "https"]) {
+			for (let scheme of ["http", "https"]) {
 				var handlerInfo = eps.getProtocolHandlerInfo(scheme);
 				handlerInfo.preferredAction = Components.interfaces.nsIHandlerInfo.useSystemDefault;
 				handlerInfo.alwaysAskBeforeHandling = false;

--- a/chrome/content/zotero/tools/csledit.js
+++ b/chrome/content/zotero/tools/csledit.js
@@ -55,7 +55,7 @@ var Zotero_CSL_Editor = new function() {
 		
 		var pageList = document.getElementById('zotero-csl-page-type');
 		var locators = Zotero.Cite.labels;
-		for each(var type in locators) {
+		for (let type of locators) {
 			var locator = type;
 			locator = Zotero.getString('citation.locator.'+locator.replace(/\s/g,''));
 			pageList.appendItem(locator, type);

--- a/chrome/content/zotero/xpcom/annotate.js
+++ b/chrome/content/zotero/xpcom/annotate.js
@@ -711,7 +711,7 @@ Zotero.Annotations.prototype.unhighlight = function(selectedRange) {
  * Refereshes display of annotations (useful if page is reloaded)
  */
 Zotero.Annotations.prototype.refresh = function() {
-	for each(var annotation in this.annotations) {
+	for (let annotation of this.annotations) {
 		annotation.display();
 	}
 }
@@ -725,12 +725,12 @@ Zotero.Annotations.prototype.save = function() {
 		Zotero.DB.query("DELETE FROM highlights WHERE itemID = ?", [this.itemID]);
 		
 		// save highlights
-		for each(var highlight in this.highlights) {
+		for (let highlight of this.highlights) {
 			if(highlight) highlight.save();
 		}
 		
 		// save annotations
-		for each(var annotation in this.annotations) {
+		for (let annotation of this.annotations) {
 			// Don't drop all annotations if one is broken (due to ~3.0 glitch)
 			try {
 				annotation.save();
@@ -778,7 +778,7 @@ Zotero.Annotations.prototype.load = Zotero.Promise.coroutine(function* () {
 Zotero.Annotations.prototype.toggleCollapsed = function() {
 	// look to see if there are any collapsed annotations
 	var status = true;
-	for each(var annotation in this.annotations) {
+	for (let annotation of this.annotations) {
 		if(annotation.collapsed) {
 			status = false;
 			break;
@@ -786,7 +786,7 @@ Zotero.Annotations.prototype.toggleCollapsed = function() {
 	}
 	
 	// set status on all annotations
-	for each(var annotation in this.annotations) {
+	for (let annotation of this.annotations) {
 		annotation.setCollapsed(status);
 	}
 }
@@ -1621,7 +1621,7 @@ Zotero.Highlight.prototype._highlightSpaceBetween = function(start, end) {
 			node = node.nextSibling;
 		}
 		
-		for each(var textNode in textArray) {
+		for (let textNode of textArray) {
 			if(firstSpan) {
 				this._highlightTextNode(textNode);
 			} else {

--- a/chrome/content/zotero/xpcom/cite.js
+++ b/chrome/content/zotero/xpcom/cite.js
@@ -235,7 +235,7 @@ Zotero.Cite = {
 			var rightPadding = .5;
 			
 			// div.csl-left-margin
-			for each(var div in leftMarginDivs) {
+			for (let div of leftMarginDivs) {
 				var divStyle = div.getAttribute("style");
 				if(!divStyle) divStyle = "";
 				
@@ -252,7 +252,7 @@ Zotero.Cite = {
 			}
 			
 			// div.csl-right-inline
-			for each(var div in Zotero.Utilities.xpath(doc, '//div[@class="csl-right-inline"]')) {
+			for (let div of Zotero.Utilities.xpath(doc, '//div[@class="csl-right-inline"]')) {
 				var divStyle = div.getAttribute("style");
 				if(!divStyle) divStyle = "";
 				
@@ -266,7 +266,7 @@ Zotero.Cite = {
 			}
 			
 			// div.csl-indent
-			for each(var div in Zotero.Utilities.xpath(doc, '//div[@class="csl-indent"]')) {
+			for (let div of Zotero.Utilities.xpath(doc, '//div[@class="csl-indent"]')) {
 				div.setAttribute("style", "margin: .5em 0 0 2em; padding: 0 0 .2em .5em; border-left: 5px solid #ccc;");
 			}
 			

--- a/chrome/content/zotero/xpcom/collectionTreeView.js
+++ b/chrome/content/zotero/xpcom/collectionTreeView.js
@@ -961,7 +961,7 @@ Zotero.CollectionTreeView.prototype.expandToCollection = Zotero.Promise.coroutin
 		path.unshift(parentID);
 		col = yield Zotero.Collections.getAsync(parentID);
 	}
-	for each(var id in path) {
+	for (let id of path) {
 		row = this._rowMap["C" + id];
 		if (!this.isContainerOpen(row)) {
 			yield this.toggleOpenState(row);
@@ -2012,7 +2012,7 @@ Zotero.CollectionTreeView.prototype.drop = Zotero.Promise.coroutine(function* (r
 				var toReconcile = [];
 				
 				var newIDs = [];
-				for each(var item in newItems) {
+				for (let item of newItems) {
 					var id = yield copyItem(item, targetLibraryID, copyOptions)
 					// Standalone attachments might not get copied
 					if (!id) {

--- a/chrome/content/zotero/xpcom/cookieSandbox.js
+++ b/chrome/content/zotero/xpcom/cookieSandbox.js
@@ -48,7 +48,7 @@ Zotero.CookieSandbox = function(browser, uri, cookieData, userAgent) {
 	this._cookies = {};
 	if(cookieData) {
 		var splitCookies = cookieData.split(/;\s*/);
-		for each(var cookie in splitCookies) {
+		for (let cookie of splitCookies) {
 			this.setCookie(cookie, this.URI.host);
 		}
 	}
@@ -292,7 +292,7 @@ Zotero.CookieSandbox.Observer = new function() {
 		
 		if(!observing) {
 			Zotero.debug("CookieSandbox: Registering observers");
-			for each(var topic in observeredTopics) observerService.addObserver(this, topic, false);
+			for (let topic of observeredTopics) observerService.addObserver(this, topic, false);
 			observing = true;
 		}
 	};

--- a/chrome/content/zotero/xpcom/integration.js
+++ b/chrome/content/zotero/xpcom/integration.js
@@ -3037,7 +3037,7 @@ Zotero.Integration.DocumentData.prototype.unserializeXML = function(xmlData) {
 		"hasBibliography":(Zotero.Utilities.xpathText(doc, '/data/style[1]/@hasBibliography') == 1),
 		"bibliographyStyleHasBeenSet":(Zotero.Utilities.xpathText(doc, '/data/style[1]/@bibliographyStyleHasBeenSet') == 1)};
 	this.prefs = {};
-	for each(var pref in Zotero.Utilities.xpath(doc, '/data/prefs[1]/pref')) {
+	for (let pref of Zotero.Utilities.xpath(doc, '/data/prefs[1]/pref')) {
 		var name = pref.getAttribute("name");
 		var value = pref.getAttribute("value");
 		if(value === "true") {

--- a/chrome/content/zotero/xpcom/integration.js
+++ b/chrome/content/zotero/xpcom/integration.js
@@ -945,7 +945,7 @@ Zotero.Integration.Document.prototype._getSession = function _getSession(require
 		
 		if(require) {
 			// check to see if fields already exist
-			for each(var fieldType in [this._app.primaryFieldType, this._app.secondaryFieldType]) {
+			for (var fieldType of [this._app.primaryFieldType, this._app.secondaryFieldType]) {
 				var fields = this._doc.getFields(this._app.primaryFieldType);
 				if(fields.hasMoreElements()) {
 					data.prefs.fieldType = this._app.primaryFieldType;
@@ -1318,7 +1318,7 @@ Zotero.Integration.Fields.prototype.addField = function(note) {
  * Gets the type and content of a field object
  */
 Zotero.Integration.Fields.prototype.getCodeTypeAndContent = function(rawCode) {
-	for each(var code in ["ITEM", "CITATION"]) {
+	for (var code of ["ITEM", "CITATION"]) {
 		if(rawCode.substr(0, code.length) === code) {
 			return [INTEGRATION_TYPE_ITEM, rawCode.substr(code.length+1)];
 		}
@@ -2672,7 +2672,7 @@ Zotero.Integration.Session.prototype._updateCitations = function() {
 	}
 	
 	
-	for each(var indexList in [this.newIndices, this.updateIndices]) {
+	for (var indexList of [this.newIndices, this.updateIndices]) {
 		for(var index in indexList) {
 			index = parseInt(index);
 			

--- a/chrome/content/zotero/xpcom/integration.js
+++ b/chrome/content/zotero/xpcom/integration.js
@@ -945,7 +945,7 @@ Zotero.Integration.Document.prototype._getSession = function _getSession(require
 		
 		if(require) {
 			// check to see if fields already exist
-			for (var fieldType of [this._app.primaryFieldType, this._app.secondaryFieldType]) {
+			for (let fieldType of [this._app.primaryFieldType, this._app.secondaryFieldType]) {
 				var fields = this._doc.getFields(this._app.primaryFieldType);
 				if(fields.hasMoreElements()) {
 					data.prefs.fieldType = this._app.primaryFieldType;
@@ -1318,7 +1318,7 @@ Zotero.Integration.Fields.prototype.addField = function(note) {
  * Gets the type and content of a field object
  */
 Zotero.Integration.Fields.prototype.getCodeTypeAndContent = function(rawCode) {
-	for (var code of ["ITEM", "CITATION"]) {
+	for (let code of ["ITEM", "CITATION"]) {
 		if(rawCode.substr(0, code.length) === code) {
 			return [INTEGRATION_TYPE_ITEM, rawCode.substr(code.length+1)];
 		}
@@ -2672,7 +2672,7 @@ Zotero.Integration.Session.prototype._updateCitations = function() {
 	}
 	
 	
-	for (var indexList of [this.newIndices, this.updateIndices]) {
+	for (let indexList of [this.newIndices, this.updateIndices]) {
 		for(var index in indexList) {
 			index = parseInt(index);
 			

--- a/chrome/content/zotero/xpcom/integration.js
+++ b/chrome/content/zotero/xpcom/integration.js
@@ -771,7 +771,7 @@ Zotero.Integration.MissingItemException.prototype = {
 		if(result == 0) {			// Cancel
 			return Zotero.Promise.reject(new Zotero.Exception.UserCancelled("document update"));
 		} else if(result == 1) {	// No
-			for each(var reselectKey in this.reselectKeys) {
+			for (let reselectKey of this.reselectKeys) {
 				this.fieldGetter._removeCodeKeys[reselectKey] = true;
 			}
 			this.fieldGetter._removeCodeFields[this.fieldIndex] = true;
@@ -1646,7 +1646,7 @@ Zotero.Integration.Fields.prototype._updateDocument = function(forceCitations, f
 		
 		if(forceBibliography || this._session.bibliographyDataHasChanged) {
 			var bibliographyData = this._session.getBibliographyData();
-			for each(var field in bibliographyFields) {
+			for (let field of bibliographyFields) {
 				field.setCode("BIBL "+bibliographyData
 					+(this._session.data.prefs.storeReferences ? " CSL_BIBLIOGRAPHY" : ""));
 			}
@@ -1674,7 +1674,7 @@ Zotero.Integration.Fields.prototype._updateDocument = function(forceCitations, f
 		}
 		
 		// set bibliography text
-		for each(var field in bibliographyFields) {
+		for (let field of bibliographyFields) {
 			if(this.progressCallback) {
 				try {
 					this.progressCallback(75+(nUpdated/nFieldUpdates)*25);

--- a/chrome/content/zotero/xpcom/ipc.js
+++ b/chrome/content/zotero/xpcom/ipc.js
@@ -45,7 +45,7 @@ Zotero.IPC = new function() {
 	 * Parses input received via instance pipe
 	 */
 	this.parsePipeInput = function(msgs) {
-		for each(var msg in msgs.split("\n")) {
+		for (let msg of msgs.split("\n")) {
 			if(!msg) continue;
 			Zotero.debug('IPC: Received "'+msg+'"');
 			
@@ -189,7 +189,7 @@ Zotero.IPC = new function() {
 			// name in application.ini
 			const myAppName = Services.appinfo.name;
 
-			for each(var appName in appNames) {
+			for (let appName of appNames) {
 				// don't send messages to ourself
 				if(appName === myAppName) continue;
 				
@@ -233,7 +233,7 @@ Zotero.IPC = new function() {
 			
 			if(!pipes.length) return false;
 			var success = false;
-			for each(var pipe in pipes) {
+			for (let pipe of pipes) {
 				Zotero.debug('IPC: Trying to broadcast "'+msg+'" to instance '+pipe.leafName);
 				
 				var defunct = false;

--- a/chrome/content/zotero/xpcom/itemTreeView.js
+++ b/chrome/content/zotero/xpcom/itemTreeView.js
@@ -2779,7 +2779,7 @@ Zotero.ItemTreeView.fileDragDataProvider.prototype = {
 				// would interrupt the dragging process, so we just log a
 				// warning to the console
 				if (useTemp) {
-					for each(var name in notFoundNames) {
+					for (let name of notFoundNames) {
 						var msg = "Attachment file for dragged item '" + name + "' not found";
 						Zotero.log(msg, 'warning',
 							'chrome://zotero/content/xpcom/itemTreeView.js');

--- a/chrome/content/zotero/xpcom/locateManager.js
+++ b/chrome/content/zotero/xpcom/locateManager.js
@@ -332,7 +332,7 @@ Zotero.LocateManager = new function() {
 		if(obj) for(var prop in obj) this[prop] = obj[prop];
 		
 		// Queue deferred serialization whenever a property is modified
-		for each(var prop in ["alias", "name", "description", "icon", "hidden"]) {
+		for (var prop of ["alias", "name", "description", "icon", "hidden"]) {
 			this.watch(prop, _watchLocateEngineProperties);
 		}
 	}

--- a/chrome/content/zotero/xpcom/locateManager.js
+++ b/chrome/content/zotero/xpcom/locateManager.js
@@ -332,7 +332,7 @@ Zotero.LocateManager = new function() {
 		if(obj) for(var prop in obj) this[prop] = obj[prop];
 		
 		// Queue deferred serialization whenever a property is modified
-		for (var prop of ["alias", "name", "description", "icon", "hidden"]) {
+		for (let prop of ["alias", "name", "description", "icon", "hidden"]) {
 			this.watch(prop, _watchLocateEngineProperties);
 		}
 	}

--- a/chrome/content/zotero/xpcom/locateManager.js
+++ b/chrome/content/zotero/xpcom/locateManager.js
@@ -142,7 +142,7 @@ Zotero.LocateManager = new function() {
 		this.init();
 		
 		// reload icons for default locate engines
-		for each(var engine in this.getEngines()) engine._updateIcon();
+		for (let engine of this.getEngines()) engine._updateIcon();
 	}
 	
 	/**

--- a/chrome/content/zotero/xpcom/mimeTypeHandler.js
+++ b/chrome/content/zotero/xpcom/mimeTypeHandler.js
@@ -206,7 +206,7 @@ Zotero.MIMETypeHandler = new function () {
 				try {
 					// remove content-disposition headers for EndNote, etc.
 					var contentType = channel.getResponseHeader("Content-Type").toLowerCase();
-					for each(var handledType in _ignoreContentDispositionTypes) {
+					for (let handledType of _ignoreContentDispositionTypes) {
 						if(contentType.length < handledType.length) {
 							break;
 						} else {
@@ -218,7 +218,7 @@ Zotero.MIMETypeHandler = new function () {
 					}
 				} catch(e) {}
 				
-				for each(var observer in _observers) {
+				for (let observer of _observers) {
 					observer(channel);
 				}
 			}

--- a/chrome/content/zotero/xpcom/schema.js
+++ b/chrome/content/zotero/xpcom/schema.js
@@ -168,7 +168,7 @@ Zotero.Schema = new function(){
 						toDelete.push(file);
 					}
 				}
-				for each(var file in toDelete) {
+				for (let file of toDelete) {
 					Zotero.debug('Removing previous backup file ' + file.leafName);
 					file.remove(false);
 				}

--- a/chrome/content/zotero/xpcom/server.js
+++ b/chrome/content/zotero/xpcom/server.js
@@ -87,7 +87,7 @@ Zotero.Server = new function() {
 	this.decodeQueryString = function(queryString) {
 		var splitData = queryString.split("&");
 		var decodedData = {};
-		for each(var variable in splitData) {
+		for (let variable of splitData) {
 			var splitIndex = variable.indexOf("=");
 			decodedData[decodeURIComponent(variable.substr(0, splitIndex))] = decodeURIComponent(variable.substr(splitIndex+1));
 		}

--- a/chrome/content/zotero/xpcom/server_connector.js
+++ b/chrome/content/zotero/xpcom/server_connector.js
@@ -108,7 +108,7 @@ Zotero.Server.Connector.GetTranslators.prototype = {
 		var responseData = [];
 		for each(var translator in translators) {
 			let serializableTranslator = {};
-			for each(var key in ["translatorID", "translatorType", "label", "creator", "target",
+			for (var key of ["translatorID", "translatorType", "label", "creator", "target",
 					"minVersion", "maxVersion", "priority", "browserSupport", "inRepository", "lastUpdated"]) {
 				serializableTranslator[key] = translator[key];
 			}

--- a/chrome/content/zotero/xpcom/server_connector.js
+++ b/chrome/content/zotero/xpcom/server_connector.js
@@ -108,7 +108,7 @@ Zotero.Server.Connector.GetTranslators.prototype = {
 		var responseData = [];
 		for each(var translator in translators) {
 			let serializableTranslator = {};
-			for (var key of ["translatorID", "translatorType", "label", "creator", "target",
+			for (let key of ["translatorID", "translatorType", "label", "creator", "target",
 					"minVersion", "maxVersion", "priority", "browserSupport", "inRepository", "lastUpdated"]) {
 				serializableTranslator[key] = translator[key];
 			}

--- a/chrome/content/zotero/xpcom/storage/storageRequest.js
+++ b/chrome/content/zotero/xpcom/storage/storageRequest.js
@@ -75,7 +75,7 @@ Zotero.Sync.Storage.Request.prototype.setMaxSize = function (size) {
  * Add callbacks from another request to this request
  */
 Zotero.Sync.Storage.Request.prototype.importCallbacks = function (request) {
-	for each(var name in this.callbacks) {
+	for (let name of this.callbacks) {
 		name = '_' + name;
 		if (request[name]) {
 			// If no handlers for this event, add them all

--- a/chrome/content/zotero/xpcom/storage/streamListener.js
+++ b/chrome/content/zotero/xpcom/storage/streamListener.js
@@ -227,7 +227,7 @@ Zotero.Sync.Storage.StreamListener.prototype = {
 		}
 		
 		if (this._data.streams) {
-			for each(var stream in this._data.streams) {
+			for (let stream of this._data.streams) {
 				stream.close();
 			}
 		}

--- a/chrome/content/zotero/xpcom/sync.js
+++ b/chrome/content/zotero/xpcom/sync.js
@@ -374,7 +374,7 @@ Zotero.Sync.Server = new function () {
 						Zotero.DB.beginTransaction();
 						
 						var types = ['collections', 'creators', 'items', 'savedSearches', 'tags'];
-						for each (var type in types) {
+						for (let type of types) {
 							var sql = "UPDATE " + type + " SET dateAdded=CURRENT_TIMESTAMP "
 									+ "WHERE dateAdded NOT BETWEEN '1970-01-01 00:00:01' AND '2038-01-19 03:14:07'";
 							Zotero.DB.query(sql);

--- a/chrome/content/zotero/xpcom/translation/translate_item.js
+++ b/chrome/content/zotero/xpcom/translation/translate_item.js
@@ -760,7 +760,7 @@ Zotero.Translate.ItemGetter.prototype = {
 						var targetFile = Components.classes["@mozilla.org/file/local;1"].
 								createInstance(Components.interfaces.nsILocalFile);
 						targetFile.initWithFile(exportDir);
-						for each(var dir in attachPath.split("/")) targetFile.append(dir);
+						for (let dir of attachPath.split("/")) targetFile.append(dir);
 						
 						// First, check that we have not gone lower than exportDir in the hierarchy
 						var parent = targetFile, inExportFileDirectory;

--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -902,7 +902,7 @@ Components.utils.import("resource://gre/modules/osfile.jsm");
 		var curSection = null;
 		var defaultSection = null;
 		var nSections = 0;
-		for each(var line in iniContents.split(/(?:\r?\n|\r)/)) {
+		for (let line of iniContents.split(/(?:\r?\n|\r)/)) {
 			let tline = line.trim();
 			if(tline[0] == "[" && tline[tline.length-1] == "]") {
 				curSection = {};
@@ -1970,7 +1970,7 @@ Components.utils.import("resource://gre/modules/osfile.jsm");
 		if (percentage === _lastPercentage) {
 			return;
 		}
-		for each(var pm in _progressMeters) {
+		for (let pm of _progressMeters) {
 			if (percentage !== null) {
 				if (pm.mode == 'undetermined') {
 					pm.max = 1000;

--- a/components/zotero-service.js
+++ b/components/zotero-service.js
@@ -281,7 +281,7 @@ function makeZoteroContext(isConnector) {
 	}
 	
 	// Load xpcomFiles for specific mode
-	for each(var xpcomFile in (isConnector ? xpcomFilesConnector : xpcomFilesLocal)) {
+	for (let xpcomFile of (isConnector ? xpcomFilesConnector : xpcomFilesLocal)) {
 		try {
 			subscriptLoader.loadSubScript("chrome://zotero/content/xpcom/" + xpcomFile + ".js", zContext);
 		}


### PR DESCRIPTION
The `for-each-in` loops are deprecated and will cause some warnings in the browser console (and are only compatible by Gecko):
```
JavaScript 1.6's for-each-in loops are deprecated; consider using ES6 for-of instead
```

@dstillman I can continue here to look at more of these loop cases, if you agree.