### PR TITLE
Mendeley import

### DIFF
--- a/chrome/content/zotero/fileInterface.js
+++ b/chrome/content/zotero/fileInterface.js
@@ -23,6 +23,8 @@
     ***** END LICENSE BLOCK *****
 */
 
+Components.utils.import("resource://gre/modules/osfile.jsm")
+
 /****Zotero_File_Exporter****
  **
  * A class to handle exporting of items, collections, or the entire library
@@ -206,10 +208,117 @@ var Zotero_File_Interface = new function() {
 		}
 	}
 	
+	
+	this.startImport = async function () {
+		// Show the wizard if a Mendeley database is found
+		var mendeleyDBs = await this.findMendeleyDatabases();
+		var showWizard = !!mendeleyDBs.length;
+		if (showWizard) {
+			this.showImportWizard();
+		}
+		// Otherwise just show the filepicker
+		else {
+			await this.importFile(null, true);
+		}
+	}
+	
+	
+	this.getMendeleyDirectory = function () {
+		Components.classes["@mozilla.org/net/osfileconstantsservice;1"]
+			.getService(Components.interfaces.nsIOSFileConstantsService)
+			.init();
+		var path = OS.Constants.Path.homeDir;
+		if (Zotero.isMac) {
+			path = OS.Path.join(path, 'Library', 'Application Support', 'Mendeley Desktop');
+		}
+		else if (Zotero.isWin) {
+			path = OS.Path.join(path, 'AppData', 'Local', 'Mendeley Ltd', 'Desktop');
+		}
+		else if (Zotero.isLinux) {
+			path = OS.Path.join(path, '.local', 'share', 'data', 'Mendeley Ltd.', 'Mendeley Desktop');
+		}
+		else {
+			throw new Error("Invalid platform");
+		}
+		return path;
+	};
+	
+	
+	this.findMendeleyDatabases = async function () {
+		var dbs = [];
+		try {
+			var dir = this.getMendeleyDirectory();
+			if (!await OS.File.exists(dir)) {
+				Zotero.debug(`${dir} does not exist`);
+				return dbs;
+			}
+			await Zotero.File.iterateDirectory(dir, function* (iterator) {
+				while (true) {
+					let entry = yield iterator.next();
+					if (entry.isDir) continue;
+					// online.sqlite, counterintuitively, is the default database before you sign in
+					if (entry.name == 'online.sqlite' || entry.name.endsWith('@www.mendeley.com.sqlite')) {
+						dbs.push({
+							name: entry.name,
+							path: entry.path,
+							lastModified: null,
+							size: null
+						});
+					}
+				}
+			});
+			for (let i = 0; i < dbs.length; i++) {
+				let dbPath = OS.Path.join(dir, dbs[i].name);
+				let info = await OS.File.stat(dbPath);
+				dbs[i].size = info.size;
+				dbs[i].lastModified = info.lastModificationDate;
+			}
+			dbs.sort((a, b) => {
+				return b.lastModified - a.lastModified;
+			});
+		}
+		catch (e) {
+			Zotero.logError(e);
+		}
+		return dbs;
+	};
+	
+	
+	this.showImportWizard = function () {
+		try {
+			let win = Services.ww.openWindow(null, "chrome://zotero/content/import/importWizard.xul",
+				"importFile", "chrome,dialog=yes,centerscreen,width=600,height=400", null);
+		}
+		catch (e) {
+			Zotero.debug(e, 1);
+			throw e;
+		}
+	};
+	
+	
 	/**
 	 * Creates Zotero.Translate instance and shows file picker for file import
+	 *
+	 * @param {Object} options
+	 * @param {nsIFile|string|null} [options.file=null] - File to import, or none to show a filepicker
+	 * @param {Boolean} [options.createNewCollection=false] - Put items in a new collection
+	 * @param {Function} [options.onBeforeImport] - Callback to receive translation object, useful
+	 *     for displaying progress in a different way. This also causes an error to be throw
+	 *     instead of shown in the main window.
 	 */
