### PR TITLE
Fix a problem with race condition during builds 

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -216,7 +216,7 @@ gulp.task('clean', () => {
 	return del('build');
 });
 
-gulp.task('symlink', ['clean'], () => {
+gulp.task('symlink', () => {
 	return getSymlinks();
 });
 


### PR DESCRIPTION
This should resolve problem with race condition during builds. Also should allow running builds without running clean first (in which case relevant files are simply overwritten).