### PR TITLE
[WIP] Set displayed date format to uniform format

### DIFF
--- a/chrome/content/zotero/bindings/itembox.xml
+++ b/chrome/content/zotero/bindings/itembox.xml
@@ -1296,6 +1296,13 @@
 						case 'dateDue':
 						case 'accepted':
 							if (fieldName == 'date' && this.item._objectType != 'feedItem') {
+								if (valueText) {
+									var date = Zotero.Date.strToDate(valueText);
+									if (date.part == undefined) {
+										// valueText = Zotero.Date.isoToDate(date).toLocaleDateString();
+										valueText = Zotero.Date.dateToISO(date);
+									}
+								}
 								break;
 							}
 							if (valueText) {

--- a/chrome/content/zotero/xpcom/date.js
+++ b/chrome/content/zotero/xpcom/date.js
@@ -623,14 +623,12 @@ Zotero.Date = new function(){
 		return string;
 	}
 	
-	this.strToISO = function (str) {
-		var date = this.strToDate(str);
-		
-		if(date.year) {
+	this.dateToISO = function (date) {
+		if (date.year) {
 			var dateString = Zotero.Utilities.lpad(date.year, "0", 4);
 			if (parseInt(date.month) == date.month) {
 				dateString += "-"+Zotero.Utilities.lpad(date.month+1, "0", 2);
-				if(date.day) {
+				if (date.day) {
 					dateString += "-"+Zotero.Utilities.lpad(date.day, "0", 2);
 				}
 			}
@@ -639,6 +637,11 @@ Zotero.Date = new function(){
 		return false;
 	}
 	
+	this.strToISO = function (str) {
+		var date = this.strToDate(str);
+		var dateString = this.dateToISO(date);
+		return dateString;
+	}
 	
 	this.sqlToISO8601 = function (sqlDate) {
 		var date = sqlDate.substr(0, 10);

--- a/chrome/content/zotero/xpcom/itemTreeView.js
+++ b/chrome/content/zotero/xpcom/itemTreeView.js
@@ -1096,6 +1096,13 @@ Zotero.ItemTreeView.prototype.getCellText = function (row, column)
 		case 'zotero-items-column-accessDate':
 		case 'zotero-items-column-date':
 			if (column.id == 'zotero-items-column-date' && !this.collectionTreeRow.isFeed()) {
+				if (val) {
+					var date = Zotero.Date.strToDate(val);
+					if (date.part == undefined) {
+						// val = Zotero.Date.isoToDate(date).toLocaleDateString();
+						val = Zotero.Date.dateToISO(date);
+					}
+				}
 				break;
 			}
 			if (val) {


### PR DESCRIPTION
This is a WIP pull request related to [this feature request](https://forums.zotero.org/discussion/14572/a-ui-proposal-for-a-better-date-field/p2).

The item date shown in the item tree view and item box now use a uniform format. 

Currently the format is always the ISO date because this is the format I prefer, but a final solution would probably create a user setting to toggle between ISO or locale dates with locale being default. Alternatively users could choose a custom date format. I am fine with any solution that allows ISO dates.