### PR TITLE
Fixes freezing occuring on linux while running tests

### DIFF
--- a/test/content/support.js
+++ b/test/content/support.js
@@ -137,7 +137,7 @@ function waitForDialog(onOpen, button='accept', url) {
 			function acceptWhenEnabled() {
 				// Handle delayed buttons
 				if (dialog.document.documentElement.getButton(button).disabled) {
-					setTimeout(function () {
+					dialog.setTimeout(function () {
 						acceptWhenEnabled();
 					}, 250);
 				}

--- a/test/tests/server_connectorTest.js
+++ b/test/tests/server_connectorTest.js
@@ -14,10 +14,12 @@ describe("Connector Server", function () {
 		
 		win = yield loadZoteroPane();
 		connectorServerPath = 'http://127.0.0.1:' + Zotero.Prefs.get('httpServer.port');
-		testServerPath = 'http://127.0.0.1:' + testServerPort;
 	});
 	
 	beforeEach(function () {
+		// Alternate ports to prevent exceptions not catchable in JS
+		testServerPort += (testServerPort & 1) ? 1 : -1;
+		testServerPath = 'http://127.0.0.1:' + testServerPort;
 		httpd = new HttpServer();
 		httpd.start(testServerPort);
 	});


### PR DESCRIPTION
server_connectorTest - alternating port prevents
exceptions not catchable in JS for httpd server when the socket
and the port remains open after httpd.stop() callback

support - changes the window on which `setTimeout()` is ran in dialogs.
If the timeout is ran on the main window the `dialog` object appears to
lose certain properties and not respond to interactions completely.