### PR TITLE
Allow translators to specify HTTP Referers for attachments

### DIFF
--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -234,7 +234,7 @@ Zotero.Attachments = new function(){
 	
 	/**
 	 * @param {Object} options - 'libraryID', 'url', 'parentItemID', 'collections', 'title',
-	 *                           'fileBaseName', 'contentType', 'cookieSandbox', 'saveOptions'
+	 *                           'fileBaseName', 'contentType', 'cookieSandbox', 'saveOptions', 'http_referer'
 	 * @return {Promise<Zotero.Item>} - A promise for the created attachment item
 	 */
 	this.importFromURL = Zotero.Promise.coroutine(function* (options) {
@@ -247,6 +247,7 @@ Zotero.Attachments = new function(){
 		var contentType = options.contentType;
 		var cookieSandbox = options.cookieSandbox;
 		var saveOptions = options.saveOptions;
+		var http_referer = options.http_referer;
 		
 		Zotero.debug('Importing attachment from URL ' + url);
 		
@@ -299,7 +300,8 @@ Zotero.Attachments = new function(){
 					undefined,
 					undefined,
 					true,
-					cookieSandbox
+					cookieSandbox,
+					http_referer
 				);
 			});
 		};
@@ -335,7 +337,12 @@ Zotero.Attachments = new function(){
 			var nsIURL = Components.classes["@mozilla.org/network/standard-url;1"]
 				.createInstance(Components.interfaces.nsIURL);
 			nsIURL.spec = url;
-			Zotero.Utilities.Internal.saveURI(wbp, nsIURL, tmpFile);
+			if (http_referer) {
+				Zotero.Utilities.Internal.saveURI(wbp, nsIURL, tmpFile, {Referer: http_referer});
+			} else {
+				Zotero.Utilities.Internal.saveURI(wbp, nsIURL, tmpFile);
+			}
+
 
 			yield deferred.promise;
 			let sample = yield Zotero.File.getContentsAsync(tmpFile, null, 1000);

--- a/chrome/content/zotero/xpcom/http.js
+++ b/chrome/content/zotero/xpcom/http.js
@@ -877,9 +877,10 @@ Zotero.HTTP = new function() {
 	 * @param {Boolean} dontDelete Don't delete the hidden browser upon completion; calling function
 	 *                             must call deleteHiddenBrowser itself.
 	 * @param {Zotero.CookieSandbox} [cookieSandbox] Cookie sandbox object
+	 * @param {String} [http_referer] Referer for the HTTP request
 	 * @return {browser} Hidden browser used for loading
 	 */
-	this.loadDocuments = function (urls, processor, onDone, onError, dontDelete, cookieSandbox) {
+	this.loadDocuments = function (urls, processor, onDone, onError, dontDelete, cookieSandbox, http_referer) {
 		// (Approximately) how many seconds to wait if the document is left in the loading state and
 		// pageshow is called before we call pageshow with an incomplete document
 		const LOADING_STATE_TIMEOUT = 120;
@@ -897,7 +898,16 @@ Zotero.HTTP = new function() {
 				currentURL++;
 				try {
 					Zotero.debug("Zotero.HTTP.loadDocuments: Loading " + url);
-					hiddenBrowser.loadURI(url);
+					
+					if (http_referer) {
+						Zotero.debug("Zotero.HTTP.loadDocuments: Referer " + http_referer);
+						var referer_uri = Components.classes["@mozilla.org/network/io-service;1"].
+											getService(Components.interfaces.nsIIOService).newURI(http_referer, null, null);
+						hiddenBrowser.loadURI(url, referer_uri);
+					} else {
+						hiddenBrowser.loadURI(url);
+					}
+
 				} catch(e) {
 					if (onError) {
 						onError(e);

--- a/chrome/content/zotero/xpcom/translation/translate_item.js
+++ b/chrome/content/zotero/xpcom/translation/translate_item.js
@@ -635,7 +635,8 @@ Zotero.Translate.ItemSaver.prototype = {
 			fileBaseName,
 			contentType: mimeType,
 			cookieSandbox: this._cookieSandbox,
-			collections: !parentItemID ? this._collections : undefined
+			collections: !parentItemID ? this._collections : undefined,
+			http_referer: attachment.http_referer
 		});
 	}),
 	


### PR DESCRIPTION
The need for this feature was discussed in #772 and in [issue #523 in the translator repository](https://github.com/zotero/translators/issues/523). It allows a translator to set
`item.attachments[i].http_referer`
which will then be used in the HTTP request downloading the attachment. This makes automatic PDF downloads possible e.g. for projecteuclid.org and papers.ssrn.com, which refuse PDF downloads if the Referer is not set. I have working translators for both of these pages, which I will submit in a separate pull request to the translator repository.

This code was compiled and tested on Linux Ubuntu 16.04 64 bit, I tested both the nativeHandlerImport and the externalHandlerImport routine extensively.