### PR TITLE
Document export-import UI and integration code

### DIFF
--- a/chrome/content/zotero-platform/mac/bibliography.css
+++ b/chrome/content/zotero-platform/mac/bibliography.css
@@ -1,0 +1,3 @@
+.chevron {
+	font-size: 1.5em;
+}

--- a/chrome/content/zotero/bibliography.js
+++ b/chrome/content/zotero/bibliography.js
@@ -32,6 +32,7 @@
 // Class to provide options for bibliography
 // Used by rtfScan.xul, integrationDocPrefs.xul, and bibliography.xul
 
+Components.utils.import("resource://gre/modules/Services.jsm");
 var Zotero_File_Interface_Bibliography = new function() {
 	var _io;
 	
@@ -174,6 +175,10 @@ var Zotero_File_Interface_Bibliography = new function() {
 				
 				document.getElementById("automaticCitationUpdates-checkbox").checked = !_io.delayCitationUpdates;
 			}
+			
+			if (_io.showImportExport) {
+				document.querySelector('#exportImport').hidden = false;
+			}
 		}
 		
 		// set style to false, in case this is cancelled
@@ -237,7 +242,38 @@ var Zotero_File_Interface_Bibliography = new function() {
 
 		window.sizeToContent();
 	};
-
+	
+	this.toggleAdvanced = function() {
+		var advancedSettings = document.querySelector("#advanced-settings");
+		advancedSettings.hidden = !advancedSettings.hidden;
+		var chevron = document.querySelector('.chevron');
+		chevron.classList.toggle('chevron-down');
+		chevron.classList.toggle('chevron-up');
+		window.sizeToContent();
+	};
+	
+	this.exportDocument = function() {
+		const importExportWikiURL = "https://www.zotero.org/support/kb/export_import_document";
+		
+		var ps = Services.prompt;
+		var buttonFlags = (ps.BUTTON_POS_0) * (ps.BUTTON_TITLE_OK)
+			+ (ps.BUTTON_POS_1) * (ps.BUTTON_TITLE_CANCEL)
+			+ (ps.BUTTON_POS_2) * (ps.BUTTON_TITLE_IS_STRING);
+		var result = ps.confirmEx(null,
+			Zotero.getString('integration.exportDocument'),
+			Zotero.getString('integration.exportDocument.description'),
+			buttonFlags,
+			null,
+			null,
+			Zotero.getString('general.moreInformation'), null, {});
+		if (result == 0) {
+			_io.exportDocument = true;
+			document.documentElement.acceptDialog();
+		} else if (result == 2) {
+			Zotero.launchURL(importExportWikiURL);
+		}
+	}
+	
 	/*
 	 * Update locale menulist when style is changed
 	 */

--- a/chrome/content/zotero/integration/integrationDocPrefs.xul
+++ b/chrome/content/zotero/integration/integrationDocPrefs.xul
@@ -26,6 +26,7 @@
 <?xml-stylesheet href="chrome://global/skin/global.css"?>
 <?xml-stylesheet href="chrome://browser/skin/preferences/preferences.css"?>
 <?xml-stylesheet href="chrome://zotero/skin/bibliography.css"?>
+<?xml-stylesheet href="chrome://zotero-platform/content/bibliography.css"?>
 <!DOCTYPE window SYSTEM "chrome://zotero/locale/zotero.dtd">
 
 <dialog
@@ -81,14 +82,27 @@
 			</radiogroup>
 		</groupbox>
 
-		<vbox id="automaticJournalAbbreviations-vbox">
+		<vbox class="pref-vbox" id="automaticJournalAbbreviations-vbox">
 			<checkbox id="automaticJournalAbbreviations-checkbox" label="&zotero.integration.prefs.automaticJournalAbbeviations.label;"/>
 			<description class="radioDescription">&zotero.integration.prefs.automaticJournalAbbeviations.caption;</description>
 		</vbox>
 		
-		<vbox id="automaticCitationUpdates-vbox">
-			<checkbox id="automaticCitationUpdates-checkbox" label="&zotero.integration.prefs.automaticCitationUpdates.label;" tooltiptext="&zotero.integration.prefs.automaticCitationUpdates.tooltip;"/>
-			<description class="radioDescription">&zotero.integration.prefs.automaticCitationUpdates.description;</description>
+		<!--<vbox id="advanced-separator" align="center">-->
+			<!--<hbox align="center" onclick="Zotero_File_Interface_Bibliography.toggleAdvanced()">-->
+                <!--<label>&zotero.general.advancedOptions.label;</label>-->
+				<!--<label class="chevron chevron-down">➤</label>-->
+			<!--</hbox>-->
+		<!--</vbox>	-->
+		
+		<vbox id="advanced-settings" hidden="false">
+			<vbox id="automaticCitationUpdates-vbox">
+				<checkbox id="automaticCitationUpdates-checkbox" label="&zotero.integration.prefs.automaticCitationUpdates.label;" tooltiptext="&zotero.integration.prefs.automaticCitationUpdates.tooltip;"/>
+				<description class="radioDescription">&zotero.integration.prefs.automaticCitationUpdates.description;</description>
+			</vbox>
+			<hbox id="exportImport" hidden="true">
+				<button label="&zotero.integration.prefs.exportDocument;" oncommand="Zotero_File_Interface_Bibliography.exportDocument()"/>
+			</hbox>
 		</vbox>
