### PR TITLE
Don't yield blurOpenField

### DIFF
--- a/chrome/content/zotero/itemPane.js
+++ b/chrome/content/zotero/itemPane.js
@@ -78,7 +78,7 @@ var ZoteroItemPane = new function() {
 			switch (index) {
 				case 0:
 				case 2:
-					yield box.blurOpenField();
+					box.blurOpenField();
 					// DEBUG: Currently broken
 					//box.scrollToTop();
 					break;


### PR DESCRIPTION
I think this got lost somewhere along the way based on `git blame`.

This also fixes a bug where sometimes clicking on new items doesn't display them until you switch tabs in the Item Pane.