### PR TITLE
Doc Integration Endpoint for the Connector

### DIFF
--- a/chrome/content/zotero-platform/mac/integration.css
+++ b/chrome/content/zotero-platform/mac/integration.css
@@ -14,6 +14,10 @@ body[multiline="true"] {
 	width: 800px;
 }
 
+#quick-format-dialog.progress-bar #quick-format-deck {
+	height: 37px;
+}
+
 #quick-format-search {
 	background: white;
 	-moz-appearance: searchfield;

--- a/chrome/content/zotero/integration/progressBar.js
+++ b/chrome/content/zotero/integration/progressBar.js
@@ -1,0 +1,129 @@
+/*
+    ***** BEGIN LICENSE BLOCK *****
+    
+    Copyright © 2018 Center for History and New Media
+				     George Mason University, Fairfax, Virginia, USA
+				     http://zotero.org
+    
+    This file is part of Zotero.
+    
+    Zotero is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    
+    Zotero is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+    
+    You should have received a copy of the GNU Affero General Public License
+    along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
+    
+    ***** END LICENSE BLOCK *****
+*/
+Components.utils.import("resource://gre/modules/Services.jsm");
+
+var Zotero_ProgressBar = new function () {
+	var initialized, io;
+	
+	/**
+	 * Pre-initialization, when the dialog has loaded but has not yet appeared
+	 */
+	this.onDOMContentLoaded = function(event) {
+		if(event.target === document) {
+			initialized = true;
+			io = window.arguments[0].wrappedJSObject;
+			if (io.onLoad) {
+				io.onLoad(_onProgress);
+			}
+			
+			// Only hide chrome on Windows or Mac
+			if(Zotero.isMac) {
+				document.documentElement.setAttribute("drawintitlebar", true);
+			} else if(Zotero.isWin) {
+				document.documentElement.setAttribute("hidechrome", true);
+			}
+			
+			new WindowDraggingElement(document.getElementById("quick-format-dialog"), window);
+		
+		}
+	};
+	
+	/**
+	 * Initialize add citation dialog
+	 */
+	this.onLoad = function(event) {
+		if(event.target !== document) return;		
+		// make sure we are visible
+		window.setTimeout(function() {
+			// window.resizeTo(window.outerWidth, window.outerHeight);
+			var screenX = window.screenX;
+			var screenY = window.screenY;
+			var xRange = [window.screen.availLeft, window.screen.width-window.outerWidth];
+			var yRange = [window.screen.availTop, window.screen.height-window.outerHeight];
+			if (screenX < xRange[0] || screenX > xRange[1] || screenY < yRange[0] || screenY > yRange[1]) {
+				var targetX = Math.max(Math.min(screenX, xRange[1]), xRange[0]);
+				var targetY = Math.max(Math.min(screenY, yRange[1]), yRange[0]);
+				Zotero.debug("Moving window to "+targetX+", "+targetY);
+				window.moveTo(targetX, targetY);
+			}
+		}, 0);
+
+		window.focus();
+	};
+	
+	/**
+	 * Called when progress changes
+	 */
+	function _onProgress(percent) {
+		var meter = document.getElementById("quick-format-progress-meter");
+		if(percent === null) {
+			meter.mode = "undetermined";
+		} else {
+			meter.mode = "determined";
+			meter.value = Math.round(percent);
+		}
+	}
+	
+	/**
+	 * Resizes windows
+	 * @constructor
+	 */
+	var Resizer = function(panel, targetWidth, targetHeight, pixelsPerStep, stepsPerSecond) {
+		this.panel = panel;
+		this.curWidth = panel.clientWidth;
+		this.curHeight = panel.clientHeight;
+		this.difX = (targetWidth ? targetWidth - this.curWidth : 0);
+		this.difY = (targetHeight ? targetHeight - this.curHeight : 0);
+		this.step = 0;
+		this.steps = Math.ceil(Math.max(Math.abs(this.difX), Math.abs(this.difY))/pixelsPerStep);
+		this.timeout = (1000/stepsPerSecond);
+		
+		var me = this;
+		this._animateCallback = function() { me.animate() };
+	};
+	
+	/**
+	 * Performs a step of the animation
+	 */
+	Resizer.prototype.animate = function() {
+		if(this.stopped) return;
+		this.step++;
+		this.panel.sizeTo(this.curWidth+Math.round(this.step*this.difX/this.steps),
+			this.curHeight+Math.round(this.step*this.difY/this.steps));
+		if(this.step !== this.steps) {
+			window.setTimeout(this._animateCallback, this.timeout);
+		}
+	};
+	
+	/**
+	 * Halts resizing
+	 */
+	Resizer.prototype.stop = function() {
+		this.stopped = true;
+	};
+}
+
+window.addEventListener("DOMContentLoaded", Zotero_ProgressBar.onDOMContentLoaded, false);
+window.addEventListener("load", Zotero_ProgressBar.onLoad, false);

