### PR TITLE
Ensure that short DOIs are resolved correctly

### DIFF
--- a/chrome/content/zotero/bindings/itembox.xml
+++ b/chrome/content/zotero/bindings/itembox.xml
@@ -427,7 +427,11 @@
 							// Pull out DOI, in case there's a prefix
 							var doi = Zotero.Utilities.cleanDOI(val);
 							if (doi) {
-								doi = "http://dx.doi.org/" + encodeURIComponent(doi);
+								if(/10\/[^\s]*[^\s\.,]/.test(x)) {
+									doi = "https://doi.org/" + doi;
+								} else {
+									doi = "https://doi.org/" + encodeURIComponent(doi);
+								}
 								label.classList.add("pointer");
 								label.setAttribute("onclick", "ZoteroPane_Local.loadURI('" + doi + "', event)");
 								label.setAttribute("tooltiptext", Zotero.getString('locate.online.tooltip'));

--- a/chrome/content/zotero/locateMenu.js
+++ b/chrome/content/zotero/locateMenu.js
@@ -416,7 +416,11 @@ var Zotero_LocateMenu = new function() {
 			if(doi && typeof doi === "string") {
 				doi = Zotero.Utilities.cleanDOI(doi);
 				if(doi) {
-					return "http://dx.doi.org/" + encodeURIComponent(doi);
+					if(/10\/[^\s]*[^\s\.,]/.test(x)) {
+						return "https://doi.org/" + doi;
+					} else {
+						return "https://doi.org/" + encodeURIComponent(doi);
+					}
 				}
 			}
 			

--- a/chrome/content/zotero/xpcom/report.js
+++ b/chrome/content/zotero/xpcom/report.js
@@ -223,7 +223,7 @@ Zotero.Report.HTML = new function () {
 			}
 			// Hyperlink DOI
 			else if (i == 'DOI') {
-				fieldText = '<a href="' + escapeXML('http://doi.org/' + obj[i]) + '">'
+				fieldText = '<a href="' + escapeXML('https://doi.org/' + obj[i]) + '">'
 					+ escapeXML(obj[i]) + '</a>';
 			}
 			// Remove SQL date from multipart dates

--- a/chrome/content/zotero/xpcom/utilities.js
+++ b/chrome/content/zotero/xpcom/utilities.js
@@ -555,7 +555,7 @@ Zotero.Utilities = {
 		str = str.replace(/([^">])(https?:\/\/[^\s]+)(\s|$)/g, '$1<a href="$2">$2</a>$3');
 		
 		// DOI
-		str = str.replace(/(doi:[ ]*)(10\.[^\s]+[0-9a-zA-Z])/g, '$1<a href="http://dx.doi.org/$2">$2</a>');
+		str = str.replace(/(doi:[ ]*)(10(?:\.|\/)[^\s]+[0-9a-zA-Z])/g, '$1<a href="https://doi.org/$2">$2</a>');
 		return str;
 	},
 	

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -4057,8 +4057,12 @@ var ZoteroPane = new function()
 					if (doi) {
 						// Pull out DOI, in case there's a prefix
 						doi = Zotero.Utilities.cleanDOI(doi);
-						if (doi) {
-							uri = "http://dx.doi.org/" + encodeURIComponent(doi);
+						if(doi) {
+							if(/10\/[^\s]*[^\s\.,]/.test(x)) {
+								uri = "https://doi.org/" + doi;
+							} else {
+								uri = "https://doi.org/" + encodeURIComponent(doi);
+							}
 						}
 					}
 				}


### PR DESCRIPTION
An alternative would be to encode short DOIs as:
`"http://shortdoi.org/" + encodeURIComponent(doi)`

But this approach seems less prone to breakage on the part of doi.org

I'm not sure what to do with the `_mapTag` function in `openurl.js` when it is passed a DOI item. This is mostly a concern for the CrossRef locator engine, which currently breaks when it passes a short DOI to the doi.org resolver. Shoul I add a conditional to `_mapTag` to look for DOIs in `data` and then treat long and short DOIs appropriately? Will being passed unescaped `/` break things if they are present in an OpenURL object (so that I should extract just the part after "10/" in the short DOI)?