### PR TITLE
Allow ZU.doGet to have requestHeaders

### DIFF
--- a/chrome/content/zotero/xpcom/http.js
+++ b/chrome/content/zotero/xpcom/http.js
@@ -201,11 +201,12 @@ Zotero.HTTP = new function() {
 	 * @param {Function} 		onDone			Callback to be executed upon request completion
 	 * @param {String} 		responseCharset	Character set to force on the response
 	 * @param {Zotero.CookieSandbox} [cookieSandbox] Cookie sandbox object
+	 * @param {Object} requestHeaders HTTP headers to include with request
 	 * @return {XMLHttpRequest} The XMLHttpRequest object if the request was sent, or
 	 *     false if the browser is offline
 	 * @deprecated Use {@link Zotero.HTTP.promise}
 	 */
-	this.doGet = function(url, onDone, responseCharset, cookieSandbox) {
+	this.doGet = function(url, onDone, responseCharset, cookieSandbox, requestHeaders) {
 		if (url instanceof Components.interfaces.nsIURI) {
 			// Don't display password in console
 			var disp = this.getDisplayURI(url);
@@ -234,6 +235,13 @@ Zotero.HTTP = new function() {
 		// Set charset
 		if (responseCharset) {
 			channel.contentCharset = responseCharset;
+		}
+		
+		// Set request headers
+		if (requestHeaders) {
+			for (var header in requestHeaders) {
+				xmlhttp.setRequestHeader(header, requestHeaders[header]);
+			}
 		}
 	
 		// Don't cache GET requests

--- a/chrome/content/zotero/xpcom/utilities_translate.js
+++ b/chrome/content/zotero/xpcom/utilities_translate.js
@@ -298,9 +298,10 @@ Zotero.Utilities.Translate.prototype.processDocuments = function(urls, processor
 * @param {Function} processor Callback to be executed for each document loaded
 * @param {Function} done Callback to be executed after all documents have been loaded
 * @param {String} responseCharset Character set to force on the response
+* @param {Object} requestHeaders HTTP headers to include with request
 * @return {Boolean} True if the request was sent, or false if the browser is offline
 */
-Zotero.Utilities.Translate.prototype.doGet = function(urls, processor, done, responseCharset) {
+Zotero.Utilities.Translate.prototype.doGet = function(urls, processor, done, responseCharset, requestHeaders) {
 	var callAgain = false,
 		me = this,
 		translate = this._translate;
@@ -332,7 +333,7 @@ Zotero.Utilities.Translate.prototype.doGet = function(urls, processor, done, res
 		} catch(e) {
 			translate.complete(false, e);
 		}
-	}, responseCharset, this._translate.cookieSandbox);
+	}, responseCharset, this._translate.cookieSandbox, requestHeaders);
 }
 
 /**


### PR DESCRIPTION
This is mainly for translators which have to work with content negotiation,
e.g. ORCID API or API calls of ISBN agencies.