### PR TITLE
Fixes feed sync bugs after conflicts.

### DIFF
--- a/chrome/content/zotero/xpcom/syncedSettings.js
+++ b/chrome/content/zotero/xpcom/syncedSettings.js
@@ -178,7 +178,10 @@ Zotero.SyncedSettings = (function () {
 			}
 			
 			// Prevents a whole bunch of headache if you continue modifying the object after calling #set()
-			if (typeof value == 'object') {
+			if (value instanceof Array) {
+				value = Array.from(value);
+			}
+			else if (typeof value == 'object') {
 				value = Object.assign({}, value);
 			}
 			

--- a/chrome/content/zotero/xpcom/syncedSettings.js
+++ b/chrome/content/zotero/xpcom/syncedSettings.js
@@ -177,6 +177,11 @@ Zotero.SyncedSettings = (function () {
 				throw new Error("Value not provided");
 			}
 			
+			// Prevents a whole bunch of headache if you continue modifying the object after calling #set()
+			if (typeof value == 'object') {
+				value = Object.assign({}, value);
+			}
+			
 			var currentValue = this.get(libraryID, setting);
 			var hasCurrentValue = currentValue !== null;
 			

--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -643,9 +643,11 @@ Components.utils.import("resource://gre/modules/osfile.jsm");
 				yield Zotero.Promise.each(
 					Zotero.Libraries.getAll(),
 					library => Zotero.Promise.coroutine(function* () {
-						yield Zotero.SyncedSettings.loadAll(library.libraryID);
-						yield Zotero.Collections.loadAll(library.libraryID);
-						yield Zotero.Searches.loadAll(library.libraryID);
+						if (library.libraryType != 'feed') {
+							yield Zotero.SyncedSettings.loadAll(library.libraryID);
+							yield Zotero.Collections.loadAll(library.libraryID);
+							yield Zotero.Searches.loadAll(library.libraryID);
+						}
 					})()
 				);
 			}

--- a/test/tests/syncedSettingsTest.js
+++ b/test/tests/syncedSettingsTest.js
@@ -1,5 +1,5 @@
 describe('Zotero.SyncedSettings', function() {
-	it('modifying object after setting does not affect cached value', function* () {
+	it('should not affect cached value when modifying the setting after #set() call', function* () {
 		let setting = {athing: 1};
 		yield Zotero.SyncedSettings.set(Zotero.Libraries.userLibraryID, 'setting', setting);
 		

--- a/test/tests/syncedSettingsTest.js
+++ b/test/tests/syncedSettingsTest.js
@@ -1,0 +1,10 @@
+describe('Zotero.SyncedSettings', function() {
+	it('modifying object after setting does not affect cached value', function* () {
+		let setting = {athing: 1};
+		yield Zotero.SyncedSettings.set(Zotero.Libraries.userLibraryID, 'setting', setting);
+		
+		setting.athing = 2;
+		let storedSetting = Zotero.SyncedSettings.get(Zotero.Libraries.userLibraryID, 'setting');
+		assert.notDeepEqual(setting, storedSetting);
+	});
+});


### PR DESCRIPTION
Reported https://forums.zotero.org/discussion/61573?page=1#Item_4

SyncedSettings.set() caches values. If an object passed to set() is
modified after the call then get() returns that modified object.