--- a/chrome/content/zotero/integration/progressBar.xul
+++ b/chrome/content/zotero/integration/progressBar.xul
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<!--
+    ***** BEGIN LICENSE BLOCK *****
+    
+    Copyright © 2018 Center for History and New Media
+                     George Mason University, Fairfax, Virginia, USA
+                     http://zotero.org
+    
+    This file is part of Zotero.
+    
+    Zotero is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    
+    Zotero is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+    
+    You should have received a copy of the GNU Affero General Public License
+    along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
+    
+    ***** END LICENSE BLOCK *****
+-->
+<?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
+<?xml-stylesheet href="chrome://global/skin/browser.css" type="text/css"?>
+<?xml-stylesheet href="chrome://zotero/skin/zotero.css" type="text/css"?>
+<?xml-stylesheet href="chrome://zotero/skin/integration.css" type="text/css"?>
+<?xml-stylesheet href="chrome://zotero-platform/content/integration.css" type="text/css"?>
+<!DOCTYPE window SYSTEM "chrome://zotero/locale/zotero.dtd">
+
+<window
+	id="quick-format-dialog"
+	class="progress-bar"
+	orient="vertical"
+	title="&zotero.progress.title;"
+	xmlns:html="http://www.w3.org/1999/xhtml"
+	xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
+	persist="screenX screenY">
+	
+	<script src="../include.js"/>
+	<script src="windowDraggingUtils.js" type="text/javascript"/>
+	<script src="progressBar.js" type="text/javascript"/>
+	
+	<box orient="horizontal" id="quick-format-entry"> 
+		<deck id="quick-format-deck" selectedIndex="0" flex="1">
+			<progressmeter id="quick-format-progress-meter" mode="undetermined" value="0" flex="1"/>
+		</deck>
+	</box>
+</window>

--- a/chrome/content/zotero/integration/quickFormat.js
+++ b/chrome/content/zotero/integration/quickFormat.js
@@ -179,6 +179,7 @@ var Zotero_QuickFormat = new function () {
 	 */
 	function _getCurrentEditorTextNode() {
 		var selection = qfiWindow.getSelection();
+		if (!selection) return false;
 		var range = selection.getRangeAt(0);
 		
 		var node = range.startContainer;

--- a/chrome/content/zotero/xpcom/connector/httpIntegrationClient.js
+++ b/chrome/content/zotero/xpcom/connector/httpIntegrationClient.js
@@ -85,8 +85,7 @@ for (let method of ["activate", "canInsertField", "displayAlert", "getDocumentDa
 
 // @NOTE Currently unused, prompts are done using the connector
 Zotero.HTTPIntegrationClient.Document.prototype._displayAlert = async function(dialogText, icon, buttons) {
-	var ps = Components.classes["@mozilla.org/embedcomp/prompt-service;1"]
-		.getService(Components.interfaces.nsIPromptService);
+	var ps = Services.prompt;
 	var buttonFlags = (ps.BUTTON_POS_0) * (ps.BUTTON_TITLE_OK)
 		+ (ps.BUTTON_POS_1) * (ps.BUTTON_TITLE_IS_STRING);
 	
@@ -172,8 +171,7 @@ Zotero.HTTPIntegrationClient.Field.prototype.getText = async function() {
 Zotero.HTTPIntegrationClient.Field.prototype.setText = async function(text, isRich) {
 	// The HTML will be stripped by Google Docs and and since we're 
 	// caching this value, we need to strip it ourselves
-	var wm = Components.classes["@mozilla.org/appshell/window-mediator;1"]
-		.getService(Components.interfaces.nsIWindowMediator);
+	var wm = Services.wm;
 	var win = wm.getMostRecentWindow('navigator:browser');
 	var doc = new win.DOMParser().parseFromString(text, "text/html");
 	this._text = doc.documentElement.textContent;

--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -1660,6 +1660,18 @@ Zotero.Utilities.Internal.activate = new function() {
 	}
 };
 
+Zotero.Utilities.Internal.sendToBack = function() {
+	if (Zotero.isMac) {
+		Zotero.Utilities.Internal.executeAppleScript(`
+			tell application "System Events"
+				if frontmost of application id "org.zotero.zotero" then
+					set visible of process "Zotero" to false
+				end if
+			end tell
+		`);
+	}
+}
+
 /**
  *  Base64 encode / decode
  *  From http://www.webtoolkit.info/

--- a/test/tests/integrationTest.js
+++ b/test/tests/integrationTest.js
@@ -305,9 +305,12 @@ describe("Zotero.Integration", function () {
 		});
 		
 		addEditCitationSpy = sinon.spy(Zotero.Integration.Interface.prototype, 'addEditCitation');
+		
+		sinon.stub(Zotero.Integration.Progress.prototype, 'show');
 	});
 	
 	after(function() {
+		Zotero.Integration.Progress.prototype.show.restore();
 		Zotero.Integration.getApplication.restore();
 		displayDialogStub.restore();
 		addEditCitationSpy.restore();


### PR DESCRIPTION
Changes:

- Moved connector communication specific code under `xpcom/connector` (directory was previously occupied by FX connector code and since got removed)
- Added `/connector/document/execCommand` and `/connector/document/respond` endpoints for integration functionality support
- Made all integration plugin invocation calls async (and added a wrapper for old integration plugins that have a sync API).
- Misc changes including support for "Http" fields, "html" citation/bibl output and plugins that do not support endnotes
- Adds a progress bar for integration interactions that do not use the quickFormat dialog