### PR TITLE
Correctly inherit "class" from parent style

### DIFF
--- a/chrome/content/zotero/xpcom/style.js
+++ b/chrome/content/zotero/xpcom/style.js
@@ -714,7 +714,14 @@ Zotero.Style.prototype.__defineGetter__("class",
  * @type String
  */
 function() {
-	if(!this._class) this.getXML();
+	if(this.source) {
+		// use class from source style
+		var parentStyle = Zotero.Styles.get(this.source);
+		if(!parentStyle) {
+			throw new Error('Style references missing parent ' + this.source);
+		}
+		return parentStyle.class;
+	}
 	return this._class;
 });
 


### PR DESCRIPTION
Fixes #1039 for me.

To test, install a dependent "note" style without a "class" attribute on `<style>` like Angelaki (https://www.zotero.org/styles?q=angelaki), and test it with a Zotero word processor plugin. In the current master branch, the style is mistakenly identified as an "in-text" style, and creates "in-text" citations. With the patch, it correctly behaves like a "note" style.

The code is a little hocus-pocus for me, but I based the new code on that of `Zotero.Style.prototype.__defineGetter__("hasBibliography", ...)` (https://github.com/zotero/zotero/blob/045554dd8e58a8a02bbac2cf621790db67797944/chrome/content/zotero/xpcom/style.js#L721), and it seems to work.