### PR TITLE
Make itemPane white on linux

### DIFF
--- a/chrome/content/zotero-platform/unix/itemPane.css
+++ b/chrome/content/zotero-platform/unix/itemPane.css
@@ -11,6 +11,15 @@
 	visibility: visible;
 }
 
+#zotero-item-pane-content {
+	margin-right: 6px;
+}
+
+/* Make the item pane appear white (same colour as treeview), making the UI more consistent */
+#zotero-item-pane-content tab, #zotero-item-pane-content tabpanels {
+	background-color: -moz-Field; /* Same as background colour for treeview */
+}
+
 /* Possibly irrelevant if mozilla fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1306425 */
 #zotero-view-tabbox tabs tab[visuallyselected=true] {
 	margin-top: 0px !important; /* Importanter than ./itemPane.css:20 */

--- a/chrome/content/zotero-platform/unix/overlay.css
+++ b/chrome/content/zotero-platform/unix/overlay.css
@@ -219,3 +219,8 @@ toolbar:not([id="nav-bar"]) #zotero-toolbar-buttons separator {
 #zotero-prefs .numberbox-input-box{
 	-moz-appearance: textfield;
 }
+/* Grippy icon missing anyway */
+#zotero-pane splitter{
+	width: 6px;
+}
+


### PR DESCRIPTION
Also reduces separator width and adds a right margin to the tabpane. 

Before:
![image](https://cloud.githubusercontent.com/assets/5899315/21616133/07e5be88-d1e9-11e6-95fc-81df2fc5ec73.png)

After:
![image](https://cloud.githubusercontent.com/assets/5899315/21616188/3a02170e-d1e9-11e6-9eb7-5f2474234eda.png)
