### PR TITLE
Asyncify Zotero.Relations.getByObject(), called only from item merge.

### DIFF
--- a/chrome/content/zotero/xpcom/data/relations.js
+++ b/chrome/content/zotero/xpcom/data/relations.js
@@ -146,7 +146,7 @@ Zotero.Relations = new function () {
 	 * @return {Object[]} - An array of objects with a Zotero.DataObject as 'subject'
 	 *     and a predicate string as 'predicate'
 	 */
-	this.getByObject = function (objectType, object) {
+	this.getByObject = Zotero.Promise.coroutine(function* (objectType, object) {
 		var objectsClass = Zotero.DataObjectUtilities.getObjectsClassForObjectType(objectType);
 		var predicateIDs = [];
 		var o = _subjectPredicatesByObject[objectType]
@@ -156,13 +156,16 @@ Zotero.Relations = new function () {
 		}
 		var toReturn = [];
 		for (let predicateID in o) {
-			o[predicateID].forEach(subjectID => toReturn.push({
-				subject: objectsClass.get(subjectID),
-				predicate: Zotero.RelationPredicates.getName(predicateID)
-			}));
+			for (let subjectID of o[predicateID]) {
+				var subject = yield objectsClass.getAsync(subjectID);
+				toReturn.push({
+					subject: subject,
+					predicate: Zotero.RelationPredicates.getName(predicateID)
+				});
+			};
 		}
 		return toReturn;
-	};
+	});
 	
 	
 	this.updateUser = Zotero.Promise.coroutine(function* (fromUserID, toUserID) {
@@ -179,9 +182,9 @@ Zotero.Relations = new function () {
 			let objects = yield Zotero.DB.columnQueryAsync(
 				sql, 'http://zotero.org/users/' + fromUserID + '/%'
 			);
-			Zotero.DB.addCurrentCallback("commit", function () {
+			Zotero.DB.addCurrentCallback("commit", function* () {
 				for (let object of objects) {
-					let subPrefs = this.getByObject(type, object);
+					let subPrefs = yield this.getByObject(type, object);
 					let newObject = object.replace(
 						new RegExp("^http://zotero.org/users/" + fromUserID + "/(.*)"),
 						"http://zotero.org/users/" + toUserID + "/$1"


### PR DESCRIPTION
This is the patch referred to in a recent [post to zotero-dev](https://groups.google.com/forum/#!topic/zotero-dev/6kFmaW5YhtY). To recap, merge of two items was failing for me in a large-ish account (10,000 items), where the "subordinate" partner in the merge had an `owl:sameAs` relation to another library that had not been opened during the session. The merge failed with an "item not loaded" error.

This change async-ifies the failing function `getByObject()`, and swaps out synchronous data object `get()` in favor of `asyncGet()`. Nothing needs to be altered up the execution chain, because the `merge()` function in `items.js` was already a generator, and its call to `getByObject()` is already `yield`-ed. One other call to `getByObject()` inside relations.js needed minor changes to work async.