### PR TITLE
Remove occurences of legacy/non-standard/non-strict js syntax

### DIFF
--- a/chrome/content/zotero/bindings/itembox.xml
+++ b/chrome/content/zotero/bindings/itembox.xml
@@ -475,7 +475,7 @@
 							
 							var popup = button.appendChild(document.createElement("menupopup"));
 							
-							for each(var v in this._fieldAlternatives[fieldName]) {
+							for (let v of this._fieldAlternatives[fieldName]) {
 								var menuitem = document.createElement("menuitem");
 								var sv = Zotero.Utilities.ellipsize(v, 60);
 								menuitem.setAttribute('label', sv);

--- a/chrome/content/zotero/bindings/tagselector.xml
+++ b/chrome/content/zotero/bindings/tagselector.xml
@@ -528,7 +528,7 @@
 							this._tags = yield Zotero.Tags.getAll(this.libraryID, this._types);
 							
 							for (let tag of this.selection) {
-								for each(var tag2 in this._tags) {
+								for (let tag2 of this._tags) {
 									if (tag == tag2) {
 										var found = true;
 										break;

--- a/chrome/content/zotero/charsetMenu.js
+++ b/chrome/content/zotero/charsetMenu.js
@@ -47,7 +47,7 @@ var Zotero_Charset_Menu = new function() {
 		Components.utils.import("resource://gre/modules/CharsetMenu.jsm");
 		var cmData = CharsetMenu.getData();
 		for (let charsetList of [cmData.pinnedCharsets, cmData.otherCharsets]) {
-			for each(var charsetInfo in charsetList) {
+			for (let charsetInfo of charsetList) {
 				if(charsetInfo.value == "UTF-8") {
 					charsets.push({
 						"label":"Unicode (UTF-8)",

--- a/chrome/content/zotero/fileInterface.js
+++ b/chrome/content/zotero/fileInterface.js
@@ -465,7 +465,7 @@ var Zotero_File_Interface = new function() {
 	function _doBibliographyOptions(name, items) {
 		// make sure at least one item is not a standalone note or attachment
 		var haveRegularItem = false;
-		for each(var item in items) {
+		for (let item of items) {
 			if (item.isRegularItem()) {
 				haveRegularItem = true;
 				break;

--- a/chrome/content/zotero/fileInterface.js
+++ b/chrome/content/zotero/fileInterface.js
@@ -602,7 +602,7 @@ var Zotero_File_Interface = new function() {
 			// open file
 			var fStream = Components.classes["@mozilla.org/network/file-output-stream;1"].
 						  createInstance(Components.interfaces.nsIFileOutputStream);
-			fStream.init(fp.file, 0x02 | 0x08 | 0x20, 0664, 0); // write, create, truncate
+			fStream.init(fp.file, 0x02 | 0x08 | 0x20, 0o664, 0); // write, create, truncate
 			return fStream;
 		} else {
 			return false;

--- a/chrome/content/zotero/locateMenu.js
+++ b/chrome/content/zotero/locateMenu.js
@@ -384,8 +384,8 @@ var Zotero_LocateMenu = new function() {
 			return _getURL(item).then((val) => val !== false);
 		}
 		this.handleItems = Zotero.Promise.coroutine(function* (items, event) {
-			var urls = yield Zotero.Promise.all([for (item of items) _getURL(item)]);
-			ZoteroPane_Local.loadURI([for (url of urls) if (url) url], event);
+			var urls = yield Zotero.Promise.all(items.map(item => _getURL(item)));
+			ZoteroPane_Local.loadURI(urls.filter(url => !!url), event);
 		});
 		
 		var _getURL = Zotero.Promise.coroutine(function* (item) {

--- a/chrome/content/zotero/locateMenu.js
+++ b/chrome/content/zotero/locateMenu.js
@@ -544,7 +544,7 @@ var Zotero_LocateMenu = new function() {
 		this.useExternalViewer = true;
 		
 		this.canHandleItem = function (item) {
-			return _getBestFile(item).then(function (item) !!item);
+			return _getBestFile(item).then(item => !!item);
 		}
 		
 		this.handleItems = Zotero.Promise.coroutine(function* (items, event) {
@@ -573,7 +573,7 @@ var Zotero_LocateMenu = new function() {
 	 */
 	ViewOptions._libraryLookup = new function() {
 		this.icon = "chrome://zotero/skin/locate-library-lookup.png";
-		this.canHandleItem = function (item) Zotero.Promise.resolve(item.isRegularItem());
+		this.canHandleItem = function (item) { return Zotero.Promise.resolve(item.isRegularItem()); };
 		this.handleItems = Zotero.Promise.method(function (items, event) {
 			var urls = [];
 			for (let item of items) {

--- a/chrome/content/zotero/recognizePDF.js
+++ b/chrome/content/zotero/recognizePDF.js
@@ -160,7 +160,7 @@ var Zotero_RecognizePDF = new function() {
 			try {
 				var inputStream = Components.classes["@mozilla.org/network/file-input-stream;1"]
 					.createInstance(Components.interfaces.nsIFileInputStream);
-				inputStream.init(cacheFile, 0x01, 0664, 0);
+				inputStream.init(cacheFile, 0x01, 0o664, 0);
 				try {
 					var intlStream = Components.classes["@mozilla.org/intl/converter-input-stream;1"]
 						.createInstance(Components.interfaces.nsIConverterInputStream);

--- a/chrome/content/zotero/rtfScan.js
+++ b/chrome/content/zotero/rtfScan.js
@@ -460,7 +460,7 @@ var Zotero_RTFScan = new function() {
 	 */
 	function _refreshCanAdvance() {
 		var canAdvance = true;
-		for each(var itemList in citationItemIDs) {
+		for (let itemList of citationItemIDs) {
 			if(itemList.length != 1) {
 				canAdvance = false;
 				break;

--- a/chrome/content/zotero/tagColorChooser.js
+++ b/chrome/content/zotero/tagColorChooser.js
@@ -70,7 +70,10 @@ var Zotero_Tag_Color_Chooser = new function() {
 			}
 			else {
 				// Get unused color at random
-				var usedColors = [for (x of tagColors.values()) x.color];
+				var usedColors = [];
+				for (let x of tagColors.values()) {
+					usedColors.push(x.color);
+				}
 				var unusedColors = Zotero.Utilities.arrayDiff(
 					colorPicker.colors, usedColors
 				);

--- a/chrome/content/zotero/test/modtime.js
+++ b/chrome/content/zotero/test/modtime.js
@@ -1,6 +1,6 @@
 var tmp = Zotero.getTempDirectory();
 tmp.append(Zotero.randomString());
-tmp.create(Components.interfaces.nsIFile.FILE_TYPE, 0644);
+tmp.create(Components.interfaces.nsIFile.FILE_TYPE, 0o644);
 
 var date = new Date();
 var nowTS = Zotero.Date.toUnixTimestamp(date) * 1000;

--- a/chrome/content/zotero/tools/csledit.js
+++ b/chrome/content/zotero/tools/csledit.js
@@ -37,7 +37,7 @@ var Zotero_CSL_Editor = new function() {
 		
 		var styles = Zotero.Styles.getAll();
 		var currentStyle = null;
-		for each(var style in styles) {
+		for (let style of styles) {
 			if (style.source) {
 				continue;
 			}

--- a/chrome/content/zotero/tools/cslpreview.js
+++ b/chrome/content/zotero/tools/cslpreview.js
@@ -56,7 +56,7 @@ var Zotero_CSL_Preview = new function() {
 			var styles = Zotero.Styles.getAll();
 			// XXX needs its own string really for the title!
 			var str = '<html><head><title></title></head><body>';
-			for each(var style in styles) {
+			for (let style of styles) {
 				if (style.source) {
 					continue;
 				}

--- a/chrome/content/zotero/xpcom/annotate.js
+++ b/chrome/content/zotero/xpcom/annotate.js
@@ -141,7 +141,7 @@ Zotero.Annotate = new function() {
 			} else {
 				var browsers = win.document.getElementsByTagNameNS(XUL_NAMESPACE, "browser");
 			}
-			for each(var browser in browsers) {
+			for (let browser of browsers) {
 				if(browser.currentURI) {
 					if(browser.currentURI.spec == annotationURL) {
 						if(haveBrowser) {
@@ -364,7 +364,7 @@ Zotero.Annotate.Path.prototype.fromNode = function(node, offset) {
 					// is still part of the first text node
 					if(sibling.getAttribute) {
 						// get offset of all child nodes
-						for each(var child in sibling.childNodes) {
+						for (let child of sibling.childNodes) {
 							if(child && child.nodeType == TEXT_TYPE) {
 								this.offset += child.nodeValue.length;
 							}
@@ -754,14 +754,14 @@ Zotero.Annotations.prototype.save = function() {
 Zotero.Annotations.prototype.load = Zotero.Promise.coroutine(function* () {
 	// load annotations
 	var rows = yield Zotero.DB.queryAsync("SELECT * FROM annotations WHERE itemID = ?", [this.itemID]);
-	for each(var row in rows) {
+	for (let row of rows) {
 		var annotation = this.createAnnotation();
 		annotation.initWithDBRow(row);
 	}
 	
 	// load highlights
 	var rows = yield Zotero.DB.queryAsync("SELECT * FROM highlights WHERE itemID = ?", [this.itemID]);
-	for each(var row in rows) {
+	for (let row of rows) {
 		try {
 			var highlight = new Zotero.Highlight(this);
 			highlight.initWithDBRow(row);

--- a/chrome/content/zotero/xpcom/api.js
+++ b/chrome/content/zotero/xpcom/api.js
@@ -76,7 +76,7 @@ Zotero.API = {
 					var s2 = new Zotero.Search();
 					s2.setScope(s);
 					var groups = Zotero.Groups.getAll();
-					for each(var group in groups) {
+					for (let group of groups) {
 						s2.addCondition('libraryID', 'isNot', group.libraryID);
 					}
 					var ids = yield s2.search();

--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -797,7 +797,7 @@ Zotero.Attachments = new function(){
 		var dir = this.getStorageDirectory(item);
 		yield _moveOrphanedDirectory(dir);
 		if (!dir.exists()) {
-			dir.create(Components.interfaces.nsIFile.DIRECTORY_TYPE, 0755);
+			dir.create(Components.interfaces.nsIFile.DIRECTORY_TYPE, 0o755);
 		}
 		return dir;
 	});
@@ -840,7 +840,7 @@ Zotero.Attachments = new function(){
 		var tmpDir = Zotero.getStorageDirectory();
 		tmpDir.append("tmp-" + Zotero.Utilities.randomString(6));
 		yield OS.File.makeDir(tmpDir.path, {
-			unixMode: 0755
+			unixMode: 0o755
 		});
 		return tmpDir;
 	});
@@ -1192,7 +1192,7 @@ Zotero.Attachments = new function(){
 		var orphaned = Zotero.getZoteroDirectory();
 		orphaned.append('orphaned-files');
 		if (!orphaned.exists()) {
-			orphaned.create(Components.interfaces.nsIFile.DIRECTORY_TYPE, 0755);
+			orphaned.create(Components.interfaces.nsIFile.DIRECTORY_TYPE, 0o755);
 		}
 		
 		// Find unique filename for orphaned file
@@ -1201,7 +1201,7 @@ Zotero.Attachments = new function(){
 		var newName = null;
 		if (orphanTarget.exists()) {
 			try {
-				orphanTarget.createUnique(Components.interfaces.nsIFile.NORMAL_FILE_TYPE, 0644);
+				orphanTarget.createUnique(Components.interfaces.nsIFile.NORMAL_FILE_TYPE, 0o644);
 				newName = orphanTarget.leafName;
 			}
 			catch (e) {

--- a/chrome/content/zotero/xpcom/cite.js
+++ b/chrome/content/zotero/xpcom/cite.js
@@ -143,7 +143,7 @@ Zotero.Cite = {
 				output.push(bib[1][i]);
 				
 				// add COinS
-				for each(var itemID in bib[0].entry_ids[i]) {
+				for (let itemID of bib[0].entry_ids[i]) {
 					try {
 						var co = Zotero.OpenURL.createContextObject(Zotero.Items.get(itemID), "1.0");
 						if(!co) continue;

--- a/chrome/content/zotero/xpcom/collectionTreeView.js
+++ b/chrome/content/zotero/xpcom/collectionTreeView.js
@@ -1533,7 +1533,7 @@ Zotero.CollectionTreeView.prototype.canDropCheck = function (row, orient, dataTr
 			var ids = data;
 			var items = Zotero.Items.get(ids);
 			var skip = true;
-			for each(var item in items) {
+			for (let item of items) {
 				// Can only drag top-level items
 				if (!item.isTopLevelItem()) {
 					Zotero.debug("Can't drag child item");
@@ -1738,7 +1738,7 @@ Zotero.CollectionTreeView.prototype.canDropCheckAsync = Zotero.Promise.coroutine
 				}
 				
 				var descendents = col.getDescendents(false, 'collection');
-				for each(var descendent in descendents) {
+				for (let descendent of descendents) {
 					descendent = Zotero.Collections.get(descendent.id);
 					// Disallow if linked collection already exists for any subcollections
 					//
@@ -1883,7 +1883,7 @@ Zotero.CollectionTreeView.prototype.drop = Zotero.Promise.coroutine(function* (r
 		if (options.childNotes) {
 			var noteIDs = item.getNotes();
 			var notes = Zotero.Items.get(noteIDs);
-			for each(var note in notes) {
+			for (let note of notes) {
 				let newNote = note.clone(targetLibraryID, { skipTags: !options.tags });
 				newNote.parentID = newItemID;
 				yield newNote.save({
@@ -1898,7 +1898,7 @@ Zotero.CollectionTreeView.prototype.drop = Zotero.Promise.coroutine(function* (r
 		if (options.childLinks || options.childFileAttachments) {
 			var attachmentIDs = item.getAttachments();
 			var attachments = Zotero.Items.get(attachmentIDs);
-			for each(var attachment in attachments) {
+			for (let attachment of attachments) {
 				var linkMode = attachment.attachmentLinkMode;
 				
 				// Skip linked files
@@ -2069,7 +2069,7 @@ Zotero.CollectionTreeView.prototype.drop = Zotero.Promise.coroutine(function* (r
 				var sameLibrary = false;
 			}
 			
-			for each(var item in items) {
+			for (let item of items) {
 				if (!item.isTopLevelItem()) {
 					continue;
 				}
@@ -2126,7 +2126,7 @@ Zotero.CollectionTreeView.prototype.drop = Zotero.Promise.coroutine(function* (r
 					var lastWin = wm.getMostRecentWindow("navigator:browser");
 					lastWin.openDialog('chrome://zotero/content/merge.xul', '', 'chrome,modal,centerscreen', io);
 					
-					for each(var obj in io.dataOut) {
+					for (let obj of io.dataOut) {
 						yield obj.ref.save();
 					}
 				}

--- a/chrome/content/zotero/xpcom/data/cachedTypes.js
+++ b/chrome/content/zotero/xpcom/data/cachedTypes.js
@@ -283,7 +283,7 @@ Zotero.CreatorTypes = new function() {
 		
 		var valid = false;
 		var types = this.getTypesForItemType(itemTypeID);
-		for each(var type in types) {
+		for (let type of types) {
 			if (type.id == creatorTypeID) {
 				valid = true;
 				break;

--- a/chrome/content/zotero/xpcom/data/cachedTypes.js
+++ b/chrome/content/zotero/xpcom/data/cachedTypes.js
@@ -371,9 +371,9 @@ Zotero.ItemTypes = new function() {
 			}
 			if (params.length) {
 				sql += 'OR id IN '
-						+ '(' + params.map(function () '?').join() + ') '
+						+ '(' + params.map(() => '?').join() + ') '
 						+ 'ORDER BY id NOT IN '
-						+ '(' + params.map(function () '?').join() + ') ';
+						+ '(' + params.map(() => '?').join() + ') ';
 				params = params.concat(params);
 			}
 			else {

--- a/chrome/content/zotero/xpcom/data/collection.js
+++ b/chrome/content/zotero/xpcom/data/collection.js
@@ -45,32 +45,32 @@ Zotero.Collection.prototype._dataTypes = Zotero.Collection._super.prototype._dat
 ]);
 
 Zotero.defineProperty(Zotero.Collection.prototype, 'ChildObjects', {
-	get: function() Zotero.Items
+	get: function() { return Zotero.Items; }
 });
 
 Zotero.defineProperty(Zotero.Collection.prototype, 'id', {
-	get: function() this._get('id'),
-	set: function(val) this._set('id', val)
+	get: function() { return this._get('id'); },
+	set: function(val) { return this._set('id', val); }
 });
 Zotero.defineProperty(Zotero.Collection.prototype, 'libraryID', {
-	get: function() this._get('libraryID'),
-	set: function(val) this._set('libraryID', val)
+	get: function() { return this._get('libraryID'); },
+	set: function(val) { return this._set('libraryID', val); }
 });
 Zotero.defineProperty(Zotero.Collection.prototype, 'key', {
-	get: function() this._get('key'),
-	set: function(val) this._set('key', val)
+	get: function() { return this._get('key'); },
+	set: function(val) { return this._set('key', val); }
 });
 Zotero.defineProperty(Zotero.Collection.prototype, 'name', {
-	get: function() this._get('name'),
-	set: function(val) this._set('name', val)
+	get: function() { return this._get('name'); },
+	set: function(val) { return this._set('name', val); }
 });
 Zotero.defineProperty(Zotero.Collection.prototype, 'version', {
-	get: function() this._get('version'),
-	set: function(val) this._set('version', val)
+	get: function() { return this._get('version'); },
+	set: function(val) { return this._set('version', val); }
 });
 Zotero.defineProperty(Zotero.Collection.prototype, 'synced', {
-	get: function() this._get('synced'),
-	set: function(val) this._set('synced', val)
+	get: function() { return this._get('synced'); },
+	set: function(val) { return this._set('synced', val); }
 });
 Zotero.defineProperty(Zotero.Collection.prototype, 'parent', {
 	get: function() {
@@ -290,14 +290,14 @@ Zotero.Collection.prototype._saveData = Zotero.Promise.coroutine(function* (env)
 		env.sqlColumns.unshift('collectionID');
 		env.sqlValues.unshift(collectionID ? { int: collectionID } : null);
 		
-		let placeholders = env.sqlColumns.map(function () '?').join();
+		let placeholders = env.sqlColumns.map(() => '?').join();
 		let sql = "INSERT INTO collections (" + env.sqlColumns.join(', ') + ") "
 			+ "VALUES (" + placeholders + ")";
 		yield Zotero.DB.queryAsync(sql, env.sqlValues);
 	}
 	else {
 		let sql = 'UPDATE collections SET '
-			+ env.sqlColumns.map(function (x) x + '=?').join(', ') + ' WHERE collectionID=?';
+			+ env.sqlColumns.map(x => x + '=?').join(', ') + ' WHERE collectionID=?';
 		env.sqlValues.push(collectionID ? { int: collectionID } : null);
 		yield Zotero.DB.queryAsync(sql, env.sqlValues);
 	}
@@ -604,7 +604,7 @@ Zotero.Collection.prototype._eraseData = Zotero.Promise.coroutine(function* (env
 		}
 	}
 	
-	var placeholders = collections.map(function () '?').join();
+	var placeholders = collections.map(() => '?').join();
 	
 	// Remove item associations for all descendent collections
 	yield Zotero.DB.queryAsync('DELETE FROM collectionItems WHERE collectionID IN '

--- a/chrome/content/zotero/xpcom/data/collections.js
+++ b/chrome/content/zotero/xpcom/data/collections.js
@@ -104,7 +104,7 @@ Zotero.Collections = function() {
 		}
 		
 		// Do proper collation sort
-		children.sort(function (a, b) Zotero.localeCompare(a.name, b.name));
+		children.sort((a, b) => Zotero.localeCompare(a.name, b.name));
 		
 		if (!recursive) return children;
 		

--- a/chrome/content/zotero/xpcom/data/dataObject.js
+++ b/chrome/content/zotero/xpcom/data/dataObject.js
@@ -66,13 +66,13 @@ Zotero.DataObject.prototype._objectType = 'dataObject';
 Zotero.DataObject.prototype._dataTypes = ['primaryData'];
 
 Zotero.defineProperty(Zotero.DataObject.prototype, 'objectType', {
-	get: function() this._objectType
+	get: function() { return this._objectType; }
 });
 Zotero.defineProperty(Zotero.DataObject.prototype, 'id', {
-	get: function() this._id
+	get: function() { return this._id; }
 });
 Zotero.defineProperty(Zotero.DataObject.prototype, 'libraryID', {
-	get: function() this._libraryID
+	get: function() { return this._libraryID; }
 });
 Zotero.defineProperty(Zotero.DataObject.prototype, 'library', {
 	get: function () {
@@ -80,18 +80,18 @@ Zotero.defineProperty(Zotero.DataObject.prototype, 'library', {
 	}
 });
 Zotero.defineProperty(Zotero.DataObject.prototype, 'key', {
-	get: function() this._key
+	get: function() { return this._key; }
 });
 Zotero.defineProperty(Zotero.DataObject.prototype, 'libraryKey', {
-	get: function() this._libraryID + "/" + this._key
+	get: function() { return this._libraryID + "/" + this._key; }
 });
 Zotero.defineProperty(Zotero.DataObject.prototype, 'parentKey', {
-	get: function () this._getParentKey(),
-	set: function(v) this._setParentKey(v)
+	get: function () { return this._getParentKey(); },
+	set: function(v) { return this._setParentKey(v); }
 });
 Zotero.defineProperty(Zotero.DataObject.prototype, 'parentID', {
-	get: function() this._getParentID(),
-	set: function(v) this._setParentID(v)
+	get: function() { return this._getParentID(); },
+	set: function(v) { return this._setParentID(v); }
 });
 
 Zotero.defineProperty(Zotero.DataObject.prototype, '_canHaveParent', {
@@ -99,7 +99,7 @@ Zotero.defineProperty(Zotero.DataObject.prototype, '_canHaveParent', {
 });
 
 Zotero.defineProperty(Zotero.DataObject.prototype, 'ObjectsClass', {
-	get: function() this._ObjectsClass
+	get: function() { return this._ObjectsClass; }
 });
 
 

--- a/chrome/content/zotero/xpcom/data/dataObjects.js
+++ b/chrome/content/zotero/xpcom/data/dataObjects.js
@@ -62,18 +62,18 @@ Zotero.DataObjects.prototype._ZDO_idOnly = false;
 
 // Public properties
 Zotero.defineProperty(Zotero.DataObjects.prototype, 'idColumn', {
-	get: function() this._ZDO_id
+	get: function() { return this._ZDO_id; }
 });
 Zotero.defineProperty(Zotero.DataObjects.prototype, 'table', {
-	get: function() this._ZDO_table
+	get: function() { return this._ZDO_table; }
 });
 
 Zotero.defineProperty(Zotero.DataObjects.prototype, 'relationsTable', {
-	get: function() this._ZDO_object + 'Relations'
+	get: function() { return this._ZDO_object + 'Relations'; }
 });
 
 Zotero.defineProperty(Zotero.DataObjects.prototype, 'primaryFields', {
-	get: function () Object.keys(this._primaryDataSQLParts)
+	get: function () { return Object.keys(this._primaryDataSQLParts); }
 }, {lazy: true});
 
 Zotero.defineProperty(Zotero.DataObjects.prototype, "_primaryDataSQLWhere", {
@@ -81,7 +81,7 @@ Zotero.defineProperty(Zotero.DataObjects.prototype, "_primaryDataSQLWhere", {
 });
 
 Zotero.defineProperty(Zotero.DataObjects.prototype, 'primaryDataSQLFrom', {
-	get: function() " " + this._primaryDataSQLFrom + " " + this._primaryDataSQLWhere
+	get: function() { return " " + this._primaryDataSQLFrom + " " + this._primaryDataSQLWhere; }
 }, {lateInit: true});
 
 Zotero.DataObjects.prototype.init = function() {

--- a/chrome/content/zotero/xpcom/data/feed.js
+++ b/chrome/content/zotero/xpcom/data/feed.js
@@ -46,13 +46,13 @@ Zotero.Feed = function(params = {}) {
 	// Feeds are not editable by the user. Remove the setter
 	this.editable = false;
 	Zotero.defineProperty(this, 'editable', {
-		get: function() this._get('_libraryEditable')
+		get: function() { return this._get('_libraryEditable'); }
 	});
 
 	// Feeds are not filesEditable by the user. Remove the setter
 	this.filesEditable = false;
 	Zotero.defineProperty(this, 'filesEditable', {
-		get: function() this._get('_libraryFilesEditable')
+		get: function() { return this._get('_libraryFilesEditable'); }
 	});
 	
 	Zotero.Utilities.assignProps(this, params, 
@@ -114,10 +114,10 @@ Zotero.defineProperty(Zotero.Feed.prototype, 'libraryTypes', {
 	value: Object.freeze(Zotero.Feed._super.prototype.libraryTypes.concat(['feed']))
 });
 Zotero.defineProperty(Zotero.Feed.prototype, 'unreadCount', {
-	get: function() this._feedUnreadCount
+	get: function() { return this._feedUnreadCount; }
 });
 Zotero.defineProperty(Zotero.Feed.prototype, 'updating', {
-	get: function() !!this._updating,
+	get: function() { return !!this._updating; }
 });
 
 (function() {
@@ -127,8 +127,8 @@ for (let i=0; i<accessors.length; i++) {
 	let name = accessors[i];
 	let prop = Zotero.Feed._colToProp(name);
 	Zotero.defineProperty(Zotero.Feed.prototype, name, {
-		get: function() this._get(prop),
-		set: function(v) this._set(prop, v)
+		get: function() { return this._get(prop); },
+		set: function(v) { return this._set(prop, v); }
 	})
 }
 let getters = ['lastCheck', 'lastUpdate', 'lastCheckError'];
@@ -136,7 +136,7 @@ for (let i=0; i<getters.length; i++) {
 	let name = getters[i];
 	let prop = Zotero.Feed._colToProp(name);
 	Zotero.defineProperty(Zotero.Feed.prototype, name, {
-		get: function() this._get(prop),
+		get: function() { return this._get(prop); }
 	})
 }
 })()

--- a/chrome/content/zotero/xpcom/data/feedItem.js
+++ b/chrome/content/zotero/xpcom/data/feedItem.js
@@ -46,7 +46,7 @@ Zotero.defineProperty(Zotero.FeedItem.prototype, 'isFeedItem', {
 });
 
 Zotero.defineProperty(Zotero.FeedItem.prototype, 'guid', {
-	get: function() this._feedItemGUID,
+	get: function() { return this._feedItemGUID; },
 	set: function(val) {
 		if (this.id) throw new Error('Cannot set GUID after item ID is already set');
 		if (typeof val != 'string') throw new Error('GUID must be a non-empty string');

--- a/chrome/content/zotero/xpcom/data/feedItems.js
+++ b/chrome/content/zotero/xpcom/data/feedItems.js
@@ -148,7 +148,7 @@ Zotero.FeedItems = new Proxy(function() {
 		}
 		
 		
-		yield Zotero.DB.executeTransaction(function() {
+		yield Zotero.DB.executeTransaction(function* () {
 			for (let i=0; i<items.length; i++) {
 				items[i].isRead = state;
 

--- a/chrome/content/zotero/xpcom/data/group.js
+++ b/chrome/content/zotero/xpcom/data/group.js
@@ -58,7 +58,7 @@ Zotero.Group._colToProp = function(c) {
 
 Zotero.defineProperty(Zotero.Group, '_rowSQLSelect', {
 	value: Zotero.Library._rowSQLSelect + ", G.groupID, "
-		+ Zotero.Group._dbColumns.map(function(c) "G." + c + " AS " + Zotero.Group._colToProp(c)).join(", ")
+		+ Zotero.Group._dbColumns.map(c => "G." + c + " AS " + Zotero.Group._colToProp(c)).join(", ")
 });
 
 Zotero.defineProperty(Zotero.Group, '_rowSQL', {
@@ -77,13 +77,13 @@ Zotero.defineProperty(Zotero.Group.prototype, 'libraryTypes', {
 });
 
 Zotero.defineProperty(Zotero.Group.prototype, 'groupID', {
-	get: function() this._groupID,
-	set: function(v) this._groupID = v
+	get: function() { return this._groupID; },
+	set: function(v) { return this._groupID = v; }
 });
 
 Zotero.defineProperty(Zotero.Group.prototype, 'id', {
-	get: function() this.groupID,
-	set: function(v) this.groupID = v
+	get: function() { return this.groupID; },
+	set: function(v) { return this.groupID = v; }
 });
 
 // Create accessors
@@ -93,8 +93,8 @@ for (let i=0; i<accessors.length; i++) {
 	let name = accessors[i];
 	let prop = Zotero.Group._colToProp(name);
 	Zotero.defineProperty(Zotero.Group.prototype, name, {
-		get: function() this._get(prop),
-		set: function(v) this._set(prop, v)
+		get: function() { return this._get(prop); },
+		set: function(v) { return this._set(prop, v); }
 	})
 }
 })();
@@ -201,7 +201,7 @@ Zotero.Group.prototype._saveData = Zotero.Promise.coroutine(function* (env) {
 		Zotero.Notifier.queue('add', 'group', this.groupID);
 	}
 	else if (changedCols.length) {
-		let sql = "UPDATE groups SET " + changedCols.map(function (v) v + '=?').join(', ')
+		let sql = "UPDATE groups SET " + changedCols.map(v => v + '=?').join(', ')
 			+ " WHERE groupID=?";
 		params.push(this.groupID);
 		yield Zotero.DB.queryAsync(sql, params);

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -89,7 +89,7 @@ Zotero.extendClass(Zotero.DataObject, Zotero.Item);
 
 Zotero.Item.prototype._objectType = 'item';
 Zotero.defineProperty(Zotero.Item.prototype, 'ContainerObjectsClass', {
-	get: function() Zotero.Collections
+	get: function() { return Zotero.Collections; }
 });
 
 Zotero.Item.prototype._dataTypes = Zotero.Item._super.prototype._dataTypes.concat([
@@ -104,8 +104,8 @@ Zotero.Item.prototype._dataTypes = Zotero.Item._super.prototype._dataTypes.conca
 ]);
 
 Zotero.defineProperty(Zotero.Item.prototype, 'id', {
-	get: function() this._id,
-	set: function(val) this.setField('id', val)
+	get: function() { return this._id; },
+	set: function(val) { return this.setField('id', val); }
 });
 Zotero.defineProperty(Zotero.Item.prototype, 'itemID', {
 	get: function() {
@@ -114,52 +114,52 @@ Zotero.defineProperty(Zotero.Item.prototype, 'itemID', {
 	}
 });
 Zotero.defineProperty(Zotero.Item.prototype, 'libraryID', {
-	get: function() this._libraryID,
-	set: function(val) this.setField('libraryID', val)
+	get: function() { return this._libraryID; },
+	set: function(val) { return this.setField('libraryID', val); }
 });
 Zotero.defineProperty(Zotero.Item.prototype, 'key', {
-	get: function() this._key,
-	set: function(val) this.setField('key', val)
+	get: function() { return this._key; },
+	set: function(val) { return this.setField('key', val); }
 });
 Zotero.defineProperty(Zotero.Item.prototype, 'itemTypeID', {
-	get: function() this._itemTypeID
+	get: function() { return this._itemTypeID; }
 });
 Zotero.defineProperty(Zotero.Item.prototype, 'dateAdded', {
-	get: function() this._dateAdded,
-	set: function(val) this.setField('dateAdded', val)
+	get: function() { return this._dateAdded; },
+	set: function(val) { return this.setField('dateAdded', val); }
 });
 Zotero.defineProperty(Zotero.Item.prototype, 'dateModified', {
-	get: function() this._dateModified,
-	set: function(val) this.setField('dateModified', val)
+	get: function() { return this._dateModified; },
+	set: function(val) { return this.setField('dateModified', val); }
 });
 Zotero.defineProperty(Zotero.Item.prototype, 'version', {
-	get: function() this._version,
-	set: function(val) this.setField('version', val)
+	get: function() { return this._version; },
+	set: function(val) { return this.setField('version', val); }
 });
 Zotero.defineProperty(Zotero.Item.prototype, 'synced', {
-	get: function() this._synced,
-	set: function(val) this.setField('synced', val)
+	get: function() { return this._synced; },
+	set: function(val) { return this.setField('synced', val); }
 });
 
 // .parentKey and .parentID defined in dataObject.js, but create aliases
 Zotero.defineProperty(Zotero.Item.prototype, 'parentItemID', {
-	get: function() this.parentID,
-	set: function(val) this.parentID = val
+	get: function() { return this.parentID; },
+	set: function(val) { return this.parentID = val; }
 });
 Zotero.defineProperty(Zotero.Item.prototype, 'parentItemKey', {
-	get: function() this.parentKey,
-	set: function(val) this.parentKey = val
+	get: function() { return this.parentKey; },
+	set: function(val) { return this.parentKey = val; }
 });
 
 
 Zotero.defineProperty(Zotero.Item.prototype, 'firstCreator', {
-	get: function() this._firstCreator
+	get: function() { return this._firstCreator; }
 });
 Zotero.defineProperty(Zotero.Item.prototype, 'sortCreator', {
-	get: function() this._sortCreator
+	get: function() { return this._sortCreator; }
 });
 Zotero.defineProperty(Zotero.Item.prototype, 'relatedItems', {
-	get: function() this._getRelatedItems()
+	get: function() { return this._getRelatedItems(); }
 });
 
 Zotero.defineProperty(Zotero.Item.prototype, 'treeViewID', {
@@ -1023,7 +1023,7 @@ Zotero.Item.prototype.getCreators = function () {
  */
 Zotero.Item.prototype.getCreatorsJSON = function () {
 	this._requireData('creators');
-	return this._creators.map(function (data) Zotero.Creators.internalToJSON(data));
+	return this._creators.map(data => Zotero.Creators.internalToJSON(data));
 }
 
 
@@ -1274,7 +1274,7 @@ Zotero.Item.prototype._saveData = Zotero.Promise.coroutine(function* (env) {
 		env.sqlValues.unshift(parseInt(itemID));
 		
 		let sql = "INSERT INTO items (" + env.sqlColumns.join(", ") + ") "
-			+ "VALUES (" + env.sqlValues.map(function () "?").join() + ")";
+			+ "VALUES (" + env.sqlValues.map(() => "?").join() + ")";
 		yield Zotero.DB.queryAsync(sql, env.sqlValues);
 		
 		if (!env.options.skipNotifier) {
@@ -1328,7 +1328,7 @@ Zotero.Item.prototype._saveData = Zotero.Promise.coroutine(function* (env) {
 		// Delete blank fields
 		if (del.length) {
 			sql = 'DELETE from itemData WHERE itemID=? AND '
-				+ 'fieldID IN (' + del.map(function () '?').join() + ')';
+				+ 'fieldID IN (' + del.map(() => '?').join() + ')';
 			yield Zotero.DB.queryAsync(sql, [itemID].concat(del));
 		}
 	}
@@ -2040,7 +2040,7 @@ Zotero.Item.prototype.getNotes = function(includeTrashed) {
 	var rows = this._notes.rows.concat();
 	// Remove trashed items if necessary
 	if (!includeTrashed) {
-		rows = rows.filter(function (row) !row.trashed);
+		rows = rows.filter(row => !row.trashed);
 	}
 	// Sort by title if necessary
 	if (!sortChronologically) {
@@ -3187,12 +3187,12 @@ Zotero.Item.prototype.getAttachments = function(includeTrashed) {
 	var rows = this._attachments.rows.concat();
 	// Remove trashed items if necessary
 	if (!includeTrashed) {
-		rows = rows.filter(function (row) !row.trashed);
+		rows = rows.filter(row => !row.trashed);
 	}
 	// Sort by title if necessary
 	if (!Zotero.Prefs.get('sortAttachmentsChronologically')) {
 		var collation = Zotero.getLocaleCollation();
-		rows.sort(function (a, b) collation.compareString(1, a.title, b.title));
+		rows.sort((a, b) => collation.compareString(1, a.title, b.title));
 	}
 	var ids = rows.map(row => row.itemID);
 	this._attachments[cacheKey] = ids;
@@ -3299,7 +3299,7 @@ Zotero.Item.prototype.getTags = function () {
  */
 Zotero.Item.prototype.hasTag = function (tagName) {
 	this._requireData('tags');
-	return this._tags.some(function (tagData) tagData.tag == tagName);
+	return this._tags.some(tagData => tagData.tag == tagName);
 }
 
 
@@ -3436,7 +3436,7 @@ Zotero.Item.prototype.replaceTag = function (oldTag, newTag) {
  */
 Zotero.Item.prototype.removeTag = function(tagName) {
 	this._requireData('tags');
-	var newTags = this._tags.filter(function (tagData) tagData.tag !== tagName);
+	var newTags = this._tags.filter(tagData => tagData.tag !== tagName);
 	if (newTags.length == this._tags.length) {
 		Zotero.debug('Cannot remove missing tag ' + tagName + ' from item ' + this.libraryKey);
 		return;
@@ -3640,7 +3640,7 @@ Zotero.Item.prototype.getImageSrcWithTags = Zotero.Promise.coroutine(function* (
 	colorData.sort(function (a, b) {
 		return a.position - b.position;
 	});
-	var colors = colorData.map(function (val) val.color);
+	var colors = colorData.map(val => val.color);
 	return Zotero.Tags.generateItemsListImage(colors, uri);
 });
 

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -447,7 +447,7 @@ Zotero.Item.prototype.setType = function(itemTypeID, loadIn) {
 				}
 			}
 			
-			for each(var oldFieldID in obsoleteFields) {
+			for (let oldFieldID of obsoleteFields) {
 				// Try to get a base type for this field
 				var baseFieldID =
 					Zotero.ItemFields.getBaseIDFromTypeAndField(oldItemTypeID, oldFieldID);
@@ -532,14 +532,14 @@ Zotero.Item.prototype.setType = function(itemTypeID, loadIn) {
 	// Initialize this._itemData with type-specific fields
 	this._itemData = {};
 	var fields = Zotero.ItemFields.getItemTypeFields(itemTypeID);
-	for each(var fieldID in fields) {
+	for (let fieldID of fields) {
 		this._itemData[fieldID] = null;
 	}
 	
 	// DEBUG: clear change item data?
 	
 	if (copiedFields) {
-		for each(var f in copiedFields) {
+		for (let f of copiedFields) {
 			// For fields that we moved to different fields in the new type
 			// (e.g., book -> bookTitle), mark the old value as explicitly
 			// false in previousData (since otherwise it would be null)
@@ -3775,7 +3775,7 @@ Zotero.Item.prototype.diff = function (item, includeMatches, ignoreFields) {
 			throw ("ignoreFields cannot be used if includeMatches is set");
 		}
 		var realDiffs = numDiffs;
-		for each(var field in ignoreFields) {
+		for (let field of ignoreFields) {
 			if (diff[0].primary[field] != undefined) {
 				realDiffs--;
 				if (realDiffs == 0) {

--- a/chrome/content/zotero/xpcom/data/itemFields.js
+++ b/chrome/content/zotero/xpcom/data/itemFields.js
@@ -75,7 +75,7 @@ Zotero.ItemFields = new function() {
 		var sql = "SELECT DISTINCT baseFieldID FROM baseFieldMappingsCombined";
 		var baseFields = yield Zotero.DB.columnQueryAsync(sql);
 		
-		for each(var field in fields) {
+		for (let field of fields) {
 			_fields[field['fieldID']] = {
 				id: field['fieldID'],
 				name: field.fieldName,
@@ -440,7 +440,7 @@ Zotero.ItemFields = new function() {
 		var baseFields = yield Zotero.DB.columnQueryAsync(sql);
 		
 		var fields = [];
-		for each(var row in rows) {
+		for (let row of rows) {
 			if (!fields[row.itemTypeID]) {
 				fields[row.itemTypeID] = [];
 			}

--- a/chrome/content/zotero/xpcom/data/items.js
+++ b/chrome/content/zotero/xpcom/data/items.js
@@ -743,12 +743,12 @@ Zotero.Items = function() {
 			var toSave = {};
 			toSave[item.id] = item;
 			
-			for each(var otherItem in otherItems) {
+			for (let otherItem of otherItems) {
 				let otherItemURI = Zotero.URI.getItemURI(otherItem);
 				
 				// Move child items to master
 				var ids = otherItem.getAttachments(true).concat(otherItem.getNotes(true));
-				for each(var id in ids) {
+				for (let id of ids) {
 					var attachment = yield this.getAsync(id);
 					
 					// TODO: Skip identical children?

--- a/chrome/content/zotero/xpcom/data/library.js
+++ b/chrome/content/zotero/xpcom/data/library.js
@@ -79,7 +79,7 @@ Zotero.Library._colToProp = function(c) {
 
 // Select all columns in a unique manner, so we can JOIN tables with same column names (e.g. version)
 Zotero.defineProperty(Zotero.Library, '_rowSQLSelect', {
-	value: "L.libraryID, " + Zotero.Library._dbColumns.map(function(c) "L." + c + " AS " + Zotero.Library._colToProp(c)).join(", ")
+	value: "L.libraryID, " + Zotero.Library._dbColumns.map(c => "L." + c + " AS " + Zotero.Library._colToProp(c)).join(", ")
 		+ ", (SELECT COUNT(*)>0 FROM collections C WHERE C.libraryID=L.libraryID) AS hasCollections"
 		+ ", (SELECT COUNT(*)>0 FROM savedSearches S WHERE S.libraryID=L.libraryID) AS hasSearches"
 });
@@ -111,18 +111,18 @@ Zotero.defineProperty(Zotero.Library.prototype, 'fixedLibraries', {
 });
 
 Zotero.defineProperty(Zotero.Library.prototype, 'libraryID', {
-	get: function() this._libraryID,
-	set: function(id) { throw new Error("Cannot change library ID") }
+	get: function() { return this._libraryID; },
+	set: function(id) { throw new Error("Cannot change library ID"); }
 });
 
 Zotero.defineProperty(Zotero.Library.prototype, 'id', {
-	get: function() this.libraryID,
-	set: function(val) this.libraryID = val
+	get: function() { return this.libraryID; },
+	set: function(val) { return this.libraryID = val; }
 });
 
 Zotero.defineProperty(Zotero.Library.prototype, 'libraryType', {
-	get: function() this._get('_libraryType'),
-	set: function(v) this._set('_libraryType', v)
+	get: function() { return this._get('_libraryType'); },
+	set: function(v) { return this._set('_libraryType', v); }
 });
 
 /**
@@ -148,8 +148,8 @@ Zotero.defineProperty(Zotero.Library.prototype, 'libraryTypeID', {
 });
 
 Zotero.defineProperty(Zotero.Library.prototype, 'libraryVersion', {
-	get: function() this._get('_libraryVersion'),
-	set: function(v) this._set('_libraryVersion', v)
+	get: function() { return this._get('_libraryVersion'); },
+	set: function(v) { return this._set('_libraryVersion', v); }
 });
 
 
@@ -159,7 +159,7 @@ Zotero.defineProperty(Zotero.Library.prototype, 'syncable', {
 
 
 Zotero.defineProperty(Zotero.Library.prototype, 'lastSync', {
-	get: function() this._get('_libraryLastSync')
+	get: function() { return this._get('_libraryLastSync'); }
 });
 
 
@@ -199,8 +199,8 @@ Zotero.defineProperty(Zotero.Library.prototype, 'hasTrash', {
 	for (let i=0; i<accessors.length; i++) {
 		let prop = Zotero.Library._colToProp(accessors[i]);
 		Zotero.defineProperty(Zotero.Library.prototype, accessors[i], {
-			get: function() this._get(prop),
-			set: function(v) this._set(prop, v)
+			get: function() { return this._get(prop); },
+			set: function(v) { return this._set(prop, v); }
 		})
 	}
 })()
@@ -514,7 +514,7 @@ Zotero.Library.prototype._saveData = Zotero.Promise.coroutine(function* (env) {
 		this._libraryID = id;
 	} else if (changedCols.length) {
 		params.push(this.libraryID);
-		let sql = "UPDATE libraries SET " + changedCols.map(function(v) v + "=?").join(", ")
+		let sql = "UPDATE libraries SET " + changedCols.map(v => v + "=?").join(", ")
 			+ " WHERE libraryID=?";
 		yield Zotero.DB.queryAsync(sql, params);
 		

--- a/chrome/content/zotero/xpcom/data/notes.js
+++ b/chrome/content/zotero/xpcom/data/notes.js
@@ -28,9 +28,9 @@ Zotero.Notes = new function() {
 	this.noteToTitle = noteToTitle;
 	
 	this.__defineGetter__("MAX_TITLE_LENGTH", function() { return 120; });
-	this.__defineGetter__("defaultNote", function () '<div class="zotero-note znv1"></div>');
-	this.__defineGetter__("notePrefix", function () '<div class="zotero-note znv1">');
-	this.__defineGetter__("noteSuffix", function () '</div>');
+	this.__defineGetter__("defaultNote", function () { return '<div class="zotero-note znv1"></div>'; });
+	this.__defineGetter__("notePrefix", function () { return '<div class="zotero-note znv1">'; });
+	this.__defineGetter__("noteSuffix", function () { return '</div>'; });
 	
 	/**
 	* Return first line (or first MAX_LENGTH characters) of note content

--- a/chrome/content/zotero/xpcom/data/search.js
+++ b/chrome/content/zotero/xpcom/data/search.js
@@ -62,31 +62,31 @@ Zotero.Search.prototype.setName = function(val) {
 }
 
 Zotero.defineProperty(Zotero.Search.prototype, 'id', {
-	get: function() this._get('id'),
-	set: function(val) this._set('id', val)
+	get: function() { return this._get('id'); },
+	set: function(val) { return this._set('id', val); }
 });
 Zotero.defineProperty(Zotero.Search.prototype, 'libraryID', {
-	get: function() this._get('libraryID'),
-	set: function(val) this._set('libraryID', val)
+	get: function() { return this._get('libraryID'); },
+	set: function(val) { return this._set('libraryID', val); }
 });
 Zotero.defineProperty(Zotero.Search.prototype, 'key', {
-	get: function() this._get('key'),
-	set: function(val) this._set('key', val)
+	get: function() { return this._get('key'); },
+	set: function(val) { return this._set('key', val); }
 });
 Zotero.defineProperty(Zotero.Search.prototype, 'name', {
-	get: function() this._get('name'),
-	set: function(val) this._set('name', val)
+	get: function() { return this._get('name'); },
+	set: function(val) { return this._set('name', val); }
 });
 Zotero.defineProperty(Zotero.Search.prototype, 'version', {
-	get: function() this._get('version'),
-	set: function(val) this._set('version', val)
+	get: function() { return this._get('version'); },
+	set: function(val) { return this._set('version', val); }
 });
 Zotero.defineProperty(Zotero.Search.prototype, 'synced', {
-	get: function() this._get('synced'),
-	set: function(val) this._set('synced', val)
+	get: function() { return this._get('synced'); },
+	set: function(val) { return this._set('synced', val); }
 });
 Zotero.defineProperty(Zotero.Search.prototype, 'conditions', {
-	get: function() this.getConditions()
+	get: function() { return this.getConditions(); }
 });
 Zotero.defineProperty(Zotero.Search.prototype, '_canHaveParent', {
 	value: false
@@ -175,14 +175,14 @@ Zotero.Search.prototype._saveData = Zotero.Promise.coroutine(function* (env) {
 		env.sqlColumns.unshift('savedSearchID');
 		env.sqlValues.unshift(searchID ? { int: searchID } : null);
 		
-		let placeholders = env.sqlColumns.map(function () '?').join();
+		let placeholders = env.sqlColumns.map(() => '?').join();
 		let sql = "INSERT INTO savedSearches (" + env.sqlColumns.join(', ') + ") "
 			+ "VALUES (" + placeholders + ")";
 		yield Zotero.DB.queryAsync(sql, env.sqlValues);
 	}
 	else {
 		let sql = 'UPDATE savedSearches SET '
-			+ env.sqlColumns.map(function (x) x + '=?').join(', ') + ' WHERE savedSearchID=?';
+			+ env.sqlColumns.map(x => x + '=?').join(', ') + ' WHERE savedSearchID=?';
 		env.sqlValues.push(searchID ? { int: searchID } : null);
 		yield Zotero.DB.queryAsync(sql, env.sqlValues);
 	}
@@ -634,7 +634,7 @@ Zotero.Search.prototype.search = Zotero.Promise.coroutine(function* (asTempTable
 		// (a separate fulltext word search filtered by fulltext content)
 		for (let condition of Object.values(this._conditions)){
 			if (condition['condition']=='fulltextContent'){
-				var fulltextWordIntersectionFilter = function (val, index, array) !!hash[val];
+				var fulltextWordIntersectionFilter = (val, index, array) => !!hash[val];
 				var fulltextWordIntersectionConditionFilter = function(val, index, array) {
 					return hash[val] ?
 						(condition.operator == 'contains') :

--- a/chrome/content/zotero/xpcom/data/search.js
+++ b/chrome/content/zotero/xpcom/data/search.js
@@ -255,7 +255,7 @@ Zotero.Search.prototype.clone = function (libraryID) {
 	
 	var conditions = this.getConditions();
 	
-	for each(var condition in conditions) {
+	for (let condition of Object.values(conditions)) {
 		var name = condition.mode ?
 			condition.condition + '/' + condition.mode :
 			condition.condition
@@ -299,7 +299,7 @@ Zotero.Search.prototype.addCondition = function (condition, operator, value, req
 	if (condition.match(/^quicksearch/)) {
 		var parts = Zotero.SearchConditions.parseSearchString(value);
 		
-		for each(var part in parts) {
+		for (let part of parts) {
 			this.addCondition('blockStart');
 			
 			// If search string is 8 characters, see if this is a item key
@@ -329,7 +329,7 @@ Zotero.Search.prototype.addCondition = function (condition, operator, value, req
 				}
 				else {
 					var splits = Zotero.Fulltext.semanticSplitter(part.text);
-					for each(var split in splits) {
+					for (let split of splits) {
 						this.addCondition('fulltextWord', operator, split, false);
 					}
 				}
@@ -498,7 +498,7 @@ Zotero.Search.prototype.getConditions = function(){
 
 Zotero.Search.prototype.hasPostSearchFilter = function() {
 	this._requireData('conditions');
-	for each(var i in this._conditions){
+	for (let i of Object.values(this._conditions)) {
 		if (i.condition == 'fulltextContent'){
 			return true;
 		}
@@ -530,7 +530,7 @@ Zotero.Search.prototype.search = Zotero.Promise.coroutine(function* (asTempTable
 		var joinMode = 'all';
 		
 		// Set some variables for conditions to avoid further lookups
-		for each(var condition in this._conditions) {
+		for (let condition of Object.values(this._conditions)) {
 			switch (condition.condition) {
 				case 'joinMode':
 					if (condition.operator == 'any') {
@@ -632,7 +632,7 @@ Zotero.Search.prototype.search = Zotero.Promise.coroutine(function* (asTempTable
 		// If join mode ANY or there's a quicksearch (which we assume
 		// fulltextContent is part of), return the union of the main search and
 		// (a separate fulltext word search filtered by fulltext content)
-		for each(var condition in this._conditions){
+		for (let condition of Object.values(this._conditions)){
 			if (condition['condition']=='fulltextContent'){
 				var fulltextWordIntersectionFilter = function (val, index, array) !!hash[val];
 				var fulltextWordIntersectionConditionFilter = function(val, index, array) {
@@ -669,7 +669,7 @@ Zotero.Search.prototype.search = Zotero.Promise.coroutine(function* (asTempTable
 					// Add any necessary conditions to the fulltext word search --
 					// those that are required in an ANY search and any outside the
 					// quicksearch in an ALL search
-					for each(var c in this._conditions) {
+					for (let c of Object.values(this._conditions)) {
 						if (c.condition == 'blockStart') {
 							var inQS = true;
 							continue;
@@ -688,7 +688,7 @@ Zotero.Search.prototype.search = Zotero.Promise.coroutine(function* (asTempTable
 					}
 					
 					var splits = Zotero.Fulltext.semanticSplitter(condition.value);
-					for each(var split in splits){
+					for (let split of splits){
 						s.addCondition('fulltextWord', condition.operator, split);
 					}
 					var fulltextWordIDs = yield s.search();
@@ -1043,7 +1043,7 @@ Zotero.Search.prototype._buildQuery = Zotero.Promise.coroutine(function* () {
 	if (this._hasPrimaryConditions) {
 		sql += " AND ";
 		
-		for each(var condition in conditions){
+		for (let condition of Object.values(conditions)){
 				var skipOperators = false;
 				var openParens = 0;
 				var condSQL = '';
@@ -1088,7 +1088,7 @@ Zotero.Search.prototype._buildQuery = Zotero.Promise.coroutine(function* () {
 							if (typeFields) {
 								condSQL += 'fieldID IN (?,';
 								// Add type-specific fields
-								for each(var fieldID in typeFields) {
+								for (let fieldID of typeFields) {
 									condSQL += '?,';
 									condSQLParams.push(fieldID);
 								}
@@ -1113,7 +1113,7 @@ Zotero.Search.prototype._buildQuery = Zotero.Promise.coroutine(function* () {
 						if (dateFields) {
 							condSQL += 'fieldID IN (?,';																
 							// Add type-specific date fields (dateEnacted, dateDecided, issueDate)
-							for each(var fieldID in dateFields) {
+							for (let fieldID of dateFields) {
 								condSQL += '?,';
 								condSQLParams.push(fieldID);
 							}
@@ -1148,7 +1148,7 @@ Zotero.Search.prototype._buildQuery = Zotero.Promise.coroutine(function* () {
 						// for the collection/search
 						if (objLibraryID === undefined) {
 							let foundLibraryID = false;
-							for each (let c in this._conditions) {
+							for (let c of Object.values(this._conditions)) {
 								if (c.condition == 'libraryID' && c.operator == 'is') {
 									foundLibraryID = true;
 									obj = yield objectTypeClass.getByLibraryAndKeyAsync(
@@ -1246,7 +1246,7 @@ Zotero.Search.prototype._buildQuery = Zotero.Promise.coroutine(function* () {
 							+ 'fileTypeID=?)';
 						var patterns = yield Zotero.DB.columnQueryAsync(ftSQL, { int: condition.value });
 						if (patterns) {
-							for each(str in patterns) {
+							for (let str of patterns) {
 								condSQL += 'contentType LIKE ? OR ';
 								condSQLParams.push(str + '%');
 							}
@@ -1402,7 +1402,7 @@ Zotero.Search.prototype._buildQuery = Zotero.Promise.coroutine(function* () {
 							if (useFreeform && dateparts['part']){
 								go = true;
 								var parts = dateparts['part'].split(' ');
-								for each (var part in parts){
+								for (let part of parts) {
 									condSQL += " AND SUBSTR(" + condition['field'] + ", 12, 100)";
 									condSQL += " LIKE ?";
 									condSQLParams.push('%' + part  + '%');

--- a/chrome/content/zotero/xpcom/data/tags.js
+++ b/chrome/content/zotero/xpcom/data/tags.js
@@ -248,7 +248,7 @@ Zotero.Tags = new function() {
 				oldItemIDs,
 				Zotero.DB.MAX_BOUND_PARAMETERS - 2,
 				Zotero.Promise.coroutine(function* (chunk) {
-					let placeholders = chunk.map(function () '?').join(',');
+					let placeholders = chunk.map(() => '?').join(',');
 					
 					// This is ugly, but it's much faster than doing replaceTag() for each item
 					let sql = 'UPDATE OR REPLACE itemTags SET tagID=?, type=0 '
@@ -349,7 +349,7 @@ Zotero.Tags = new function() {
 				Zotero.Utilities.arrayUnique(oldItemIDs),
 				Zotero.DB.MAX_BOUND_PARAMETERS - 1,
 				Zotero.Promise.coroutine(function* (chunk) {
-					let placeholders = chunk.map(function () '?').join(',');
+					let placeholders = chunk.map(() => '?').join(',');
 					
 					sql = 'UPDATE items SET synced=0, clientDateModified=? '
 						+ 'WHERE itemID IN (' + placeholders + ')'
@@ -539,7 +539,7 @@ Zotero.Tags = new function() {
 				return;
 			}
 			
-			tagColors = tagColors.filter(function (val) val.name != name);
+			tagColors = tagColors.filter(val => val.name != name);
 		}
 		else {
 			// Get current position if present
@@ -620,7 +620,7 @@ Zotero.Tags = new function() {
 			var affectedItems = [];
 			
 			// Get all items linked to previous or current tag colors
-			var tagNames = tagColors.concat(previousTagColors).map(function (val) val.name);
+			var tagNames = tagColors.concat(previousTagColors).map(val => val.name);
 			tagNames = Zotero.Utilities.arrayUnique(tagNames);
 			if (tagNames.length) {
 				for (let i=0; i<tagNames.length; i++) {

--- a/chrome/content/zotero/xpcom/db.js
+++ b/chrome/content/zotero/xpcom/db.js
@@ -375,7 +375,7 @@ Zotero.DBConnection.prototype.getNextName = Zotero.Promise.coroutine(function* (
 		+ " WHERE libraryID=? AND " + field + " LIKE ? ORDER BY " + field;
 	var params = [libraryID, name + "%"];
 	var suffixes = yield this.columnQueryAsync(sql, params);
-	suffixes.filter(function (x) x.match(/^( [0-9]+)?$/));
+	suffixes.filter(x => x.match(/^( [0-9]+)?$/));
 	
 	// If none found or first one has a suffix, use default name
 	if (!suffixes.length || suffixes[0]) {
@@ -834,15 +834,15 @@ Zotero.DBConnection.prototype.executeSQLFile = Zotero.Promise.coroutine(function
 		// Ugly hack to parse triggers with embedded semicolons
 		.replace(/;---/g, "TEMPSEMI")
 		.split("\n")
-		.filter(function (x) nonCommentRE.test(x))
-		.map(function (x) x.match(trailingCommentRE)[1])
+		.filter(x => nonCommentRE.test(x))
+		.map(x => x.match(trailingCommentRE)[1])
 		.join("");
 	if (sql.substr(-1) == ";") {
 		sql = sql.substr(0, sql.length - 1);
 	}
 	
 	var statements = sql.split(";")
-		.map(function (x) x.replace(/TEMPSEMI/g, ";"));
+		.map(x => x.replace(/TEMPSEMI/g, ";"));
 	
 	this.requireTransaction();
 	

--- a/chrome/content/zotero/xpcom/duplicates.js
+++ b/chrome/content/zotero/xpcom/duplicates.js
@@ -36,8 +36,8 @@ Zotero.Duplicates = function (libraryID) {
 }
 
 
-Zotero.Duplicates.prototype.__defineGetter__('name', function () Zotero.getString('pane.collections.duplicate'));
-Zotero.Duplicates.prototype.__defineGetter__('libraryID', function () this._libraryID);
+Zotero.Duplicates.prototype.__defineGetter__('name', function () { return Zotero.getString('pane.collections.duplicate'); });
+Zotero.Duplicates.prototype.__defineGetter__('libraryID', function () { return this._libraryID; });
 
 /**
  * Get duplicates, populate a temporary table, and return a search based
@@ -251,7 +251,7 @@ Zotero.Duplicates.prototype._findDuplicates = Zotero.Promise.coroutine(function*
 				+ "JOIN itemData USING (itemID) "
 				+ "JOIN itemDataValues USING (valueID) "
 				+ "WHERE libraryID=? AND fieldID IN ("
-				+ dateFields.map(function () '?').join() + ") "
+				+ dateFields.map(() => '?').join() + ") "
 				+ "AND SUBSTR(value, 1, 4) != '0000' "
 				+ "AND itemID NOT IN (SELECT itemID FROM deletedItems) "
 				+ "ORDER BY value";

--- a/chrome/content/zotero/xpcom/duplicates.js
+++ b/chrome/content/zotero/xpcom/duplicates.js
@@ -392,7 +392,7 @@ Zotero.Duplicates.prototype._findDuplicates = Zotero.Promise.coroutine(function*
 	
 	// Match on exact fields
 	/*var fields = [''];
-	for each(var field in fields) {
+	for (let field of fields) {
 		var sql = "SELECT itemID, value FROM items JOIN itemData USING (itemID) "
 					+ "JOIN itemDataValues USING (valueID) "
 					+ "WHERE libraryID=? AND fieldID=? "

--- a/chrome/content/zotero/xpcom/file.js
+++ b/chrome/content/zotero/xpcom/file.js
@@ -119,7 +119,7 @@ Zotero.File = new function(){
 	this.getBinaryContents = function(file) {
 		var iStream = Components.classes["@mozilla.org/network/file-input-stream;1"]
 					 .createInstance(Components.interfaces.nsIFileInputStream);
-		iStream.init(file, 0x01, 0664, 0);
+		iStream.init(file, 0x01, 0o664, 0);
 		var bStream = Components.classes["@mozilla.org/binaryinputstream;1"]
 					 .createInstance(Components.interfaces.nsIBinaryInputStream);
 		bStream.setInputStream(iStream);
@@ -149,7 +149,7 @@ Zotero.File = new function(){
 		} else if(file instanceof Components.interfaces.nsIFile) {
 			fis = Components.classes["@mozilla.org/network/file-input-stream;1"].
 				createInstance(Components.interfaces.nsIFileInputStream);
-			fis.init(file, 0x01, 0664, 0);
+			fis.init(file, 0x01, 0o664, 0);
 		} else {
 			throw new Error("File is not an nsIInputStream or nsIFile");
 		}
@@ -342,7 +342,7 @@ Zotero.File = new function(){
 		}
 		var fos = Components.classes["@mozilla.org/network/file-output-stream;1"].
 				createInstance(Components.interfaces.nsIFileOutputStream);
-		fos.init(file, 0x02 | 0x08 | 0x20, 0664, 0);  // write, create, truncate
+		fos.init(file, 0x02 | 0x08 | 0x20, 0o664, 0);  // write, create, truncate
 		
 		var os = Components.classes["@mozilla.org/intl/converter-output-stream;1"]
 						   .createInstance(Components.interfaces.nsIConverterOutputStream);
@@ -472,7 +472,7 @@ Zotero.File = new function(){
 			.getTypeFromFile(file);
 		var inputStream = Components.classes["@mozilla.org/network/file-input-stream;1"]
 			.createInstance(Components.interfaces.nsIFileInputStream);
-		inputStream.init(file, 0x01, 0600, 0);
+		inputStream.init(file, 0x01, 0o600, 0);
 		var stream = Components.classes["@mozilla.org/binaryinputstream;1"]
 			.createInstance(Components.interfaces.nsIBinaryInputStream);
 		stream.setInputStream(inputStream);
@@ -598,7 +598,7 @@ Zotero.File = new function(){
 		file = this.pathToFile(file);
 		newFile = this.pathToFile(newFile);
 		
-		newFile.createUnique(Components.interfaces.nsIFile.NORMAL_FILE_TYPE, 0644);
+		newFile.createUnique(Components.interfaces.nsIFile.NORMAL_FILE_TYPE, 0o644);
 		var newName = newFile.leafName;
 		newFile.remove(null);
 		
@@ -637,7 +637,7 @@ Zotero.File = new function(){
 			if (dir.exists() && !dir.isDirectory()) {
 				dir.remove(null);
 			}
-			dir.create(Components.interfaces.nsIFile.DIRECTORY_TYPE, 0755);
+			dir.create(Components.interfaces.nsIFile.DIRECTORY_TYPE, 0o755);
 		}
 	}
 	
@@ -648,7 +648,7 @@ Zotero.File = new function(){
 				path,
 				{
 					ignoreExisting: true,
-					unixMode: 0755
+					unixMode: 0o755
 				}
 			)
 		);

--- a/chrome/content/zotero/xpcom/http.js
+++ b/chrome/content/zotero/xpcom/http.js
@@ -633,7 +633,7 @@ Zotero.HTTP = new function() {
 	 * through the error log and doing a fragile string comparison.
 	 */
 	_pacInstalled = function () {
-		return Zotero.getErrors(true).some(function (val) val.indexOf("PAC file installed") == 0)
+		return Zotero.getErrors(true).some(val => val.indexOf("PAC file installed") == 0)
 	}
 	
 	

--- a/chrome/content/zotero/xpcom/integration.js
+++ b/chrome/content/zotero/xpcom/integration.js
@@ -1500,7 +1500,7 @@ Zotero.Integration.Fields.prototype._processFields = function(i) {
 					e.setContext(this, i)
 				} else if(e instanceof Zotero.Integration.MissingItemException) {						
 					// Check if we've already decided to remove this field code
-					for each(var reselectKey in e.reselectKeys) {
+					for (let reselectKey of e.reselectKeys) {
 						if(this._removeCodeKeys[reselectKey]) {
 							this._removeCodeFields[i] = true;
 							removeCode = true;
@@ -2173,7 +2173,7 @@ Zotero.Integration.Session.prototype.reselectItem = function(doc, exception) {
 			var itemID = io.dataOut[0];
 			
 			// add reselected item IDs to hash, so they can be used
-			for each(var reselectKey in exception.reselectKeys) {
+			for (let reselectKey of exception.reselectKeys) {
 				me.reselectedItems[reselectKey] = itemID;
 			}
 			// add old URIs to map, so that they will be included
@@ -2379,7 +2379,7 @@ Zotero.Integration.Session.prototype.lookupItems = function(citation, index) {
 			}
 			
 			// look to see if item has already been reselected
-			for each(var reselectKey in reselectKeys) {
+			for (let reselectKey of reselectKeys) {
 				if(this.reselectedItems[reselectKey]) {
 					zoteroItem = Zotero.Items.get(this.reselectedItems[reselectKey]);
 					citationItem.id = zoteroItem.id;
@@ -2479,7 +2479,7 @@ Zotero.Integration.Session.prototype.unserializeCitation = function(arg, index) 
 		
 		if(!citation.properties) citation.properties = {};
 		
-		for each(var citationItem in citation.citationItems) {
+		for (let citationItem of citation.citationItems) {
 			// for upgrade from Zotero 2.0 or earlier
 			if(citationItem.locatorType) {
 				citationItem.label = citationItem.locatorType;
@@ -2634,7 +2634,7 @@ Zotero.Integration.Session.prototype.formatCitation = function(index, citation) 
 			Zotero.debug("Integration: style.processCitationCluster("+citation.toSource()+", "+citationsPre.toSource()+", "+citationsPost.toSource());
 		}
 		var newCitations = this.style.processCitationCluster(citation, citationsPre, citationsPost);
-		for each(var newCitation in newCitations[1]) {
+		for (let newCitation of newCitations[1]) {
 			this.citationText[citationIndices[newCitation[0]]] = newCitation[1];
 			this.updateIndices[citationIndices[newCitation[0]]] = true;
 		}
@@ -2651,7 +2651,7 @@ Zotero.Integration.Session.prototype._updateCitations = function* () {
 	if(force) {
 		allUpdatesForced = true;
 		// make sure at least one citation gets updated
-		updateLoop: for each(var indexList in [this.newIndices, this.updateIndices]) {
+		updateLoop: for (let indexList of [this.newIndices, this.updateIndices]) {
 			for(var i in indexList) {
 				if(!this.citationsByIndex[i].properties.delete) {
 					allUpdatesForced = false;
@@ -2736,7 +2736,7 @@ Zotero.Integration.Session.prototype.loadBibliographyData = function(json) {
 		if(documentData.uncited[0]) {
 			// new style array of arrays with URIs
 			let zoteroItem, needUpdate;
-			for each(var uris in documentData.uncited) {
+			for (let uris of documentData.uncited) {
 				[zoteroItem, needUpdate] = this.uriMap.getZoteroItemForURIs(uris);
 				var id = zoteroItem.cslItemID ? zoteroItem.cslItemID : zoteroItem.id;
 				if(zoteroItem && !this.citationsByItemID[id]) {
@@ -2765,7 +2765,7 @@ Zotero.Integration.Session.prototype.loadBibliographyData = function(json) {
 		if(documentData.custom[0]) {
 			// new style array of arrays with URIs
 			var zoteroItem, needUpdate;
-			for each(var custom in documentData.custom) {
+			for (let custom of documentData.custom) {
 				[zoteroItem, needUpdate] = this.uriMap.getZoteroItemForURIs(custom[0]);
 				if(!zoteroItem) continue;
 				if(needUpdate) this.bibliographyDataHasChanged = true;
@@ -2794,7 +2794,7 @@ Zotero.Integration.Session.prototype.loadBibliographyData = function(json) {
 	// set entries to be omitted from bibliography
 	if(documentData.omitted) {
 			let zoteroItem, needUpdate;
-			for each(var uris in documentData.omitted) {
+			for (let uris of documentData.omitted) {
 				[zoteroItem, update] = this.uriMap.getZoteroItemForURIs(uris);
 				var id = zoteroItem.cslItemID ? zoteroItem.cslItemID : zoteroItem.id;
 				if(zoteroItem && this.citationsByItemID[id]) {

--- a/chrome/content/zotero/xpcom/ipc.js
+++ b/chrome/content/zotero/xpcom/ipc.js
@@ -33,7 +33,7 @@ Zotero.IPC = new function() {
 		if(!Zotero.isWin) {	// no pipe support on Fx 3.6
 			_instancePipe = _getPipeDirectory();
 			if(!_instancePipe.exists()) {
-				_instancePipe.create(Ci.nsIFile.DIRECTORY_TYPE, 0700);
+				_instancePipe.create(Ci.nsIFile.DIRECTORY_TYPE, 0o700);
 			}
 			_instancePipe.append(Zotero.instanceID);
 			
@@ -121,7 +121,7 @@ Zotero.IPC = new function() {
 		// On Linux, O_NONBLOCK = 00004000
 		// On both, O_WRONLY = 0x0001
 		var mode = 0x0001;
-		if(!block) mode = mode | (Zotero.isLinux ? 00004000 : 0x0004);
+		if(!block) mode = mode | (Zotero.isLinux ? 0o0004000 : 0x0004);
 		
 		var fd = open(pipe.path, mode);
 		if(fd === -1) return false;			
@@ -377,7 +377,7 @@ Zotero.IPC.Pipe = new function() {
 		}
 		
 		// make pipe
-		var ret = _mkfifo(file.path, 0600);
+		var ret = _mkfifo(file.path, 0o600);
 		return file.exists();
 	}
 	

--- a/chrome/content/zotero/xpcom/itemTreeView.js
+++ b/chrome/content/zotero/xpcom/itemTreeView.js
@@ -467,7 +467,7 @@ Zotero.ItemTreeView.prototype.notify = Zotero.Promise.coroutine(function* (actio
 	// Clear item type icon and tag colors when a tag is added to or removed from an item
 	if (type == 'item-tag') {
 		// TODO: Only update if colored tag changed?
-		ids.map(function (val) val.split("-")[0]).forEach(function (val) {
+		ids.map(val => val.split("-")[0]).forEach(function (val) {
 			delete this._itemImages[val];
 		}.bind(this));
 		return;
@@ -1405,7 +1405,7 @@ Zotero.ItemTreeView.prototype.sort = function (itemID) {
 	// Cache primary values while sorting, since base-field-mapped getField()
 	// calls are relatively expensive
 	var cache = {};
-	sortFields.forEach(function (x) cache[x] = {})
+	sortFields.forEach(x => cache[x] = {})
 	
 	// Get the display field for a row (which might be a placeholder title)
 	function getField(field, row) {

--- a/chrome/content/zotero/xpcom/itemTreeView.js
+++ b/chrome/content/zotero/xpcom/itemTreeView.js
@@ -503,7 +503,7 @@ Zotero.ItemTreeView.prototype.notify = Zotero.Promise.coroutine(function* (actio
 				var col = this._treebox.columns.getNamedColumn(
 					'zotero-items-column-' + extraData.column
 				);
-				for each(var id in ids) {
+				for (let id of ids) {
 					if (extraData.column == 'title') {
 						delete this._itemImages[id];
 					}
@@ -511,7 +511,7 @@ Zotero.ItemTreeView.prototype.notify = Zotero.Promise.coroutine(function* (actio
 				}
 			}
 			else {
-				for each(var id in ids) {
+				for (let id of ids) {
 					delete this._itemImages[id];
 					this._treebox.invalidateRow(this._rowMap[id]);
 				}
@@ -576,7 +576,7 @@ Zotero.ItemTreeView.prototype.notify = Zotero.Promise.coroutine(function* (actio
 		}
 		
 		var splitIDs = [];
-		for each(var id in ids) {
+		for (let id of ids) {
 			var split = id.split('-');
 			// Skip if not an item in this collection
 			if (split[0] != collectionTreeRow.ref.id) {
@@ -751,7 +751,7 @@ Zotero.ItemTreeView.prototype.notify = Zotero.Promise.coroutine(function* (actio
 			var allDeleted = true;
 			var isTrash = collectionTreeRow.isTrash();
 			var items = Zotero.Items.get(ids);
-			for each(var item in items) {
+			for (let item of items) {
 				// If not viewing trash and all items were deleted, ignore modify
 				if (allDeleted && !isTrash && !item.deleted) {
 					allDeleted = false;
@@ -844,7 +844,7 @@ Zotero.ItemTreeView.prototype.notify = Zotero.Promise.coroutine(function* (actio
 				var items = Zotero.Items.get(ids);
 				if (items) {
 					var found = false;
-					for each(var item in items) {
+					for (let item of items) {
 						// Check for note and attachment type, since it's quicker
 						// than checking for parent item
 						if (item.itemTypeID == 1 || item.itemTypeID == 14) {
@@ -1760,7 +1760,7 @@ Zotero.ItemTreeView.prototype.selectItems = function(ids) {
 	}
 	
 	var rows = [];
-	for each(var id in ids) {
+	for (let id of ids) {
 		if(this._rowMap[id] !== undefined) rows.push(this._rowMap[id]);
 	}
 	rows.sort(function (a, b) {
@@ -2004,7 +2004,7 @@ Zotero.ItemTreeView.prototype._saveOpenState = function (close) {
 
 Zotero.ItemTreeView.prototype.rememberOpenState = function (itemIDs) {
 	var rowsToOpen = [];
-	for each(var id in itemIDs) {
+	for (let id of itemIDs) {
 		var row = this._rowMap[id];
 		// Item may not still exist
 		if (row == undefined) {
@@ -2149,7 +2149,7 @@ Zotero.ItemTreeView.prototype.getVisibleFields = function() {
  */
 Zotero.ItemTreeView.prototype.getSortedItems = function(asIDs) {
 	var items = [];
-	for each(var item in this._rows) {
+	for (let item of this._rows) {
 		if (asIDs) {
 			items.push(item.ref.id);
 		}
@@ -2819,7 +2819,7 @@ Zotero.ItemTreeView.prototype.canDropCheck = function (row, orient, dataTransfer
 		if (rowItem) {
 			var canDrop = false;
 			
-			for each(var item in items) {
+			for (let item of items) {
 				// If any regular items, disallow drop
 				if (item.isRegularItem()) {
 					return false;
@@ -2841,7 +2841,7 @@ Zotero.ItemTreeView.prototype.canDropCheck = function (row, orient, dataTransfer
 		
 		// In library, allow children to be dragged out of parent
 		else if (collectionTreeRow.isLibrary(true) || collectionTreeRow.isCollection()) {
-			for each(var item in items) {
+			for (let item of items) {
 				// Don't allow drag if any top-level items
 				if (item.isTopLevelItem()) {
 					return false;

--- a/chrome/content/zotero/xpcom/itemTreeView.js
+++ b/chrome/content/zotero/xpcom/itemTreeView.js
@@ -2629,7 +2629,7 @@ Zotero.ItemTreeView.fileDragDataProvider.prototype = {
 				if (destDir.exists()) {
 					destDir.remove(true);
 				}
-				destDir.create(Components.interfaces.nsIFile.DIRECTORY_TYPE, 0755);
+				destDir.create(Components.interfaces.nsIFile.DIRECTORY_TYPE, 0o755);
 			}
 			
 			var copiedFiles = [];
@@ -2677,7 +2677,7 @@ Zotero.ItemTreeView.fileDragDataProvider.prototype = {
 								// directory, it's a duplicate, so give this one
 								// a different name
 								else {
-									copiedFile.createUnique(Components.interfaces.nsIFile.NORMAL_FILE_TYPE, 0644);
+									copiedFile.createUnique(Components.interfaces.nsIFile.NORMAL_FILE_TYPE, 0o644);
 									var newName = copiedFile.leafName;
 									copiedFile.remove(null);
 								}
@@ -2718,7 +2718,7 @@ Zotero.ItemTreeView.fileDragDataProvider.prototype = {
 								// it's a duplicate, so give this one a different
 								// name
 								else {
-									copiedFile.createUnique(Components.interfaces.nsIFile.NORMAL_FILE_TYPE, 0644);
+									copiedFile.createUnique(Components.interfaces.nsIFile.NORMAL_FILE_TYPE, 0o644);
 									var newName = copiedFile.leafName;
 									copiedFile.remove(null);
 								}

--- a/chrome/content/zotero/xpcom/locateManager.js
+++ b/chrome/content/zotero/xpcom/locateManager.js
@@ -132,7 +132,7 @@ Zotero.LocateManager = new function() {
 		if(locateDir.exists()) locateDir.remove(true);
 		
 		// create new locate dir
-		locateDir.create(Components.interfaces.nsIFile.DIRECTORY_TYPE, 0700);
+		locateDir.create(Components.interfaces.nsIFile.DIRECTORY_TYPE, 0o700);
 		
 		// copy default file to new locate dir
 		Zotero.File.putContents(_jsonFile,
@@ -233,7 +233,7 @@ Zotero.LocateManager = new function() {
 		// write the icon to the file
 		var fos = Components.classes["@mozilla.org/network/file-output-stream;1"].
 				createInstance(Components.interfaces.nsIFileOutputStream);
-		fos.init(iconFile, 0x02 | 0x08 | 0x20, 0664, 0);  // write, create, truncate
+		fos.init(iconFile, 0x02 | 0x08 | 0x20, 0o664, 0);  // write, create, truncate
 		var bos = Components.classes["@mozilla.org/binaryoutputstream;1"].
 				createInstance(Components.interfaces.nsIBinaryOutputStream);
 		bos.setOutputStream(fos);

--- a/chrome/content/zotero/xpcom/locateManager.js
+++ b/chrome/content/zotero/xpcom/locateManager.js
@@ -75,7 +75,7 @@ Zotero.LocateManager = new function() {
 	/**
 	 * Returns an array of all search engines
 	 */
-	this.getEngines = function() _locateEngines.slice(0);
+	this.getEngines = function() { return _locateEngines.slice(0); }
 	
 	/**
 	 * Returns an array of all search engines visible that should be visible in the dropdown

--- a/chrome/content/zotero/xpcom/locateManager.js
+++ b/chrome/content/zotero/xpcom/locateManager.js
@@ -89,7 +89,7 @@ Zotero.LocateManager = new function() {
 	 */
 	this.getEngineByName = function(engineName) {
 		engineName = engineName.toLowerCase();
-		for each(var engine in _locateEngines) if(engine.name.toLowerCase() == engineName) return engine;
+		for (let engine of _locateEngines) if(engine.name.toLowerCase() == engineName) return engine;
 		return null;
 	}
 	
@@ -98,7 +98,7 @@ Zotero.LocateManager = new function() {
 	 */
 	this.getEngineByAlias = function(engineAlias) {
 		engineAlias = engineAlias.toLowerCase();
-		for each(var engine in _locateEngines) if(engine.alias.toLowerCase() == engineAlias) return engine;
+		for (let engine of _locateEngines) if(engine.alias.toLowerCase() == engineAlias) return engine;
 		return null;
 	}
 	

--- a/chrome/content/zotero/xpcom/progressWindow.js
+++ b/chrome/content/zotero/xpcom/progressWindow.js
@@ -217,7 +217,7 @@ Zotero.ProgressWindow = function(_window = null) {
 		var newDescription = _progressWindow.document.createElement("description");
 		
 		var parts = Zotero.Utilities.parseMarkup(text);
-		for each(var part in parts) {
+		for (let part of parts) {
 			if (part.type == 'text') {
 				var elem = _progressWindow.document.createTextNode(part.text);
 			}

--- a/chrome/content/zotero/xpcom/proxy.js
+++ b/chrome/content/zotero/xpcom/proxy.js
@@ -55,8 +55,8 @@ Zotero.Proxies = new function() {
 				rows.map(row => this.newProxyFromRow(row))
 			);
 			
-			for each(var proxy in Zotero.Proxies.proxies) {
-				for each(var host in proxy.hosts) {
+			for (let proxy of Zotero.Proxies.proxies) {
+				for (let host of proxy.hosts) {
 					Zotero.Proxies.hosts[host] = proxy;
 				}
 			}
@@ -110,7 +110,7 @@ Zotero.Proxies = new function() {
 		// see if there is a proxy we already know
 		var m = false;
 		var proxy;
-		for each(proxy in Zotero.Proxies.proxies) {
+		for (proxy of Zotero.Proxies.proxies) {
 			if(proxy.proxyID && proxy.regexp && proxy.multiHost) {
 				m = proxy.regexp.exec(url);
 				if(m) break;
@@ -312,7 +312,7 @@ Zotero.Proxies = new function() {
 		// if there is a proxy ID (i.e., if this is a persisting, transparent proxy), add to host
 		// list to do reverse mapping
 		if(proxy.proxyID) {
-			for each(var host in proxy.hosts) {
+			for (let host of proxy.hosts) {
 				Zotero.Proxies.hosts[host] = proxy;
 			}
 		}
@@ -344,7 +344,7 @@ Zotero.Proxies = new function() {
 	 * @type String
 	 */
 	this.proxyToProper = function(url, onlyReturnIfProxied) {
-		for each(var proxy in Zotero.Proxies.proxies) {
+		for (let proxy of Zotero.Proxies.proxies) {
 			if(proxy.regexp) {
 				var m = proxy.regexp.exec(url);
 				if(m) {
@@ -405,9 +405,9 @@ Zotero.Proxies = new function() {
 			/^muse\.jhu\.edu$/
 		]
 		
-		for each(var blackPattern in hostBlacklist) {
+		for (let blackPattern of hostBlacklist) {
 			if(blackPattern.test(host)) {
-				for each(var whitePattern in hostWhitelist) {
+				for (let whitePattern of hostWhitelist) {
 					if(whitePattern.test(host)) {
 						return false;
 					}
@@ -625,7 +625,7 @@ Zotero.Proxy.prototype.validate = function() {
 		return ["scheme.invalid"];
 	}
 	
-	for each(var host in this.hosts) {
+	for (let host of this.hosts) {
 		var oldHost = Zotero.Proxies.hosts[host];
 		if(oldHost && oldHost.proxyID && oldHost != this) {
 			return ["host.proxyExists", host];
@@ -810,7 +810,7 @@ Zotero.Proxies.Detectors.EZProxy = function(channel) {
 		if(fromProxy && toProxy && fromProxy.host == toProxy.host && fromProxy.port != toProxy.port
 				&& [80, 443, -1].indexOf(toProxy.port) == -1) {
 			var proxy;
-			for each(proxy in Zotero.Proxies.proxies) {
+			for (proxy of Zotero.Proxies.proxies) {
 				if(proxy.regexp) {
 					var m = proxy.regexp.exec(fromProxy.spec);
 					if(m) break;

--- a/chrome/content/zotero/xpcom/quickCopy.js
+++ b/chrome/content/zotero/xpcom/quickCopy.js
@@ -460,7 +460,7 @@ Zotero.QuickCopy = new function() {
 		// add styles to list
 		_formattedNames = {};
 		var styles = Zotero.Styles.getVisible();
-		for each(var style in styles) {
+		for (let style of styles) {
 			_formattedNames['bibliography=' + style.styleID] = style.title;
 		}
 		

--- a/chrome/content/zotero/xpcom/quickCopy.js
+++ b/chrome/content/zotero/xpcom/quickCopy.js
@@ -67,7 +67,12 @@ Zotero.QuickCopy = new function() {
 			+ "WHERE setting='quickCopySite'";
 		var rows = yield Zotero.DB.queryAsync(sql);
 		// Unproxify storage row
-		_siteSettings = [for (row of rows) { domainPath: row.domainPath, format: row.format }];
+		_siteSettings = rows.map(row => {
+			return {
+				domainPath: row.domainPath,
+				format: row.format 
+			};
+		});
 	});
 	
 	

--- a/chrome/content/zotero/xpcom/report.js
+++ b/chrome/content/zotero/xpcom/report.js
@@ -98,7 +98,7 @@ Zotero.Report.HTML = new function () {
 						content += '\t\t\t\t<h3 class="notes">' + escapeXML(Zotero.getString('report.notes')) + '</h3>\n';
 					}
 					content += '\t\t\t\t<ul class="notes">\n';
-					for each(var note in obj.reportChildren.notes) {
+					for (let note of obj.reportChildren.notes) {
 						content += '\t\t\t\t\t<li id="item_' + note.itemKey + '">\n';
 						
 						// If not valid XML, display notes with entities encoded
@@ -180,7 +180,7 @@ Zotero.Report.HTML = new function () {
 			table = true;
 			var displayText;
 			
-			for each(var creator in obj['creators']) {
+			for (let creator of obj['creators']) {
 				// One field
 				if (creator.name !== undefined) {
 					displayText = creator.name;

--- a/chrome/content/zotero/xpcom/server_connector.js
+++ b/chrome/content/zotero/xpcom/server_connector.js
@@ -183,7 +183,7 @@ Zotero.Server.Connector.Detect.prototype = {
 	 */
 	"_translatorsAvailable":function(obj, translators) {
 		var jsons = [];
-		for each(var translator in translators) {
+		for (let translator of translators) {
 			if(translator.itemType == "multiple") {
 				var icon = "treesource-collection.png"
 			} else {

--- a/chrome/content/zotero/xpcom/storage.js
+++ b/chrome/content/zotero/xpcom/storage.js
@@ -27,8 +27,8 @@
 Zotero.Sync.Storage = new function () {
 	
 	// TEMP
-	this.__defineGetter__("defaultError", function () Zotero.getString('sync.storage.error.default', Zotero.appName));
-	this.__defineGetter__("defaultErrorRestart", function () Zotero.getString('sync.storage.error.defaultRestart', Zotero.appName));
+	this.__defineGetter__("defaultError", function () { return Zotero.getString('sync.storage.error.default', Zotero.appName); });
+	this.__defineGetter__("defaultErrorRestart", function () { return Zotero.getString('sync.storage.error.defaultRestart', Zotero.appName); });
 	
 	var _itemDownloadPercentages = {};
 	

--- a/chrome/content/zotero/xpcom/storage/storageLocal.js
+++ b/chrome/content/zotero/xpcom/storage/storageLocal.js
@@ -654,7 +654,7 @@ Zotero.Sync.Storage.Local = {
 			+ " into attachment directory as '" + fileName + "'");
 		try {
 			var finalFileName = Zotero.File.createShortened(
-				path, Components.interfaces.nsIFile.NORMAL_FILE_TYPE, 0644
+				path, Components.interfaces.nsIFile.NORMAL_FILE_TYPE, 0o644
 			);
 		}
 		catch (e) {
@@ -825,7 +825,7 @@ Zotero.Sync.Storage.Local = {
 			let shortened;
 			try {
 				shortened = Zotero.File.createShortened(
-					destPath, Components.interfaces.nsIFile.NORMAL_FILE_TYPE, 0644
+					destPath, Components.interfaces.nsIFile.NORMAL_FILE_TYPE, 0o644
 				);
 			}
 			catch (e) {

--- a/chrome/content/zotero/xpcom/storage/storageRequest.js
+++ b/chrome/content/zotero/xpcom/storage/storageRequest.js
@@ -85,8 +85,8 @@ Zotero.Sync.Storage.Request.prototype.importCallbacks = function (request) {
 			}
 			// Otherwise add functions that don't already exist
 			var add = true;
-			for each(var newFunc in request[name]) {
-				for each(var currentFunc in this[name]) {
+			for (let newFunc of request[name]) {
+				for (let currentFunc of this[name]) {
 					if (newFunc.toString() === currentFunc.toString()) {
 						Zotero.debug("Callback already exists in request -- not importing");
 						add = false;
@@ -266,8 +266,8 @@ Zotero.Sync.Storage.Request.prototype.onProgress = function (progress, progressM
 		Zotero.Sync.Storage.setItemDownloadPercentage(this.name, this.percentage);
 	}
 	
-	if (this.onProgress) {
-		for each(var f in this._onProgress) {
+	if (this.onProgress && this._onProgress) {
+		for (let f of this._onProgress) {
 			f(progress, progressMax);
 		}
 	}

--- a/chrome/content/zotero/xpcom/style.js
+++ b/chrome/content/zotero/xpcom/style.js
@@ -336,7 +336,7 @@ Zotero.Styles = new function() {
 			
 			if(existingFile) {
 				// find associated style
-				for each(var existingStyle in _styles) {
+				for (let existingStyle of _styles) {
 					if(destFile.equals(existingStyle.file)) {
 						existingTitle = existingStyle.title;
 						break;

--- a/chrome/content/zotero/xpcom/sync.js
+++ b/chrome/content/zotero/xpcom/sync.js
@@ -181,7 +181,7 @@ Zotero.Sync.Server = new function () {
 					if (ids) {
 						var items = Zotero.Items.get(ids);
 						var rolledBack = false;
-						for each(var item in items) {
+						for (let item of items) {
 							var file = item.getFile();
 							if (!file) {
 								continue;
@@ -563,7 +563,7 @@ Zotero.Sync.Server.Data = new function() {
 			introMsg += Zotero.getString('sync.conflict.tag.addedToLocal');
 		}
 		var itemText = [];
-		for each(var id in addedItemIDs) {
+		for (let id of addedItemIDs) {
 			var item = Zotero.Items.get(id);
 			var title = item.getField('title');
 			var text = " - " + title;

--- a/chrome/content/zotero/xpcom/translation/translate_firefox.js
+++ b/chrome/content/zotero/xpcom/translation/translate_firefox.js
@@ -786,7 +786,7 @@ Zotero.Translate.IO.Read.prototype = {
 		if(this._rawStream) this._rawStream.close();
 		this._rawStream = Components.classes["@mozilla.org/network/file-input-stream;1"]
 								  .createInstance(Components.interfaces.nsIFileInputStream);
-		this._rawStream.init(this.file, 0x01, 0664, 0);
+		this._rawStream.init(this.file, 0x01, 0o664, 0);
 	},
 	
 	"_rewind":function() {
@@ -921,7 +921,7 @@ Zotero.Translate.IO.Write = function(file) {
 	Zotero.Translate.IO.maintainedInstances.push(this);
 	this._rawStream = Components.classes["@mozilla.org/network/file-output-stream;1"]
 		.createInstance(Components.interfaces.nsIFileOutputStream);
-	this._rawStream.init(file, 0x02 | 0x08 | 0x20, 0664, 0); // write, create, truncate
+	this._rawStream.init(file, 0x02 | 0x08 | 0x20, 0o664, 0); // write, create, truncate
 	this._writtenToStream = false;
 }
 

--- a/chrome/content/zotero/xpcom/translation/translate_item.js
+++ b/chrome/content/zotero/xpcom/translation/translate_item.js
@@ -709,7 +709,7 @@ Zotero.Translate.ItemGetter.prototype = {
 		this._exportFileDirectory.append(name);
 		
 		// create directory
-		this._exportFileDirectory.create(Components.interfaces.nsIFile.DIRECTORY_TYPE, 0700);
+		this._exportFileDirectory.create(Components.interfaces.nsIFile.DIRECTORY_TYPE, 0o700);
 		
 		// generate a new location for the exported file, with the appropriate
 		// extension
@@ -786,7 +786,7 @@ Zotero.Translate.ItemGetter.prototype = {
 						// Create intermediate directories if they don't exist
 						parent = targetFile;
 						while((parent = parent.parent) && !parent.exists()) {
-							parent.create(Components.interfaces.nsIFile.DIRECTORY_TYPE, 0700);
+							parent.create(Components.interfaces.nsIFile.DIRECTORY_TYPE, 0o700);
 						}
 						
 						// Delete any existing file if overwriteExisting is set, or throw an exception

--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -98,7 +98,7 @@ Zotero.Utilities.Internal = {
 			var istream = Components.classes["@mozilla.org/network/file-input-stream;1"]
 							.createInstance(Components.interfaces.nsIFileInputStream);
 			// open for reading
-			istream.init(strOrFile, 0x01, 0444, 0);
+			istream.init(strOrFile, 0x01, 0o444, 0);
 			var ch = Components.classes["@mozilla.org/security/hash;1"]
 						   .createInstance(Components.interfaces.nsICryptoHash);
 			// we want to use the MD5 algorithm

--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -76,7 +76,7 @@ Components.utils.import("resource://gre/modules/osfile.jsm");
 	 * @property	{Boolean}	locked		Whether all Zotero panes are locked
 	 *										with an overlay
 	 */
-	this.__defineGetter__('locked', function () _locked);
+	this.__defineGetter__('locked', function () { return _locked; });
 	this.__defineSetter__('locked', function (lock) {
 		var wasLocked = _locked;
 		_locked = lock;
@@ -804,7 +804,7 @@ Components.utils.import("resource://gre/modules/osfile.jsm");
 				var e = {
 					name: 'NS_ERROR_FILE_ACCESS_DENIED',
 					message: msg,
-					toString: function () this.message
+					toString: function () { return this.message; }
 				};
 				throw (e);
 			}

--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -1747,7 +1747,7 @@ Components.utils.import("resource://gre/modules/osfile.jsm");
 	
 	
 	function moveToUnique(file, newFile){
-		newFile.createUnique(Components.interfaces.nsIFile.NORMAL_FILE_TYPE, 0644);
+		newFile.createUnique(Components.interfaces.nsIFile.NORMAL_FILE_TYPE, 0o644);
 		var newName = newFile.leafName;
 		newFile.remove(null);
 		

--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -947,7 +947,7 @@ Components.utils.import("resource://gre/modules/osfile.jsm");
 		if(defaultSection.IsRelative === "1") {
 			var defaultProfile = prefDir.clone().QueryInterface(Components.interfaces.nsILocalFile);
 			try {
-				for each(var dir in defaultSection.Path.split("/")) defaultProfile.append(dir);
+				for (let dir of defaultSection.Path.split("/")) defaultProfile.append(dir);
 			} catch(e) {
 				Zotero.logError("Could not find profile at "+defaultSection.Path);
 				throw e;
@@ -1429,7 +1429,7 @@ Components.utils.import("resource://gre/modules/osfile.jsm");
 	function getErrors(asStrings) {
 		var errors = [];
 		
-		for each(var msg in _startupErrors.concat(_recentErrors)) {
+		for (let msg of _startupErrors.concat(_recentErrors)) {
 			// Remove password in malformed XML messages
 			if (msg.category == 'malformed-xml') {
 				try {
@@ -2012,7 +2012,7 @@ Components.utils.import("resource://gre/modules/osfile.jsm");
 			Zotero.debug("already initialized search menu");
 			button = button[0];
 			var menupopup = button.firstChild;
-			for each(var menuitem in menupopup.childNodes) {
+			for (let menuitem of menupopup.childNodes) {
 				if (menuitem.id.substr(prefixLen) == mode) {
 					menuitem.setAttribute('checked', true);
 					searchBox.placeholder = modes[mode].label;
@@ -2502,7 +2502,7 @@ Zotero.Keys = new function() {
 		var cmds = Zotero.Prefs.prefBranch.getChildList('keys', {}, {});
 		
 		// Get the key=>command mappings from the prefs
-		for each(var cmd in cmds) {
+		for (let cmd of cmds) {
 			cmd = cmd.substr(5); // strips 'keys.'
 			// Remove old pref
 			if (cmd == 'overrideGlobal') {

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -34,7 +34,7 @@ var ZoteroPane = new function()
 	this.itemsView = false;
 	this.progressWindow = false;
 	this._listeners = {};
-	this.__defineGetter__('loaded', function () _loaded);
+	this.__defineGetter__('loaded', function () { return _loaded; });
 	var _lastSelectedItems = [];
 	
 	//Privileged methods

--- a/components/zotero-autocomplete.js
+++ b/components/zotero-autocomplete.js
@@ -231,10 +231,10 @@ ZoteroAutoComplete.prototype.startSearch = Zotero.Promise.coroutine(function* (s
 		if (resultsCallback) {
 			resultsCallback(results);
 			this.updateResults(
-				[for (x of results) x.val],
-				[for (x of results) x.comment],
+				Object.values(results).map(x => x.val),
+				Object.values(results).map(x => x.comment),
 				false
-			)
+			);
 		}
 		resultCode = null;
 		Zotero.debug("Autocomplete query completed");

--- a/components/zotero-protocol-handler.js
+++ b/components/zotero-protocol-handler.js
@@ -596,7 +596,7 @@ function ZoteroProtocolHandler() {
 						var search = new Zotero.Search();
 						search.setScope(s);
 						var groups = Zotero.Groups.getAll();
-						for each(var group in groups) {
+						for (let group of groups) {
 							search.addCondition('libraryID', 'isNot', group.libraryID);
 						}
 						break;

--- a/components/zotero-protocol-handler.js
+++ b/components/zotero-protocol-handler.js
@@ -74,8 +74,10 @@ function ZoteroProtocolHandler() {
 						Zotero.API.Data.getGenerator(path)
 					);
 				}
-				catch (e if e instanceof Zotero.Router.InvalidPathException) {
-					return "URL could not be parsed";
+				catch (e) {
+					if (e instanceof Zotero.Router.InvalidPathException) {
+						return "URL could not be parsed";	
+					}
 				}
 			});
 		}

--- a/components/zotero-service.js
+++ b/components/zotero-service.js
@@ -324,7 +324,7 @@ function makeZoteroContext(isConnector) {
 	// add connector-related properties
 	zContext.Zotero.isConnector = isConnector;
 	zContext.Zotero.instanceID = instanceID;
-	zContext.Zotero.__defineGetter__("isFirstLoadThisSession", function() isFirstLoadThisSession);
+	zContext.Zotero.__defineGetter__("isFirstLoadThisSession", function() { return isFirstLoadThisSession; });
 };
 
 /**


### PR DESCRIPTION
- Replace legacy syntax `for each...in` with `for...of`
- Replaced non-strict syntax for octal number literals (strict version requires octals to be prefixed with `0o`, non-strict allows just `0`)
- Remove use of non-standard array comprehension syntax (it has [never made it](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Array_comprehensions) to a standard and [is no longer supported by babel](https://babeljs.io/docs/learn-es2015/#comprehensions))
- Remove use of syntax where curly brackets are omitted in function definition
- Remove non-standard syntax for conditional exception handling
- Few other syntax fixes (e.g. yield inside a non-generator function)
