### PR TITLE
Adds a way to distinguish linux windows

### DIFF
--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -22,7 +22,11 @@ if [ -z "$FX_EXECUTABLE" ]; then
 	fi
 fi
 
-FX_ARGS=""
+if [ -z "$DISPLAY" ]; then
+	FX_ARGS=""
+else
+	FX_ARGS="--class=ZTestFirefox"
+fi
 
 function usage {
 	cat >&2 <<DONE


### PR DESCRIPTION
Only enabled on Xorg environments, so checks $DISPLAY
https://developer.mozilla.org/en-US/docs/Mozilla/Command_Line_Options#X11_options

Can be used in combination with compiz to create a window rule and make Firefox not steal focus.