### PR TITLE
Amend short form of French months (continuing #64)

### DIFF
--- a/resource/schema/dateFormats.json
+++ b/resource/schema/dateFormats.json
@@ -306,13 +306,13 @@
 			"mar",
 			"avr",
 			"mai",
-			"jun",
-			"jul",
+			"juin",
+			"juil",
 			"aoû",
 			"sep",
 			"oct",
 			"nov",
-			"dec"
+			"déc"
 		],
 		"long": [
 			"janvier",

--- a/test/tests/dateTest.js
+++ b/test/tests/dateTest.js
@@ -9,7 +9,7 @@ describe("Zotero.Date", function() {
 			"October", "November", "December"
 		];
 		var frenchShort = [
-			"jan", "fév", "mar", "avr", "mai", "jun", "jul", "aoû", "sep", "oct", "nov", "dec"
+			"jan", "fév", "mar", "avr", "mai", "juin", "juil", "aoû", "sep", "oct", "nov", "déc"
 		];
 		var frenchLong = [
 			"janvier", "février", "mars", "avril", "mai", "juin", "juillet", "août", "septembre",


### PR DESCRIPTION
The Firefox French language pack contains some mistakes regarding the short form of months. I don't know where Mozilla found this list… Anyway French month parsing didn't work (for juin, juillet, décembre).

Actually these values aren't even the correct abbreviations but only the three or four first letters of the correct abbreviations. See the <a href="https://github.com/citation-style-language/locales/blob/master/locales-fr-FR.xml#L298">French CSL locale</a> for the correct abbreviations.

There's still a small glitch: when you put your mouse over the date field, if it contains "juill." "déc.", the tooltip shows 00 for the month, even if the parsing is correct (and the parsing indicator says d m y).