### PR TITLE
Fix shortDOI for doi.org resolver

### DIFF
--- a/chrome/content/zotero/xpcom/utilities.js
+++ b/chrome/content/zotero/xpcom/utilities.js
@@ -311,7 +311,11 @@ Zotero.Utilities = {
 			throw "cleanDOI: argument must be a string";
 		}
 
-		var doi = x.match(/10\.[0-9]{4,}\/[^\s]*[^\s\.,]/);
+		if(/10\/[^\s]*[^\s\.,]/.test(x)) {
+			var doi = /10\/([^\s]*[^\s\.,])/.exec(x);
+		} else {
+			var doi = x.match(/10\.[0-9]{4,}\/[^\s]*[^\s\.,]/);
+		}
 		return doi ? doi[0] : null;
 	},
 


### PR DESCRIPTION
The https://doi.org/ resolver doesn't properly handle short DOIs that have been passed through encodeURIComponent()

The resolver works find for unescaped short DOIs:
https://doi.org/10/aabbe

But if the short DOI is escaped, the resolver fails:
https://doi.org/10%2Faabbe

It interprets that, for some reason, as:
https://doi.org/10/10/aabbe

This patch gets around that bug by only capturing the part of a short DOI after "10/", which is all that is needed to resolve a short DOI URL:
https://doi.org/aabbe