### PR TITLE
Adds custom view groups for different library types.

### DIFF
--- a/chrome/content/zotero/xpcom/collectionTreeRow.js
+++ b/chrome/content/zotero/xpcom/collectionTreeRow.js
@@ -194,6 +194,15 @@ Zotero.CollectionTreeRow.prototype.__defineGetter__('filesEditable', function ()
 	return false;
 });
 
+
+Zotero.CollectionTreeRow.visibilityGroups = {'feed': 'feed'};
+
+
+Zotero.CollectionTreeRow.prototype.__defineGetter__('visibilityGroup', function() {
+	return Zotero.CollectionTreeRow.visibilityGroups[this.type] || 'default';
+});
+
+
 Zotero.CollectionTreeRow.prototype.getName = function()
 {
 	switch (this.type) {

--- a/chrome/content/zotero/xpcom/itemTreeView.js
+++ b/chrome/content/zotero/xpcom/itemTreeView.js
@@ -2320,9 +2320,9 @@ Zotero.ItemTreeView.prototype.onColumnPickerShowing = function (event) {
 		menupopup.insertBefore(moreMenu, lastChild);
 
 		// Disable certain entries for feeds
-		let elems = Array.from(treecols.getElementsByAttribute('hidden-in', '*'))
+		let elems = Array.from(treecols.getElementsByAttribute('disabled-in', '*'));
 		let labels = Array.from(elems)
-			.filter(e => e.getAttribute('hidden-in').split(' ').indexOf(this.collectionTreeRow.type) != -1)
+			.filter(e => e.getAttribute('disabled-in').split(' ').indexOf(this.collectionTreeRow.type) != -1)
 			.map(e => e.getAttribute('label'));
 		for (let i = 0; i < menupopup.childNodes.length; i++) {
 			let elem = menupopup.childNodes[i];

--- a/chrome/content/zotero/xpcom/itemTreeView.js
+++ b/chrome/content/zotero/xpcom/itemTreeView.js
@@ -2306,6 +2306,16 @@ Zotero.ItemTreeView.prototype.onColumnPickerShowing = function (event) {
 				moreItems.push(elem);
 			}
 		}
+
+		// Disable certain fields for feeds
+		let elems = Array.from(treecols.getElementsByAttribute('disabled-in', '*'));
+		let labels = Array.from(elems)
+			.filter(e => e.getAttribute('disabled-in').split(' ').indexOf(this.collectionTreeRow.type) != -1)
+			.map(e => e.getAttribute('label'));
+		for (let i = 0; i < menupopup.childNodes.length; i++) {
+			let elem = menupopup.childNodes[i];
+			elem.setAttribute('disabled', labels.indexOf(elem.getAttribute('label')) != -1);
+		}
 		
 		// Sort fields and move to submenu
 		var collation = Zotero.getLocaleCollation();
@@ -2318,16 +2328,6 @@ Zotero.ItemTreeView.prototype.onColumnPickerShowing = function (event) {
 		
 		moreMenu.appendChild(moreMenuPopup);
 		menupopup.insertBefore(moreMenu, lastChild);
-
-		// Disable certain entries for feeds
-		let elems = Array.from(treecols.getElementsByAttribute('disabled-in', '*'));
-		let labels = Array.from(elems)
-			.filter(e => e.getAttribute('disabled-in').split(' ').indexOf(this.collectionTreeRow.type) != -1)
-			.map(e => e.getAttribute('label'));
-		for (let i = 0; i < menupopup.childNodes.length; i++) {
-			let elem = menupopup.childNodes[i];
-			elem.setAttribute('disabled', labels.indexOf(elem.getAttribute('label')) != -1);
-		}
 	}
 	catch (e) {
 		Components.utils.reportError(e);

--- a/chrome/content/zotero/xpcom/itemTreeView.js
+++ b/chrome/content/zotero/xpcom/itemTreeView.js
@@ -2308,8 +2308,7 @@ Zotero.ItemTreeView.prototype.onColumnPickerShowing = function (event) {
 		}
 
 		// Disable certain fields for feeds
-		let elems = Array.from(treecols.getElementsByAttribute('disabled-in', '*'));
-		let labels = Array.from(elems)
+		let labels = Array.from(treecols.getElementsByAttribute('disabled-in', '*'))
 			.filter(e => e.getAttribute('disabled-in').split(' ').indexOf(this.collectionTreeRow.type) != -1)
 			.map(e => e.getAttribute('label'));
 		for (let i = 0; i < menupopup.childNodes.length; i++) {

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -1243,39 +1243,41 @@ var ZoteroPane = new function()
 			document.getElementById('zotero-items-tree').view = this.itemsView;
 			
 			try {
+				let tree = document.getElementById('zotero-items-tree');
 				let treecols = document.getElementById('zotero-items-columns-header');
 				let treecolpicker = treecols.boxObject.firstChild.nextSibling;
 				let menupopup = treecolpicker.boxObject.firstChild.nextSibling;
 				// Add events to treecolpicker to update menu before showing/hiding
 				let attr = menupopup.getAttribute('onpopupshowing');
 				if (attr.indexOf('Zotero') == -1) {
-					menupopup.setAttribute('onpopupshowing', 'ZoteroPane.itemsView.onColumnPickerShowing(event);')
+					menupopup.setAttribute('onpopupshowing', 'ZoteroPane.itemsView.onColumnPickerShowing(event); '
 						// Keep whatever else is there
-						+ ' ' + attr;
-					menupopup.setAttribute('onpopuphidden', 'ZoteroPane.itemsView.onColumnPickerHidden(event);')
+						+ attr);
+					menupopup.setAttribute('onpopuphidden', 'ZoteroPane.itemsView.onColumnPickerHidden(event); '
 						// Keep whatever else is there
-						+ ' ' + menupopup.getAttribute('onpopuphidden');
+						+ menupopup.getAttribute('onpopuphidden'));
 				}
 				
-				// Hide certain columns for feeds
-				let elems = treecols.getElementsByAttribute('hidden-in', '*');
-				for (let i = 0; i < elems.length; i++) {
-					let shouldHide = elems[i].getAttribute('hidden-in').split(' ')
-						.indexOf(collectionTreeRow.type) != -1;
-					let userHidden = elems[i].hasAttribute('user-hidden');
-					// The slightly convoluted logic here is such:
-					// If the current tree being displayed is in the list of types 'hidden-in'
-					// specifies and it's not already been hidden by another 'hidden-in' rule
-					// (i.e. its normal state of being displayed has not been suppressed yet),
-					// then hide it
-					if (shouldHide && !userHidden) {
-						// Store old value on entry to feed view
-						elems[i].setAttribute('user-hidden', elems[i].getAttribute('hidden'));
-						elems[i].setAttribute('hidden', 'true');
-					} else if (!shouldHide && userHidden) {
-						// Restore old value on exit from feed view
-						elems[i].setAttribute('hidden', elems[i].getAttribute('user-hidden'));
-						elems[i].removeAttribute('user-hidden');
+				// Items view column visibility for different groups
+				let prevViewGroup = tree.getAttribute('current-view-group');
+				let curViewGroup = collectionTreeRow.visibilityGroup;
+				tree.setAttribute('current-view-group', curViewGroup);
+				if (curViewGroup != prevViewGroup) {
+					let cols = Array.prototype.slice.call(treecols.querySelectorAll('treecol'));
+					let settings = JSON.parse(Zotero.Prefs.get('itemsView.columnVisibility') || '{}');
+					// Store previous view settings
+					settings[prevViewGroup] = cols.map((col) => col.getAttribute('hidden') == 'true' ? 0 : 1);
+					Zotero.Prefs.set('itemsView.columnVisibility', JSON.stringify(settings));
+					
+					// Recover current view settings
+					if (settings[curViewGroup]) {
+						cols.forEach((col, idx) => col.setAttribute('hidden', !settings[curViewGroup][idx]));
+					} else {
+						cols.forEach((col) => {
+							col.setAttribute('hidden', !(col.hasAttribute('default-in') &&
+									col.getAttribute('default-in').split(' ').indexOf(curViewGroup) != -1)
+							)
+						})
 					}
 				}
 			}

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -1263,15 +1263,25 @@ var ZoteroPane = new function()
 				let curViewGroup = collectionTreeRow.visibilityGroup;
 				tree.setAttribute('current-view-group', curViewGroup);
 				if (curViewGroup != prevViewGroup) {
-					let cols = Array.prototype.slice.call(treecols.querySelectorAll('treecol'));
+					let cols = Array.from(treecols.getElementsByTagName('treecol'));
 					let settings = JSON.parse(Zotero.Prefs.get('itemsView.columnVisibility') || '{}');
-					// Store previous view settings
-					settings[prevViewGroup] = cols.map((col) => col.getAttribute('hidden') == 'true' ? 0 : 1);
-					Zotero.Prefs.set('itemsView.columnVisibility', JSON.stringify(settings));
+					if (prevViewGroup) {
+						// Store previous view settings
+						let setting = {};
+						for (let col of cols) {
+							let colType = col.id.substring('zotero-items-column-'.length);
+							setting[colType] = col.getAttribute('hidden') == 'true' ? 0 : 1
+						}
+						settings[prevViewGroup] = setting;
+						Zotero.Prefs.set('itemsView.columnVisibility', JSON.stringify(settings));
+					}
 					
 					// Recover current view settings
 					if (settings[curViewGroup]) {
-						cols.forEach((col, idx) => col.setAttribute('hidden', !settings[curViewGroup][idx]));
+						for (let col of cols) {
+							let colType = col.id.substring('zotero-items-column-'.length);
+							col.setAttribute('hidden', !settings[curViewGroup][colType]);
+						}
 					} else {
 						cols.forEach((col) => {
 							col.setAttribute('hidden', !(col.hasAttribute('default-in') &&

--- a/chrome/content/zotero/zoteroPane.xul
+++ b/chrome/content/zotero/zoteroPane.xul
@@ -370,186 +370,187 @@
 								onkeydown="ZoteroPane_Local.handleKeyDown(event, this.id)"
 								onselect="ZoteroPane_Local.itemSelected(event)"
 								oncommand="ZoteroPane_Local.serializePersist()"
-								flex="1">
+								flex="1"
+								zotero-persists="current-view-group">
 								<treecols id="zotero-items-columns-header">
 									<treecol
-										id="zotero-items-column-title" primary="true"
+										id="zotero-items-column-title" primary="true" default-in="default feed"
 										label="&zotero.items.title_column;"
 										flex="4" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-firstCreator"
+										id="zotero-items-column-firstCreator" default-in="default"
 										label="&zotero.items.creator_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-itemType" hidden="true"
+										id="zotero-items-column-itemType"
 										label="&zotero.items.type_column;"
 										width="40" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-date" hidden="true"
+										id="zotero-items-column-date" default-in="feed"
 										label="&zotero.items.date_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-year" hidden="true"
+										id="zotero-items-column-year"
 										label="&zotero.items.year_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-publisher" hidden="true"
+										id="zotero-items-column-publisher"
 										label="&zotero.items.publisher_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-publicationTitle" hidden="true"
+										id="zotero-items-column-publicationTitle"
 										label="&zotero.items.publication_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-journalAbbreviation" hidden="true"
+										id="zotero-items-column-journalAbbreviation"
 										submenu="true"
 										label="&zotero.items.journalAbbr_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-language" hidden="true"
+										id="zotero-items-column-language"
 										submenu="true"
 										label="&zotero.items.language_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-accessDate" hidden="true"
+										id="zotero-items-column-accessDate"
 										submenu="true"
 										label="&zotero.items.accessDate_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-libraryCatalog" hidden="true"
+										id="zotero-items-column-libraryCatalog"
 										submenu="true"
 										label="&zotero.items.libraryCatalog_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-callNumber" hidden="true"
+										id="zotero-items-column-callNumber"
 										submenu="true"
 										label="&zotero.items.callNumber_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-rights" hidden="true"
+										id="zotero-items-column-rights"
 										submenu="true"
 										label="&zotero.items.rights_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-dateAdded" hidden="true" hidden-in="feed"
+										id="zotero-items-column-dateAdded" disabled-in="feed"
 										label="&zotero.items.dateAdded_column;"
-										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection user-hidden"/>
+										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-dateModified" hidden="true" hidden-in="feed"
+										id="zotero-items-column-dateModified" disabled-in="feed"
 										label="&zotero.items.dateModified_column;"
-										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection user-hidden"/>
+										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-archive" hidden="true"
+										id="zotero-items-column-archive"
 										submenu="true"
 										label="&zotero.items.archive_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>								
 									<treecol
-										id="zotero-items-column-archiveLocation" hidden="true"
+										id="zotero-items-column-archiveLocation"
 										submenu="true"
 										label="&zotero.items.archiveLocation_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-place" hidden="true"
+										id="zotero-items-column-place"
 										submenu="true"
 										label="&zotero.items.place_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-volume" hidden="true"
+										id="zotero-items-column-volume"
 										submenu="true"
 										label="&zotero.items.volume_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-edition" hidden="true"
+										id="zotero-items-column-edition"
 										submenu="true"
 										label="&zotero.items.edition_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-pages" hidden="true"
+										id="zotero-items-column-pages"
 										submenu="true"
 										label="&zotero.items.pages_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-issue" hidden="true"
+										id="zotero-items-column-issue"
 										submenu="true"
 										label="&zotero.items.issue_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-series" hidden="true"
+										id="zotero-items-column-series"
 										submenu="true"
 										label="&zotero.items.series_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-seriesTitle" hidden="true"
+										id="zotero-items-column-seriesTitle"
 										submenu="true"
 										label="&zotero.items.seriesTitle_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-court" hidden="true"
+										id="zotero-items-column-court"
 										submenu="true"
 										label="&zotero.items.court_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-medium" hidden="true"
+										id="zotero-items-column-medium"
 										submenu="true"
 										label="&zotero.items.medium_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-genre" hidden="true"
+										id="zotero-items-column-genre"
 										submenu="true"
 										label="&zotero.items.genre_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-system" hidden="true"
+										id="zotero-items-column-system"
 										submenu="true"
 										label="&zotero.items.system_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-extra" hidden="true"
+										id="zotero-items-column-extra"
 										label="&zotero.items.extra_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-hasAttachment" hidden-in="feed"
+										id="zotero-items-column-hasAttachment" default-in="default" disabled-in="feed" 
 										class="treecol-image"
 										label="&zotero.tabs.attachments.label;"
 										src="chrome://zotero/skin/attach-small.png"
 										fixed="true"
-										zotero-persist="ordinal hidden sortActive sortDirection user-hidden"/>
+										zotero-persist="ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-numNotes" hidden="true" hidden-in="feed"
+										id="zotero-items-column-numNotes" disabled-in="feed"
 										class="treecol-image"
 										label="&zotero.tabs.notes.label;"
 										src="chrome://zotero/skin/treeitem-note-small.png"
-										zotero-persist="width ordinal hidden sortActive sortDirection user-hidden"/>
+										zotero-persist="width ordinal hidden sortActive sortDirection"/>
 								</treecols>
 								<treechildren ondragstart="ZoteroPane_Local.itemsView.onDragStart(event)"
 									ondragenter="return ZoteroPane_Local.itemsView.onDragEnter(event)"

--- a/chrome/content/zotero/zoteroPane.xul
+++ b/chrome/content/zotero/zoteroPane.xul
@@ -379,7 +379,7 @@
 										flex="4" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-firstCreator" default-in="default"
+										id="zotero-items-column-firstCreator" default-in="default feed"
 										label="&zotero.items.creator_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>

--- a/chrome/content/zotero/zoteroPane.xul
+++ b/chrome/content/zotero/zoteroPane.xul
@@ -394,7 +394,7 @@
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-year"
+										id="zotero-items-column-year" disabled-in="feed"
 										label="&zotero.items.year_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
@@ -404,12 +404,12 @@
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-publicationTitle"
+										id="zotero-items-column-publicationTitle" disabled-in="feed"
 										label="&zotero.items.publication_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-journalAbbreviation"
+										id="zotero-items-column-journalAbbreviation" disabled-in="feed"
 										submenu="true"
 										label="&zotero.items.journalAbbr_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
@@ -421,19 +421,19 @@
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-accessDate"
+										id="zotero-items-column-accessDate" disabled-in="feed"
 										submenu="true"
 										label="&zotero.items.accessDate_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-libraryCatalog"
+										id="zotero-items-column-libraryCatalog" disabled-in="feed"
 										submenu="true"
 										label="&zotero.items.libraryCatalog_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-callNumber"
+										id="zotero-items-column-callNumber" disabled-in="feed"
 										submenu="true"
 										label="&zotero.items.callNumber_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
@@ -455,85 +455,85 @@
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-archive"
+										id="zotero-items-column-archive" disabled-in="feed"
 										submenu="true"
 										label="&zotero.items.archive_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>								
 									<treecol
-										id="zotero-items-column-archiveLocation"
+										id="zotero-items-column-archiveLocation" disabled-in="feed"
 										submenu="true"
 										label="&zotero.items.archiveLocation_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-place"
+										id="zotero-items-column-place" disabled-in="feed"
 										submenu="true"
 										label="&zotero.items.place_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-volume"
+										id="zotero-items-column-volume" disabled-in="feed"
 										submenu="true"
 										label="&zotero.items.volume_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-edition"
+										id="zotero-items-column-edition" disabled-in="feed"
 										submenu="true"
 										label="&zotero.items.edition_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-pages"
+										id="zotero-items-column-pages" disabled-in="feed"
 										submenu="true"
 										label="&zotero.items.pages_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-issue"
+										id="zotero-items-column-issue" disabled-in="feed"
 										submenu="true"
 										label="&zotero.items.issue_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-series"
+										id="zotero-items-column-series" disabled-in="feed"
 										submenu="true"
 										label="&zotero.items.series_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-seriesTitle"
+										id="zotero-items-column-seriesTitle" disabled-in="feed"
 										submenu="true"
 										label="&zotero.items.seriesTitle_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-court"
+										id="zotero-items-column-court" disabled-in="feed"
 										submenu="true"
 										label="&zotero.items.court_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-medium"
+										id="zotero-items-column-medium" disabled-in="feed"
 										submenu="true"
 										label="&zotero.items.medium_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-genre"
+										id="zotero-items-column-genre" disabled-in="feed"
 										submenu="true"
 										label="&zotero.items.genre_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-system"
+										id="zotero-items-column-system" disabled-in="feed"
 										submenu="true"
 										label="&zotero.items.system_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>
 									<treecol
-										id="zotero-items-column-extra"
+										id="zotero-items-column-extra" disabled-in="feed"
 										label="&zotero.items.extra_column;"
 										flex="1" zotero-persist="width ordinal hidden sortActive sortDirection"/>
 									<splitter class="tree-splitter"/>

--- a/chrome/content/zotero/zoteroPane.xul
+++ b/chrome/content/zotero/zoteroPane.xul
@@ -371,7 +371,7 @@
 								onselect="ZoteroPane_Local.itemSelected(event)"
 								oncommand="ZoteroPane_Local.serializePersist()"
 								flex="1"
-								zotero-persists="current-view-group">
+								zotero-persist="current-view-group">
 								<treecols id="zotero-items-columns-header">
 									<treecol
 										id="zotero-items-column-title" primary="true" default-in="default feed"

--- a/test/tests/zoteroPaneTest.js
+++ b/test/tests/zoteroPaneTest.js
@@ -314,11 +314,8 @@ describe("ZoteroPane", function() {
 	describe("#onCollectionSelected()", function() {
 		var cv;
 		
-		before(function* () {
-			cv = zp.collectionsView;
-		});
-		
 		beforeEach(function* () {
+			cv = zp.collectionsView;
 			yield cv.selectLibrary(Zotero.Libraries.userLibraryID);
 			Zotero.Prefs.clear('itemsView.columnVisibility');
 			yield clearFeeds();

--- a/test/tests/zoteroPaneTest.js
+++ b/test/tests/zoteroPaneTest.js
@@ -310,4 +310,50 @@ describe("ZoteroPane", function() {
 			assert.lengthOf(Object.keys(conditions), 2);
 		});
 	});
+	
+	describe("#onCollectionSelected()", function() {
+		var cv;
+		
+		before(function* () {
+			cv = zp.collectionsView;
+		});
+		
+		beforeEach(function* () {
+			yield cv.selectLibrary(Zotero.Libraries.userLibraryID);
+			Zotero.Prefs.clear('itemsView.columnVisibility');
+			yield clearFeeds();
+		});
+		
+		it("should store column visibility settings when switching from default to feeds", function* () {
+			doc.getElementById('zotero-items-column-dateAdded').setAttribute('hidden', false);
+			var feed = yield createFeed();
+			yield cv.selectLibrary(feed.libraryID);
+			var settings = JSON.parse(Zotero.Prefs.get('itemsView.columnVisibility'));
+			assert.isOk(settings.default.dateAdded);
+		});
+		
+		it("should restore column visiblity when switching between default and feeds", function* () {
+			doc.getElementById('zotero-items-column-dateAdded').setAttribute('hidden', false);
+			var feed = yield createFeed();
+			yield cv.selectLibrary(feed.libraryID);
+			assert.equal(doc.getElementById('zotero-items-column-dateAdded').getAttribute('hidden'), 'true');
+			doc.getElementById('zotero-items-column-firstCreator').setAttribute('hidden', true);
+			yield cv.selectLibrary(Zotero.Libraries.userLibraryID);
+			assert.equal(doc.getElementById('zotero-items-column-dateAdded').getAttribute('hidden'), 'false');
+			yield cv.selectLibrary(feed.libraryID);
+			assert.equal(doc.getElementById('zotero-items-column-firstCreator').getAttribute('hidden'), 'true');
+		});
+		
+		it("should restore column visibility settings on restart", function* () {
+			doc.getElementById('zotero-items-column-dateAdded').setAttribute('hidden', false);
+			assert.equal(doc.getElementById('zotero-items-column-dateAdded').getAttribute('hidden'), 'false');
+			
+			win.close();
+			win = yield loadZoteroPane();
+			doc = win.document;
+			zp = win.ZoteroPane;
+			
+			assert.equal(doc.getElementById('zotero-items-column-dateAdded').getAttribute('hidden'), 'false');
+		});
+	});
 })


### PR DESCRIPTION
I originally attempted this with zotero-persists and column attributes,
but there is no good way to make it succint paramswise and the code was
painful to look at too. Thus different group settings are stored in
preferences.

Currently there are two view groups: "feed" and "default". Items view
columns have two new attributes:
`default-in` - a space separated list of views in which a column is
visible by default
`disabled-in` - a space separated list of views in which a column is
disabled by default (invisible + not possible to enable)

Currently the settings are stored in a pref named `itemsView.columnVisibility`, but it could probably use a better name.