### PR TITLE
Refactor integration and delay citation updates

### DIFF
--- a/chrome/content/zotero/bibliography.js
+++ b/chrome/content/zotero/bibliography.js
@@ -283,8 +283,7 @@ var Zotero_File_Interface_Bibliography = new function() {
 		document.documentElement.getButton('cancel').click();
 		var win = Zotero.Utilities.Internal.openPreferences('zotero-prefpane-cite', { tab: 'styles-tab' });
 		if (isDocPrefs) {
-			// TODO: Move activate() code elsewhere
-			Zotero.Integration.activate(win);
+			Zotero.Utilities.Internal.activate(win);
 		}
 	};
 }

--- a/chrome/content/zotero/bibliography.js
+++ b/chrome/content/zotero/bibliography.js
@@ -167,10 +167,23 @@ var Zotero_File_Interface_Bibliography = new function() {
 				document.getElementById("automaticJournalAbbreviations-checkbox").checked = true;
 			}
 		}
+		if (document.getElementById("delayCitationUpdates-checkbox")) {
+			if (_io.delayCitationUpdates) {
+				document.getElementById("delayCitationUpdates-checkbox").checked = true;
+			}
+		}
 		
 		// set style to false, in case this is cancelled
 		_io.style = false;
 	});
+	
+	this.openHelpLink = function() {
+		var url = "https://www.zotero.org/support/word_processor_plugin_usage";
+		var win = Components.classes["@mozilla.org/appshell/window-mediator;1"]
+						.getService(Components.interfaces.nsIWindowMediator)
+						.getMostRecentWindow("navigator:browser");
+		Zotero.launchURL(url);
+	};
 
 	/*
 	 * Called when locale is changed
@@ -210,6 +223,13 @@ var Zotero_File_Interface_Bibliography = new function() {
 		if(document.getElementById("automaticJournalAbbreviations-vbox")) {
 			document.getElementById("automaticJournalAbbreviations-vbox").hidden =
 				!selectedStyleObj.usesAbbreviation;
+		}
+		// Hide the delayCitationUpdates checkbox before the prompt is shown
+		document.getElementById("delayCitationUpdates-vbox").hidden = _io.dontAskDelayCitationUpdates == undefined;
+		// Highlight delay citations checkbox after displaying the alert
+		// NOTE: Currently unused
+		if (_io.highlightDelayCitations) {
+			document.getElementById("delayCitationUpdates-vbox").style.border = "1px dashed #e52e2e"
 		}
 		
 		//
@@ -266,6 +286,7 @@ var Zotero_File_Interface_Bibliography = new function() {
 			}
 			_io.useEndnotes = document.getElementById("displayAs").selectedIndex;
 			_io.fieldType = (document.getElementById("formatUsing").selectedIndex == 0 ? _io.primaryFieldType : _io.secondaryFieldType);
+			_io.delayCitationUpdates = document.getElementById("delayCitationUpdates-checkbox").checked;
 		}
 		
 		// remember style and locale if user selected these explicitly

--- a/chrome/content/zotero/integration/addCitationDialog.js
+++ b/chrome/content/zotero/integration/addCitationDialog.js
@@ -59,10 +59,8 @@ var Zotero_Citation_Dialog = new function () {
 	this.listItemSelected = listItemSelected;
 	this.up = up;
 	this.down = down;
-	this.add = add;
 	this.remove = remove;
 	this.setSortToggle = setSortToggle;
-	this.citationSortUnsort = citationSortUnsort;
 	this.confirmRegenerate = confirmRegenerate;
 	this.accept = accept;
 	this.cancel = cancel;
@@ -373,13 +371,13 @@ var Zotero_Citation_Dialog = new function () {
 	/*
 	 * Adds an item to the multipleSources list
 	 */
