### PR TITLE
Preserve format tags and entities in bibliography editor

### DIFF
--- a/chrome/content/zotero/bindings/styled-textbox.xml
+++ b/chrome/content/zotero/bindings/styled-textbox.xml
@@ -84,7 +84,7 @@
 					var _rexData = [
 						[
 							[
-								["<span style=\"font-variant:small-caps;\">"],
+								["<span +style=\"font-variant: *small-caps;\">"],
 								["{\\scaps ", "{\\scaps{}"]
 							],
 							[
@@ -94,7 +94,7 @@
 						],
 						[
 							[
-								["<span style=\"text-decoration:underline;\">"],
+								["<span +style=\"text-decoration: *underline;\">"],
 								["{\\ul{}", "{\\ul "]
 							],
 							[
@@ -164,7 +164,7 @@
 						],
 						[
 							[
-								["<span style=\"font-variant:normal;\">"],
+								["<span +style=\"font-variant: *normal;\">"],
 								["{\\scaps0{}", "{\\scaps0 "]
 							],
 							[
@@ -174,7 +174,7 @@
 						],
 						[
 							[
-								["<span style=\"font-style:normal;\">"],
+								["<span +style=\"font-style: *normal;\">"],
 								["{\\i0{}", "{\\i0 "]
 							],
 							[
@@ -184,7 +184,7 @@
 						],
 						[
 							[
-								["<span style=\"font-weight:normal;\">"],
+								["<span +style=\"font-weight: *normal;\">"],
 								["{\\b0{}", "{\\b0 "]
 							],
 							[
@@ -203,6 +203,16 @@
 							return 0;
 						}
 					}
+					
+					function normalizeRegexpString(str) {
+						if (!str) return str;
+						return str.replace(/\s+/g, " ")
+									.replace(/(?:[\+]|\s[\*])/g, "")
+									.replace(/[\']/g, '\"')
+									.replace(/:\s/g, ":");
+					}
+
+					this.normalizeRegexpString = normalizeRegexpString;
 					
 					function composeRex(rexes, noGlobal) {
 						var lst = [];
@@ -247,13 +257,15 @@
 					function openTagRemapMaker(segment) {
 						var ret = {};
 						for (var i=0,ilen=_rexData.length; i < ilen; i++) {
-							var master = _rexData[i][0][segment][0];
+							var primaryVal = normalizeRegexpString(_rexData[i][0][segment][0]);
 							for (var j=0,jlen=_rexData[i][0][segment].length; j < jlen; j++) {
-								ret[_rexData[i][0][segment][j]] = master;
+								var key = normalizeRegexpString(_rexData[i][0][segment][j]);
+								ret[key] = primaryVal;
 							}
 						}
 						return ret;
 					}
+
 					this.rtfHTMLopenTagRemap = openTagRemapMaker(1);
 					this.htmlRTFopenTagRemap = openTagRemapMaker(0);
 					
@@ -262,11 +274,11 @@
 						var ret = {};
 						var rexes = {};
 						for (var i=0,ilen=_rexData.length; i < ilen; i++) {
-							var master = _rexData[i][0][segment][0];
+							var primaryVal = _rexData[i][0][segment][0];
 							for (var j=0,jlen=_rexData[i][1][segment].length; j < jlen; j++) {
 								rexes[_rexData[i][1][segment][j]] = true;
 							}
-							ret[master] = composeRex(rexes);
+							ret[primaryVal] = composeRex(rexes);
 						}
 						return ret;
 					}
@@ -281,14 +293,15 @@
 						}
 						var ret = {};
 						for (var i=0,ilen=_rexData.length; i < ilen; i++) {
-							var master = _rexData[i][0][segment][0];
-							ret[master] = {
-								open: _rexData[i][0][antisegment][0],
+							var primaryVal = normalizeRegexpString(_rexData[i][0][segment][0]);
+							ret[primaryVal] = {
+								open: normalizeRegexpString(_rexData[i][0][antisegment][0]),
 								close: _rexData[i][1][antisegment][0]
 							}
 						}
 						return ret;
 					}
+					
 					this.rtfHTMLtagRegistry = tagRegistryMaker(1);
 					this.htmlRTFtagRegistry = tagRegistryMaker(0);
 
@@ -311,7 +324,7 @@
 				this.getOpenTag = function(mode, str) {
 					var m = str.match(this[mode + "openSniffRex"]);
 					if (m) {
-						m = this[mode + "openTagRemap"][m[0]];
+						m = this[mode + "openTagRemap"][this.normalizeRegexpString(m[0])];
 					}
 					return m;
 				}

--- a/chrome/content/zotero/bindings/styled-textbox.xml
+++ b/chrome/content/zotero/bindings/styled-textbox.xml
@@ -51,19 +51,26 @@
 				this._onInitCallbacks = [];
 				this._iframe = document.getAnonymousElementByAttribute(this, "anonid", "rt-view");
 				
+				// Atomic units, HTML -> RTF (cleanup)
+				//[/<\/p>(?!\s*$)/g, "\\par{}"],
+				//[/ /g, "&nbsp;"],
+				//[/\u00A0/g, " "],
 				this._htmlRTFmap = [
-					// Atomic units, HTML -> RTF (cleanup)
 					[/<br \/>/g, "\x0B"],
+					[/<span class=\"tab\">&nbsp;<\/span>/g, "\\tab{}"],
+					[/&lsquo;/g, "‘"],
+					[/&rsquo;/g, "’"],
+					[/&ldquo;/g, "“"],
+					[/&rdquo;/g, "”"],
+					[/&nbsp;/g, "\u00A0"],
 					[/"(\w)/g, "“$1"],
 					[/([\w,.?!])"/g, "$1”"],
 					[/<p>/g, ""],
-					//[/<\/p>(?!\s*$)/g, "\\par{}"],
-					[/<\/?div[^>]*>/g, ""],
-					[/[\x7F-\uFFFF]/g, function(aChar) { return "\\uc0\\u"+aChar.charCodeAt(0).toString()+"{}"}]
+					[/<\/?div[^>]*>/g, ""]
 				];
 				
+				// Atomic units, RTF -> HTML (cleanup)
 				this._rtfHTMLmap = [
-					// Atomic units, RTF -> HTML (cleanup)
 					[/\\uc0\{?\\u([0-9]+)\}?(?:{}| )?/g, function(wholeStr, aCode) { return String.fromCharCode(aCode) }],
 					[/\\tab(?:\{\}| )/g, '<span class="tab">&nbsp;</span>'],
 					[/(?:\\par{}|\\\r?\n)/g, "</p><p>"]
@@ -339,14 +346,13 @@
 				}
 				
 				this.htmlToRTF = function(txt) {
-					// Catch this one before &nbsp; is clobbered by unescape
-					txt = txt.replace(/<span class=\"tab\">&nbsp;<\/span>/g, "\\tab{}");
-					txt = Zotero.Utilities.unescapeHTML(txt);
+					txt = this.convert("htmlRTF", txt);
 					for (var i=0,ilen=this._htmlRTFmap.length; i < ilen; i++) {
 						var entry = this._htmlRTFmap[i];
 						txt = txt.replace(entry[0], entry[1]);
 					}
-					txt = this.convert("htmlRTF", txt);
+					txt = Zotero.Utilities.unescapeHTML(txt);
+					txt = txt.replace(/[\x7F-\uFFFF]/g, function(aChar) { return "\\uc0\\u"+aChar.charCodeAt(0).toString()+"{}"});
 					return txt.trim();
 				}
 				

--- a/chrome/content/zotero/bindings/styled-textbox.xml
+++ b/chrome/content/zotero/bindings/styled-textbox.xml
@@ -204,7 +204,7 @@
 						}
 					}
 					
-					function normalizeRegexpString(str) {
+					function normalizeRegExpString(str) {
 						if (!str) return str;
 						return str.replace(/\s+/g, " ")
 									.replace(/(?:[\+]|\s[\*])/g, "")
@@ -212,7 +212,7 @@
 									.replace(/:\s/g, ":");
 					}
 
-					this.normalizeRegexpString = normalizeRegexpString;
+					this.normalizeRegExpString = normalizeRegExpString;
 					
 					function composeRex(rexes, noGlobal) {
 						var lst = [];
@@ -257,9 +257,9 @@
 					function openTagRemapMaker(segment) {
 						var ret = {};
 						for (var i=0,ilen=_rexData.length; i < ilen; i++) {
-							var primaryVal = normalizeRegexpString(_rexData[i][0][segment][0]);
+							var primaryVal = normalizeRegExpString(_rexData[i][0][segment][0]);
 							for (var j=0,jlen=_rexData[i][0][segment].length; j < jlen; j++) {
-								var key = normalizeRegexpString(_rexData[i][0][segment][j]);
+								var key = normalizeRegExpString(_rexData[i][0][segment][j]);
 								ret[key] = primaryVal;
 							}
 						}
@@ -293,9 +293,9 @@
 						}
 						var ret = {};
 						for (var i=0,ilen=_rexData.length; i < ilen; i++) {
-							var primaryVal = normalizeRegexpString(_rexData[i][0][segment][0]);
+							var primaryVal = normalizeRegExpString(_rexData[i][0][segment][0]);
 							ret[primaryVal] = {
-								open: normalizeRegexpString(_rexData[i][0][antisegment][0]),
+								open: normalizeRegExpString(_rexData[i][0][antisegment][0]),
 								close: _rexData[i][1][antisegment][0]
 							}
 						}
@@ -324,7 +324,7 @@
 				this.getOpenTag = function(mode, str) {
 					var m = str.match(this[mode + "openSniffRex"]);
 					if (m) {
-						m = this[mode + "openTagRemap"][this.normalizeRegexpString(m[0])];
+						m = this[mode + "openTagRemap"][this.normalizeRegExpString(m[0])];
 					}
 					return m;
 				}

--- a/chrome/content/zotero/integration/addCitationDialog.js
+++ b/chrome/content/zotero/integration/addCitationDialog.js
@@ -41,6 +41,7 @@ var Zotero_Citation_Dialog = new function () {
 	var _previewShown = false;
 	var _suppressNextTreeSelect = false;
 	var _suppressNextListSelect = false;
+	var _customHTML = false;
 	var _locatorIndexArray = {};
 	var _locatorNameArray = {};
 	var _autoRegeneratePref;
@@ -556,6 +557,9 @@ var Zotero_Citation_Dialog = new function () {
 		
 		if(_previewShown) {
 			document.documentElement.getButton("extra2").label = Zotero.getString("citation.hideEditor");		
+			if (!text && _customHTML) {
+				text = _customHTML;
+			}
 			if(text) {
 				io.preview().then(function(preview) {
 					_originalHTML = preview;
@@ -565,6 +569,11 @@ var Zotero_Citation_Dialog = new function () {
 				_updatePreview();
 			}
 		} else {
+			if (editor.initialized) {
+				if (editor.value) {
+					_customHTML = editor.value;
+				}
+			}
 			document.documentElement.getButton("extra2").label = Zotero.getString("citation.showEditor");		
 		}
 	}


### PR DESCRIPTION
Addresses #1138, fixing errors in previous commits 55bfe54a (#939) and 9431e0de (#937), which were meant to address #935.
- Apply `unescapeHTML` after RTF tag and entity conversions
- Remove RTF high-bit character escape from entity converter, and apply it separately after remaining HTML entities are decoded by `unescapeHTML`.

@dstillman  I hope this fixes everything around HTML/RTF conversion of formatted text delivered by `citeproc-js`, but give me a shout if anything is still messed up. 

(The moral of the story is that I should read more carefully—I missed that `unescapeHTML` strips HTML tags.)
