### PR TITLE
Fixes for csledit

### DIFF
--- a/chrome/content/zotero/tools/csledit.js
+++ b/chrome/content/zotero/tools/csledit.js
@@ -35,7 +35,7 @@ var Zotero_CSL_Editor = new function() {
 		
 		var lastStyle = Zotero.Prefs.get('export.lastStyle');
 		
-		var styles = Zotero.Styles.getAll();
+		var styles = Zotero.Styles.getVisible();
 		var currentStyle = null;
 		for (let style of styles) {
 			if (style.source) {
@@ -119,7 +119,7 @@ var Zotero_CSL_Editor = new function() {
 	function loadCSL(cslID) {
 		var editor = document.getElementById('zotero-csl-editor');
 		var style = Zotero.Styles.get(cslID);
-		editor.value = Zotero.File.getContents(style.file);
+		editor.value = Zotero.File.getContents(style.independentFile);
 		editor.cslID = cslID;
 		editor.doCommand();
 		document.getElementById('zotero-csl-list').value = cslID;

--- a/chrome/content/zotero/xpcom/style.js
+++ b/chrome/content/zotero/xpcom/style.js
@@ -347,8 +347,9 @@ Zotero.Styles = new function() {
 			
 			if(existingFile) {
 				// find associated style
-				for (let existingStyle of _styles) {
-					if(destFile.equals(existingStyle.file)) {
+				for (let id in _styles) {
+					let existingStyle = _styles[id];
+					if(existingStyle.file && destFile.equals(existingStyle.file)) {
 						existingTitle = existingStyle.title;
 						break;
 					}
@@ -594,6 +595,9 @@ Zotero.Style = function (style, path) {
 	if (path) {
 		this.path = path;
 		this.fileName = OS.Path.basename(path);
+	}
+	else {
+		this.string = style;
 	}
 	
 	this.styleID = Zotero.Utilities.xpathText(doc, '/csl:style/csl:info[1]/csl:id[1]',


### PR DESCRIPTION
This PR fixes some small bugs that blocked operation of the csledit  tool in 5.0 (master).

in Zotero_CSL_Editor:
(1) use `getVisible` to obtain a sorted array of styles.
(2) get file path with `style.independentFile` so that
the code behind dependent styles can be edited.

in Zotero.Style:
(3) set the string representation of the style on
`style.string`, for use when `file.path` is not available.
(4) Fix a small iteration bug affecting style installs.

I'm not sure how the `style.file` attribute that figures in line 352 of `style.js` is managed in other code. It seems to be missing sometimes (or maybe always?), which throws an error when it's fed to `destFile.equals`. I've added a condition there to control for it, but that may not be the best solution.