-	function add(first_item) {
+	this.add = Zotero.Promise.coroutine(function* (first_item) {
 		
 		var pos, len;
 		var item = itemsView.getSelectedItems()[0]; // treeview from xpcom/itemTreeView.js
 		
 		if (!item) {
-			sortCitation();
+			yield sortCitation();
 			_updateAccept();
 			_updatePreview();
 			return;
@@ -412,11 +410,11 @@ var Zotero_Citation_Dialog = new function () {
 		_citationList.ensureElementIsVisible(selectionNode);
 
 		// allow user to press OK
-		selectionNode = sortCitation(selectionNode);
+		selectionNode = yield sortCitation(selectionNode);
 		_citationList.selectItem(selectionNode);
 		_updateAccept();
 		_updatePreview();
-	}
+	});
 	
 	/*
 	 * Deletes a citation from the multipleSources list
@@ -446,11 +444,11 @@ var Zotero_Citation_Dialog = new function () {
 	/*
 	 * Sorts preview citations, if preview is open.
 	 */
-	function citationSortUnsort() {
+	this.citationSortUnsort = Zotero.Promise.coroutine(function* () {
 		setSortToggle();
-		sortCitation();
+		yield sortCitation();
 		_updatePreview();
-	}
+	});
 
 	/*
 	 * Sets the current sort toggle state persistently on the citation.
@@ -468,7 +466,7 @@ var Zotero_Citation_Dialog = new function () {
 	/*
 	 * Sorts the list of citations
  	 */
-	function sortCitation(scrollToItem) {
+	var sortCitation = Zotero.Promise.coroutine(function* (scrollToItem) {
  		if(!_sortCheckbox) return scrollToItem;
  		if(!_sortCheckbox.checked) {
  			io.citation.properties.unsorted = true;
@@ -485,7 +483,7 @@ var Zotero_Citation_Dialog = new function () {
 		
 		// run preview function to re-sort, if it hasn't already been
 		// run
-		io.sort();
+		yield io.sort();
 		
 		// add items back to list
 		scrollToItem = null;
@@ -502,7 +500,7 @@ var Zotero_Citation_Dialog = new function () {
 		
 		if(scrollToItem) _citationList.ensureElementIsVisible(scrollToItem);
 		return scrollToItem;
-	}
+	});
 	
 	/*
 	 * Ask whether to modifiy the preview

--- a/chrome/content/zotero/integration/editBibliographyDialog.js
+++ b/chrome/content/zotero/integration/editBibliographyDialog.js
@@ -74,8 +74,8 @@ var Zotero_Bibliography_Dialog = new function () {
 		if(selectedItemIDs.length) {
 			for (let itemID of selectedItemIDs) {
 				var itemIndexToSelect = false;
-				for(var i in bibEditInterface.bibliography[0].entry_ids) {
-					if(bibEditInterface.bibliography[0].entry_ids[i].indexOf(itemID) !== -1) {
+				for(var i in bibEditInterface.bib[0].entry_ids) {
+					if(bibEditInterface.bib[0].entry_ids[i].indexOf(itemID) !== -1) {
 						itemIndexToSelect = i;
 						continue;
 					}
@@ -254,7 +254,7 @@ var Zotero_Bibliography_Dialog = new function () {
 	 */
 	function _getSelectedListItemIDs() {
 		return Array.from(_itemList.selectedItems)
-			.map(item => bibEditInterface.bibliography[0].entry_ids[item.value][0]);
+			.map(item => bibEditInterface.bib[0].entry_ids[item.value][0]);
 	}
 	
 	/**
@@ -287,8 +287,8 @@ var Zotero_Bibliography_Dialog = new function () {
 		
 		editor.readonly = index === undefined;
 		if(index !== undefined) {
-			var itemID = bibEditInterface.bibliography[0].entry_ids[index];
-			editor.value = bibEditInterface.bibliography[1][index];
+			var itemID = bibEditInterface.bib[0].entry_ids[index];
+			editor.value = bibEditInterface.bib[1][index];
 			_lastSelectedIndex = index;
 			_lastSelectedItemID = itemID;
 			_lastSelectedValue = editor.value;
@@ -304,7 +304,7 @@ var Zotero_Bibliography_Dialog = new function () {
 	 * loads items from itemSet
 	 */
 	function _loadItems() {
-		var itemIDs = bibEditInterface.bibliography[0].entry_ids;
+		var itemIDs = bibEditInterface.bib[0].entry_ids;
 		var items = itemIDs.map(itemID => Zotero.Cite.getItem(itemID[0]));
 		
 		// delete all existing items from list

--- a/chrome/content/zotero/integration/integrationDocPrefs.xul
+++ b/chrome/content/zotero/integration/integrationDocPrefs.xul
@@ -31,10 +31,11 @@
 <dialog
 	id="zotero-doc-prefs-dialog"
 	orient="vertical"
-	buttons="accept,cancel"
+	buttons="accept,cancel,help"
 	title="&zotero.integration.docPrefs.title;"
 	onload="Zotero_File_Interface_Bibliography.init();"
 	ondialogaccept="Zotero_File_Interface_Bibliography.acceptSelection();"
+	ondialoghelp="Zotero_File_Interface_Bibliography.openHelpLink();"
 	onclose="document.documentElement.cancelDialog(); event.preventDefault(); event.stopPropagation();"
 	xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
 	persist="screenX screenY"
@@ -83,6 +84,11 @@
 		<vbox id="automaticJournalAbbreviations-vbox">
 			<checkbox id="automaticJournalAbbreviations-checkbox" label="&zotero.integration.prefs.automaticJournalAbbeviations.label;"/>
 			<description class="radioDescription">&zotero.integration.prefs.automaticJournalAbbeviations.caption;</description>
+		</vbox>
+		
+		<vbox id="delayCitationUpdates-vbox">
+			<checkbox id="delayCitationUpdates-checkbox" label="&zotero.integration.prefs.delayCitationUpdates.label;" tooltiptext="&zotero.integration.prefs.delayCitationUpdates.tooltip;"/>
+			<description class="radioDescription">&zotero.integration.prefs.delayCitationUpdates.description;</description>
 		</vbox>
 	</vbox>
 </dialog>

--- a/chrome/content/zotero/integration/quickFormat.js
+++ b/chrome/content/zotero/integration/quickFormat.js
@@ -1320,7 +1320,7 @@ var Zotero_QuickFormat = new function () {
 		pane.selectItem(id);
 		
 		// Pull window to foreground
-		Zotero.Integration.activate(pane.document.defaultView);
+		Zotero.Utilities.Internal.activate(pane.document.defaultView);
 	}
 	
 	/**

--- a/chrome/content/zotero/integration/quickFormat.js
+++ b/chrome/content/zotero/integration/quickFormat.js
@@ -710,7 +710,7 @@ var Zotero_QuickFormat = new function () {
 	/**
 	 * Converts the selected item to a bubble
 	 */
-	function _bubbleizeSelected() {
+	var _bubbleizeSelected = Zotero.Promise.coroutine(function* () {
 		if(!referenceBox.hasChildNodes() || !referenceBox.selectedItem) return false;
 		
 		var citationItem = {"id":referenceBox.selectedItem.getAttribute("zotero-item")};
@@ -733,11 +733,11 @@ var Zotero_QuickFormat = new function () {
 		node.nodeValue = "";
 		var bubble = _insertBubble(citationItem, node);
 		_clearEntryList();
-		_previewAndSort();
+		yield _previewAndSort();
 		_refocusQfe();
 		
 		return true;
-	}
+	});
 	
 	/**
 	 * Ignores clicks (for use on separators in the rich list box)
@@ -901,13 +901,13 @@ var Zotero_QuickFormat = new function () {
 	/**
 	 * Generates the preview and sorts citations
 	 */
-	function _previewAndSort() {
+	var _previewAndSort = Zotero.Promise.coroutine(function* () {
 		var shouldKeepSorted = keepSorted.hasAttribute("checked"),
 			editorShowing = showEditor.hasAttribute("checked");
 		if(!shouldKeepSorted && !editorShowing) return;
 		
 		_updateCitationObject();
-		io.sort();
+		yield io.sort();
 		if(shouldKeepSorted) {
 			// means we need to resort citations
 			_clearCitation();
@@ -919,7 +919,7 @@ var Zotero_QuickFormat = new function () {
 			
 			_moveCursorToEnd();
 		}
-	}
+	});
 	
 	/**
 	 * Shows the citation properties panel for a given bubble
@@ -1058,7 +1058,7 @@ var Zotero_QuickFormat = new function () {
 	/**
 	 * Handle return or escape
 	 */
-	function _onQuickSearchKeyPress(event) {
+	var _onQuickSearchKeyPress = Zotero.Promise.coroutine(function* (event) {
 		// Prevent hang if another key is pressed after Enter
 		// https://forums.zotero.org/discussion/59157/
 		if (accepted) {
@@ -1070,7 +1070,7 @@ var Zotero_QuickFormat = new function () {
 		var keyCode = event.keyCode;
 		if (keyCode === event.DOM_VK_RETURN) {
 			event.preventDefault();
-			if(!_bubbleizeSelected() && !_getEditorContent()) {
+			if(!(yield _bubbleizeSelected()) && !_getEditorContent()) {
 				_accept();
 			}
 		} else if(keyCode === event.DOM_VK_TAB || event.charCode === 59 /* ; */) {
@@ -1149,7 +1149,7 @@ var Zotero_QuickFormat = new function () {
 		} else {
 			_resetSearchTimer();
 		}
-	}
+	});
 	
 	/**
 	 * Adds a dummy element to make dragging work
@@ -1177,7 +1177,7 @@ var Zotero_QuickFormat = new function () {
 	/**
 	 * Replaces the dummy element with a node to make dropping work
 	 */
-	function _onBubbleDrop(event) {
+	var _onBubbleDrop = Zotero.Promise.coroutine(function* (event) {
 		event.preventDefault();
 		event.stopPropagation();
 
@@ -1195,9 +1195,9 @@ var Zotero_QuickFormat = new function () {
 			keepSorted.removeAttribute("checked");
 		}
 
-		_previewAndSort();
+		yield _previewAndSort();
 		_moveCursorToEnd();
-	}
+	});
 	
 	/**
 	 * Handle a click on a bubble

--- a/chrome/content/zotero/xpcom/cite.js
+++ b/chrome/content/zotero/xpcom/cite.js
@@ -303,7 +303,7 @@ Zotero.Cite = {
 				session = Zotero.Integration.sessions[sessionID],
 				item;
 			if(session) {
-				item = session.embeddedZoteroItems[id.substr(slashIndex+1)];
+				item = session.embeddedItems[id.substr(slashIndex+1)];
 			}
 			
 			if(!item) {

--- a/chrome/content/zotero/xpcom/cite.js
+++ b/chrome/content/zotero/xpcom/cite.js
@@ -16,13 +16,13 @@ Zotero.Cite = {
 	 * Remove specified item IDs in-place from a citeproc-js bibliography object returned
 	 * by makeBibliography()
 	 * @param {bib} citeproc-js bibliography object
-	 * @param {Array} itemsToRemove Array of items to remove
+	 * @param {Set} itemsToRemove Set of items to remove
 	 */
 	"removeFromBibliography":function(bib, itemsToRemove) {
 		var removeItems = [];
 		for(let i in bib[0].entry_ids) {
 			for(let j in bib[0].entry_ids[i]) {
-				if(itemsToRemove[bib[0].entry_ids[i][j]]) {
+				if(itemsToRemove.has(`${bib[0].entry_ids[i][j]}`)) {
 					removeItems.push(i);
 					break;
 				}

--- a/chrome/content/zotero/xpcom/cite.js
+++ b/chrome/content/zotero/xpcom/cite.js
@@ -526,7 +526,7 @@ Zotero.Cite.System.prototype = {
 		}
 
 		if(!zoteroItem) {
-			throw "Zotero.Cite.System.retrieveItem called on non-item "+item;
+			throw new Error("Zotero.Cite.System.retrieveItem called on non-item "+item);
 		}
 		
 		var cslItem = Zotero.Utilities.itemToCSLJSON(zoteroItem);

--- a/chrome/content/zotero/xpcom/integration.js
+++ b/chrome/content/zotero/xpcom/integration.js
@@ -530,12 +530,14 @@ Zotero.Integration.Interface.prototype.addBibliography = Zotero.Promise.coroutin
 	
 	let field = new Zotero.Integration.BibliographyField(yield this._session.fields.addField());
 	field.clearCode();
+	var citationsMode = FORCE_CITATIONS_FALSE;
 	if(this._session.data.prefs.delayCitationUpdates) {
 		// Refreshes citeproc state before proceeding
 		this._session.reload = true;
+		citationsMode = FORCE_CITATIONS_REGENERATE;
 	}
-	yield this._session.fields.updateSession(FORCE_CITATIONS_FALSE);
-	yield this._session.fields.updateDocument(FORCE_CITATIONS_FALSE, true, false);
+	yield this._session.fields.updateSession(citationsMode);
+	yield this._session.fields.updateDocument(citationsMode, true, false);
 })
 
 /**
@@ -561,13 +563,15 @@ Zotero.Integration.Interface.prototype.editBibliography = Zotero.Promise.corouti
 			[], "integration.error.title");
 	}
 	let bibliography = new Zotero.Integration.Bibliography(bibliographyField);
+	var citationsMode = FORCE_CITATIONS_FALSE;
 	if(this._session.data.prefs.delayCitationUpdates) {
 		// Refreshes citeproc state before proceeding
 		this._session.reload = true;
+		citationsMode = FORCE_CITATIONS_REGENERATE;
 	}
-	yield this._session.fields.updateSession(FORCE_CITATIONS_FALSE);
+	yield this._session.fields.updateSession(citationsMode);
 	yield this._session.editBibliography(bibliography);
-	yield this._session.fields.updateDocument(FORCE_CITATIONS_FALSE, true, false);
+	yield this._session.fields.updateDocument(citationsMode, true, false);
 });
 
 
@@ -598,13 +602,15 @@ Zotero.Integration.Interface.prototype.addEditBibliography = Zotero.Promise.coro
 	}
 	
 	let bibliography = new Zotero.Integration.Bibliography(bibliographyField);
+	var citationsMode = FORCE_CITATIONS_FALSE;
 	if(this._session.data.prefs.delayCitationUpdates) {
 		// Refreshes citeproc state before proceeding
 		this._session.reload = true;
+		citationsMode = FORCE_CITATIONS_REGENERATE;
 	}
-	yield this._session.fields.updateSession(FORCE_CITATIONS_FALSE);
+	yield this._session.fields.updateSession(citationsMode);
 	if (!newBibliography) yield this._session.editBibliography(bibliography);
-	yield this._session.fields.updateDocument(FORCE_CITATIONS_FALSE, true, false);
+	yield this._session.fields.updateDocument(citationsMode, true, false);
 });
 
 /**

--- a/chrome/content/zotero/xpcom/integration.js
+++ b/chrome/content/zotero/xpcom/integration.js
@@ -1604,6 +1604,18 @@ Zotero.Integration.Session.prototype.writeDelayedCitation = Zotero.Promise.corou
 	field.code = citation.serialize();
 	field.text = text;
 	field.writeToDoc();
+	
+	// Update bibliography with a static string
+	var fields = yield this.fields.get();
+	var bibliographyField;
+	for (let i = fields.length-1; i >= 0; i--) {
+		let field = Zotero.Integration.Field.loadExisting(fields[i]);
+		if (field.type == INTEGRATION_TYPE_BIBLIOGRAPHY) {
+			field.setText(Zotero.getString('integration.delayCitationUpdates.bibliography'), false)
+			break;
+		}
+	}
+	
 });
 
 

--- a/chrome/content/zotero/xpcom/integration.js
+++ b/chrome/content/zotero/xpcom/integration.js
@@ -217,7 +217,7 @@ Zotero.Integration = new function() {
 			// (depending on what is possible)
 			document = (application.getDocument && docId ? application.getDocument(docId) : application.getActiveDocument());
 			try {
-				yield Zotero.Promise.resolve((new Zotero.Integration.Document(application, document))[command]());
+				yield Zotero.Promise.resolve((new Zotero.Integration.Interface(application, document))[command]());
 			}
 			catch (e) {
 				if(!(e instanceof Zotero.Exception.UserCancelled)) {
@@ -508,7 +508,7 @@ const BIBLIOGRAPHY_PLACEHOLDER = "{Bibliography}";
  * All methods for interacting with a document
  * @constructor
  */
-Zotero.Integration.Document = function(app, doc) {
+Zotero.Integration.Interface = function(app, doc) {
 	this._app = app;
 	this._doc = doc;
 }
@@ -517,7 +517,7 @@ Zotero.Integration.Document = function(app, doc) {
  * @param data {Zotero.Integration.DocumentData} Document data for new session
  * @return {Zotero.Integration.Session}
  */
-Zotero.Integration.Document.prototype._createNewSession = function _createNewSession(data) {
+Zotero.Integration.Interface.prototype._createNewSession = function _createNewSession(data) {
 	data.sessionID = Zotero.randomString();
 	var session = Zotero.Integration.sessions[data.sessionID] = new Zotero.Integration.Session(this._doc);
 	return session;
@@ -533,7 +533,7 @@ Zotero.Integration.Document.prototype._createNewSession = function _createNewSes
  *    dontRunSetDocPrefs is true and no session was found, or rejected with
  *    Zotero.Exception.UserCancelled if the document preferences window was cancelled.
  */
-Zotero.Integration.Document.prototype._getSession = Zotero.Promise.coroutine(function *(require, dontRunSetDocPrefs) {
+Zotero.Integration.Interface.prototype._getSession = Zotero.Promise.coroutine(function *(require, dontRunSetDocPrefs) {
 	var dataString = this._doc.getDocumentData(),
 		data,
 		me = this;
@@ -673,7 +673,7 @@ Zotero.Integration.Document.prototype._getSession = Zotero.Promise.coroutine(fun
  * Adds a citation to the current document.
  * @return {Promise}
  */
-Zotero.Integration.Document.prototype.addCitation = function() {
+Zotero.Integration.Interface.prototype.addCitation = function() {
 	var me = this;
 	return this._getSession(false, false).then(function() {
 		return (new Zotero.Integration.Fields(me._session, me._doc)).addEditCitation(null);
@@ -684,7 +684,7 @@ Zotero.Integration.Document.prototype.addCitation = function() {
  * Edits the citation at the cursor position.
  * @return {Promise}
  */
-Zotero.Integration.Document.prototype.editCitation = function() {
+Zotero.Integration.Interface.prototype.editCitation = function() {
 	var me = this;
 	return this._getSession(true, false).then(function() {
 		var field = me._doc.cursorInField(me._session.data.prefs['fieldType']);
@@ -701,7 +701,7 @@ Zotero.Integration.Document.prototype.editCitation = function() {
  * Edits the citation at the cursor position if one exists, or else adds a new one.
  * @return {Promise}
  */
-Zotero.Integration.Document.prototype.addEditCitation = function() {
+Zotero.Integration.Interface.prototype.addEditCitation = function() {
 	var me = this;
 	return this._getSession(false, false).then(function() {
 		var field = me._doc.cursorInField(me._session.data.prefs['fieldType']);
@@ -713,7 +713,7 @@ Zotero.Integration.Document.prototype.addEditCitation = function() {
  * Adds a bibliography to the current document.
  * @return {Promise}
  */
-Zotero.Integration.Document.prototype.addBibliography = function() {
+Zotero.Integration.Interface.prototype.addBibliography = function() {
 	var me = this;
 	return this._getSession(true, false).then(function() {
 		// Make sure we can have a bibliography
@@ -736,7 +736,7 @@ Zotero.Integration.Document.prototype.addBibliography = function() {
  * Edits bibliography metadata.
  * @return {Promise}
  */
-Zotero.Integration.Document.prototype.editBibliography = function() {
+Zotero.Integration.Interface.prototype.editBibliography = function() {
 	// Make sure we have a bibliography
 	var me = this, fieldGetter;
 	return this._getSession(true, false).then(function() {
@@ -766,7 +766,7 @@ Zotero.Integration.Document.prototype.editBibliography = function() {
 }
 
 
-Zotero.Integration.Document.prototype.addEditBibliography = Zotero.Promise.coroutine(function *() {
+Zotero.Integration.Interface.prototype.addEditBibliography = Zotero.Promise.coroutine(function *() {
 	// Check if we have a bibliography
 	var session = yield this._getSession(true, false);
 	
@@ -803,7 +803,7 @@ Zotero.Integration.Document.prototype.addEditBibliography = Zotero.Promise.corou
  * Updates the citation data for all citations and bibliography entries.
  * @return {Promise}
  */
-Zotero.Integration.Document.prototype.refresh = function() {
+Zotero.Integration.Interface.prototype.refresh = function() {
 	var me = this;
 	return this._getSession(true, false).then(function() {
 		// Send request, forcing update of citations and bibliography
@@ -818,7 +818,7 @@ Zotero.Integration.Document.prototype.refresh = function() {
  * Deletes field codes.
  * @return {Promise}
  */
-Zotero.Integration.Document.prototype.removeCodes = function() {
+Zotero.Integration.Interface.prototype.removeCodes = function() {
 	var me = this;
 	return this._getSession(true, false).then(function() {
 		var fieldGetter = new Zotero.Integration.Fields(me._session, me._doc);

--- a/chrome/content/zotero/xpcom/server_connector.js
+++ b/chrome/content/zotero/xpcom/server_connector.js
@@ -884,7 +884,7 @@ Zotero.Server.Connector.IncompatibleVersion.prototype = {
 		sendResponseCallback(404);
 		if(Zotero.Server.Connector.IncompatibleVersion._errorShown) return;
 		
-		Zotero.Integration.activate();
+		Zotero.Utilities.Internal.activate();
 		var ps = Components.classes["@mozilla.org/embedcomp/prompt-service;1"].
 				createInstance(Components.interfaces.nsIPromptService);
 		ps.alert(null,

--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -1267,6 +1267,382 @@ Zotero.Utilities.Internal = {
 }
 
 /**
+ * Runs an AppleScript on OS X
+ *
+ * @param script {String}
+ * @param block {Boolean} Whether the script should block until the process is finished.
+ */
+Zotero.Utilities.Internal.executeAppleScript = new function() {
+	var _osascriptFile;
+	
+	return function(script, block) {
+		if(_osascriptFile === undefined) {
+			_osascriptFile = Components.classes["@mozilla.org/file/local;1"].
+			createInstance(Components.interfaces.nsILocalFile);
+			_osascriptFile.initWithPath("/usr/bin/osascript");
+			if(!_osascriptFile.exists()) _osascriptFile = false;
+		}
+		if(_osascriptFile) {
+			var proc = Components.classes["@mozilla.org/process/util;1"].
+			createInstance(Components.interfaces.nsIProcess);
+			proc.init(_osascriptFile);
+			try {
+				proc.run(!!block, ['-e', script], 2);
+			} catch(e) {}
+		}
+	}
+}
+	
+
+/**
+ * Activates Firefox
+ */
+Zotero.Utilities.Internal.activate = new function() {
+	// For Carbon and X11
+	var _carbon, ProcessSerialNumber, SetFrontProcessWithOptions;
+	var _x11, _x11Display, _x11RootWindow, XClientMessageEvent, XFetchName, XFree, XQueryTree,
+		XOpenDisplay, XCloseDisplay, XFlush, XDefaultRootWindow, XInternAtom, XSendEvent,
+		XMapRaised, XGetWindowProperty, X11Atom, X11Bool, X11Display, X11Window, X11Status;
+					
+	/** 
+	 * Bring a window to the foreground by interfacing directly with X11
+	 */
+	function _X11BringToForeground(win, intervalID) {
+		var windowTitle = win.QueryInterface(Ci.nsIInterfaceRequestor)
+			.getInterface(Ci.nsIWebNavigation).QueryInterface(Ci.nsIBaseWindow).title;
+		
+		var x11Window = _X11FindWindow(_x11RootWindow, windowTitle);
+		if(!x11Window) return;
+		win.clearInterval(intervalID);
+			
+		var event = new XClientMessageEvent();
+		event.type = 33; /* ClientMessage*/
+		event.serial = 0;
+		event.send_event = 1;
+		event.message_type = XInternAtom(_x11Display, "_NET_ACTIVE_WINDOW", 0);
+		event.display = _x11Display;
+		event.window = x11Window;
+		event.format = 32;
+		event.l0 = 2;
+		var mask = 1<<20 /* SubstructureRedirectMask */ | 1<<19 /* SubstructureNotifyMask */;
+		
+		if(XSendEvent(_x11Display, _x11RootWindow, 0, mask, event.address())) {
+			XMapRaised(_x11Display, x11Window);
+			XFlush(_x11Display);
+			Zotero.debug("Integration: Activated successfully");
+		} else {
+			Zotero.debug("Integration: An error occurred activating the window");
+		}
+	}
+	
+	/**
+	 * Find an X11 window given a name
+	 */
+	function _X11FindWindow(w, searchName) {
+		Components.utils.import("resource://gre/modules/ctypes.jsm");
+		
+		var res = _X11GetProperty(w, "_NET_CLIENT_LIST", 33 /** XA_WINDOW **/)
+			|| _X11GetProperty(w, "_WIN_CLIENT_LIST", 6 /** XA_CARDINAL **/);
+		if(!res) return false;
+		
+		var nClients = res[1],
+			clientList = ctypes.cast(res[0], X11Window.array(nClients).ptr).contents,
+			foundName = new ctypes.char.ptr();
+		for(var i=0; i<nClients; i++) {			
+			if(XFetchName(_x11Display, clientList.addressOfElement(i).contents,
+					foundName.address())) {
+				var foundNameString = undefined;
+				try {
+					foundNameString = foundName.readString();
+				} catch(e) {}
+				XFree(foundName);
+				if(foundNameString === searchName) return clientList.addressOfElement(i).contents;
+			}
+		}
+		XFree(res[0]);
+		
+		return foundWindow;
+	}
+	
+	/**
+	 * Get a property from an X11 window
+	 */
+	function _X11GetProperty(win, propertyName, propertyType) {
+		Components.utils.import("resource://gre/modules/ctypes.jsm");
+		
+		var returnType = new X11Atom(),
+			returnFormat = new ctypes.int(),
+			nItemsReturned = new ctypes.unsigned_long(),
+			nBytesAfterReturn = new ctypes.unsigned_long(),
+			data = new ctypes.char.ptr();
+		if(!XGetWindowProperty(_x11Display, win, XInternAtom(_x11Display, propertyName, 0), 0, 1024,
+				0, propertyType, returnType.address(), returnFormat.address(),
+				nItemsReturned.address(), nBytesAfterReturn.address(), data.address())) {
+			var nElements = ctypes.cast(nItemsReturned, ctypes.unsigned_int).value;
+			if(nElements) return [data, nElements];
+		}
+		return null;
+	}
+	
+	return function(win) {
+		if (Zotero.isMac) {
+			const BUNDLE_IDS = {
+				"Zotero":"org.zotero.zotero",
+				"Firefox":"org.mozilla.firefox",
+				"Aurora":"org.mozilla.aurora",
+				"Nightly":"org.mozilla.nightly"
+			};
+			
+			if (win) {
+				Components.utils.import("resource://gre/modules/ctypes.jsm");
+				win.focus();
+				
+				if(!_carbon) {
+					_carbon = ctypes.open("/System/Library/Frameworks/Carbon.framework/Carbon");
+					/*
+					 * struct ProcessSerialNumber {
+					 *    unsigned long highLongOfPSN;
+					 *    unsigned long lowLongOfPSN;
+					 * };
+					 */
+					ProcessSerialNumber = new ctypes.StructType("ProcessSerialNumber", 
+						[{"highLongOfPSN":ctypes.uint32_t}, {"lowLongOfPSN":ctypes.uint32_t}]);
+						
+					/*
+					 * OSStatus SetFrontProcessWithOptions (
+					 *    const ProcessSerialNumber *inProcess,
+					 *    OptionBits inOptions
+					 * );
+					 */
+					SetFrontProcessWithOptions = _carbon.declare("SetFrontProcessWithOptions",
+						ctypes.default_abi, ctypes.int32_t, ProcessSerialNumber.ptr,
+						ctypes.uint32_t);
+				}
+				
+				var psn = new ProcessSerialNumber();
+				psn.highLongOfPSN = 0;
+				psn.lowLongOfPSN = 2 // kCurrentProcess
+				
+				win.addEventListener("load", function() {
+					var res = SetFrontProcessWithOptions(
+						psn.address(),
+						1 // kSetFrontProcessFrontWindowOnly = (1 << 0)
+					);
+				}, false);
+			} else {
+				Zotero.Utilities.Internal.executeAppleScript('tell application id "'+BUNDLE_IDS[Zotero.appName]+'" to activate');
+			}
+		} else if(!Zotero.isWin && win) {
+			Components.utils.import("resource://gre/modules/ctypes.jsm");
+
+			if(_x11 === false) return;
+			if(!_x11) {
+				try {
+					_x11 = ctypes.open("libX11.so.6");
+				} catch(e) {
+					try {
+						var libName = ctypes.libraryName("X11");
+					} catch(e) {
+						_x11 = false;
+						Zotero.debug("Integration: Could not get libX11 name; not activating");
+						Zotero.logError(e);
+						return;
+					}
+					
+					try {
+						_x11 = ctypes.open(libName);
+					} catch(e) {
+						_x11 = false;
+						Zotero.debug("Integration: Could not open "+libName+"; not activating");
+						Zotero.logError(e);
+						return;
+					}
+				}
+				
+				X11Atom = ctypes.unsigned_long;
+				X11Bool = ctypes.int;
+				X11Display = new ctypes.StructType("Display");
+				X11Window = ctypes.unsigned_long;
+				X11Status = ctypes.int;
+					
+				/*
+				 * typedef struct {
+				 *     int type;
+				 *     unsigned long serial;	/ * # of last request processed by server * /
+				 *     Bool send_event;			/ * true if this came from a SendEvent request * /
+				 *     Display *display;		/ * Display the event was read from * /
+				 *     Window window;
+				 *     Atom message_type;
+				 *     int format;
+				 *     union {
+				 *         char b[20];
+				 *         short s[10];
+				 *         long l[5];
+				 *     } data;
+				 * } XClientMessageEvent;
+				 */
+				XClientMessageEvent = new ctypes.StructType("XClientMessageEvent",
+					[
+						{"type":ctypes.int},
+						{"serial":ctypes.unsigned_long},
+						{"send_event":X11Bool},
+						{"display":X11Display.ptr},
+						{"window":X11Window},
+						{"message_type":X11Atom},
+						{"format":ctypes.int},
+						{"l0":ctypes.long},
+						{"l1":ctypes.long},
+						{"l2":ctypes.long},
+						{"l3":ctypes.long},
+						{"l4":ctypes.long}
+					]
+				);
+				
+				/*
+				 * Status XFetchName(
+				 *    Display*		display,
+				 *    Window		w,
+				 *    char**		window_name_return
+				 * );
+				 */
+				XFetchName = _x11.declare("XFetchName", ctypes.default_abi, X11Status,
+					X11Display.ptr, X11Window, ctypes.char.ptr.ptr);
+					
+				/*
+				 * Status XQueryTree(
+				 *    Display*		display,
+				 *    Window		w,
+				 *    Window*		root_return,
+				 *    Window*		parent_return,
+				 *    Window**		children_return,
+				 *    unsigned int*	nchildren_return
+				 * );
+				 */
+				XQueryTree = _x11.declare("XQueryTree", ctypes.default_abi, X11Status,
+					X11Display.ptr, X11Window, X11Window.ptr, X11Window.ptr, X11Window.ptr.ptr,
+					ctypes.unsigned_int.ptr);
+				
+				/*
+				 * int XFree(
+				 *    void*		data
+				 * );
+				 */
+				XFree = _x11.declare("XFree", ctypes.default_abi, ctypes.int, ctypes.voidptr_t);
+				
+				/*
+				 * Display *XOpenDisplay(
+				 *     _Xconst char*	display_name
+				 * );
+				 */
+				XOpenDisplay = _x11.declare("XOpenDisplay", ctypes.default_abi, X11Display.ptr,
+					ctypes.char.ptr);
+				 
+				/*
+				 * int XCloseDisplay(
+				 *     Display*		display
+				 * );
+				 */
+				XCloseDisplay = _x11.declare("XCloseDisplay", ctypes.default_abi, ctypes.int,
+					X11Display.ptr);
+				
+				/*
+				 * int XFlush(
+				 *     Display*		display
+				 * );
+				 */
+				XFlush = _x11.declare("XFlush", ctypes.default_abi, ctypes.int, X11Display.ptr);
+				
+				/*
+				 * Window XDefaultRootWindow(
+				 *     Display*		display
+				 * );
+				 */
+				XDefaultRootWindow = _x11.declare("XDefaultRootWindow", ctypes.default_abi,
+					X11Window, X11Display.ptr);
+					
+				/*
+				 * Atom XInternAtom(
+				 *     Display*			display,
+				 *     _Xconst char*	atom_name,
+				 *     Bool				only_if_exists
+				 * );
+				 */
+				XInternAtom = _x11.declare("XInternAtom", ctypes.default_abi, X11Atom,
+					X11Display.ptr, ctypes.char.ptr, X11Bool);
+				 
+				/*
+				 * Status XSendEvent(
+				 *     Display*		display,
+				 *     Window		w,
+				 *     Bool			propagate,
+				 *     long			event_mask,
+				 *     XEvent*		event_send
+				 * );
+				 */
+				XSendEvent = _x11.declare("XSendEvent", ctypes.default_abi, X11Status,
+					X11Display.ptr, X11Window, X11Bool, ctypes.long, XClientMessageEvent.ptr);
+				
+				/*
+				 * int XMapRaised(
+				 *     Display*		display,
+				 *     Window		w
+				 * );
+				 */
+				XMapRaised = _x11.declare("XMapRaised", ctypes.default_abi, ctypes.int,
+					X11Display.ptr, X11Window);
+				
+				/*
+				 * extern int XGetWindowProperty(
+				 *     Display*		 display,
+				 *     Window		 w,
+				 *     Atom		 property,
+				 *     long		 long_offset,
+				 *     long		 long_length,
+				 *     Bool		 delete,
+				 *     Atom		 req_type,
+				 *     Atom*		 actual_type_return,
+				 *     int*		 actual_format_return,
+				 *     unsigned long*	 nitems_return,
+				 *     unsigned long*	 bytes_after_return,
+				 *     unsigned char**	 prop_return 
+				 * );
+				 */
+				XGetWindowProperty = _x11.declare("XGetWindowProperty", ctypes.default_abi,
+					ctypes.int, X11Display.ptr, X11Window, X11Atom, ctypes.long, ctypes.long,
+					X11Bool, X11Atom, X11Atom.ptr, ctypes.int.ptr, ctypes.unsigned_long.ptr,
+					ctypes.unsigned_long.ptr, ctypes.char.ptr.ptr);
+				
+					
+				_x11Display = XOpenDisplay(null);
+				if(!_x11Display) {
+					Zotero.debug("Integration: Could not open display; not activating");
+					_x11 = false;
+					return;
+				}
+				
+				Zotero.addShutdownListener(function() {
+					XCloseDisplay(_x11Display);
+				});
+				
+				_x11RootWindow = XDefaultRootWindow(_x11Display);
+				if(!_x11RootWindow) {
+					Zotero.debug("Integration: Could not get root window; not activating");
+					_x11 = false;
+					return;
+				}
+			}
+
+			win.addEventListener("load", function() {
+				var intervalID;
+				intervalID = win.setInterval(function() {
+					_X11BringToForeground(win, intervalID);
+				}, 50);
+			}, false);
+		}
+	}
+};
+
+/**
  *  Base64 encode / decode
  *  From http://www.webtoolkit.info/
  */

--- a/chrome/locale/en-US/zotero/zotero.dtd
+++ b/chrome/locale/en-US/zotero/zotero.dtd
@@ -231,6 +231,10 @@
 <!ENTITY zotero.integration.prefs.bookmarks.label		"Bookmarks">
 <!ENTITY zotero.integration.prefs.bookmarks.caption		"Bookmarks can be shared between Word and LibreOffice, but may cause errors if accidentally modified and cannot be inserted into footnotes.">
 
+<!ENTITY zotero.integration.prefs.delayCitationUpdates.label		"Delay citation updates until manual refresh">
+<!ENTITY zotero.integration.prefs.delayCitationUpdates.tooltip		"Citations with pending updates are visually highlighted">
+<!ENTITY zotero.integration.prefs.delayCitationUpdates.description	"Delaying updates can speed up citation insertion in large documents.">
+
 
 <!ENTITY zotero.integration.prefs.automaticJournalAbbeviations.label 		"Use MEDLINE journal abbreviations">
 <!ENTITY zotero.integration.prefs.automaticJournalAbbeviations.caption	"The “Journal Abbr” field will be ignored.">

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -871,6 +871,7 @@ integration.citationChanged				= You have modified this citation since Zotero ge
 integration.citationChanged.description	= Clicking "Yes" will prevent Zotero from updating this citation if you add additional citations, switch styles, or modify the item to which it refers. Clicking "No" will erase your changes.
 integration.citationChanged.edit		= You have modified this citation since Zotero generated it. Editing will clear your modifications. Do you want to continue?
 integration.delayCitationUpdates.alert	= Updating citations in this document is taking a long time. Would you like to delay citation updates until manual refresh?\n\nYou can change this setting later in the document preferences.
+integration.delayCitationUpdates.bibliography	= Delayed citing mode is enabled. To see the bibliography click Refresh in Zotero plugin.
 
 styles.install.title				= Install Style
 styles.install.unexpectedError		= An unexpected error occurred while installing "%1$S"

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -870,6 +870,7 @@ integration.corruptBibliography.description = All items cited in the text will a
 integration.citationChanged				= You have modified this citation since Zotero generated it. Do you want to keep your modifications and prevent future updates?
 integration.citationChanged.description	= Clicking "Yes" will prevent Zotero from updating this citation if you add additional citations, switch styles, or modify the item to which it refers. Clicking "No" will erase your changes.
 integration.citationChanged.edit		= You have modified this citation since Zotero generated it. Editing will clear your modifications. Do you want to continue?
+integration.delayCitationUpdates.alert	= Updating citations in this document is taking a long time. Would you like to delay citation updates until manual refresh?\n\nYou can change this setting later in the document preferences.
 
 styles.install.title				= Install Style
 styles.install.unexpectedError		= An unexpected error occurred while installing "%1$S"

--- a/test/tests/integrationTest.js
+++ b/test/tests/integrationTest.js
@@ -348,18 +348,7 @@ describe("Zotero.Integration", function () {
 				setDocumentDataSpy.restore();
 			});
 			
-			it('should call doc.setDocumentData on a fresh document', function* () {
-				yield execCommand('addEditCitation', docID);
-				assert.isTrue(setDocumentDataSpy.calledOnce);
-			});
-			
-			it('should not call doc.setDocumentData on subsequent invocations', function* () {
-				yield execCommand('addEditCitation', docID);
-				assert.isFalse(setDocumentDataSpy.called);
-			});
-			
-			it('should call doc.setDocumentData when document communicates for first time since restart to write new sessionID', function* () {
-				Zotero.Integration.sessions = {};
+			it('should call doc.setDocumentData once', function* () {
 				yield execCommand('addEditCitation', docID);
 				assert.isTrue(setDocumentDataSpy.calledOnce);
 			});
@@ -390,8 +379,7 @@ describe("Zotero.Integration", function () {
 				});
 			
 				describe('when the style is not from a trusted source', function() {
-					it('should download the style and not call doc.setDocumentData if user clicks YES', function* () {
-						setDocumentDataSpy.reset();
+					it('should download the style and if user clicks YES', function* () {
 						var styleInstallStub = sinon.stub(Zotero.Styles, "install").resolves();
 						var style = Zotero.Styles.get(styleID);
 						var styleGetCalledOnce = false;
@@ -407,7 +395,6 @@ describe("Zotero.Integration", function () {
 						assert.isTrue(displayAlertStub.calledOnce);
 						assert.isFalse(displayDialogStub.calledWith(applications[docID].doc, 'chrome://zotero/content/integration/integrationDocPrefs.xul'));
 						assert.isTrue(styleInstallStub.calledOnce);
-						assert.isFalse(setDocumentDataSpy.called);
 						assert.isOk(Zotero.Styles.get(style.styleID));
 						styleInstallStub.restore();
 						styleGetStub.restore();

--- a/test/tests/integrationTest.js
+++ b/test/tests/integrationTest.js
@@ -322,7 +322,7 @@ describe("Zotero.Integration", function () {
 			return Zotero.Promise.resolve();
 		});
 		
-		addEditCitationSpy = sinon.spy(Zotero.Integration.Document.prototype, 'addEditCitation');
+		addEditCitationSpy = sinon.spy(Zotero.Integration.Interface.prototype, 'addEditCitation');
 	});
 	
 	after(function() {

--- a/test/tests/integrationTest.js
+++ b/test/tests/integrationTest.js
@@ -2,6 +2,9 @@
 
 describe("Zotero.Integration", function () {
 	Components.utils.import("resource://gre/modules/XPCOMUtils.jsm");
+	const INTEGRATION_TYPE_ITEM = 1;
+	const INTEGRATION_TYPE_BIBLIOGRAPHY = 2;
+	const INTEGRATION_TYPE_TEMP = 3;
 	/**
 	 * To be used as a reference for Zotero-Word Integration plugins
 	 */
@@ -235,6 +238,7 @@ describe("Zotero.Integration", function () {
 		if (typeof docID === "undefined") {
 			throw new Error(`docID cannot be undefined`)
 		}
+		Zotero.debug(`execCommand '${command}': ${docID}`, 2);
 		return Zotero.Integration.execCommand("dummy", command, docID);
 	}
 	
@@ -273,23 +277,13 @@ describe("Zotero.Integration", function () {
 	
 	function setAddEditItems(items) {
 		if (items.length == undefined) items = [items];
-		dialogResults.quickFormat = function(dialogName) {
-			var citationItems = items.map((i) => {return {id: i.id} });
-			var field = new Zotero.Integration.CitationField(Zotero.Integration.currentDoc.insertField("Field", 0));
-			field.clearCode();
-			field.writeToDoc();
-			var citation = new Zotero.Integration.Citation(field);
-			var integrationDoc = addEditCitationSpy.lastCall.thisValue;
-			var fieldGetter = new Zotero.Integration.Fields(integrationDoc._session, integrationDoc._doc, () => 0);
-			var io = new Zotero.Integration.CitationEditInterface(
-				citation,
-				field,
-				fieldGetter,
-				integrationDoc._session
-			);
-			io._acceptDeferred.resolve();
-			return io;
-		}
+		dialogResults.quickFormat = function(dialogName, io) {
+			io.citation.citationItems = items.map(function(item) {
+				item = Zotero.Cite.getItem(item.id);
+				return {id: item.id, uris: item.cslURIs, itemData: item.cslItemData};
+			});
+			io._acceptDeferred.resolve(() => {});
+		};
 	}
 	
 	before(function* () {
@@ -319,9 +313,10 @@ describe("Zotero.Integration", function () {
 			Zotero.debug(`Display dialog: ${dialogName}`, 2);
 			var ioResult = dialogResults[dialogName.substring(dialogName.lastIndexOf('/')+1, dialogName.length-4)];
 			if (typeof ioResult == 'function') {
-				ioResult = ioResult(dialogName);
+				ioResult(dialogName, io);
+			} else {
+				Object.assign(io, ioResult);
 			}
-			Object.assign(io, ioResult);
 			return Zotero.Promise.resolve();
 		});
 		
@@ -334,8 +329,8 @@ describe("Zotero.Integration", function () {
 		addEditCitationSpy.restore();
 	});
 	
-	describe('Document', function() {
-		describe('#addEditCitation', function() {
+	describe('Interface', function() {
+		describe('#execCommand', function() {
 			var setDocumentDataSpy;
 			var docID = this.fullTitle();
 			
@@ -437,6 +432,68 @@ describe("Zotero.Integration", function () {
 			});
 		});
 		
+		describe('#addEditCitation', function() {
+			var insertMultipleCitations = Zotero.Promise.coroutine(function *() {
+				var docID = this.test.fullTitle();
+				if (!(docID in applications)) initDoc(docID);
+				var doc = applications[docID].doc;
+
+				setAddEditItems(testItems[0]);
+				yield execCommand('addEditCitation', docID);
+				assert.equal(doc.fields.length, 1);
+				var citation = (new Zotero.Integration.CitationField(doc.fields[0])).unserialize();
+				assert.equal(citation.citationItems.length, 1);
+				assert.equal(citation.citationItems[0].id, testItems[0].id);
+
+				setAddEditItems(testItems.slice(1, 3));
+				yield execCommand('addEditCitation', docID);
+				assert.equal(doc.fields.length, 2);
+				citation = (new Zotero.Integration.CitationField(doc.fields[1])).unserialize();
+				assert.equal(citation.citationItems.length, 2);
+				for (let i = 1; i < 3; i++) {
+					assert.equal(citation.citationItems[i-1].id, testItems[i].id);
+				}
+			});
+			it('should insert citation if not in field', insertMultipleCitations);
+			
+			it('should edit citation if in citation field', function* () {
+				yield insertMultipleCitations.call(this);
+				var docID = this.test.fullTitle();
+				var doc = applications[docID].doc;
+
+				sinon.stub(doc, 'cursorInField').returns(doc.fields[0]);
+				sinon.stub(doc, 'canInsertField').returns(false);
+
+				setAddEditItems(testItems.slice(3, 5));
+				yield execCommand('addEditCitation', docID);
+				assert.equal(doc.fields.length, 2);
+				var citation = (new Zotero.Integration.CitationField(doc.fields[0])).unserialize();
+				assert.equal(citation.citationItems.length, 2);
+				assert.equal(citation.citationItems[0].id, testItems[3].id);
+			});
+			
+			it('should update bibliography if present', function* () {
+				yield insertMultipleCitations.call(this);
+				var docID = this.test.fullTitle();
+				var doc = applications[docID].doc;
+				
+				let getCiteprocBibliographySpy =
+					sinon.spy(Zotero.Integration.Bibliography.prototype, 'getCiteprocBibliography');
+					
+				yield execCommand('addEditBibliography', docID);
+				assert.isTrue(getCiteprocBibliographySpy.calledOnce);
+				
+				assert.equal(getCiteprocBibliographySpy.lastCall.returnValue[0].entry_ids.length, 3);
+				getCiteprocBibliographySpy.reset();
+
+				setAddEditItems(testItems[3]);
+				yield execCommand('addEditCitation', docID);
+				assert.equal(getCiteprocBibliographySpy.lastCall.returnValue[0].entry_ids.length, 4);
+
+				getCiteprocBibliographySpy.restore();
+			});
+		});
+		
 		describe('#addEditBibliography', function() {
 			var docID = this.fullTitle();
 			beforeEach(function* () {
@@ -445,12 +502,13 @@ describe("Zotero.Integration", function () {
 			});
 			
 			it('should insert bibliography if no bibliography field present', function* () {
+				displayDialogStub.reset();
 				yield execCommand('addEditBibliography', docID);
+				assert.isFalse(displayDialogStub.called);
 				var biblPresent = false;
 				for (let i = applications[docID].doc.fields.length-1; i >= 0; i--) {
-					let field = applications[docID].doc.fields[i];
-					Zotero.debug(field.getCode(), 1);
-					if (field.getCode().includes("CSL_BIBLIOGRAPHY")) {
+					let field = Zotero.Integration.Field.loadExisting(applications[docID].doc.fields[i]);
+					if (field.type == INTEGRATION_TYPE_BIBLIOGRAPHY) {
 						biblPresent = true;
 						break;
 					}


### PR DESCRIPTION
So integration.js needed a refactor and some tests for a long time now. There is still a lot of room to improve, as the code is still quite dirty, but it's much better and more readable now, than before. Mainly, the document and session updates are localized and not all over the place, but there are still some weird circular object dependencies and for `Zotero.Integration.execCommand()` the session and document objects are globally exposed during a transaction.

----

The PR introduces the ability to delay citation updates and closes #1241. Note that this will speed up inserts that take 10min to 2s or so. Pretty good.

When a document update takes longer than 5s, a prompt is displayed:
<img src="https://cloud.githubusercontent.com/assets/5899315/26823064/e4835a28-4ab4-11e7-9481-9320ca49e46d.png" width="400"/>

Clicking *Yes* or *No* opens up document preferences window with the new option highlighted:
<img src="https://cloud.githubusercontent.com/assets/5899315/26823088/fb11c86a-4ab4-11e7-8a73-9bf9c78459d7.png" width="450"/>

The checkbox is then always available for that document and the prompt is not displayed again.

Clicking *Cancel* in the prompt displays the prompt the next time an update takes longer than 5s, until the user chooses either *Yes* or *No*.

I think a KB page would be useful to link to from the checkbox description.

This is what the delayed citation looks like (note the wavy underlining):
![image](https://cloud.githubusercontent.com/assets/5899315/26823234/99fb4dde-4ab5-11e7-862b-53f61a48087c.png)

See other possible [RTF formatting options](http://www.biblioscape.com/rtf15_spec.htm#Heading42)