### PR TITLE
Closes #1008. Omit certain item list columns in feed views

### DIFF
--- a/chrome/content/zotero/xpcom/itemTreeView.js
+++ b/chrome/content/zotero/xpcom/itemTreeView.js
@@ -2276,8 +2276,8 @@ Zotero.ItemTreeView.prototype.onColumnPickerShowing = function (event) {
 	
 	var lastChild = menupopup.lastChild;
 	
-	// More Columns menu
 	try {
+		// More Columns menu
 		let id = prefix + 'more-menu';
 		
 		let moreMenu = doc.createElementNS(ns, 'menu');
@@ -2314,6 +2314,16 @@ Zotero.ItemTreeView.prototype.onColumnPickerShowing = function (event) {
 		
 		moreMenu.appendChild(moreMenuPopup);
 		menupopup.insertBefore(moreMenu, lastChild);
+
+		// Disable certain entries for feeds
+		let elems = Array.from(treecols.getElementsByAttribute('hidden-in', '*'))
+		let labels = Array.from(elems)
+			.filter(e => e.getAttribute('hidden-in').split(' ').indexOf(this.collectionTreeRow.type) != -1)
+			.map(e => e.getAttribute('label'));
+		for (let i = 0; i < menupopup.childNodes.length; i++) {
+			let elem = menupopup.childNodes[i];
+			elem.setAttribute('disabled', labels.indexOf(elem.getAttribute('label')) != -1);
+		}
 	}
 	catch (e) {
 		Components.utils.reportError(e);

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -1242,11 +1242,11 @@ var ZoteroPane = new function()
 			
 			document.getElementById('zotero-items-tree').view = this.itemsView;
 			
-			// Add events to treecolpicker to update menu before showing/hiding
 			try {
 				let treecols = document.getElementById('zotero-items-columns-header');
 				let treecolpicker = treecols.boxObject.firstChild.nextSibling;
 				let menupopup = treecolpicker.boxObject.firstChild.nextSibling;
+				// Add events to treecolpicker to update menu before showing/hiding
 				let attr = menupopup.getAttribute('onpopupshowing');
 				if (attr.indexOf('Zotero') == -1) {
 					menupopup.setAttribute('onpopupshowing', 'ZoteroPane.itemsView.onColumnPickerShowing(event);')
@@ -1255,6 +1255,28 @@ var ZoteroPane = new function()
 					menupopup.setAttribute('onpopuphidden', 'ZoteroPane.itemsView.onColumnPickerHidden(event);')
 						// Keep whatever else is there
 						+ ' ' + menupopup.getAttribute('onpopuphidden');
+				}
+				
+				// Hide certain columns for feeds
+				let elems = treecols.getElementsByAttribute('hidden-in', '*');
+				for (let i = 0; i < elems.length; i++) {
+					let shouldHide = elems[i].getAttribute('hidden-in').split(' ')
+						.indexOf(collectionTreeRow.type) != -1;
+					let userHidden = elems[i].hasAttribute('user-hidden');
+					// The slightly convoluted logic here is such:
+					// If the current tree being displayed is in the list of types 'hidden-in'
+					// specifies and it's not already been hidden by another 'hidden-in' rule
+					// (i.e. its normal state of being displayed has not been suppressed yet),
+					// then hide it
+					if (shouldHide && !userHidden) {
+						// Store old value on entry to feed view
+						elems[i].setAttribute('user-hidden', elems[i].getAttribute('hidden'));
+						elems[i].setAttribute('hidden', 'true');
+					} else if (!shouldHide && userHidden) {
+						// Restore old value on exit from feed view
+						elems[i].setAttribute('hidden', elems[i].getAttribute('user-hidden'));
+						elems[i].removeAttribute('user-hidden');
+					}
 				}
 			}
 			catch (e) {

--- a/chrome/content/zotero/zoteroPane.xul
+++ b/chrome/content/zotero/zoteroPane.xul
@@ -444,14 +444,14 @@
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-dateAdded" hidden="true"
+										id="zotero-items-column-dateAdded" hidden="true" hidden-in="feed"
 										label="&zotero.items.dateAdded_column;"
-										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
+										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection user-hidden"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-dateModified" hidden="true"
+										id="zotero-items-column-dateModified" hidden="true" hidden-in="feed"
 										label="&zotero.items.dateModified_column;"
-										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
+										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection user-hidden"/>
 									<splitter class="tree-splitter"/>
 									<treecol
 										id="zotero-items-column-archive" hidden="true"
@@ -537,19 +537,19 @@
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-hasAttachment"
+										id="zotero-items-column-hasAttachment" hidden-in="feed"
 										class="treecol-image"
 										label="&zotero.tabs.attachments.label;"
 										src="chrome://zotero/skin/attach-small.png"
 										fixed="true"
-										zotero-persist="ordinal hidden sortActive sortDirection"/>
+										zotero-persist="ordinal hidden sortActive sortDirection user-hidden"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-numNotes" hidden="true"
+										id="zotero-items-column-numNotes" hidden="true" hidden-in="feed"
 										class="treecol-image"
 										label="&zotero.tabs.notes.label;"
 										src="chrome://zotero/skin/treeitem-note-small.png"
-										zotero-persist="width ordinal hidden sortActive sortDirection"/>
+										zotero-persist="width ordinal hidden sortActive sortDirection user-hidden"/>
 								</treecols>
 								<treechildren ondragstart="ZoteroPane_Local.itemsView.onDragStart(event)"
 									ondragenter="return ZoteroPane_Local.itemsView.onDragEnter(event)"


### PR DESCRIPTION
Omitted Date Added, Date Modified, Attachments and Notes. Implemented using custom treecol attributes with `zotero-persist` to retain the configuration between sessions.