### PR TITLE
Limits the size of maximum snapshot file to 8MB

### DIFF
--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -476,7 +476,7 @@ Zotero.Utilities.Internal = {
 		var deferred = Zotero.Promise.defer();
 		wbp.progressListener = new Zotero.WebProgressFinishListener(function () {
 			deferred.resolve();
-		});
+		}, 8*1024*1024);
 		
 		wbp.saveDocument(
 			document,

--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -2460,7 +2460,7 @@ Zotero.Browser = new function() {
 /*
  * Implements nsIWebProgressListener
  */
-Zotero.WebProgressFinishListener = function(onFinish) {
+Zotero.WebProgressFinishListener = function(onFinish, maxSize=0) {
 	this.onStateChange = function(wp, req, stateFlags, status) {
 		//Zotero.debug('onStageChange: ' + stateFlags);
 		if (stateFlags & Components.interfaces.nsIWebProgressListener.STATE_STOP
@@ -2470,9 +2470,16 @@ Zotero.WebProgressFinishListener = function(onFinish) {
 	}
 	
 	this.onProgressChange = function(wp, req, curSelfProgress, maxSelfProgress, curTotalProgress, maxTotalProgress) {
-		//Zotero.debug('onProgressChange');
-		//Zotero.debug('Current: ' + curTotalProgress);
-		//Zotero.debug('Max: ' + maxTotalProgress);
+		// Zotero.debug(`onProgressChange ${req.name}`);
+		// Zotero.debug(`Self: ${curSelfProgress}/${maxSelfProgress}`);
+		// Zotero.debug(`Total: ${curTotalProgress}/${maxTotalProgress}`);
+		
+		// -1 if size unknown or too big to fit a long (2GB upwards)
+		var curMax = maxSelfProgress != -1 ? maxSelfProgress : maxTotalProgress;
+		if (maxSize && curMax != -1 && curMax > maxSize) {
+			Zotero.debug(`Canceling request to ${req.name} with size ${curMax/1024}KB > ${maxSize/1024}KB`, 2);
+			req.cancel(Components.results.NS_BINDING_ABORTED);
+		}
 	}
 	
 	this.onLocationChange = function(wp, req, location) {}


### PR DESCRIPTION
Note that this does not limit the maximum size the snapshot will use on
disk and only cancels individual files. This also technically orphans the files
but getting the correct filenames to delete is non-trivial (WBP seems to remove
'.min' from minified filenames for example) and snapshot directories are a general
mess not to be looked at anyway.

See https://forums.zotero.org/discussion/comment/266997 for the original report