-	this.importFile = Zotero.Promise.coroutine(function* (file, createNewCollection) {
+	this.importFile = Zotero.Promise.coroutine(function* (options = {}) {
+		if (!options) {
+			options = {};
+		}
+		if (typeof options == 'string' || options instanceof Components.interfaces.nsIFile) {
+			Zotero.debug("WARNING: importFile() now takes a single options object -- update your code");
+			options = { file: options };
+		}
+		
+		var file = options.file ? Zotero.File.pathToFile(options.file) : null;
+		var createNewCollection = options.createNewCollection;
+		var onBeforeImport = options.onBeforeImport;
+		
 		if(createNewCollection === undefined) {
 			createNewCollection = true;
 		} else if(!createNewCollection) {
@@ -231,21 +340,51 @@ var Zotero_File_Interface = new function() {
 			fp.appendFilters(nsIFilePicker.filterAll);
 			
 			var collation = Zotero.getLocaleCollation();
-			translators.sort((a, b) => collation.compareString(1, a.label, b.label))
-			for (let translator of translators) {
-				fp.appendFilter(translator.label, "*." + translator.target);
+			
+			// Add Mendeley DB, which isn't a translator
+			let mendeleyFilter = {
+				label: "Mendeley Database", // TODO: Localize
+				target: "*.sqlite"
+			};
+			let filters = [...translators];
+			filters.push(mendeleyFilter);
+			
+			filters.sort((a, b) => collation.compareString(1, a.label, b.label));
+			for (let filter of filters) {
+				fp.appendFilter(filter.label, "*." + filter.target);
 			}
 			
 			var rv = fp.show();
+			Zotero.debug(rv);
 			if (rv !== nsIFilePicker.returnOK && rv !== nsIFilePicker.returnReplace) {
 				return false;
 			}
 			
 			file = fp.file;
+			
+			Zotero.debug(`File is ${file.path}`);
 		}
-
+		
+		var defaultNewCollectionPrefix = Zotero.getString("fileInterface.imported");
+		
+		// Check if the file is an SQLite database
+		var sample = yield Zotero.File.getSample(file.path);
+		if (Zotero.MIME.sniffForMIMEType(sample) == 'application/x-sqlite3'
+				// Blacklist the current Zotero database, which would cause a hang
+				&& file.path != Zotero.DataDirectory.getDatabase()) {
+			// Mendeley import doesn't use the real translation architecture, but we create a
+			// translation object with the same interface
+			translation = yield _getMendeleyTranslation();
+			defaultNewCollectionPrefix = "Mendeley Import";
+		}
+		
 		translation.setLocation(file);
-		yield _finishImport(translation, createNewCollection);
+		return _finishImport({
+			translation,
+			createNewCollection,
+			defaultNewCollectionPrefix,
+			onBeforeImport
+		});
 	});
 	
 	
@@ -287,17 +426,29 @@ var Zotero_File_Interface = new function() {
 	});
 	
 	
-	var _finishImport = Zotero.Promise.coroutine(function* (translation, createNewCollection) {
+	var _finishImport = Zotero.Promise.coroutine(function* (options) {
+		var translation = options.translation;
+		var createNewCollection = options.createNewCollection;
+		var defaultNewCollectionPrefix = options.defaultNewCollectionPrefix;
+		var onBeforeImport = options.onBeforeImport;
+		
+		var showProgressWindow = !onBeforeImport;
+		
 		let translators = yield translation.getTranslators();
-
-		if(!translators.length) {
-			var ps = Components.classes["@mozilla.org/embedcomp/prompt-service;1"]
-									.getService(Components.interfaces.nsIPromptService);
-			var buttonFlags = (ps.BUTTON_POS_0) * (ps.BUTTON_TITLE_OK)
-								+ (ps.BUTTON_POS_1) * (ps.BUTTON_TITLE_IS_STRING);
-			var index = ps.confirmEx(
+		
+		// Unrecognized file
+		if (!translators.length) {
+			if (onBeforeImport) {
+				yield onBeforeImport(false);
+			}
+			
+			let ps = Components.classes["@mozilla.org/embedcomp/prompt-service;1"]
+				.getService(Components.interfaces.nsIPromptService);
+			let buttonFlags = ps.BUTTON_POS_0 * ps.BUTTON_TITLE_OK
+				+ ps.BUTTON_POS_1 * ps.BUTTON_TITLE_IS_STRING;
+			let index = ps.confirmEx(
 				null,
-				"",
+				Zotero.getString('general.error'),
 				Zotero.getString("fileInterface.unsupportedFormat"),
 				buttonFlags,
 				null,
@@ -305,17 +456,17 @@ var Zotero_File_Interface = new function() {
 				null, null, {}
 			);
 			if (index == 1) {
-				ZoteroPane_Local.loadURI("http://zotero.org/support/kb/importing");
+				Zotero.launchURL("https://www.zotero.org/support/kb/importing");
 			}
-			return;
+			return false;
 		}
-
+		
 		let importCollection = null, libraryID = Zotero.Libraries.userLibraryID;
 		try {
 			libraryID = ZoteroPane.getSelectedLibraryID();
 			importCollection = ZoteroPane.getSelectedCollection();
 		} catch(e) {}
-
+		
 		if(createNewCollection) {
 			// Create a new collection to take imported items
 			let collectionName;
@@ -330,8 +481,9 @@ var Zotero_File_Interface = new function() {
 						break;
 					}
 				}
-			} else {
-				collectionName = Zotero.getString("fileInterface.imported")+" "+(new Date()).toLocaleString();
+			}
+			else {
+				collectionName = defaultNewCollectionPrefix + " " + (new Date()).toLocaleString();
 			}
 			importCollection = new Zotero.Collection;
 			importCollection.libraryID = libraryID;
@@ -342,22 +494,29 @@ var Zotero_File_Interface = new function() {
 		translation.setTranslator(translators[0]);
 		
 		// Show progress popup
-		var progressWin = new Zotero.ProgressWindow({
-			closeOnClick: false
-		});
-		progressWin.changeHeadline(Zotero.getString('fileInterface.importing'));
-		var icon = 'chrome://zotero/skin/treesource-unfiled' + (Zotero.hiDPI ? "@2x" : "") + '.png';
-		let progress = new progressWin.ItemProgress(
-			icon, translation.path ? OS.Path.basename(translation.path) : translators[0].label
-		);
-		progressWin.show();
+		var progressWin;
+		var progress;
+		if (showProgressWindow) {
+			progressWin = new Zotero.ProgressWindow({
+				closeOnClick: false
+			});
+			progressWin.changeHeadline(Zotero.getString('fileInterface.importing'));
+			let icon = 'chrome://zotero/skin/treesource-unfiled' + (Zotero.hiDPI ? "@2x" : "") + '.png';
+			progress = new progressWin.ItemProgress(
+				icon, translation.path ? OS.Path.basename(translation.path) : translators[0].label
+			);
+			progressWin.show();
+			
+			translation.setHandler("itemDone",  function () {
+				progress.setProgress(translation.getProgress());
+			});
+			
+			yield Zotero.Promise.delay(0);
+		}
+		else {
+			yield onBeforeImport(translation);
+		}
 		
-		translation.setHandler("itemDone",  function () {
-			progress.setProgress(translation.getProgress());
-		});
-
-		yield Zotero.Promise.delay(0);
-
 		let failed = false;
 		try {
 			yield translation.translate({
@@ -365,6 +524,10 @@ var Zotero_File_Interface = new function() {
 				collections: importCollection ? [importCollection.id] : null
 			});
 		} catch(e) {
+			if (!showProgressWindow) {
+				throw e;
+			}
+			
 			progressWin.close();
 			Zotero.logError(e);
 			Zotero.alert(
@@ -372,25 +535,58 @@ var Zotero_File_Interface = new function() {
 				Zotero.getString('general.error'),
 				Zotero.getString("fileInterface.importError")
 			);
-			return;
+			return false;
 		}
 		
 		// Show popup on completion
-		var numItems = translation.newItems.length;
-		progressWin.changeHeadline(Zotero.getString('fileInterface.importComplete'));
-		if (numItems == 1) {
-			var icon = translation.newItems[0].getImageSrc();
+		if (showProgressWindow) {
+			let numItems = translation.newItems.length;
+			progressWin.changeHeadline(Zotero.getString('fileInterface.importComplete'));
+			let icon;
+			if (numItems == 1) {
+				icon = translation.newItems[0].getImageSrc();
+			}
+			else {
+				icon = 'chrome://zotero/skin/treesource-unfiled' + (Zotero.hiDPI ? "@2x" : "") + '.png';
+			}
+			let text = Zotero.getString(`fileInterface.itemsWereImported`, numItems, numItems);
+			progress.setIcon(icon);
+			progress.setText(text);
+			// For synchronous translators, which don't update progress
+			progress.setProgress(100);
+			progressWin.startCloseTimer(5000);
 		}
-		else {
-			var icon = 'chrome://zotero/skin/treesource-unfiled' + (Zotero.hiDPI ? "@2x" : "") + '.png';
-		}
-		var text = Zotero.getString(`fileInterface.itemsWereImported`, numItems, numItems);
-		progress.setIcon(icon);
-		progress.setText(text);
-		// For synchronous translators, which don't update progress
-		progress.setProgress(100);
-		progressWin.startCloseTimer(5000);
+		
+		return true;
 	});
+	
+	
+	var _getMendeleyTranslation = async function () {
+		if (true) {
+			Components.utils.import("chrome://zotero/content/import/mendeley/mendeleyImport.js");
+		}
+		// TEMP: Load uncached from ~/zotero-client for development
+		else {
+			Components.utils.import("resource://gre/modules/FileUtils.jsm");
+			let file = FileUtils.getDir("Home", []);
+			file = OS.Path.join(
+				file.path,
+				'zotero-client', 'chrome', 'content', 'zotero', 'import', 'mendeley', 'mendeleyImport.js'
+			);
+			let fileURI = OS.Path.toFileURI(file);
+			let xmlhttp = await Zotero.HTTP.request(
+				'GET',
+				fileURI,
+				{
+					dontCache: true,
+					responseType: 'text'
+				}
+			);
+			eval(xmlhttp.response);
+		}
+		return new Zotero_Import_Mendeley();
+	}
+	
 	
 	/**
 	 * Creates a bibliography from a collection or saved search

--- a/chrome/content/zotero/fileInterface.js
+++ b/chrome/content/zotero/fileInterface.js
@@ -427,6 +427,8 @@ var Zotero_File_Interface = new function() {
 	
 	
 	var _finishImport = Zotero.Promise.coroutine(function* (options) {
+		var t = performance.now();
+		
 		var translation = options.translation;
 		var createNewCollection = options.createNewCollection;
 		var defaultNewCollectionPrefix = options.defaultNewCollectionPrefix;
@@ -538,9 +540,10 @@ var Zotero_File_Interface = new function() {
 			return false;
 		}
 		
+		var numItems = translation.newItems.length;
+		
 		// Show popup on completion
 		if (showProgressWindow) {
-			let numItems = translation.newItems.length;
 			progressWin.changeHeadline(Zotero.getString('fileInterface.importComplete'));
 			let icon;
 			if (numItems == 1) {
@@ -556,6 +559,8 @@ var Zotero_File_Interface = new function() {
 			progress.setProgress(100);
 			progressWin.startCloseTimer(5000);
 		}
+		
+		Zotero.debug(`Imported ${numItems} item(s) in ${performance.now() - t} ms`);
 		
 		return true;
 	});

--- a/chrome/content/zotero/import/importWizard.js
+++ b/chrome/content/zotero/import/importWizard.js
@@ -1,0 +1,202 @@
+var Zotero_Import_Wizard = {
+	_wizard: null,
+	_dbs: null,
+	_file: null,
+	_translation: null,
+	
+	
+	init: function () {
+		this._wizard = document.getElementById('import-wizard');
+		
+		Zotero.Translators.init(); // async
+	},
+	
+	
+	onModeChosen: async function () {
+		var wizard = this._wizard;
+		
+		this._disableCancel();
+		wizard.canRewind = false;
+		wizard.canAdvance = false;
+		
+		var mode = document.getElementById('import-source').selectedItem.id;
+		try {
+			switch (mode) {
+			case 'radio-import-source-file':
+				await this.doImport();
+				break;
+				
+			case 'radio-import-source-mendeley':
+				this._dbs = await Zotero_File_Interface.findMendeleyDatabases();
+				// This shouldn't happen, because we only show the wizard if there are databases
+				if (!this._dbs.length) {
+					throw new Error("No databases found");
+				}
+				if (this._dbs.length > 1 || true) {
+					this._populateFileList(this._dbs);
+					document.getElementById('file-options-header').textContent
+						= Zotero.getString('fileInterface.chooseAppDatabaseToImport', 'Mendeley')
+					wizard.goTo('page-file-options');
+					wizard.canRewind = true;
+					this._enableCancel();
+				}
+				break;
+			
+			default:
+				throw new Error(`Unknown mode ${mode}`);
+			}
+		}
+		catch (e) {
+			this._onDone(
+				Zotero.getString('general.error'),
+				Zotero.getString('fileInterface.importError'),
+				true
+			);
+			throw e;
+		}
+	},
+	
+	
+	onFileSelected: async function () {
+		this._wizard.canAdvance = true;
+	},
+	
+	
+	onFileChosen: async function () {
+		var index = document.getElementById('file-list').selectedIndex;
+		this._file = this._dbs[index].path;
+		this._disableCancel();
+		this._wizard.canRewind = false;
+		this._wizard.canAdvance = false;
+		await this.doImport();
+	},
+	
+	
+	onBeforeImport: async function (translation) {
+		// Unrecognized translator
+		if (!translation) {
+			// Allow error dialog to be displayed, and then close window
+			setTimeout(function () {
+				window.close();
+			});
+			return;
+		}
+		
+		this._translation = translation;
+		
+		// Switch to progress pane
+		this._wizard.goTo('page-progress');
+		var pm = document.getElementById('import-progressmeter');
+		
+		translation.setHandler('itemDone', function () {
+			pm.value = translation.getProgress();
+		});
+	},
+	
+	
+	doImport: async function () {
+		try {
+			let result = await Zotero_File_Interface.importFile({
+				file: this._file,
+				onBeforeImport: this.onBeforeImport.bind(this)
+			});
+			
+			// Cancelled by user or due to error
+			if (!result) {
+				window.close();
+				return;
+			}
+			
+			let numItems = this._translation.newItems.length;
+			this._onDone(
+				Zotero.getString('fileInterface.importComplete'),
+				Zotero.getString(`fileInterface.itemsWereImported`, numItems, numItems)
+			);
+		}
+		catch (e) {
+			this._onDone(
+				Zotero.getString('general.error'),
+				Zotero.getString('fileInterface.importError'),
+				true
+			);
+			throw e;
+		}
+	},
+	
+	
+	reportError: function () {
+		Zotero.getActiveZoteroPane().reportErrors();
+		window.close();
+	},
+	
+	
+	_populateFileList: async function (files) {
+		var listbox = document.getElementById('file-list');
+		
+		// Remove existing entries
+		var items = listbox.getElementsByTagName('listitem');
+		for (let item of items) {
+			listbox.removeChild(item);
+		}
+		
+		for (let file of files) {
+			let li = document.createElement('listitem');
+			
+			let name = document.createElement('listcell');
+			// Simply filenames
+			let nameStr = file.name
+				.replace(/\.sqlite$/, '')
+				.replace(/@www\.mendeley\.com$/, '');
+			if (nameStr == 'online') {
+				nameStr = Zotero.getString('dataDir.default', 'online.sqlite');
+			}
+			name.setAttribute('label', nameStr + ' ');
+			li.appendChild(name);
+			
+			let lastModified = document.createElement('listcell');
+			lastModified.setAttribute('label', file.lastModified.toLocaleString() + ' ');
+			li.appendChild(lastModified);
+			
+			let size = document.createElement('listcell');
+			size.setAttribute(
+				'label',
+				Zotero.getString('general.nMegabytes', (file.size / 1024 / 1024).toFixed(1)) + ' '
+			);
+			li.appendChild(size);
+			
+			listbox.appendChild(li);
+		}
+		
+		if (files.length == 1) {
+			listbox.selectedIndex = 0;
+		}
+	},
+	
+	
+	_enableCancel: function () {
+		this._wizard.getButton('cancel').disabled = false;
+	},
+	
+	
+	_disableCancel: function () {
+		this._wizard.getButton('cancel').disabled = true;
+	},
+	
+	
+	_onDone: function (label, description, showReportErrorButton) {
+		var wizard = this._wizard;
+		wizard.getPageById('page-done').setAttribute('label', label);
+		document.getElementById('result-description').textContent = description;
+		
+		if (showReportErrorButton) {
+			let button = document.getElementById('result-report-error');
+			button.setAttribute('label', Zotero.getString('errorReport.reportError'));
+			button.hidden = false;
+		}
+		
+		// When done, move to last page and allow closing
+		wizard.canAdvance = true;
+		wizard.goTo('page-done');
+		wizard.canRewind = false;
+	}
+};

--- a/chrome/content/zotero/import/importWizard.xul
+++ b/chrome/content/zotero/import/importWizard.xul
@@ -1,0 +1,62 @@
+<?xml version="1.0"?>
+
+<?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
+<?xml-stylesheet href="chrome://zotero/skin/importWizard.css" type="text/css"?>
+
+<!DOCTYPE window SYSTEM "chrome://zotero/locale/zotero.dtd">
+
+<wizard id="import-wizard"
+		xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
+		title="&zotero.import;"
+		onload="Zotero_Import_Wizard.init()">
+	
+	<script src="../include.js"/>
+	<script src="../fileInterface.js"/>
+	<script src="importWizard.js"/>
+	
+	<wizardpage pageid="page-start"
+			label="&zotero.import.whereToImportFrom;"
+			next="page-progress"
+			onpageadvanced="Zotero_Import_Wizard.onModeChosen(); return false;">
+		<radiogroup id="import-source">
+			<radio id="radio-import-source-file" label="&zotero.import.source.file;"/>
+			<radio id="radio-import-source-mendeley" label="Mendeley"/>
+		</radiogroup>
+	</wizardpage>
+	
+	<wizardpage pageid="page-file-options"
+			next="page-progress"
+			onpagerewound="var w = document.getElementById('import-wizard'); w.goTo('page-start'); w.canAdvance = true; return false;"
+			onpageadvanced="Zotero_Import_Wizard.onFileChosen()">
+		<description id="file-options-header"/>
+		<listbox id="file-list" onselect="Zotero_Import_Wizard.onFileSelected()">
+			<listhead>
+				<listheader label="&zotero.import.database;"/>
+				<listheader label="&zotero.import.lastModified;"/>
+				<listheader label="&zotero.import.size;"/>
+			</listhead>
+			
+			<listcols>
+				<listcol flex="1"/>
+				<listcol/>
+				<listcol/>
+			</listcols>
+		</listbox>
+	</wizardpage>
+	
+	<wizardpage pageid="page-progress"
+			label="&zotero.import.importing;"
+			onpageshow="document.getElementById('import-wizard').canRewind = false;"
+			next="page-done">
+		<progressmeter id="import-progressmeter" mode="determined"/>
+	</wizardpage>
+	
+	<wizardpage pageid="page-done">
+		<description id="result-description"/>
+		<hbox>
+			<button id="result-report-error"
+				oncommand="Zotero_Import_Wizard.reportError()"
+				hidden="true"/>
+		</hbox>
+	</wizardpage>
+</wizard>

--- a/chrome/content/zotero/import/mendeley/mendeleyImport.js
+++ b/chrome/content/zotero/import/mendeley/mendeleyImport.js
@@ -203,10 +203,10 @@ Zotero_Import_Mendeley.prototype._getFolderDescendents = function (folderID, fol
 			};
 			// Store local id and remote UUID
 			c.relations = {
-				"z:mendeleyFolderID": f.id.toString()
+				"mendeleyDB:folderID": f.id.toString()
 			};
 			if (f.remoteUuid) {
-				c.relations['z:mendeleyRemoteFolderUUID'] = f.remoteUuid;
+				c.relations['mendeleyDB:remoteFolderUUID'] = f.remoteUuid;
 			}
 			return c;
 		});
@@ -566,10 +566,10 @@ Zotero_Import_Mendeley.prototype._documentToAPIJSON = async function (map, docum
 	}
 	
 	parent.relations = {
-		'z:mendeleyDocumentUUID': documentRow.uuid.replace(/^\{/, '').replace(/\}$/, '')
+		'mendeleyDB:documentUUID': documentRow.uuid.replace(/^\{/, '').replace(/\}$/, '')
 	};
 	if (documentRow.remoteUuid) {
-		parent.relations['z:mendeleyRemoteDocumentUUID'] = documentRow.remoteUuid;
+		parent.relations['mendeleyDB:remoteDocumentUUID'] = documentRow.remoteUuid;
 	}
 	
 	parent.documentID = documentRow.id;
@@ -764,8 +764,8 @@ Zotero_Import_Mendeley.prototype._saveFilesAndAnnotations = async function (file
 					attachment = await Zotero.Attachments.linkFromFile(options);
 				}
 				attachment.relations = {
-					'z:mendeleyFileHash': file.hash,
-					'z:mendeleyFileUUID': file.uuid
+					'mendeleyDB:fileHash': file.hash,
+					'mendeleyDB:fileUUID': file.uuid
 				};
 				await attachment.saveTx({
 					skipSelect: true

--- a/chrome/content/zotero/import/mendeley/mendeleyImport.js
+++ b/chrome/content/zotero/import/mendeley/mendeleyImport.js
@@ -1,0 +1,832 @@
+var EXPORTED_SYMBOLS = ["Zotero_Import_Mendeley"];
+
+Components.utils.import("resource://gre/modules/Services.jsm");
+Components.utils.import("resource://gre/modules/osfile.jsm");
+Services.scriptloader.loadSubScript("chrome://zotero/content/include.js");
+
+var Zotero_Import_Mendeley = function () {
+	this.newItems = [];
+	
+	this._db;
+	this._file;
+	this._itemDone;
+	this._progress = 0;
+	this._progressMax;
+};
+
+Zotero_Import_Mendeley.prototype.setLocation = function (file) {
+	this._file = file.path || file;
+};
+
+Zotero_Import_Mendeley.prototype.setHandler = function (name, handler) {
+	switch (name) {
+	case 'itemDone':
+		this._itemDone = handler;
+		break;
+	}
+};
+
+Zotero_Import_Mendeley.prototype.getProgress = function () {
+	return this._progress / this._progressMax * 100;
+};
+
+Zotero_Import_Mendeley.prototype.getTranslators = async function () {
+	return [{
+		label: Zotero.getString('fileInterface.appDatabase', 'Mendeley')
+	}];
+};
+
+Zotero_Import_Mendeley.prototype.setTranslator = function () {};
+
+Zotero_Import_Mendeley.prototype.translate = async function (options) {
+	if (true) {
+		Services.scriptloader.loadSubScript("chrome://zotero/content/import/mendeley/mendeleySchemaMap.js");
+	}
+	// TEMP: Load uncached from ~/zotero-client for development
+	else {
+		Components.utils.import("resource://gre/modules/FileUtils.jsm");
+		let file = FileUtils.getDir("Home", []);
+		file = OS.Path.join(file.path, 'zotero-client', 'chrome', 'content', 'zotero', 'import', 'mendeley', 'mendeleySchemaMap.js');
+		let fileURI = OS.Path.toFileURI(file);
+		let xmlhttp = await Zotero.HTTP.request(
+			'GET',
+			fileURI,
+			{
+				dontCache: true,
+				responseType: 'text'
+			}
+		);
+		eval(xmlhttp.response);
+	}
+	
+	const libraryID = options.libraryID || Zotero.Libraries.userLibraryID;
+	const { key: rootCollectionKey } = options.collections
+		? Zotero.Collections.getLibraryAndKeyFromID(options.collections[0])
+		: {};
+	
+	// TODO: Get appropriate version based on schema version
+	const mapVersion = 83;
+	map = map[mapVersion];
+	
+	const mendeleyGroupID = 0;
+	
+	// Disable syncing while we're importing
+	var resumeSync = Zotero.Sync.Runner.delayIndefinite();
+	
+	this._db = new Zotero.DBConnection(this._file);
+	
+	try {
+		if (!await this._isValidDatabase()) {
+			throw new Error("Not a valid Mendeley database");
+		}
+		
+		// Collections
+		let folders = await this._getFolders(mendeleyGroupID);
+		let collectionJSON = this._foldersToAPIJSON(folders, rootCollectionKey);
+		let folderKeys = this._getFolderKeys(collectionJSON);
+		await this._saveCollections(libraryID, collectionJSON);
+		
+		//
+		// Items
+		//
+		let documents = await this._getDocuments(mendeleyGroupID);
+		this._progressMax = documents.length;
+		// Get various attributes mapped to document ids
+		let urls = await this._getDocumentURLs(mendeleyGroupID);
+		let creators = await this._getDocumentCreators(mendeleyGroupID, map.creatorTypes);
+		let tags = await this._getDocumentTags(mendeleyGroupID);
+		let collections = await this._getDocumentCollections(
+			mendeleyGroupID,
+			documents,
+			rootCollectionKey,
+			folderKeys
+		);
+		let files = await this._getDocumentFiles(mendeleyGroupID);
+		let annotations = await this._getDocumentAnnotations(mendeleyGroupID);
+		for (let document of documents) {
+			// Save each document with its attributes
+			let itemJSON = await this._documentToAPIJSON(
+				map,
+				document,
+				urls.get(document.id),
+				creators.get(document.id),
+				tags.get(document.id),
+				collections.get(document.id),
+				annotations.get(document.id)
+			);
+			let documentIDMap = await this._saveItems(libraryID, itemJSON);
+			// Save the document's attachments and extracted annotations for any of them
+			let docFiles = files.get(document.id);
+			if (docFiles) {
+				await this._saveFilesAndAnnotations(
+					docFiles,
+					libraryID,
+					documentIDMap.get(document.id),
+					annotations.get(document.id)
+				);
+			}
+			this.newItems.push(Zotero.Items.get(documentIDMap.get(document.id)));
+			this._progress++;
+			if (this._itemDone) {
+				this._itemDone();
+			}
+		}
+	}
+	finally {
+		try {
+			await this._db.closeDatabase();
+		}
+		catch (e) {
+			Zotero.logError(e);
+		}
+		
+		resumeSync();
+	}
+};
+
+Zotero_Import_Mendeley.prototype._isValidDatabase = async function () {
+	var tables = [
+		'DocumentContributors',
+		'DocumentFiles',
+		'DocumentFolders',
+		'DocumentKeywords',
+		'DocumentTags',
+		'DocumentUrls',
+		'Documents',
+		'Files',
+		'Folders',
+		'RemoteDocuments',
+		'RemoteFolders'
+	];
+	for (let table of tables) {
+		if (!await this._db.tableExists(table)) {
+			return false;
+		}
+	}
+	return true;
+};
+
+//
+// Collections
+//
+Zotero_Import_Mendeley.prototype._getFolders = async function (groupID) {
+	return this._db.queryAsync(
+		`SELECT F.*, RF.remoteUuid FROM Folders F `
+			+ `JOIN RemoteFolders RF ON (F.id=RF.folderId) `
+			+ `WHERE groupId=?`,
+		groupID
+	);
+};
+
+/**
+ * Get flat array of collection API JSON with parentCollection set
+ *
+ * The returned objects include an extra 'id' property for matching collections to documents.
+ */
+Zotero_Import_Mendeley.prototype._foldersToAPIJSON = function (folderRows, parentKey) {
+	var maxDepth = 50;
+	return this._getFolderDescendents(-1, parentKey, folderRows, maxDepth);
+};
+
+Zotero_Import_Mendeley.prototype._getFolderDescendents = function (folderID, folderKey, folderRows, maxDepth) {
+	if (maxDepth == 0) return []
+	var descendents = [];
+	var children = folderRows
+		.filter(f => f.parentId == folderID)
+		.map(f => {
+			let c = {
+				folderID: f.id,
+				remoteUUID: f.remoteUuid,
+				key: Zotero.DataObjectUtilities.generateKey(),
+				name: f.name,
+				parentCollection: folderKey
+			};
+			// Store local id and remote UUID
+			c.relations = {
+				"z:mendeleyFolderID": f.id.toString()
+			};
+			if (f.remoteUuid) {
+				c.relations['z:mendeleyRemoteFolderUUID'] = f.remoteUuid;
+			}
+			return c;
+		});
+	
+	for (let child of children) {
+		descendents.push(
+			child,
+			...this._getFolderDescendents(child.folderID, child.key, folderRows, maxDepth - 1)
+		);
+	}
+	return descendents;
+};
+
+Zotero_Import_Mendeley.prototype._getFolderKeys = function (collections) {
+	var map = new Map();
+	for (let collection of collections) {
+		map.set(collection.folderID, collection.key);
+	}
+	return map;
+};
+
+/**
+ * @param {Integer} libraryID
+ * @param {Object[]} json
+ */
+Zotero_Import_Mendeley.prototype._saveCollections = async function (libraryID, json) {
+	var idMap = new Map();
+	for (let collectionJSON of json) {
+		let collection = new Zotero.Collection;
+		collection.libraryID = libraryID;
+		if (collectionJSON.key) {
+			collection.key = collectionJSON.key;
+			await collection.loadPrimaryData();
+		}
+		
+		// Remove external ids before saving
+		let toSave = Object.assign({}, collectionJSON);
+		delete toSave.folderID;
+		delete toSave.remoteUUID;
+		
+		collection.fromJSON(toSave);
+		await collection.saveTx({
+			skipSelect: true
+		});
+		idMap.set(collectionJSON.folderID, collection.id);
+	}
+	return idMap;
+};
+
+
+//
+// Items
+//
+Zotero_Import_Mendeley.prototype._getDocuments = async function (groupID) {
+	return this._db.queryAsync(
+		`SELECT D.*, RD.remoteUuid FROM Documents D `
+			+ `JOIN RemoteDocuments RD ON (D.id=RD.documentId) `
+			+ `WHERE groupId=? AND inTrash='false'`,
+		groupID
+	);
+};
+
+/**
+ * Get a Map of document ids to arrays of URLs
+ */
+Zotero_Import_Mendeley.prototype._getDocumentURLs = async function (groupID) {
+	var rows = await this._db.queryAsync(
+		`SELECT documentId, CAST(url AS TEXT) AS url FROM DocumentUrls DU `
+			+ `JOIN RemoteDocuments USING (documentId) `
+			+ `WHERE groupId=? ORDER BY position`,
+		groupID
+	);
+	var map = new Map();
+	for (let row of rows) {
+		let docURLs = map.get(row.documentId);
+		if (!docURLs) docURLs = [];
+		docURLs.push(row.url);
+		map.set(row.documentId, docURLs);
+	}
+	return map;
+};
+
+/**
+ * Get a Map of document ids to arrays of creator API JSON
+ *
+ * @param {Integer} groupID
+ * @param {Object} creatorTypeMap - Mapping of Mendeley creator types to Zotero creator types
+ */
+Zotero_Import_Mendeley.prototype._getDocumentCreators = async function (groupID, creatorTypeMap) {
+	var rows = await this._db.queryAsync(
+		`SELECT * FROM DocumentContributors `
+			+ `JOIN RemoteDocuments USING (documentId) `
+			+ `WHERE groupId=?`,
+		groupID
+	);
+	var map = new Map();
+	for (let row of rows) {
+		let docCreators = map.get(row.documentId);
+		if (!docCreators) docCreators = [];
+		docCreators.push(this._makeCreator(
+			creatorTypeMap[row.contribution] || 'author',
+			row.firstNames,
+			row.lastName
+		));
+		map.set(row.documentId, docCreators);
+	}
+	return map;
+};
+
+/**
+ * Get a Map of document ids to arrays of tag API JSON
+ */
+Zotero_Import_Mendeley.prototype._getDocumentTags = async function (groupID) {
+	var rows = await this._db.queryAsync(
+		// Manual tags
+		`SELECT documentId, tag, 0 AS type FROM DocumentTags `
+			+ `JOIN RemoteDocuments USING (documentId) `
+			+ `WHERE groupId=? `
+			+ `UNION `
+			// Automatic tags
+			+ `SELECT documentId, keyword AS tag, 1 AS type FROM DocumentKeywords `
+			+ `JOIN RemoteDocuments USING (documentId) `
+			+ `WHERE groupId=?`,
+		[groupID, groupID]
+	);
+	var map = new Map();
+	for (let row of rows) {
+		let docTags = map.get(row.documentId);
+		if (!docTags) docTags = [];
+		docTags.push({
+			tag: row.tag,
+			type: row.type
+		});
+		map.set(row.documentId, docTags);
+	}
+	return map;
+};
+
+/**
+ * Get a Map of document ids to arrays of collection keys
+ */
+Zotero_Import_Mendeley.prototype._getDocumentCollections = async function (groupID, documents, rootCollectionKey, folderKeys) {
+	var rows = await this._db.queryAsync(
+		`SELECT documentId, folderId FROM DocumentFolders DF `
+			+ `JOIN RemoteDocuments USING (documentId) `
+			+ `WHERE groupId=?`,
+		groupID
+	);
+	var map = new Map(
+		// Add all documents to root collection if specified
+		documents.map(d => [d.id, rootCollectionKey ? [rootCollectionKey] : []])
+	);
+	for (let row of rows) {
+		let keys = map.get(row.documentId);
+		keys.push(folderKeys.get(row.folderId));
+		map.set(row.documentId, keys);
+	}
+	return map;
+};
+
+/**
+ * Get a Map of document ids to file metadata
+ */
+Zotero_Import_Mendeley.prototype._getDocumentFiles = async function (groupID) {
+	var rows = await this._db.queryAsync(
+		`SELECT documentId, hash, remoteFileUuid, localUrl FROM DocumentFiles `
+			+ `JOIN Files USING (hash) `
+			+ `JOIN RemoteDocuments USING (documentId) `
+			+ `WHERE groupId=?`,
+		groupID
+	);
+	var map = new Map();
+	for (let row of rows) {
+		let docFiles = map.get(row.documentId);
+		if (!docFiles) docFiles = [];
+		docFiles.push({
+			hash: row.hash,
+			uuid: row.remoteFileUuid,
+			fileURL: row.localUrl
+		});
+		map.set(row.documentId, docFiles);
+	}
+	return map;
+};
+
+/**
+ * Get a Map of document ids to arrays of annotations
+ */
+Zotero_Import_Mendeley.prototype._getDocumentAnnotations = async function (groupID) {
+	var rows = await this._db.queryAsync(
+		`SELECT documentId, uuid, fileHash, page, note, color `
+			+ `FROM FileNotes `
+			+ `JOIN RemoteDocuments USING (documentId) `
+			+ `WHERE groupId=? `
+			+ `ORDER BY page, y, x`,
+		groupID
+	);
+	var map = new Map();
+	for (let row of rows) {
+		let docAnnotations = map.get(row.documentId);
+		if (!docAnnotations) docAnnotations = [];
+		docAnnotations.push({
+			uuid: row.uuid,
+			hash: row.fileHash,
+			note: row.note,
+			page: row.page,
+			color: row.color
+		});
+		map.set(row.documentId, docAnnotations);
+	}
+	return map;
+};
+
+/**
+ * Create API JSON array with item and any child attachments or notes
+ */
+Zotero_Import_Mendeley.prototype._documentToAPIJSON = async function (map, documentRow, urls, creators, tags, collections, annotations) {
+	var parent = {
+		key: Zotero.DataObjectUtilities.generateKey()
+	};
+	var children = [];
+	
+	parent.itemType = map.itemTypes[documentRow.type];
+	if (!parent.itemType) {
+		Zotero.warn(`Unmapped item type ${documentRow.type}`);
+	}
+	if (!parent.itemType || parent.itemType == 'document') {
+		parent.itemType = this._guessItemType(documentRow);
+		Zotero.debug(`Guessing type ${parent.itemType}`);
+	}
+	var itemTypeID = Zotero.ItemTypes.getID(parent.itemType);
+	
+	for (let [mField, zField] of Object.entries(map.fields)) {
+		// If not mapped, skip
+		if (!zField) {
+			continue;
+		}
+		let val = documentRow[mField];
+		// If no value, skip
+		if (!val) {
+			continue;
+		}
+		
+		if (typeof zField == 'string') {
+			this._processField(parent, children, zField, val);
+		}
+		// Function embedded in map file
+		else if (typeof zField == 'function') {
+			let [field, val] = zField(documentRow[mField], parent);
+			this._processField(parent, children, field, val);
+		}
+	}
+	
+	// URLs
+	if (urls) {
+		for (let i = 0; i < urls.length; i++) {
+			let url = urls[i];
+			let isPDF = url.includes('pdf');
+			if (i == 0 && !isPDF) {
+				parent.url = url;
+			}
+			else {
+				children.push({
+					itemType: 'attachment',
+					parentItem: parent.key,
+					linkMode: 'linked_url',
+					url,
+					title: isPDF ? 'PDF' : '',
+					contentType: isPDF ? 'application/pdf' : ''
+				});
+			}
+		}
+	}
+	
+	// Combine date parts if present
+	if (documentRow.year) {
+		parent.date = documentRow.year.toString().substr(0, 4).padStart(4, '0');
+		if (documentRow.month) {
+			parent.date += '-' + documentRow.month.toString().substr(0, 2).padStart(2, '0');
+			if (documentRow.day) {
+				parent.date += '-' + documentRow.day.toString().substr(0, 2).padStart(2, '0');
+			}
+		}
+	}
+	
+	for (let field in parent) {
+		switch (field) {
+		case 'itemType':
+		case 'key':
+		case 'parentItem':
+		case 'note':
+		case 'creators':
+		case 'dateAdded':
+		case 'dateModified':
+			continue;
+		}
+		
+		// Move unknown/invalid fields to Extra
+		let fieldID = Zotero.ItemFields.getID(field)
+			&& Zotero.ItemFields.getFieldIDFromTypeAndBase(parent.itemType, field);
+		if (!fieldID) {
+			Zotero.warn(`Moving '${field}' to Extra for type ${parent.itemType}`);
+			parent.extra = this._addExtraField(parent.extra, field, parent[field]);
+			delete parent[field];
+			continue;
+		}
+		let newField = Zotero.ItemFields.getName(fieldID);
+		if (field != newField) {
+			parent[newField] = parent[field];
+			delete parent[field];
+		}
+	}
+	
+	if (!parent.dateModified) {
+		parent.dateModified = parent.dateAdded;
+	}
+	
+	if (creators) {
+		// Add main creators before any added by fields (e.g., seriesEditor)
+		parent.creators = [...creators, ...(parent.creators || [])];
+		
+		// If item type has a different primary type, use that for author to prevent a warning
+		let primaryCreatorType = Zotero.CreatorTypes.getName(
+			Zotero.CreatorTypes.getPrimaryIDForType(itemTypeID)
+		);
+		if (primaryCreatorType != 'author') {
+			for (let creator of parent.creators) {
+				if (creator.creatorType == 'author') {
+					creator.creatorType = primaryCreatorType;
+				}
+			}
+		}
+		
+		for (let creator of parent.creators) {
+			// seriesEditor isn't valid on some item types (e.g., book)
+			if (creator.creatorType == 'seriesEditor'
+					&& !Zotero.CreatorTypes.isValidForItemType(
+							Zotero.CreatorTypes.getID('seriesEditor'), itemTypeID)) {
+				creator.creatorType = 'editor';
+			}
+		}
+	}
+	if (tags) parent.tags = tags;
+	if (collections) parent.collections = collections;
+	
+	// Copy date added/modified to child item
+	var parentDateAdded = parent.dateAdded;
+	var parentDateModified = parent.dateModified;
+	for (let child of children) {
+		child.dateAdded = parentDateAdded;
+		child.dateModified = parentDateModified;
+	}
+	
+	// Don't set an explicit key if no children
+	if (!children.length) {
+		delete parent.key;
+	}
+	
+	parent.relations = {
+		'z:mendeleyDocumentUUID': documentRow.uuid.replace(/^\{/, '').replace(/\}$/, '')
+	};
+	if (documentRow.remoteUuid) {
+		parent.relations['z:mendeleyRemoteDocumentUUID'] = documentRow.remoteUuid;
+	}
+	
+	parent.documentID = documentRow.id;
+	
+	var json = [parent, ...children];
+	//Zotero.debug(json);
+	return json;
+};
+
+/**
+ * Try to figure out item type based on available fields
+ */
+Zotero_Import_Mendeley.prototype._guessItemType = function (documentRow) {
+	if (documentRow.issn || documentRow.issue) {
+		return 'journalArticle';
+	}
+	if (documentRow.isbn) {
+		return 'book';
+	}
+	return 'document';
+};
+
+Zotero_Import_Mendeley.prototype._extractSubfield = function (field) {
+	var sub = field.match(/([a-z]+)\[([^\]]+)]/);
+	return sub ? { field: sub[1], subfield: sub[2] } : { field };
+};
+
+Zotero_Import_Mendeley.prototype._processField = function (parent, children, zField, val) {
+	var { field, subfield } = this._extractSubfield(zField);
+	if (subfield) {
+		// Combine 'city' and 'country' into 'place'
+		if (field == 'place') {
+			if (subfield == 'city') {
+				parent.place = val + (parent.place ? ', ' + parent.place : '');
+			}
+			else if (subfield == 'country') {
+				parent.place = (parent.place ? ', ' + parent.place : '') + val;
+			}
+		}
+		// Convert some item fields as creators
+		else if (field == 'creator') {
+			if (!parent.creators) {
+				parent.creators = [];
+			}
+			parent.creators.push(this._makeCreator(subfield, null, val));
+		}
+		else if (field == 'extra') {
+			parent.extra = this._addExtraField(parent.extra, subfield, val);
+		}
+		// Functions
+		else if (field == 'func') {
+			// Convert unix timestamps to ISO dates
+			if (subfield.startsWith('fromUnixtime')) {
+				let [, zField] = subfield.split(':');
+				parent[zField] = Zotero.Date.dateToISO(new Date(val));
+			}
+			// If 'pages' isn't valid for itemType, use 'numPages' instead
+			else if (subfield == 'pages') {
+				let itemTypeID = Zotero.ItemTypes.getID(parent.itemType);
+				if (!Zotero.ItemFields.isValidForType('pages', itemTypeID)
+						&& Zotero.ItemFields.isValidForType('numPages', itemTypeID)) {
+					zField = 'numPages';
+				}
+				else {
+					zField = 'pages';
+				}
+				parent[zField] = val;
+			}
+			// Notes become child items
+			else if (subfield == 'note') {
+				children.push({
+					parentItem: parent.key,
+					itemType: 'note',
+					note: this._convertNote(val)
+				});
+			}
+			else {
+				Zotero.warn(`Unknown function subfield: ${subfield}`);
+				return;
+			}
+		}
+		else {
+			Zotero.warn(`Unknown field: ${field}[${subfield}]`);
+		}
+	}
+	else {
+		// These are added separately so that they're available for notes
+		if (zField == 'dateAdded' || zField == 'dateModified') {
+			return;
+		}
+		parent[zField] = val;
+	}
+};
+
+Zotero_Import_Mendeley.prototype._makeCreator = function (creatorType, firstName, lastName) {
+	var creator = { creatorType };
+	if (firstName) {
+		creator.firstName = firstName;
+		creator.lastName = lastName;
+	}
+	else {
+		creator.name = lastName;
+	}
+	return creator;
+};
+
+Zotero_Import_Mendeley.prototype._addExtraField = function (extra, field, val) {
+	// Strip the field if it appears at the beginning of the value (to avoid "DOI: DOI: 10...")
+	if (typeof val == 'string') {
+		val = val.replace(new RegExp(`^${field}:\s*`, 'i'), "");
+	}
+	extra = extra ? extra + '\n' : '';
+	if (field != 'arXiv') {
+		field = field[0].toUpperCase() + field.substr(1);
+		field = field.replace(/([a-z])([A-Z][a-z])/, "$1 $2");
+	}
+	return extra + `${field}: ${val}`;
+};
+
+Zotero_Import_Mendeley.prototype._convertNote = function (note) {
+	return note
+		// Add newlines after <br>
+		.replace(/<br\s*\/>/g, '<br\/>\n')
+		//
+		// Legacy pre-HTML stuff
+		//
+		// <m:linebreak>
+		.replace(/<m:linebreak><\/m:linebreak>/g, '<br/>')
+		// <m:bold>
+		.replace(/<(\/)?m:bold>/g, '<$1b>')
+		// <m:italic>
+		.replace(/<(\/)?m:italic>/g, '<$1i>')
+		// <m:center>
+		.replace(/<m:center>/g, '<p style="text-align: center;">')
+		.replace(/<\/m:center>/g, '</p>')
+		// <m:underline>
+		.replace(/<m:underline>/g, '<span style="text-decoration: underline;">')
+		.replace(/<\/m:underline>/g, '</span>');
+};
+
+Zotero_Import_Mendeley.prototype._saveItems = async function (libraryID, json) {
+	var idMap = new Map();
+	await Zotero.DB.executeTransaction(async function () {
+		for (let itemJSON of json) {
+			let item = new Zotero.Item;
+			item.libraryID = libraryID;
+			if (itemJSON.key) {
+				item.key = itemJSON.key;
+				await item.loadPrimaryData();
+			}
+			
+			// Remove external id before save
+			let toSave = Object.assign({}, itemJSON);
+			delete toSave.documentID;
+			
+			item.fromJSON(toSave);
+			await item.save({
+				skipSelect: true,
+				skipDateModifiedUpdate: true
+			});
+			if (itemJSON.documentID) {
+				idMap.set(itemJSON.documentID, item.id);
+			}
+		}
+	}.bind(this));
+	return idMap;
+};
+
+/**
+ * Saves attachments and extracted annotations for a given document
+ */
+Zotero_Import_Mendeley.prototype._saveFilesAndAnnotations = async function (files, libraryID, parentItemID, annotations) {
+	for (let file of files) {
+		try {
+			if (!file.fileURL) continue;
+			
+			let path = OS.Path.fromFileURI(file.fileURL);
+			
+			let attachment;
+			if (await OS.File.exists(path)) {
+				let options = {
+					libraryID,
+					parentItemID,
+					file: path
+				};
+				// If file is in Mendeley downloads folder, import it
+				if (OS.Path.dirname(path).endsWith(OS.Path.join('Mendeley Desktop', 'Downloaded'))) {
+					attachment = await Zotero.Attachments.importFromFile(options);
+				}
+				// Otherwise link it
+				else {
+					attachment = await Zotero.Attachments.linkFromFile(options);
+				}
+				attachment.relations = {
+					'z:mendeleyFileHash': file.hash,
+					'z:mendeleyFileUUID': file.uuid
+				};
+				await attachment.saveTx({
+					skipSelect: true
+				});
+			}
+			else {
+				Zotero.warn(path + " not found -- not importing");
+			}
+			
+			if (annotations) {
+				await this._saveAnnotations(
+					// We have annotations from all files for this document, so limit to just those on
+					// this file
+					annotations.filter(a => a.hash == file.hash),
+					parentItemID,
+					attachment ? attachment.id : null
+				);
+			}
+		}
+		catch (e) {
+			Zotero.logError(e);
+		}
+	}
+}
+
+Zotero_Import_Mendeley.prototype._saveAnnotations = async function (annotations, parentItemID, attachmentItemID) {
+	if (!annotations.length) return;
+	var noteStrings = [];
+	var parentItem = Zotero.Items.get(parentItemID);
+	var libraryID = parentItem.libraryID;
+	if (attachmentItemID) {
+		var attachmentItem = Zotero.Items.get(attachmentItemID);
+		var attachmentURIPath = Zotero.API.getLibraryPrefix(libraryID) + '/items/' + attachmentItem.key;
+	}
+	
+	for (let annotation of annotations) {
+		if (!annotation.note || !annotation.note.trim()) continue;
+		
+		let linkStr;
+		let linkText = `note on p. ${annotation.page}`;
+		if (attachmentItem) {
+			let url = `zotero://open-pdf/${attachmentURIPath}?page=${annotation.page}`;
+			linkStr = `<a href="${url}">${linkText}</a>`;
+		}
+		else {
+			linkStr = linkText;
+		}
+		
+		noteStrings.push(
+			Zotero.Utilities.text2html(annotation.note.trim())
+				+ `<p class="pdf-link" style="margin-top: -0.5em; margin-bottom: 2em; font-size: .9em; text-align: right;">(${linkStr})</p>`
+		);
+	}
+	
+	if (!noteStrings.length) return;
+	
+	let note = new Zotero.Item('note');
+	note.libraryID = libraryID;
+	note.parentItemID = parentItemID;
+	note.setNote('<h1>' + Zotero.getString('extractedAnnotations') + '</h1>\n' + noteStrings.join('\n'));
+	return note.saveTx({
+		skipSelect: true
+	});
+};

--- a/chrome/content/zotero/import/mendeley/mendeleyImport.js
+++ b/chrome/content/zotero/import/mendeley/mendeleyImport.js
@@ -201,12 +201,10 @@ Zotero_Import_Mendeley.prototype._getFolderDescendents = function (folderID, fol
 				name: f.name,
 				parentCollection: folderKey
 			};
-			// Store local id and remote UUID
-			c.relations = {
-				"mendeleyDB:folderID": f.id.toString()
-			};
 			if (f.remoteUuid) {
-				c.relations['mendeleyDB:remoteFolderUUID'] = f.remoteUuid;
+				c.relations = {
+					'mendeleyDB:remoteFolderUUID': f.remoteUuid
+				};
 			}
 			return c;
 		});

--- a/chrome/content/zotero/import/mendeley/mendeleySchemaMap.js
+++ b/chrome/content/zotero/import/mendeley/mendeleySchemaMap.js
@@ -1,0 +1,102 @@
+var map = {
+	83: {
+		itemTypes: {
+			Bill: "bill",
+			Book: "book",
+			BookSection: "bookSection",
+			Case: "case",
+			ComputerProgram: "computerProgram",
+			ConferenceProceedings: "conferencePaper",
+			EncyclopediaArticle: "encyclopediaArticle",
+			Film: "film",
+			Generic: "document",
+			JournalArticle: "journalArticle",
+			MagazineArticle: "magazineArticle",
+			NewspaperArticle: "newspaperArticle",
+			Patent: "patent",
+			Report: "report",
+			Statute: "statute",
+			TelevisionBroadcast: "tvBroadcast",
+			Thesis: "thesis",
+			WebPage: "webpage",
+			WorkingPaper: "report"
+		},
+		fields: {
+			id: "",
+			uuid: "",
+			reviewedArticle: "",
+			revisionNumber: "",
+			publisher: "publisher",
+			reprintEdition: "",
+			series: "seriesTitle",
+			seriesNumber: "seriesNumber",
+			sections: "section",
+			seriesEditor: "creator[seriesEditor]", // falls back to editor if necessary
+			owner: "",
+			pages: "func[pages]",
+			month: "", // handled explicitly
+			originalPublication: "",
+			publication: "publicationTitle",
+			publicLawNumber: "publicLawNumber",
+			pmid: "extra[PMID]",
+			sourceType: "",
+			session: "session",
+			shortTitle: "shortTitle",
+			volume: "volume",
+			year: "", // handled explicitly
+			userType: "type",
+			country: "place[country]",
+			dateAccessed: "accessDate",
+			committee: "committee",
+			counsel: "creator[counsel]",
+			doi: "DOI",
+			edition: "edition",
+			day: "", // handled explicitly
+			department: "",
+			citationKey: "citationKey", // put in Extra
+			city: "place[city]",
+			chapter: "",
+			codeSection: "section",
+			codeVolume: "codeVolume",
+			code: "code",
+			codeNumber: "codeNumber",
+			issue: "issue",
+			language: "language",
+			isbn: "ISBN",
+			issn: "ISSN",
+			length: "",
+			medium: "medium",
+			lastUpdate: "",
+			legalStatus: "legalStatus",
+			hideFromMendeleyWebIndex: "",
+			institution: "publisher",
+			genre: "genre",
+			internationalTitle: "",
+			internationalUserType: "",
+			internationalAuthor: "",
+			internationalNumber: "",
+			deletionPending: "",
+			favourite: "", // tag?
+			confirmed: "", // tag?
+			deduplicated: "",
+			read: "", // tag?
+			type: "", // item type handled separately
+			title: "title",
+			privacy: "",
+			applicationNumber: "applicationNumber",
+			arxivId: "extra[arXiv]",
+			advisor: "",
+			articleColumn: "",
+			modified: "func[fromUnixtime:dateModified]",
+			abstract: "abstractNote",
+			added: "func[fromUnixtime:dateAdded]",
+			note: "func[note]",
+			importer: ""
+		},
+		creatorTypes: {
+			DocumentAuthor: "author",
+			DocumentEditor: "editor",
+			DocumentTranslator: "translator"
+		}
+	}
+};

--- a/chrome/content/zotero/xpcom/api.js
+++ b/chrome/content/zotero/xpcom/api.js
@@ -154,7 +154,7 @@ Zotero.API = {
 			return 'groups/' + Zotero.Groups.getGroupIDFromLibraryID(libraryID);
 		
 		default:
-			throw new Error(`Invalid type '${type}`);
+			throw new Error(`Invalid type '${type}'`);
 		}
 	}
 };

--- a/chrome/content/zotero/xpcom/data/collection.js
+++ b/chrome/content/zotero/xpcom/data/collection.js
@@ -712,7 +712,7 @@ Zotero.Collection.prototype.toJSON = function (options = {}) {
 	
 	obj.name = this.name;
 	obj.parentCollection = this.parentKey ? this.parentKey : false;
-	obj.relations = {}; // TEMP
+	obj.relations = this.getRelations();
 	
 	return this._postToJSON(env);
 }

--- a/chrome/content/zotero/xpcom/data/collection.js
+++ b/chrome/content/zotero/xpcom/data/collection.js
@@ -698,8 +698,7 @@ Zotero.Collection.prototype.fromJSON = function (json) {
 	this.name = json.name;
 	this.parentKey = json.parentCollection ? json.parentCollection : false;
 	
-	// TODO
-	//this.setRelations(json.relations);
+	this.setRelations(json.relations);
 }
 
 

--- a/chrome/content/zotero/xpcom/data/dataObject.js
+++ b/chrome/content/zotero/xpcom/data/dataObject.js
@@ -285,7 +285,7 @@ Zotero.DataObject.prototype._setParentKey = function(key) {
 /**
  * Returns all relations of the object
  *
- * @return {Object} - Object with predicates as keys and arrays of URIs as values
+ * @return {Object} - Object with predicates as keys and arrays of values
  */
 Zotero.DataObject.prototype.getRelations = function () {
 	this._requireData('relations');

--- a/chrome/content/zotero/xpcom/data/dataObject.js
+++ b/chrome/content/zotero/xpcom/data/dataObject.js
@@ -410,7 +410,7 @@ Zotero.DataObject.prototype.setRelations = function (newRelations) {
 	
 	// Limit predicates to letters and colons for now
 	for (let p in newRelations) {
-		if (!/[a-z]+:[a-z]+/.test(p)) {
+		if (!/^[a-z]+:[a-z]+$/i.test(p)) {
 			throw new Error(`Invalid relation predicate '${p}'`);
 		}
 	}

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -1051,8 +1051,7 @@ Zotero.Item.prototype.setCreator = function (orderIndex, data) {
 		var msg = "Creator type '" + Zotero.CreatorTypes.getName(data.creatorTypeID) + "' "
 			+ "isn't valid for " + Zotero.ItemTypes.getName(itemTypeID)
 			+ " -- changing to primary creator";
-		Zotero.debug(msg, 2);
-		Components.utils.reportError(msg);
+		Zotero.warn(msg);
 		data.creatorTypeID = Zotero.CreatorTypes.getPrimaryIDForType(itemTypeID);
 	}
 	

--- a/chrome/content/zotero/xpcom/data/itemFields.js
+++ b/chrome/content/zotero/xpcom/data/itemFields.js
@@ -260,6 +260,11 @@ Zotero.ItemFields = new function() {
 			throw new Error("Invalid field '" + baseField + '" for base field');
 		}
 		
+		// If field isn't a base field, return it if it's valid for the type
+		if (!this.isBaseField(baseFieldID)) {
+			return this.isValidForType(baseFieldID, itemTypeID) ? baseFieldID : false;
+		}
+		
 		return _baseTypeFields[itemTypeID][baseFieldID];
 	}
 	

--- a/chrome/content/zotero/xpcom/data/items.js
+++ b/chrome/content/zotero/xpcom/data/items.js
@@ -315,7 +315,21 @@ Zotero.Items = function() {
 			item._clearChanged('itemData');
 			
 			// Display titles
-			item.updateDisplayTitle()
+			try {
+				item.updateDisplayTitle()
+			}
+			catch (e) {
+				// A few item types need creators to be loaded. Instead of making
+				// updateDisplayTitle() async and loading conditionally, just catch the error
+				// and load on demand
+				if (e instanceof Zotero.Exception.UnloadedDataException) {
+					yield item.loadDataType('creators');
+					item.updateDisplayTitle()
+				}
+				else {
+					throw e;
+				}
+			}
 		}
 	});
 	

--- a/chrome/content/zotero/xpcom/data/relations.js
+++ b/chrome/content/zotero/xpcom/data/relations.js
@@ -32,7 +32,8 @@ Zotero.Relations = new function () {
 	
 	this._namespaces = {
 		dc: 'http://purl.org/dc/elements/1.1/',
-		owl: 'http://www.w3.org/2002/07/owl#'
+		owl: 'http://www.w3.org/2002/07/owl#',
+		mendeleyDB: 'http://zotero.org/namespaces/mendeleyDB#'
 	};
 	
 	var _types = ['collection', 'item'];

--- a/chrome/content/zotero/xpcom/db.js
+++ b/chrome/content/zotero/xpcom/db.js
@@ -879,7 +879,7 @@ Zotero.DBConnection.prototype.vacuum = function () {
 // TEMP
 Zotero.DBConnection.prototype.info = Zotero.Promise.coroutine(function* () {
 	var info = {};
-	var pragmas = ['auto_vacuum', 'cache_size', 'locking_mode', 'page_size'];
+	var pragmas = ['auto_vacuum', 'cache_size', 'main.locking_mode', 'page_size'];
 	for (let p of pragmas) {
 		info[p] = yield Zotero.DB.valueQueryAsync(`PRAGMA ${p}`);
 	}
@@ -1038,7 +1038,7 @@ Zotero.DBConnection.prototype.backupDatabase = Zotero.Promise.coroutine(function
 		// the lock is lost
 		try {
 			if (DB_LOCK_EXCLUSIVE) {
-				yield this.queryAsync("PRAGMA locking_mode=NORMAL", false, { inBackup: true });
+				yield this.queryAsync("PRAGMA main.locking_mode=NORMAL", false, { inBackup: true });
 			}
 			storageService.backupDatabaseFile(file, OS.Path.basename(tmpFile), file.parent);
 		}
@@ -1049,7 +1049,7 @@ Zotero.DBConnection.prototype.backupDatabase = Zotero.Promise.coroutine(function
 		}
 		finally {
 			if (DB_LOCK_EXCLUSIVE) {
-				yield this.queryAsync("PRAGMA locking_mode=EXCLUSIVE", false, { inBackup: true });
+				yield this.queryAsync("PRAGMA main.locking_mode=EXCLUSIVE", false, { inBackup: true });
 			}
 		}
 		
@@ -1288,10 +1288,10 @@ Zotero.DBConnection.prototype._getConnectionAsync = Zotero.Promise.coroutine(fun
 	}
 	
 	if (DB_LOCK_EXCLUSIVE) {
-		yield this.queryAsync("PRAGMA locking_mode=EXCLUSIVE");
+		yield this.queryAsync("PRAGMA main.locking_mode=EXCLUSIVE");
 	}
 	else {
-		yield this.queryAsync("PRAGMA locking_mode=NORMAL");
+		yield this.queryAsync("PRAGMA main.locking_mode=NORMAL");
 	}
 	
 	// Set page cache size to 8MB

--- a/chrome/content/zotero/xpcom/db.js
+++ b/chrome/content/zotero/xpcom/db.js
@@ -31,8 +31,8 @@
 // the same database is accessed simultaneously by multiple Zotero instances.
 const DB_LOCK_EXCLUSIVE = true;
 
-Zotero.DBConnection = function(dbName) {
-	if (!dbName) {
+Zotero.DBConnection = function(dbNameOrPath) {
+	if (!dbNameOrPath) {
 		throw ('DB name not provided in Zotero.DBConnection()');
 	}
 	
@@ -70,8 +70,18 @@ Zotero.DBConnection = function(dbName) {
 		return Zotero.Date.toUnixTimestamp(d);
 	});
 	
-	// Private members
-	this._dbName = dbName;
+	// Absolute path to DB
+	if (dbNameOrPath.startsWith('/') || (Zotero.isWin && dbNameOrPath.includes('\\'))) {
+		this._dbName = OS.Path.basename(dbNameOrPath).replace(/\.sqlite$/, '');
+		this._dbPath = dbNameOrPath;
+		this._externalDB = true;
+	}
+	// DB name in data directory
+	else {
+		this._dbName = dbNameOrPath;
+		this._dbPath = Zotero.DataDirectory.getDatabase(dbNameOrPath);
+		this._externalDB = false;
+	}
 	this._shutdown = false;
 	this._connection = null;
 	this._transactionID = null;
@@ -91,6 +101,14 @@ Zotero.DBConnection = function(dbName) {
 	this._dbIsCorrupt = null
 	
 	this._transactionPromise = null;
+	
+	if (dbNameOrPath == 'zotero') {
+		this.IncompatibleVersionException = function (msg, dbClientVersion) {
+			this.message = msg;
+			this.dbClientVersion = dbClientVersion;
+		}
+		this.IncompatibleVersionException.prototype = Object.create(Error.prototype);
+	}
 }
 
 /////////////////////////////////////////////////////////////////
@@ -105,7 +123,7 @@ Zotero.DBConnection = function(dbName) {
  * @return	void
  */
 Zotero.DBConnection.prototype.test = function () {
-	return this._getConnectionAsync().return();
+	return this._getConnectionAsync().then(() => {});
 }
 
 Zotero.DBConnection.prototype.getAsyncStatement = Zotero.Promise.coroutine(function* (sql) {
@@ -895,9 +913,13 @@ Zotero.DBConnection.prototype.integrityCheck = Zotero.Promise.coroutine(function
 
 
 Zotero.DBConnection.prototype.checkException = function (e) {
+	if (this._externalDB) {
+		return true;
+	}
+	
 	if (e.message.includes(this.DB_CORRUPTION_STRING)) {
 		// Write corrupt marker to data directory
-		var file = Zotero.File.pathToFile(Zotero.DataDirectory.getDatabase(this._dbName, 'is.corrupt'));
+		var file = Zotero.File.pathToFile(this._dbPath + '.is.corrupt');
 		Zotero.File.putContents(file, '');
 		
 		this._dbIsCorrupt = true;
@@ -948,6 +970,11 @@ Zotero.DBConnection.prototype.closeDatabase = Zotero.Promise.coroutine(function*
 
 
 Zotero.DBConnection.prototype.backupDatabase = Zotero.Promise.coroutine(function* (suffix, force) {
+	if (this.skipBackup || this._externalDB || Zotero.skipLoading) {
+		this._debug("Skipping backup of database '" + this._dbName + "'", 1);
+		return false;
+	}
+	
 	var storageService = Components.classes["@mozilla.org/storage/service;1"]
 		.getService(Components.interfaces.mozIStorageService);
 	
@@ -981,27 +1008,21 @@ Zotero.DBConnection.prototype.backupDatabase = Zotero.Promise.coroutine(function
 	});
 	
 	try {
-		var corruptMarker = Zotero.File.pathToFile(
-			Zotero.DataDirectory.getDatabase(this._dbName, 'is.corrupt')
-		);
+		let corruptMarker = Zotero.File.pathToFile(this._dbPath + '.is.corrupt');
 		
-		if (this.skipBackup || Zotero.skipLoading) {
-			this._debug("Skipping backup of database '" + this._dbName + "'", 1);
-			return false;
-		}
-		else if (this._dbIsCorrupt || corruptMarker.exists()) {
+		if (this._dbIsCorrupt || corruptMarker.exists()) {
 			this._debug("Database '" + this._dbName + "' is marked as corrupt -- skipping backup", 1);
 			return false;
 		}
 		
-		var file = Zotero.File.pathToFile(Zotero.DataDirectory.getDatabase(this._dbName));
+		let file = this._dbPath;
 		
 		// For standard backup, make sure last backup is old enough to replace
 		if (!suffix && !force) {
-			var backupFile = Zotero.File.pathToFile(Zotero.DataDirectory.getDatabase(this._dbName, 'bak'));
-			if (yield OS.File.exists(backupFile.path)) {
-				var currentDBTime = (yield OS.File.stat(file.path)).lastModificationDate;
-				var lastBackupTime = (yield OS.File.stat(backupFile.path)).lastModificationDate;
+			let backupFile = this._dbPath + '.bak';
+			if (yield OS.File.exists(backupFile)) {
+				let currentDBTime = (yield OS.File.stat(file.path)).lastModificationDate;
+				let lastBackupTime = (yield OS.File.stat(backupFile)).lastModificationDate;
 				if (currentDBTime == lastBackupTime) {
 					Zotero.debug("Database '" + this._dbName + "' hasn't changed -- skipping backup");
 					return;
@@ -1022,7 +1043,7 @@ Zotero.DBConnection.prototype.backupDatabase = Zotero.Promise.coroutine(function
 		
 		// Copy via a temporary file so we don't run into disk space issues
 		// after deleting the old backup file
-		var tmpFile = Zotero.DataDirectory.getDatabase(this._dbName, 'tmp');
+		var tmpFile = this._dbPath + '.tmp';
 		if (yield OS.File.exists(tmpFile)) {
 			try {
 				yield OS.File.remove(tmpFile);
@@ -1041,11 +1062,14 @@ Zotero.DBConnection.prototype.backupDatabase = Zotero.Promise.coroutine(function
 			if (DB_LOCK_EXCLUSIVE) {
 				yield this.queryAsync("PRAGMA main.locking_mode=NORMAL", false, { inBackup: true });
 			}
-			storageService.backupDatabaseFile(file, OS.Path.basename(tmpFile), file.parent);
+			storageService.backupDatabaseFile(
+				Zotero.File.pathToFile(file),
+				OS.Path.basename(tmpFile),
+				Zotero.File.pathToFile(file).parent
+			);
 		}
 		catch (e) {
-			Zotero.debug(e);
-			Components.utils.reportError(e);
+			Zotero.logError(e);
 			return false;
 		}
 		finally {
@@ -1081,7 +1105,7 @@ Zotero.DBConnection.prototype.backupDatabase = Zotero.Promise.coroutine(function
 		// Special backup
 		if (!suffix && numBackups > 1) {
 			// Remove oldest backup file
-			var targetFile = Zotero.DataDirectory.getDatabase(this._dbName, (numBackups - 1) + '.bak');
+			let targetFile = this._dbPath + '.' + (numBackups - 1) + '.bak';
 			if (yield OS.File.exists(targetFile)) {
 				yield OS.File.remove(targetFile);
 			}
@@ -1091,12 +1115,8 @@ Zotero.DBConnection.prototype.backupDatabase = Zotero.Promise.coroutine(function
 				var targetNum = i;
 				var sourceNum = targetNum - 1;
 				
-				var targetFile = Zotero.DataDirectory.getDatabase(
-					this._dbName, targetNum + '.bak'
-				);
-				var sourceFile = Zotero.DataDirectory.getDatabase(
-					this._dbName, sourceNum ? sourceNum + '.bak' : 'bak'
-				);
+				let targetFile = this._dbPath + '.' + targetNum + '.bak';
+				let sourceFile = this._dbPath + '.' + (sourceNum ? sourceNum + '.bak' : 'bak')
 				
 				if (!(yield OS.File.exists(sourceFile))) {
 					continue;
@@ -1108,9 +1128,7 @@ Zotero.DBConnection.prototype.backupDatabase = Zotero.Promise.coroutine(function
 			}
 		}
 		
-		var backupFile = Zotero.DataDirectory.getDatabase(
-			this._dbName, (suffix ? suffix + '.' : '') + 'bak'
-		);
+		let backupFile = this._dbPath + '.' + (suffix ? suffix + '.' : '') + 'bak';
 		
 		// Remove old backup file
 		if (yield OS.File.exists(backupFile)) {
@@ -1147,11 +1165,11 @@ Zotero.DBConnection.prototype._getConnection = function (options) {
 /*
  * Retrieve a link to the data store asynchronously
  */
-Zotero.DBConnection.prototype._getConnectionAsync = Zotero.Promise.coroutine(function* (options) {
+Zotero.DBConnection.prototype._getConnectionAsync = async function (options) {
 	// If a backup is in progress, wait until it's done
 	if (this._backupPromise && this._backupPromise.isPending() && (!options || !options.inBackup)) {
 		Zotero.debug("Waiting for database backup to complete", 2);
-		yield this._backupPromise;
+		await this._backupPromise;
 	}
 	
 	if (this._connection) {
@@ -1162,48 +1180,50 @@ Zotero.DBConnection.prototype._getConnectionAsync = Zotero.Promise.coroutine(fun
 	}
 	
 	this._debug("Asynchronously opening database '" + this._dbName + "'");
+	Zotero.debug(this._dbPath);
 	
 	// Get the storage service
 	var store = Components.classes["@mozilla.org/storage/service;1"].
 		getService(Components.interfaces.mozIStorageService);
 	
-	var file = Zotero.File.pathToFile(Zotero.DataDirectory.getDatabase(this._dbName));
-	var backupFile = Zotero.File.pathToFile(Zotero.DataDirectory.getDatabase(this._dbName, 'bak'));
-	
-	var fileName = this._dbName + '.sqlite';
+	var file = this._dbPath;
+	var backupFile = this._dbPath + '.bak';
+	var fileName = OS.Path.basename(file);
+	var corruptMarker = this._dbPath + '.is.corrupt';
 	
 	catchBlock: try {
-		var corruptMarker = Zotero.File.pathToFile(Zotero.DataDirectory.getDatabase(this._dbName, 'is.corrupt'));
-		if (corruptMarker.exists()) {
+		if (await OS.File.exists(corruptMarker)) {
 			throw new Error(this.DB_CORRUPTION_STRING);
 		}
-		this._connection = yield Zotero.Promise.resolve(this.Sqlite.openConnection({
-			path: file.path
+		this._connection = await Zotero.Promise.resolve(this.Sqlite.openConnection({
+			path: file
 		}));
 	}
 	catch (e) {
+		// Don't deal with corrupted external dbs
+		if (this._externalDB) {
+			throw e;
+		}
+		
 		Zotero.logError(e);
 		
 		if (e.message.includes(this.DB_CORRUPTION_STRING)) {
-			this._debug("Database file '" + file.leafName + "' corrupted", 1);
+			this._debug(`Database file '${fileName}' corrupted`, 1);
 			
 			// No backup file! Eek!
-			if (!backupFile.exists()) {
+			if (!await OS.File.exists(backupFile)) {
 				this._debug("No backup file for DB '" + this._dbName + "' exists", 1);
 				
 				// Save damaged filed
 				this._debug('Saving damaged DB file with .damaged extension', 1);
-				var damagedFile = Zotero.File.pathToFile(
-					Zotero.DataDirectory.getDatabase(this._dbName, 'damaged')
-				);
+				let damagedFile = this._dbPath + '.damaged';
 				Zotero.moveToUnique(file, damagedFile);
 				
 				// Create new main database
-				var file = Zotero.File.pathToFile(Zotero.DataDirectory.getDatabase(this._dbName));
 				this._connection = store.openDatabase(file);
 				
-				if (corruptMarker.exists()) {
-					corruptMarker.remove(null);
+				if (await OS.File.exists(corruptMarker)) {
+					await OS.File.remove(corruptMarker);
 				}
 				
 				Zotero.alert(
@@ -1216,24 +1236,21 @@ Zotero.DBConnection.prototype._getConnectionAsync = Zotero.Promise.coroutine(fun
 			
 			// Save damaged file
 			this._debug('Saving damaged DB file with .damaged extension', 1);
-			var damagedFile = Zotero.File.pathToFile(
-				Zotero.DataDirectory.getDatabase(this._dbName, 'damaged')
-			);
+			let damagedFile = this._dbPath + '.damaged';
 			Zotero.moveToUnique(file, damagedFile);
 			
 			// Test the backup file
 			try {
 				Zotero.debug("Asynchronously opening DB connection");
-				this._connection = yield Zotero.Promise.resolve(this.Sqlite.openConnection({
-					path: backupFile.path
+				this._connection = await Zotero.Promise.resolve(this.Sqlite.openConnection({
+					path: backupFile
 				}));
 			}
 			// Can't open backup either
 			catch (e) {
 				// Create new main database
-				var file = Zotero.File.pathToFile(Zotero.DataDirectory.getDatabase(this._dbName));
-				this._connection = yield Zotero.Promise.resolve(this.Sqlite.openConnection({
-					path: file.path
+				this._connection = await Zotero.Promise.resolve(this.Sqlite.openConnection({
+					path: file
 				}));
 				
 				Zotero.alert(
@@ -1242,8 +1259,8 @@ Zotero.DBConnection.prototype._getConnectionAsync = Zotero.Promise.coroutine(fun
 					Zotero.getString('db.dbRestoreFailed', fileName)
 				);
 				
-				if (corruptMarker.exists()) {
-					corruptMarker.remove(null);
+				if (await OS.File.exists(corruptMarker)) {
+					await OS.File.remove(corruptMarker);
 				}
 				
 				break catchBlock;
@@ -1254,7 +1271,7 @@ Zotero.DBConnection.prototype._getConnectionAsync = Zotero.Promise.coroutine(fun
 			// Copy backup file to main DB file
 			this._debug("Restoring database '" + this._dbName + "' from backup file", 1);
 			try {
-				backupFile.copyTo(backupFile.parent, fileName);
+				await OS.File.copy(backupFile, file);
 			}
 			catch (e) {
 				// TODO: deal with low disk space
@@ -1262,8 +1279,7 @@ Zotero.DBConnection.prototype._getConnectionAsync = Zotero.Promise.coroutine(fun
 			}
 			
 			// Open restored database
-			var file = OS.Path.join(Zotero.DataDirectory.dir, fileName);
-			this._connection = yield Zotero.Promise.resolve(this.Sqlite.openConnection({
+			this._connection = await Zotero.Promise.resolve(this.Sqlite.openConnection({
 				path: file
 			}));
 			this._debug('Database restored', 1);
@@ -1272,13 +1288,13 @@ Zotero.DBConnection.prototype._getConnectionAsync = Zotero.Promise.coroutine(fun
 				Zotero.getString('general.warning'),
 				Zotero.getString('db.dbRestored', [
 					fileName,
-					Zotero.Date.getFileDateString(backupFile),
-					Zotero.Date.getFileTimeString(backupFile)
+					Zotero.Date.getFileDateString(Zotero.File.pathToFile(backupFile)),
+					Zotero.Date.getFileTimeString(Zotero.File.pathToFile(backupFile))
 				])
 			);
 			
-			if (corruptMarker.exists()) {
-				corruptMarker.remove(null);
+			if (await OS.File.exists(corruptMarker)) {
+				await OS.File.remove(corruptMarker);
 			}
 			
 			break catchBlock;
@@ -1288,44 +1304,36 @@ Zotero.DBConnection.prototype._getConnectionAsync = Zotero.Promise.coroutine(fun
 		throw (e);
 	}
 	
-	if (DB_LOCK_EXCLUSIVE) {
-		yield this.queryAsync("PRAGMA main.locking_mode=EXCLUSIVE");
+	if (!this._externalDB) {
+		if (DB_LOCK_EXCLUSIVE) {
+			await this.queryAsync("PRAGMA main.locking_mode=EXCLUSIVE");
+		}
+		else {
+			await this.queryAsync("PRAGMA main.locking_mode=NORMAL");
+		}
+		
+		// Set page cache size to 8MB
+		let pageSize = await this.valueQueryAsync("PRAGMA page_size");
+		let cacheSize = 8192000 / pageSize;
+		await this.queryAsync("PRAGMA cache_size=" + cacheSize);
+		
+		// Enable foreign key checks
+		await this.queryAsync("PRAGMA foreign_keys=true");
+		
+		// Register idle observer for DB backup
+		Zotero.Schema.schemaUpdatePromise.then(() => {
+			Zotero.debug("Initializing DB backup idle observer");
+			var idleService = Components.classes["@mozilla.org/widget/idleservice;1"]
+				.getService(Components.interfaces.nsIIdleService);
+			idleService.addIdleObserver(this, 300);
+		});
 	}
-	else {
-		yield this.queryAsync("PRAGMA main.locking_mode=NORMAL");
-	}
-	
-	// Set page cache size to 8MB
-	var pageSize = yield this.valueQueryAsync("PRAGMA page_size");
-	var cacheSize = 8192000 / pageSize;
-	yield this.queryAsync("PRAGMA cache_size=" + cacheSize);
-	
-	// Enable foreign key checks
-	yield this.queryAsync("PRAGMA foreign_keys=true");
-	
-	// Register idle observer for DB backup
-	Zotero.Schema.schemaUpdatePromise.then(() => {
-		Zotero.debug("Initializing DB backup idle observer");
-		var idleService = Components.classes["@mozilla.org/widget/idleservice;1"]
-			.getService(Components.interfaces.nsIIdleService);
-		idleService.addIdleObserver(this, 300);
-	});
 	
 	return this._connection;
-});
+};
 
 
 Zotero.DBConnection.prototype._debug = function (str, level) {
 	var prefix = this._dbName == 'zotero' ? '' : '[' + this._dbName + '] ';
 	Zotero.debug(prefix + str, level);
 }
-
-
-// Initialize main database connection
-Zotero.DB = new Zotero.DBConnection('zotero');
-
-Zotero.DB.IncompatibleVersionException = function (msg, dbClientVersion) {
-	this.message = msg;
-	this.dbClientVersion = dbClientVersion;
-}
-Zotero.DB.IncompatibleVersionException.prototype = Object.create(Error.prototype);

--- a/chrome/content/zotero/xpcom/db.js
+++ b/chrome/content/zotero/xpcom/db.js
@@ -818,9 +818,10 @@ Zotero.DBConnection.prototype.logQuery = function (sql, params = [], options) {
 }
 
 
-Zotero.DBConnection.prototype.tableExists = Zotero.Promise.coroutine(function* (table) {
+Zotero.DBConnection.prototype.tableExists = Zotero.Promise.coroutine(function* (table, db) {
 	yield this._getConnectionAsync();
-	var sql = "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND tbl_name=?";
+	var prefix = db ? db + '.' : '';
+	var sql = `SELECT COUNT(*) FROM ${prefix}sqlite_master WHERE type='table' AND tbl_name=?`;
 	var count = yield this.valueQueryAsync(sql, [table]);
 	return !!count;
 });

--- a/chrome/content/zotero/xpcom/mime.js
+++ b/chrome/content/zotero/xpcom/mime.js
@@ -47,8 +47,9 @@ Zotero.MIME = new function(){
 		["\uFFFDPNG", 'image/png', 0],
 		["JFIF", 'image/jpeg'],
 		["FLV", "video/x-flv", 0],
-		["\u0000\u0000\u0001\u0000", "image/vnd.microsoft.icon", 0]
-		
+		["\u0000\u0000\u0001\u0000", "image/vnd.microsoft.icon", 0],
+		["\u0053\u0051\u004C\u0069\u0074\u0065\u0020\u0066"
+			+ "\u006F\u0072\u006D\u0061\u0074\u0020\u0033\u0000", "application/x-sqlite3", 0]
 	];
 	
 	var _extensions = {

--- a/chrome/content/zotero/xpcom/mime.js
+++ b/chrome/content/zotero/xpcom/mime.js
@@ -26,7 +26,6 @@
 Zotero.MIME = new function(){
 	this.isTextType = isTextType;
 	this.getPrimaryExtension = getPrimaryExtension;
-	this.sniffForMIMEType = sniffForMIMEType;
 	this.sniffForBinary = sniffForBinary;
 	this.hasNativeHandler = hasNativeHandler;
 	this.hasInternalHandler = hasInternalHandler;
@@ -228,12 +227,12 @@ Zotero.MIME = new function(){
 	/*
 	 * Searches string for magic numbers
 	 */
-	function sniffForMIMEType(str){
-		for (var i in _snifferEntries){
-			var match = false;
+	this.sniffForMIMEType = function (str) {
+		for (let i in _snifferEntries) {
+			let match = false;
 			// If an offset is defined, match only from there
-			if (typeof _snifferEntries[i][2] != 'undefined') {
-				if (str.substr(i[2]).indexOf(_snifferEntries[i][0]) == 0) {
+			if (_snifferEntries[i][2] != undefined) {
+				if (str.substr(_snifferEntries[i][2]).indexOf(_snifferEntries[i][0]) == 0) {
 					match = true;
 				}
 			}
@@ -274,7 +273,7 @@ Zotero.MIME = new function(){
 	 * ext is an optional file extension hint if data sniffing is unsuccessful
 	 */
 	this.getMIMETypeFromData = function (str, ext){
-		var mimeType = sniffForMIMEType(str);
+		var mimeType = this.sniffForMIMEType(str);
 		if (mimeType){
 			Zotero.debug('Detected MIME type ' + mimeType);
 			return mimeType;

--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -877,6 +877,9 @@ Services.scriptloader.loadSubScript("resource://zotero/polyfill.js");
 	 * Initializes the DB connection
 	 */
 	var _initDB = Zotero.Promise.coroutine(function* (haveReleasedLock) {
+		// Initialize main database connection
+		Zotero.DB = new Zotero.DBConnection('zotero');
+		
 		try {
 			// Test read access
 			yield Zotero.DB.test();

--- a/chrome/content/zotero/zoteroPane.xul
+++ b/chrome/content/zotero/zoteroPane.xul
@@ -49,7 +49,7 @@
 	
 	<commandset id="mainCommandSet">
 		<command id="cmd_zotero_reportErrors" oncommand="ZoteroPane_Local.reportErrors();"/>
-		<command id="cmd_zotero_import" oncommand="Zotero_File_Interface.importFile();"/>
+		<command id="cmd_zotero_import" oncommand="Zotero_File_Interface.startImport();"/>
 		<command id="cmd_zotero_importFromClipboard" oncommand="Zotero_File_Interface.importFromClipboard();"/>
 		<command id="cmd_zotero_exportLibrary" oncommand="Zotero_File_Interface.exportFile();"/>
 		<command id="cmd_zotero_advancedSearch" oncommand="ZoteroPane_Local.openAdvancedSearchWindow();"/>

--- a/chrome/locale/en-US/zotero/zotero.dtd
+++ b/chrome/locale/en-US/zotero/zotero.dtd
@@ -202,6 +202,14 @@
 
 <!ENTITY zotero.progress.title							"Progress">
 
+<!ENTITY zotero.import                                 "Import">
+<!ENTITY zotero.import.whereToImportFrom               "Where do you want to import from?">
+<!ENTITY zotero.import.source.file                     "A file (BibTeX, RIS, Zotero RDF, etc.)">
+<!ENTITY zotero.import.importing                       "Importing…">
+<!ENTITY zotero.import.database                        "Database">
+<!ENTITY zotero.import.lastModified                    "Last Modified">
+<!ENTITY zotero.import.size                            "Size">
+
 <!ENTITY zotero.exportOptions.title						"Export…">
 <!ENTITY zotero.exportOptions.format.label				"Format:">
 <!ENTITY zotero.exportOptions.translatorOptions.label	"Translator Options">

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -69,6 +69,7 @@ general.processing      = Processing
 general.submitted      = Submitted
 general.thanksForHelpingImprove = Thanks for helping to improve %S!
 general.describeProblem			= Briefly describe the problem:
+general.nMegabytes                 = %S MB
 
 general.operationInProgress = A Zotero operation is currently in progress.
 general.operationInProgress.waitUntilFinished = Please wait until it has finished.
@@ -688,10 +689,12 @@ fileInterface.importComplete = Import Complete
 fileInterface.itemsWereImported = %1$S item was imported;%1$S items were imported
 fileInterface.itemsExported		= Exporting items…
 fileInterface.import			= Import
+fileInterface.chooseAppDatabaseToImport = Choose the %S database to import
 fileInterface.export			= Export
 fileInterface.exportedItems		= Exported Items
 fileInterface.imported 			= Imported
 fileInterface.unsupportedFormat = The selected file is not in a supported format.
+fileInterface.appDatabase      = %S Database
 fileInterface.viewSupportedFormats = View Supported Formats…
 fileInterface.untitledBibliography = Untitled Bibliography
 fileInterface.bibliographyHTMLTitle = Bibliography
@@ -1075,6 +1078,7 @@ rtfScan.rtf							= Rich Text Format (.rtf)
 rtfScan.saveTitle					= Select a location in which to save the formatted file
 rtfScan.scannedFileSuffix			= (Scanned)
 
+extractedAnnotations               = Extracted Annotations
 
 file.accessError.theFileCannotBeCreated = The file '%S' cannot be created.
 file.accessError.theFileCannotBeUpdated = The file '%S' cannot be updated.

--- a/chrome/skin/default/zotero/importWizard.css
+++ b/chrome/skin/default/zotero/importWizard.css
@@ -1,0 +1,44 @@
+.wizard-header-label {
+	font-size: 16px;
+	font-weight: bold;
+}
+
+/* Start */
+wizard[currentpageid="page-start"] .wizard-header-label {
+	padding-top: 24px;
+}
+
+wizard[currentpageid="page-start"] .wizard-page-box {
+	margin-top: -2px;
+	padding-top: 0;
+}
+
+radiogroup {
+	font-size: 14px;
+	margin-top: 4px;
+}
+
+radio {
+	padding-top: 5px;
+}
+
+/* File options */
+wizard[currentpageid="page-file-options"] .wizard-header {
+	display: none;
+}
+
+#file-options-header {
+	font-size: 15px;
+	font-weight: bold;
+	margin-bottom: 6px;
+}
+
+listbox, #result-description {
+	font-size: 13px;
+}
+
+#result-report-error {
+	margin-top: 13px;
+	margin-left: 0;
+	font-size: 13px;
+}

--- a/resource/tinymce/css/note-content.css
+++ b/resource/tinymce/css/note-content.css
@@ -1,3 +1,36 @@
+h1 {
+	font-size: 1.6em;
+	padding-bottom: .2em;
+}
+
+h2 {
+	font-size: 1.4em;
+	font-weight: normal;
+	margin-top: 0;
+	padding-bottom: .2em;
+	border-bottom: 1px solid lightgray;
+}
+
+h3 {
+	font-size: 1.1em;
+}
+
+h4 {
+	font-size: 1em;
+	margin-bottom: 1em;
+}
+
+h5 {
+	font-size: .9em;
+	margin-bottom: 1em;
+}
+
+h6 {
+	font-size: .8em;
+	margin-top: 1.6em;
+	margin-bottom: 1.3em;
+}
+
 blockquote {
 	margin-top: 1.5em;
 	margin-bottom: 1.5em;


### PR DESCRIPTION
Accept Mendeley SQLite databases via File -> Import… and perform a direct import, including collections, timestamps, notes, and attachments.

Known fields that aren't valid for a type are stored in Extra. A few fields are not currently mapped.

Files in the Mendeley 'Downloaded' folder are stored. Files elsewhere are linked.

This should not yet be used on a production Zotero database, and imported data cannot yet be synced.

To-do:

- [ ] More testing on real databases (ideally by someone who actually has Mendeley installed)
- [ ] Review data mappings and check for additional things to be mapped
- [x] Automatic DB selection, with an intermediate window when selecting File -> Import… that allows "Mendeley" to be chosen as an import  option
- [x] Test error handling (e.g., if a non-Mendeley SQLite DB is passed)
- [ ] Format Extra fields before passing to citeproc-js (since we're storing them title-cased and with spaces, and citeproc-js supposedly only allows lowercase and hyphens)
- [x] Allow syncing of new predicates, or switch to owl:sameAs with a URI for the UUIDs
- <del>Update or skip items previously imported from Zotero (DocumentsZotero table)</del> Can't do this safely, because only local ids are available in the Mendeley database
- <del>Group support? Group library items are currently ignored.</del> Not going to worry about this.
- [ ] An easier way to move all subcollections of the imported library to the library root, either with a menu option (easy but awkward) or multi-selection for collections
- [ ] Support linked citations from documents created by Mendeley after import
- <del>Annotations/highlights?</del> These are stored in the DB in Mendeley, and we don't have a good way of applying them to the file. It's possible we could figure out a way to do this later or swap in PDFs from an export (which apparently includes the option of embedded annotations).
- [x] Extract annotations?
