### PR TITLE
Expose styleEngine in csledit.js, for Abbreviation Filter

### DIFF
--- a/chrome/content/zotero/tools/csledit.js
+++ b/chrome/content/zotero/tools/csledit.js
@@ -157,6 +157,7 @@ var Zotero_CSL_Editor = new function() {
 	
 	this.generateBibliography = function(style) {
 		var iframe = document.getElementById('zotero-csl-preview-box');
+		var editor = document.getElementById('zotero-csl-editor');
 		
 		var items = Zotero.getActiveZoteroPane().getSelectedItems();
 		if (items.length == 0) {
@@ -228,6 +229,7 @@ var Zotero_CSL_Editor = new function() {
 				iframe.contentDocument.documentElement.innerHTML = '<div>' + Zotero.getString('styles.editor.warning.renderError') + '</div><div>'+e+'</div>';
 				throw e;
 		}
+		editor.styleEngine = styleEngine;
 	}
 	
 	


### PR DESCRIPTION
Some users have expressed a desire to use the Abbreviation Filter plugin with Zotero. A version compatible with the Zotero 5.0 code is available, but to work with the Style Editor embedded in Zotero, it needs access to the style instantiated in the editor popup. This pull request exposes the style for that purpose.
