### PR TITLE
Clone feed item if no translators available

### DIFF
--- a/chrome/content/zotero/xpcom/data/feedItem.js
+++ b/chrome/content/zotero/xpcom/data/feedItem.js
@@ -208,6 +208,7 @@ Zotero.FeedItem.prototype.toggleRead = Zotero.Promise.coroutine(function* (state
  * @return {Promise<FeedItem|Item>} translated feed item
  */
 Zotero.FeedItem.prototype.translate = Zotero.Promise.coroutine(function* (libraryID, collectionID) {
+	Zotero.debug("Translating feed item " + this.id + " with URL " + this.getField('url'), 2);
 	if (Zotero.locked) {
 		Zotero.debug('Zotero locked, skipping feed item translation');
 		return;
@@ -224,9 +225,8 @@ Zotero.FeedItem.prototype.translate = Zotero.Promise.coroutine(function* (librar
 		translate.clearHandlers("itemDone");
 		translate.setHandler("done", win.Zotero_Browser.progress.Translation.doneHandler);
 		translate.setHandler("itemDone", win.Zotero_Browser.progress.Translation.itemDoneHandler());
-		let collection;
 		if (collectionID) {
-			collection = yield Zotero.Collections.getAsync(collectionID);
+			var collection = yield Zotero.Collections.getAsync(collectionID);
 		}
 		win.Zotero_Browser.progress.show();
 		win.Zotero_Browser.progress.Translation.scrapingTo(libraryID, collection);
@@ -250,7 +250,27 @@ Zotero.FeedItem.prototype.translate = Zotero.Promise.coroutine(function* (librar
 	let translators = yield deferred.promise;
 	if (!translators || !translators.length) {
 		Zotero.debug("No translators detected for feed item " + this.id + " with URL " + this.getField('url'), 2);
-		throw new Zotero.Error("No translators detected for feed item " + this.id + " with URL " + this.getField('url'))
+		Zotero.debug("Cloning item instead", 2);
+		let dbItem = this.clone(libraryID);
+		yield dbItem.saveTx();
+		if (collection) {
+			yield collection.addItem(dbItem);
+		}
+		
+		let item = {title: dbItem.getField('title'), itemType: dbItem.itemType};
+		
+		// Add snapshot
+		if (Zotero.Libraries.get(libraryID).filesEditable) {
+			item.attachments = [{title: "Snapshot"}];
+			yield Zotero.Attachments.importFromDocument({
+				document: doc,
+				parentItemID: dbItem.id
+			});
+		}
+		
+		win.Zotero_Browser.progress.Translation.itemDoneHandler()(null, null, item);
+		win.Zotero_Browser.progress.Translation.doneHandler(null, true);
+		return;
 	}
 	translate.setTranslator(translators[0]);
 

--- a/chrome/content/zotero/xpcom/data/feedItem.js
+++ b/chrome/content/zotero/xpcom/data/feedItem.js
@@ -253,7 +253,7 @@ Zotero.FeedItem.prototype.translate = Zotero.Promise.coroutine(function* (librar
 			' -- cloning item instead', 2);
 		let dbItem = this.clone(libraryID);
 		if (collectionID) {
-			dbItem.setCollections(collectionID);
+			dbItem.addToCollection(collectionID);
 		}
 		yield dbItem.saveTx();
 		

--- a/chrome/content/zotero/xpcom/data/feedItem.js
+++ b/chrome/content/zotero/xpcom/data/feedItem.js
@@ -249,12 +249,12 @@ Zotero.FeedItem.prototype.translate = Zotero.Promise.coroutine(function* (librar
 	translate.getTranslators();
 	let translators = yield deferred.promise;
 	if (!translators || !translators.length) {
-		Zotero.debug("No translators detected for feed item " + this.id + " with URL " + this.getField('url'), 2);
-		Zotero.debug("Cloning item instead", 2);
+		Zotero.debug("No translators detected for feed item " + this.id + " with URL " + this.getField('url') + 
+			'\nCloning item instead', 2);
 		let dbItem = this.clone(libraryID);
 		yield dbItem.saveTx();
-		if (collection) {
-			yield collection.addItem(dbItem);
+		if (collectionID) {
+			dbItem.setCollections(collectionID);
 		}
 		
 		let item = {title: dbItem.getField('title'), itemType: dbItem.itemType};

--- a/chrome/content/zotero/xpcom/data/feedItem.js
+++ b/chrome/content/zotero/xpcom/data/feedItem.js
@@ -250,12 +250,12 @@ Zotero.FeedItem.prototype.translate = Zotero.Promise.coroutine(function* (librar
 	let translators = yield deferred.promise;
 	if (!translators || !translators.length) {
 		Zotero.debug("No translators detected for feed item " + this.id + " with URL " + this.getField('url') + 
-			'\nCloning item instead', 2);
+			' -- cloning item instead', 2);
 		let dbItem = this.clone(libraryID);
-		yield dbItem.saveTx();
 		if (collectionID) {
 			dbItem.setCollections(collectionID);
 		}
+		yield dbItem.saveTx();
 		
 		let item = {title: dbItem.getField('title'), itemType: dbItem.itemType};
 		


### PR DESCRIPTION
Closes #1059

Instead of falling back to webpage translation which is less detailed and accurate, clones the feed item into the library.