### PR TITLE
Remove reference to Actions menu (Report Error instructions)

### DIFF
--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -94,7 +94,7 @@ upgrade.nonupgradeableDB2          = To continue, upgrade your database using Zo
 
 errorReport.reportError				= Report Error…
 errorReport.reportErrors			= Report Errors…
-errorReport.reportInstructions		= You can report this error by selecting "%S" from the Actions (gear) menu.
+errorReport.reportInstructions		= You can report this error by selecting "%S" from the Help menu.
 errorReport.followingReportWillBeSubmitted = The following report will be submitted:
 errorReport.noErrorsLogged         = No errors have been logged since %S started.
 errorReport.advanceMessage			= Press %S to send the report to the Zotero developers.


### PR DESCRIPTION
"Report Errors" menu item was in Actions (gear) menu, which has been
hidden in 5.0 (cf. 82292eef77701c5f6eb19ec4b65aee0e7ebdbf30). It is now accessible from the Help menu.
Adjust Report Error instructions accordingly.