### PR TITLE
Allow string path as argument to Zotero.launchFile()

### DIFF
--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -1223,6 +1223,7 @@ Components.utils.import("resource://gre/modules/osfile.jsm");
 	 * Launch a file, the best way we can
 	 */
 	this.launchFile = function (file) {
+		file = Zotero.File.pathToFile(file);
 		try {
 			file.launch();
 		}


### PR DESCRIPTION
Not sure whether this is desired but it helps to reduce the use of nsIFile to a minimum. `file.launch()` and `file.reveal()` are two of the few things that are not possible with OS.File/OS.Path. When that changes, Zotero.launchFile is the only function that needs to be modified if it works with string paths.