### PR TITLE
Set embedded metadata as Zotero item in Quick Format

### DIFF
--- a/chrome/content/zotero/integration/quickFormat.js
+++ b/chrome/content/zotero/integration/quickFormat.js
@@ -622,7 +622,7 @@ var Zotero_QuickFormat = new function () {
 	 * Builds the string to go inside a bubble
 	 */
 	function _buildBubbleString(citationItem) {
-		var item = Zotero.Cite.getItem(citationItem.id);
+		var item = Zotero.Cite.getItem(citationItem.id, true);
 		// create text for bubble
 		
 		// Creator
@@ -944,7 +944,7 @@ var Zotero_QuickFormat = new function () {
 		
 		Zotero.Cite.getItem(panelRefersToBubble.citationItem.id).key;
 
-		var item = Zotero.Cite.getItem(target.citationItem.id);
+		var item = Zotero.Cite.getItem(target.citationItem.id, true);
 		document.getElementById("citation-properties-title").textContent = item.getDisplayTitle();
 		while(panelInfo.hasChildNodes()) panelInfo.removeChild(panelInfo.firstChild);
 		_buildItemDescription(item, panelInfo);


### PR DESCRIPTION
This one is probably on the fixit list already, but here goes.

In the current beta of the client, attempting to edit a citation to an item that has been removed from the Zotero database after insertion in the document brings up the Quick Copy popup with no content. The cause was in calling `getItem()` with a single argument, which delivers embedded metadata in (I think) raw CSL-JSON form when a proper Zotero item is not available. With a second argument of `true`, the embedded data is converted to a Zotero item before delivery, and everything works.