### PR TITLE
Change padding-left to margin-left property for hanging indent

### DIFF
--- a/chrome/content/zotero/xpcom/cite.js
+++ b/chrome/content/zotero/xpcom/cite.js
@@ -206,7 +206,7 @@ Zotero.Cite = {
 				}
 				// If only one field, apply hanging indent on root
 				else if (!multiField) {
-					style += "padding-left: " + hangingIndent + "em; text-indent:-" + hangingIndent + "em;";
+					style += "margin-left: " + hangingIndent + "em; text-indent:-" + hangingIndent + "em;";
 				}
 			}
 			


### PR DESCRIPTION
In response to [the quick copy indent thread](https://forums.zotero.org/discussion/9846/incorrect-margins-when-dragging-reference-to-word-2007-from-zotero-1-0/p2).

I've played around and these are my results:

- MS Word and Outlook outright ignore both padding and margin, but respect text-indent.
- Libre Office appears to ignore css styling completely.
- Gdocs ignores padding, but respects margin.
- Gmail ignores text-indent and randomly respects/ignores both padding and margin.

People should be using Word Plugins anyway, which work properly and we can fix this for at least Gdocs. Email users are screwed, but then again, email layout is an engineering field of its own.

Any ideas if the change could break anything else prominently used?