### PR TITLE
Replaced the 9 tag colours with 15 new ones based on the http://clrs.cc

### DIFF
--- a/chrome/content/zotero/tagColorChooser.js
+++ b/chrome/content/zotero/tagColorChooser.js
@@ -52,9 +52,21 @@ var Zotero_Tag_Color_Chooser = new function() {
 			colorPicker.setAttribute('tileWidth', 24);
 			colorPicker.setAttribute('tileHeight', 24);
 			colorPicker.colors = [
-				'#990000', '#CC9933', '#FF9900',
-				'#FFCC00', '#007439', '#1049A9',
-				'#9999FF', '#CC66CC', '#993399'
+				"#0056AF",
+				"#0088FF",
+				"#7FDBFF",
+				"#39CCCC",
+				"#3D9970",
+				"#2ECC40",
+				"#01FF70",
+				"#FFDC00",
+				"#ff9b1b",
+				"#ff3428",
+				"#d614aa",
+				"#8d00f5",
+				"#ff76fa",
+				"#111111",
+				"#BBBBBB"
 			];
 			
 			var maxTags = document.getElementById('max-tags');

--- a/chrome/content/zotero/xpcom/data/tags.js
+++ b/chrome/content/zotero/xpcom/data/tags.js
@@ -28,7 +28,7 @@
  * Same structure as Zotero.Creators -- make changes in both places if possible
  */
 Zotero.Tags = new function() {
-	this.MAX_COLORED_TAGS = 9;
+	this.MAX_COLORED_TAGS = 15;
 	this.MAX_SYNC_LENGTH = 255;
 	
 	var _initialized = false;


### PR DESCRIPTION
The nine colours on offer to users are dull and restrictive. I've replaced them with fifteen colours, based on the http://clrs.cc web library.

### Before
<img width="125" alt="screen shot 2017-03-16 at 01 16 30" src="https://cloud.githubusercontent.com/assets/237556/23977466/55a37540-09e6-11e7-9765-002853c60941.png">

### After
<img width="131" alt="screen shot 2017-03-16 at 01 16 47" src="https://cloud.githubusercontent.com/assets/237556/23977472/5e8768b0-09e6-11e7-957c-882df04d8dc3.png">

<img width="483" alt="screen shot 2017-03-16 at 00 33 05" src="https://cloud.githubusercontent.com/assets/237556/23977432/138c078a-09e6-11e7-9629-dd9aafd1a2f7.png">