### PR TITLE
Use feed item links for guid if id unavailable

### DIFF
--- a/chrome/content/zotero/xpcom/feedReader.js
+++ b/chrome/content/zotero/xpcom/feedReader.js
@@ -360,13 +360,14 @@ Zotero.FeedReader._processCreators = function(feedEntry, field, role) {
 Zotero.FeedReader._getFeedItem = function(feedEntry, feedInfo) {
 	// ID is not required, but most feeds have these and we have to rely on them
 	// to handle updating properly
-	if (!feedEntry.id) {
-		Zotero.debug("FeedReader: Feed item missing an ID");
+	// Can probably fall back to links on missing id - unlikely to change
+	if (!feedEntry.id && !feedEntry.link) {
+		Zotero.debug("FeedReader: Feed item missing an ID or link - discarding");
 		return;
 	}
 	
 	let item = {
-		guid: feedEntry.id
+		guid: feedEntry.id || feedEntry.link.spec
 	};
 			
 	if (feedEntry.title) item.title = Zotero.FeedReader._getRichText(feedEntry.title, 'title');


### PR DESCRIPTION
https://forums.zotero.org/discussion/60800?page=0#Item_10

Probably no reason to not fall back on links. Must be some crazy feeds if they change that and don't provide a GUID.