### PR TITLE
Adjust expected add and modify array lengths in recognizePDFTest

### DIFF
--- a/test/tests/recognizePDFTest.js
+++ b/test/tests/recognizePDFTest.js
@@ -42,10 +42,10 @@ describe("PDF Recognition", function() {
 		
 		var addedIDs = await waitForItemEvent("add");
 		var modifiedIDs = await waitForItemEvent("modify");
-		assert.lengthOf(addedIDs, 1);
+		assert.lengthOf(addedIDs, 2);
 		var item = Zotero.Items.get(addedIDs[0]);
 		assert.equal(item.getField("title"), "Scaling study of an improved fermion action on quenched lattices");
-		assert.lengthOf(modifiedIDs, 2);
+		assert.lengthOf(modifiedIDs, 1);
 		
 		// Wait for status to show as complete
 		var progressWindow = getWindows("chrome://zotero/content/recognizePDFDialog.xul")[0];
@@ -76,9 +76,9 @@ describe("PDF Recognition", function() {
 		
 		var addedIDs = await waitForItemEvent("add");
 		var modifiedIDs = await waitForItemEvent("modify");
-		assert.lengthOf(addedIDs, 1);
+		assert.lengthOf(addedIDs, 2);
 		var item = Zotero.Items.get(addedIDs[0]);
-		assert.lengthOf(modifiedIDs, 2);
+		assert.lengthOf(modifiedIDs, 1);
 		
 		// Wait for status to show as complete
 		var progressWindow = getWindows("chrome://zotero/content/recognizePDFDialog.xul")[0];
@@ -106,9 +106,9 @@ describe("PDF Recognition", function() {
 		
 		var addedIDs = await waitForItemEvent("add");
 		var modifiedIDs = await waitForItemEvent("modify");
-		assert.lengthOf(addedIDs, 1);
+		assert.lengthOf(addedIDs, 2);
 		var item = Zotero.Items.get(addedIDs[0]);
-		assert.lengthOf(modifiedIDs, 2);
+		assert.lengthOf(modifiedIDs, 1);
 		
 		// Wait for status to show as complete
 		var progressWindow = getWindows("chrome://zotero/content/recognizePDFDialog.xul")[0];


### PR DESCRIPTION
I won't pretend to understand the underlying code changes: this just adjusts the fixtures to reflect the return values in the current release. As far as I can tell, recognition and conversion are working well in a client that passes the revised fixtures.