+		
 	</vbox>
 </dialog>

--- a/chrome/content/zotero/xpcom/connector/httpIntegrationClient.js
+++ b/chrome/content/zotero/xpcom/connector/httpIntegrationClient.js
@@ -59,12 +59,16 @@ Zotero.HTTPIntegrationClient.Application = function() {
 	this.secondaryFieldType = "Http";
 	this.outputFormat = 'html';
 	this.supportedNotes = ['footnotes'];
+	this.supportsImportExport = false;
+	this.processorName = "HTTP Integration";
 };
 Zotero.HTTPIntegrationClient.Application.prototype = {
 	getActiveDocument: async function() {
 		let result = await Zotero.HTTPIntegrationClient.sendCommand('Application.getActiveDocument');
 		this.outputFormat = result.outputFormat || this.outputFormat;
 		this.supportedNotes = result.supportedNotes || this.supportedNotes;
+		this.supportsImportExport = result.supportsImportExport || this.supportsImportExport;
+		this.processorName = result.processorName || this.processorName;
 		return new Zotero.HTTPIntegrationClient.Document(result.documentID);
 	}
 };
@@ -76,7 +80,7 @@ Zotero.HTTPIntegrationClient.Document = function(documentID) {
 	this._documentID = documentID;
 };
 for (let method of ["activate", "canInsertField", "displayAlert", "getDocumentData",
-	"setDocumentData", "setBibliographyStyle"]) {
+	"setDocumentData", "setBibliographyStyle", "importDocument", "exportDocument"]) {
 	Zotero.HTTPIntegrationClient.Document.prototype[method] = async function() {
 		return Zotero.HTTPIntegrationClient.sendCommand("Document."+method,
 			[this._documentID].concat(Array.prototype.slice.call(arguments)));

--- a/chrome/content/zotero/xpcom/connector/server_connectorIntegration.js
+++ b/chrome/content/zotero/xpcom/connector/server_connectorIntegration.js
@@ -74,7 +74,7 @@ Zotero.Server.Endpoints['/connector/document/respond'].prototype = {
 // For managing macOS integration and progress window focus
 Zotero.Server.Endpoints['/connector/sendToBack'] = function() {};
 Zotero.Server.Endpoints['/connector/sendToBack'].prototype = {
-	supportedMethods: ["POST"],
+	supportedMethods: ["POST", "GET"],
 	supportedDataTypes: ["application/json"],
 	permitBookmarklet: true,
 	init: function() {

--- a/chrome/locale/en-US/zotero/zotero.dtd
+++ b/chrome/locale/en-US/zotero/zotero.dtd
@@ -243,9 +243,11 @@
 <!ENTITY zotero.integration.prefs.automaticCitationUpdates.tooltip     "Citations with pending updates will be highlighted in the document">
 <!ENTITY zotero.integration.prefs.automaticCitationUpdates.description "Disabling updates can speed up citation insertion in large documents. Click Refresh to update citations manually.">
 
-
 <!ENTITY zotero.integration.prefs.automaticJournalAbbeviations.label 		"Use MEDLINE journal abbreviations">
 <!ENTITY zotero.integration.prefs.automaticJournalAbbeviations.caption	"The “Journal Abbr” field will be ignored.">
+
+<!ENTITY zotero.integration.prefs.exportDocument 		"Export document…">
+<!ENTITY zotero.integration.prefs.importDocument 		"Import document…">
 
 <!ENTITY zotero.integration.showEditor.label			"Show Editor">
 <!ENTITY zotero.integration.classicView.label			"Classic View">

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -900,8 +900,8 @@ integration.delayCitationUpdates.bibliography.tab	= Automatic citation updates a
 integration.importDocument                          = Import Document?
 integration.importDocument.description              = Would you like to import this document for use with Zotero?
 integration.exportDocument                          = Export Document?
-integration.exportDocument.description              = Exporting the document will allow you to use it with a different Zotero supported word processor and retain citation links. Do you want to proceed?
-integration.importInstructions = This document contains exported Zotero citations. To import it click "Refresh" in the Zotero plugin.
+integration.exportDocument.description              = Exporting the document will allow you to import it in a different Zotero supported word processor and retain citation links. You should make a backup of your document before exporting. Do you want to proceed?
+integration.importInstructions = This document contains exported Zotero citations. Open it with a Zotero supported document editor and press "Refresh" in the Zotero plugin to import it. NOTE: Do not copy and paste the contents of the document from one processor to the other.
 
 styles.install.title				= Install Style
 styles.install.unexpectedError		= An unexpected error occurred while installing "%1$S"

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -897,6 +897,11 @@ integration.delayCitationUpdates.alert.text2.tab = You will need to click Refres
 integration.delayCitationUpdates.alert.text3 = You can change this setting later in the document preferences.
 integration.delayCitationUpdates.bibliography.toolbar	= Automatic citation updates are disabled. To see the bibliography, click Refresh in the Zotero toolbar.
 integration.delayCitationUpdates.bibliography.tab	= Automatic citation updates are disabled. To see the bibliography, click Refresh in the Zotero tab.
+integration.importDocument                          = Import Document?
+integration.importDocument.description              = Would you like to import this document for use with Zotero?
+integration.exportDocument                          = Export Document?
+integration.exportDocument.description              = Exporting the document will allow you to use it with a different Zotero supported word processor and retain citation links. Do you want to proceed?
+integration.importInstructions = This document contains exported Zotero citations. To import it click "Refresh" in the Zotero plugin.
 
 styles.install.title				= Install Style
 styles.install.unexpectedError		= An unexpected error occurred while installing "%1$S"

--- a/chrome/skin/default/zotero/bibliography.css
+++ b/chrome/skin/default/zotero/bibliography.css
@@ -25,6 +25,25 @@ radio:not(:first-child)
 }
 
 
-#automaticJournalAbbreviations-vbox, #automaticCitationUpdates-vbox {
+#automaticJournalAbbreviations-vbox, #advanced-settings {
 	padding: 0 14px;
+}
+
+#advanced-separator * {
+	cursor: pointer;
+}
+
+.chevron {
+	color: #444;
+}
+
+.chevron.chevron-down {
+	transform: rotate(90deg);
+}
+.chevron.chevron-up {
+	transform: rotate(-90deg);
+}
+
+#advanced-settings > * {
+	margin-bottom: 10px;
 }

--- a/test/tests/integrationTest.js
+++ b/test/tests/integrationTest.js
@@ -21,6 +21,7 @@ describe("Zotero.Integration", function () {
 		this.primaryFieldType = "Field";
 		this.secondaryFieldType = "Bookmark";
 		this.supportedNotes = ['footnotes', 'endnotes'];
+		this.supportsImportExport = true;
 		this.fields = [];
 	};
 	DocumentPluginDummy.Application.prototype = {
@@ -119,6 +120,31 @@ describe("Zotero.Integration", function () {
 		 * Informs the document processor that the operation is complete
 		 */
 		complete: () => 0,
+		
+		/**
+		 * Converts field text in document to their underlying codes and appends
+		 * document preferences and bibliography style as paragraphs at the end
+		 * of the document. Prefixes:
+		 * 	- Bibliography style: "BIBLIOGRAPHY_STYLE "
+		 * 	- Document preferences: "DOCUMENT_PREFERENCES "
+		 * 	
+		 * 	All Zotero exported text must be converted to a hyperlink
+		 * 	(with any url, e.g. http://www.zotero.org)
+		 */
+		exportDocument: (fieldType) => 0,
+		
+		/**
+		 * Converts a document from an exported form described in #exportDocument()
+		 * to a Zotero editable form. Bibliography Style and Document Preferences
+		 * text is removed and stored internally within the doc. The citation codes are
+		 * also stored within the doc in appropriate representation. 
+		 * 
+		 * Note that no citation text updates are needed. Zotero will issue field updates 
+		 * manually.
+		 * 
+		 * @returns {Boolean} whether the document contained importable data
+		 */
+		importDocument: (fieldType) => 0,
 	};
 
 	/**


### PR DESCRIPTION
I need ideas for what the dialogs for Export and Import should say. Export converts all citations to their field-code representations (and appends doc prefs and bibl style at the end of the doc). Import reverses this. 

Support of this feature has to be implemented for each individual docs plugin separately (and the buttons will only appear if the plugins have support).

Addresses zotero/zotero-google-docs-integration#1

<img src="https://user-images.githubusercontent.com/5899315/40060323-01368c72-585f-11e8-9fcd-a747737c50b3.png" width="350px">