### PR TITLE
Add universal progress queues

### DIFF
--- a/chrome/content/zotero/progressQueueDialog.js
+++ b/chrome/content/zotero/progressQueueDialog.js
@@ -234,6 +234,6 @@ var Zotero_ProgressQueue_Dialogs = new function () {
 	}
 	
 	this.getDialog = function (id) {
-		return _dialogs.find(d => d.progressQueue.getId() === id);
+		return _dialogs.find(d => d.progressQueue.getID() === id);
 	}
 };

--- a/chrome/content/zotero/progressQueueDialog.xul
+++ b/chrome/content/zotero/progressQueueDialog.xul
@@ -3,7 +3,7 @@
 <!DOCTYPE window SYSTEM "chrome://zotero/locale/zotero.dtd">
 
 <window xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
-	title="&zotero.progress.title;" width="550" height="230"
+	width="550" height="230"
 	id="zotero-progress">
 	<vbox style="padding:10px" flex="1">
 		<label id="label" control="progress-indicator" value=""/>
@@ -17,9 +17,9 @@
 			<treecols>
 				<treecol id="success-col" style="width:20px;"/>
 				<splitter class="tree-splitter" hidden="true"/>
-				<treecol label="&zotero.recognizePDF.pdfName.label;" id="pdf-col" flex="1"/>
+				<treecol id="col1" flex="1"/>
 				<splitter class="tree-splitter"/>
-				<treecol label="&zotero.recognizePDF.itemName.label;" id="item-col" flex="2"/>
+				<treecol id="col2" flex="2"/>
 			</treecols>
 			<treechildren id="treechildren"/>
 		</tree>

--- a/chrome/content/zotero/xpcom/progressQueue.js
+++ b/chrome/content/zotero/xpcom/progressQueue.js
@@ -1,0 +1,281 @@
+/*
+    ***** BEGIN LICENSE BLOCK *****
+    
+    Copyright © 2018 Center for History and New Media
+                     George Mason University, Fairfax, Virginia, USA
+                     http://zotero.org
+    
+    This file is part of Zotero.
+    
+    Zotero is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    
+    Zotero is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+    
+    You should have received a copy of the GNU Affero General Public License
+    along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
+    
+    ***** END LICENSE BLOCK *****
+*/
+
+Zotero.ProgressQueue = function (options) {
+	const OFFLINE_RECHECK_DELAY = 60 * 1000;
+	
+	let _id = options.id;
+	let _title = options.title;
+	let _columns = options.columns;
+	let _processor = options.processor;
+	
+	let _listeners = {};
+	let _rows = [];
+	let _queue = [];
+	let _queueProcessing = false;
+	
+	
+	this.getId = function () {
+		return _id;
+	};
+	
+	
+	this.getTitle = function () {
+		return _title;
+	};
+	
+	
+	this.getColumns = function () {
+		return _columns;
+	};
+	
+	
+	/**
+	 * Add listener
+	 * @param name Event name
+	 * @param callback
+	 */
+	this.addListener = function (name, callback) {
+		_listeners[name] = callback;
+	};
+	
+	
+	/**
+	 * Remove listener
+	 * @param name Event name
+	 */
+	this.removeListener = function (name) {
+		delete _listeners[name];
+	};
+	
+	
+	/**
+	 * Adds items to the queue and triggers processing
+	 * @param items {Zotero.Item}
+	 */
+	this.addItems = function (items) {
+		for (let item of items) {
+			_addItem(item);
+		}
+		_processQueue();
+	};
+	
+	
+	/**
+	 * Returns all rows
+	 * @return {Array}
+	 */
+	this.getRows = function () {
+		return _rows;
+	};
+	
+	
+	/**
+	 * Returns rows count
+	 * @return {Number}
+	 */
+	this.getTotal = function () {
+		return _rows.length;
+	};
+	
+	
+	/**
+	 * Returns processed rows count
+	 * @return {Number}
+	 */
+	this.getProcessedTotal = function () {
+		return _rows.filter(row => row.status > Zotero.ProgressQueue.ROW_PROCESSING).length;
+	};
+	
+	
+	/**
+	 * Stop processing items
+	 */
+	this.cancel = function () {
+		_queue = [];
+		_rows = [];
+		if (_listeners['empty']) {
+			_listeners['empty']();
+		}
+	};
+	
+	
+	/**
+	 * Add item for processing
+	 * @param item
+	 * @return {null}
+	 */
+	function _addItem(item) {
+		for (let row of _rows) {
+			if (row.id === item.id) {
+				if (row.status > Zotero.ProgressQueue.ROW_PROCESSING) {
+					_deleteRow(row.id);
+					break;
+				}
+				return null;
+			}
+		}
+		
+		let row = {
+			id: item.id,
+			status: Zotero.ProgressQueue.ROW_QUEUED,
+			fileName: item.getField('title'),
+			message: ''
+		};
+		
+		_rows.unshift(row);
+		_queue.unshift(item.id);
+		
+		if (_listeners['rowadded']) {
+			_listeners['rowadded'](row);
+		}
+		
+		if (_listeners['nonempty'] && _rows.length === 1) {
+			_listeners['nonempty']();
+		}
+	}
+	
+	
+	/**
+	 * Update row status and message
+	 * @param itemID
+	 * @param status
+	 * @param message
+	 */
+	function _updateRow(itemID, status, message) {
+		for (let row of _rows) {
+			if (row.id === itemID) {
+				row.status = status;
+				row.message = message;
+				if (_listeners['rowupdated']) {
+					_listeners['rowupdated']({
+						id: row.id,
+						status,
+						message: message || ''
+					});
+				}
+				return;
+			}
+		}
+	}
+	
+	
+	/**
+	 * Delete row
+	 * @param itemID
+	 */
+	function _deleteRow(itemID) {
+		for (let i = 0; i < _rows.length; i++) {
+			let row = _rows[i];
+			if (row.id === itemID) {
+				_rows.splice(i, 1);
+				if (_listeners['rowdeleted']) {
+					_listeners['rowdeleted']({
+						id: row.id
+					});
+				}
+				return;
+			}
+		}
+	}
+	
+	
+	/**
+	 * Triggers queue processing and returns when all items in the queue are processed
+	 * @return {Promise}
+	 */
+	async function _processQueue() {
+		await Zotero.Schema.schemaUpdatePromise;
+		
+		if (_queueProcessing) return;
+		_queueProcessing = true;
+		
+		while (1) {
+			// While all current progress queue usages are related with
+			// online APIs, check internet connectivity here
+			if (Zotero.HTTP.browserIsOffline()) {
+				await Zotero.Promise.delay(OFFLINE_RECHECK_DELAY);
+				continue;
+			}
+			
+			let itemID = _queue.shift();
+			if (!itemID) break;
+			
+			_updateRow(itemID, Zotero.ProgressQueue.ROW_PROCESSING, Zotero.getString('general.processing'));
+			
+			try {
+				let item = await Zotero.Items.getAsync(itemID);
+				
+				if (!item) {
+					throw new Error();
+				}
+				
+				let res = await _processor(item);
+				_updateRow(itemID, Zotero.ProgressQueue.ROW_SUCCEEDED, res);
+			}
+			catch (e) {
+				Zotero.logError(e);
+				
+				_updateRow(
+					itemID,
+					Zotero.ProgressQueue.ROW_FAILED,
+					e instanceof Zotero.Exception.Alert
+						? e.message
+						: Zotero.getString('general.error')
+				);
+			}
+		}
+		
+		_queueProcessing = false;
+	}
+};
+
+
+Zotero.ProgressQueue.ROW_QUEUED = 1;
+Zotero.ProgressQueue.ROW_PROCESSING = 2;
+Zotero.ProgressQueue.ROW_FAILED = 3;
+Zotero.ProgressQueue.ROW_SUCCEEDED = 4;
+
+
+Zotero.ProgressQueues = new function () {
+	let _queues = [];
+	
+	
+	this.createQueue = function (options) {
+		let queue = new Zotero.ProgressQueue(options);
+		_queues.push(queue);
+		return queue;
+	};
+	
+	
+	this.getQueue = function (id) {
+		return _queues.find(queue => queue.getId() === id);
+	};
+	
+	
+	this.getAllQueues = function () {
+		return _queues;
+	};
+};

--- a/chrome/content/zotero/xpcom/progressQueue.js
+++ b/chrome/content/zotero/xpcom/progressQueue.js
@@ -24,17 +24,26 @@
 */
 
 Zotero.ProgressQueue = function (options) {
-	const OFFLINE_RECHECK_DELAY = 60 * 1000;
-	
 	let _id = options.id;
 	let _title = options.title;
 	let _columns = options.columns;
-	let _processor = options.processor;
 	
 	let _listeners = {};
 	let _rows = [];
-	let _queue = [];
-	let _queueProcessing = false;
+	
+	let _dialog = null;
+	
+	let _progressQueue = this;
+	
+	/**
+	 * @return {Zotero.ProgressQueueDialog}
+	 */
+	this.getDialog = function() {
+		if(!_dialog) {
+			_dialog = new Zotero.ProgressQueueDialog(_progressQueue);
+		}
+		return _dialog;
+	};
 	
 	/**
 	 * @return {Number}
@@ -80,18 +89,6 @@ Zotero.ProgressQueue = function (options) {
 	
 	
 	/**
-	 * Adds items to the queue and triggers processing
-	 * @param {Zotero.Item[]} items
-	 */
-	this.addItems = function (items) {
-		for (let item of items) {
-			_addItem(item);
-		}
-		_processQueue();
-	};
-	
-	
-	/**
 	 * Returns all rows
 	 * @return {Object[]}
 	 */
@@ -122,10 +119,13 @@ Zotero.ProgressQueue = function (options) {
 	 * Stop processing items
 	 */
 	this.cancel = function () {
-		_queue = [];
 		_rows = [];
 		if (_listeners.empty) {
 			_listeners.empty();
+		}
+		
+		if (_listeners.cancel) {
+			_listeners.cancel();
 		}
 	};
 	
@@ -134,20 +134,8 @@ Zotero.ProgressQueue = function (options) {
 	 * Add item for processing
 	 * @param {Zotero.Item} item
 	 */
-	function _addItem(item) {
-		// Check if item is already in the list
-		for (let row of _rows) {
-			if (row.id === item.id) {
-				// If it's already processed, delete the existing row
-				// and allow to add it again for reprocessing
-				if (row.status > Zotero.ProgressQueue.ROW_PROCESSING) {
-					_deleteRow(row.id);
-					break;
-				}
-				// If it's still waiting to be processed just ignore it
-				return;
-			}
-		}
+	this.addRow = function(item) {
+		this.deleteRow(item.id);
 		
 		let row = {
 			id: item.id,
@@ -156,17 +144,16 @@ Zotero.ProgressQueue = function (options) {
 			message: ''
 		};
 		
-		_rows.unshift(row);
-		_queue.unshift(item.id);
+		_rows.push(row);
 		
 		if (_listeners.rowadded) {
 			_listeners.rowadded(row);
 		}
 		
-		if (_listeners.nonempty && _rows.length === 1) {
+		if (_listeners.nonempty) {
 			_listeners.nonempty();
 		}
-	}
+	};
 	
 	
 	/**
@@ -175,7 +162,7 @@ Zotero.ProgressQueue = function (options) {
 	 * @param {Number} status
 	 * @param {String} message
 	 */
-	function _updateRow(itemID, status, message) {
+	this.updateRow = function(itemID, status, message) {
 		for (let row of _rows) {
 			if (row.id === itemID) {
 				row.status = status;
@@ -190,77 +177,24 @@ Zotero.ProgressQueue = function (options) {
 				return;
 			}
 		}
-	}
+	};
 	
 	
 	/**
 	 * Delete row
 	 * @param {Number} itemID
 	 */
-	function _deleteRow(itemID) {
-		for (let i = 0; i < _rows.length; i++) {
-			let row = _rows[i];
-			if (row.id === itemID) {
-				_rows.splice(i, 1);
-				if (_listeners.rowdeleted) {
-					_listeners.rowdeleted({
-						id: row.id
-					});
-				}
-				return;
+	this.deleteRow = function(itemID) {
+		let row = _rows.find(x => x.id === itemID);
+		if(row) {
+			_rows.splice(_rows.indexOf(row), 1);
+			if (_listeners.rowdeleted) {
+				_listeners.rowdeleted({
+					id: row.id
+				});
 			}
 		}
-	}
-	
-	
-	/**
-	 * Triggers queue processing and returns when all items in the queue are processed
-	 * @return {Promise}
-	 */
-	async function _processQueue() {
-		await Zotero.Schema.schemaUpdatePromise;
-		
-		if (_queueProcessing) return;
-		_queueProcessing = true;
-		
-		while (1) {
-			// While all current progress queue usages are related with
-			// online APIs, check internet connectivity here
-			if (Zotero.HTTP.browserIsOffline()) {
-				await Zotero.Promise.delay(OFFLINE_RECHECK_DELAY);
-				continue;
-			}
-			
-			let itemID = _queue.shift();
-			if (!itemID) break;
-			
-			_updateRow(itemID, Zotero.ProgressQueue.ROW_PROCESSING, Zotero.getString('general.processing'));
-			
-			try {
-				let item = await Zotero.Items.getAsync(itemID);
-				
-				if (!item) {
-					throw new Error();
-				}
-				
-				let res = await _processor(item);
-				_updateRow(itemID, Zotero.ProgressQueue.ROW_SUCCEEDED, res);
-			}
-			catch (e) {
-				Zotero.logError(e);
-				
-				_updateRow(
-					itemID,
-					Zotero.ProgressQueue.ROW_FAILED,
-					e instanceof Zotero.Exception.Alert
-						? e.message
-						: Zotero.getString('general.error')
-				);
-			}
-		}
-		
-		_queueProcessing = false;
-	}
+	};
 };
 
 
@@ -277,7 +211,7 @@ Zotero.ProgressQueues = new function () {
 	 * @param {Object} options
 	 * @return {Zotero.ProgressQueue}
 	 */
-	this.createQueue = function (options) {
+	this.create = function (options) {
 		let queue = new Zotero.ProgressQueue(options);
 		_queues.push(queue);
 		return queue;
@@ -287,14 +221,14 @@ Zotero.ProgressQueues = new function () {
 	 * @param {Number} id
 	 * @return {Zotero.ProgressQueue}
 	 */
-	this.getQueue = function (id) {
+	this.get = function (id) {
 		return _queues.find(queue => queue.getID() === id);
 	};
 	
 	/**
 	 * @return {Zotero.ProgressQueue[]}
 	 */
-	this.getAllQueues = function () {
+	this.getAll = function () {
 		return _queues;
 	};
 };

--- a/chrome/content/zotero/xpcom/recognizePDF.js
+++ b/chrome/content/zotero/xpcom/recognizePDF.js
@@ -407,8 +407,6 @@ Zotero.RecognizePDF = new function () {
 	 * @return {Promise}
 	 */
 	async function _recognize(item) {
-		if(!item.isAttachment()) return null;
-		
 		let filePath = await item.getFilePath();
 		
 		if (!filePath || !await OS.File.exists(filePath)) throw new Zotero.Exception.Alert('recognizePDF.fileNotFound');

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -79,10 +79,10 @@ var ZoteroPane = new function()
 		let progressQueues = Zotero.ProgressQueues.getAllQueues();
 		for (let progressQueue of progressQueues) {
 			let button = document.createElement('toolbarbutton');
-			button.id = 'zotero-tb-pq-' + progressQueue.getId();
+			button.id = 'zotero-tb-pq-' + progressQueue.getID();
 			button.hidden = progressQueue.getTotal() < 1;
 			button.addEventListener('command', function () {
-				Zotero_ProgressQueue_Dialogs.getDialog(progressQueue.getId()).open();
+				Zotero_ProgressQueue_Dialogs.getDialog(progressQueue.getID()).open();
 			}, false);
 			
 			progressQueue.addListener('empty', function () {

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -76,13 +76,13 @@ var ZoteroPane = new function()
 		
 		// Init toolbar buttons for all progress queues
 		let progressQueueButtons = document.getElementById('zotero-pq-buttons');
-		let progressQueues = Zotero.ProgressQueues.getAllQueues();
+		let progressQueues = Zotero.ProgressQueues.getAll();
 		for (let progressQueue of progressQueues) {
 			let button = document.createElement('toolbarbutton');
 			button.id = 'zotero-tb-pq-' + progressQueue.getID();
 			button.hidden = progressQueue.getTotal() < 1;
 			button.addEventListener('command', function () {
-				Zotero_ProgressQueue_Dialogs.getDialog(progressQueue.getID()).open();
+				Zotero.ProgressQueues.get(progressQueue.getID()).getDialog().open();
 			}, false);
 			
 			progressQueue.addListener('empty', function () {
@@ -4481,7 +4481,7 @@ var ZoteroPane = new function()
 	
 	this.recognizeSelected = function() {
 		Zotero.RecognizePDF.recognizeItems(ZoteroPane.getSelectedItems());
-		Zotero_ProgressQueue_Dialogs.getDialog('recognize').open();
+		Zotero.ProgressQueues.get('recognize').getDialog().open();
 	};
 	
 	

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -74,14 +74,27 @@ var ZoteroPane = new function()
 		// Set key down handler
 		document.getElementById('appcontent').addEventListener('keydown', ZoteroPane_Local.handleKeyDown, true);
 		
-		// Hide or show the PDF recognizer button
-		Zotero.RecognizePDF.addListener('empty', function (row) {
-			document.getElementById('zotero-tb-recognize').hidden = true;
-		});
-		
-		Zotero.RecognizePDF.addListener('nonempty', function (row) {
-			document.getElementById('zotero-tb-recognize').hidden = false;
-		});
+		// Init toolbar buttons for all progress queues
+		let progressQueueButtons = document.getElementById('zotero-pq-buttons');
+		let progressQueues = Zotero.ProgressQueues.getAllQueues();
+		for (let progressQueue of progressQueues) {
+			let button = document.createElement('toolbarbutton');
+			button.id = 'zotero-tb-pq-' + progressQueue.getId();
+			button.hidden = progressQueue.getTotal() < 1;
+			button.addEventListener('command', function () {
+				Zotero_ProgressQueue_Dialogs.getDialog(progressQueue.getId()).open();
+			}, false);
+			
+			progressQueue.addListener('empty', function () {
+				button.hidden = true;
+			});
+			
+			progressQueue.addListener('nonempty', function () {
+				button.hidden = false;
+			});
+			
+			progressQueueButtons.appendChild(button);
+		}
 		
 		_loaded = true;
 		
@@ -4468,7 +4481,7 @@ var ZoteroPane = new function()
 	
 	this.recognizeSelected = function() {
 		Zotero.RecognizePDF.recognizeItems(ZoteroPane.getSelectedItems());
-		Zotero_RecognizePDF_Dialog.open();
+		Zotero_ProgressQueue_Dialogs.getDialog('recognize').open();
 	};
 	
 	

--- a/chrome/content/zotero/zoteroPane.xul
+++ b/chrome/content/zotero/zoteroPane.xul
@@ -42,7 +42,7 @@
 	<script src="fileInterface.js"/>
 	<script src="reportInterface.js"/>
 	<script src="timelineInterface.js"/>
-	<script src="recognizePDFDialog.js"/>
+	<script src="progressQueueDialog.js"/>
 	<script src="lookup.js"/>
 	<script src="locateMenu.js" type="application/javascript;version=1.8"/>
 	
@@ -185,8 +185,8 @@
 						</hbox>
 					</hbox>
 
-					<toolbarbutton id="zotero-tb-recognize" hidden="true"
-						oncommand="Zotero_RecognizePDF_Dialog.open()"/>
+					<hbox id="zotero-pq-buttons">
+					</hbox>
 
 					<toolbarbutton id="zotero-tb-sync-error" hidden="true"/>
 					

--- a/chrome/locale/en-US/zotero/zotero.dtd
+++ b/chrome/locale/en-US/zotero/zotero.dtd
@@ -288,9 +288,6 @@
 <!ENTITY zotero.feedSettings.cleanupReadAfter.label1         "Remove read feed items after">
 <!ENTITY zotero.feedSettings.cleanupReadAfter.label2         "day(s)">
 
-<!ENTITY zotero.recognizePDF.pdfName.label				"PDF Name">
-<!ENTITY zotero.recognizePDF.itemName.label				"Item Name">
-
 <!ENTITY zotero.rtfScan.title		                    "RTF Scan">
 <!ENTITY zotero.rtfScan.cancel.label					"Cancel">
 <!ENTITY zotero.rtfScan.citation.label					"Citation">

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -66,6 +66,7 @@ general.copyToClipboard = Copy to Clipboard
 general.cancel			= Cancel
 general.clear			= Clear
 general.processing      = Processing
+general.finished      = Finished
 general.submitted      = Submitted
 general.thanksForHelpingImprove = Thanks for helping to improve %S!
 general.describeProblem			= Briefly describe the problem:
@@ -1069,6 +1070,7 @@ proxies.notification.settings.button	= Proxy Settings…
 proxies.recognized.message			= Adding this proxy will allow Zotero to recognize items from its pages and will automatically redirect future requests to %1$S through %2$S.
 proxies.recognized.add				= Add Proxy
 
+recognizePDF.title					= PDF Metadata Retrieval
 recognizePDF.noOCR					= PDF does not contain OCRed text
 recognizePDF.couldNotRead			= Could not read text from PDF
 recognizePDF.noMatches				= No matching references found
@@ -1077,6 +1079,8 @@ recognizePDF.error				    = An unexpected error occurred
 recognizePDF.recognizing.label      = Retrieving Metadata…
 recognizePDF.complete.label			= Metadata Retrieval Complete
 recognizePDF.reportMetadata			= Report Incorrect Metadata
+recognizePDF.pdfName.label			= PDF Name
+recognizePDF.itemName.label         = Item Name
 
 rtfScan.openTitle					= Select a file to scan
 rtfScan.scanning.label				= Scanning RTF Document…

--- a/chrome/skin/default/zotero/overlay.css
+++ b/chrome/skin/default/zotero/overlay.css
@@ -608,11 +608,11 @@
 	text-align: right;
 }
 
-#zotero-tb-recognize {
+#zotero-tb-pq-recognize {
 	list-style-image: url(chrome://zotero/skin/pdf-search.png);
 }
 
-#zotero-tb-recognize .toolbarbutton-icon {
+#zotero-tb-pq-recognize .toolbarbutton-icon {
 	width: 18px;
 	margin-top: 1px;
 }
@@ -764,7 +764,7 @@
 	#zotero-tb-advanced-search { list-style-image: url('chrome://zotero/skin/toolbar-advanced-search@2x.png'); }
 	#zotero-tb-locate { list-style-image: url('chrome://zotero/skin/toolbar-go-arrow@2x.png'); }
 	#zotero-tb-sync-stop { list-style-image: url(chrome://zotero/skin/control_stop_blue@2x.png); }
-	#zotero-tb-recognize  { list-style-image: url(chrome://zotero/skin/pdf-search@2x.png); }
+	#zotero-tb-pq-recognize  { list-style-image: url(chrome://zotero/skin/pdf-search@2x.png); }
 	#zotero-tb-sync-error  { list-style-image: url(chrome://zotero/skin/error@2x.png); }
 	#zotero-tb-sync-error[state=warning]  { list-style-image: url(chrome://zotero/skin/warning@2x.png); }
 	#zotero-tb-sync  { list-style-image: url(chrome://zotero/skin/arrow_rotate_static@2x.png); }

--- a/components/zotero-service.js
+++ b/components/zotero-service.js
@@ -105,6 +105,7 @@ const xpcomFilesLocal = [
 	'mime',
 	'notifier',
 	'openPDF',
+	'progressQueue',
 	'quickCopy',
 	'recognizePDF',
 	'report',

--- a/components/zotero-service.js
+++ b/components/zotero-service.js
@@ -106,6 +106,7 @@ const xpcomFilesLocal = [
 	'notifier',
 	'openPDF',
 	'progressQueue',
+	'progressQueueDialog',
 	'quickCopy',
 	'recognizePDF',
 	'report',

--- a/test/content/support.js
+++ b/test/content/support.js
@@ -20,9 +20,9 @@ function waitForDOMEvent(target, event, capture) {
 }
 
 async function waitForRecognizer() {
-	var win = await waitForWindow('chrome://zotero/content/recognizePDFDialog.xul')
+	var win = await waitForWindow('chrome://zotero/content/progressQueueDialog.xul')
 	// Wait for status to show as complete
-	var completeStr = Zotero.getString("recognizePDF.complete.label");
+	var completeStr = Zotero.getString("general.finished");
 	while (win.document.getElementById("label").value != completeStr) {
 		await Zotero.Promise.delay(20);
 	}

--- a/test/tests/itemTreeViewTest.js
+++ b/test/tests/itemTreeViewTest.js
@@ -932,7 +932,7 @@ describe("Zotero.ItemTreeView", function() {
 			
 			var progressWindow = await recognizerPromise;
 			progressWindow.close();
-			Zotero.ProgressQueues.getQueue('recognize').cancel();
+			Zotero.ProgressQueues.get('recognize').cancel();
 			assert.isFalse(item.isTopLevelItem());
 			
 			Zotero.HTTP.mock = null;

--- a/test/tests/itemTreeViewTest.js
+++ b/test/tests/itemTreeViewTest.js
@@ -932,7 +932,7 @@ describe("Zotero.ItemTreeView", function() {
 			
 			var progressWindow = await recognizerPromise;
 			progressWindow.close();
-			Zotero.RecognizePDF.cancel();
+			Zotero.ProgressQueues.getQueue('recognize').cancel();
 			assert.isFalse(item.isTopLevelItem());
 			
 			Zotero.HTTP.mock = null;

--- a/test/tests/recognizePDFTest.js
+++ b/test/tests/recognizePDFTest.js
@@ -19,7 +19,7 @@ describe("PDF Recognition", function() {
 		for(let win of getWindows("chrome://zotero/content/progressQueueDialog.xul")) {
 			win.close();
 		}
-		Zotero.ProgressQueues.getQueue('recognize').cancel();
+		Zotero.ProgressQueues.get('recognize').cancel();
 	});
 	
 	after(function() {

--- a/test/tests/recognizePDFTest.js
+++ b/test/tests/recognizePDFTest.js
@@ -16,10 +16,10 @@ describe("PDF Recognition", function() {
 	});
 	
 	afterEach(function() {
-		for(let win of getWindows("chrome://zotero/content/recognizePDFDialog.xul")) {
+		for(let win of getWindows("chrome://zotero/content/progressQueueDialog.xul")) {
 			win.close();
 		}
-		Zotero.RecognizePDF.cancel();
+		Zotero.ProgressQueues.getQueue('recognize').cancel();
 	});
 	
 	after(function() {
@@ -50,8 +50,8 @@ describe("PDF Recognition", function() {
 		assert.lengthOf(modifiedIDs, 2);
 		
 		// Wait for status to show as complete
-		var progressWindow = getWindows("chrome://zotero/content/recognizePDFDialog.xul")[0];
-		var completeStr = Zotero.getString("recognizePDF.complete.label");
+		var progressWindow = getWindows("chrome://zotero/content/progressQueueDialog.xul")[0];
+		var completeStr = Zotero.getString("general.finished");
 		while (progressWindow.document.getElementById("label").value != completeStr) {
 			await Zotero.Promise.delay(20);
 		}
@@ -84,8 +84,8 @@ describe("PDF Recognition", function() {
 		assert.lengthOf(modifiedIDs, 1);
 		
 		// Wait for status to show as complete
-		var progressWindow = getWindows("chrome://zotero/content/recognizePDFDialog.xul")[0];
-		var completeStr = Zotero.getString("recognizePDF.complete.label");
+		var progressWindow = getWindows("chrome://zotero/content/progressQueueDialog.xul")[0];
+		var completeStr = Zotero.getString("general.finished");
 		while (progressWindow.document.getElementById("label").value != completeStr) {
 			await Zotero.Promise.delay(20);
 		}
@@ -118,8 +118,8 @@ describe("PDF Recognition", function() {
 		assert.lengthOf(modifiedIDs, 1);
 		
 		// Wait for status to show as complete
-		var progressWindow = getWindows("chrome://zotero/content/recognizePDFDialog.xul")[0];
-		var completeStr = Zotero.getString("recognizePDF.complete.label");
+		var progressWindow = getWindows("chrome://zotero/content/progressQueueDialog.xul")[0];
+		var completeStr = Zotero.getString("general.finished");
 		while (progressWindow.document.getElementById("label").value != completeStr) {
 			await Zotero.Promise.delay(20);
 		}
@@ -149,8 +149,8 @@ describe("PDF Recognition", function() {
 		assert.lengthOf(modifiedIDs, 1);
 		
 		// Wait for status to show as complete
-		var progressWindow = getWindows("chrome://zotero/content/recognizePDFDialog.xul")[0];
-		var completeStr = Zotero.getString("recognizePDF.complete.label");
+		var progressWindow = getWindows("chrome://zotero/content/progressQueueDialog.xul")[0];
+		var completeStr = Zotero.getString("general.finished");
 		while (progressWindow.document.getElementById("label").value != completeStr) {
 			await Zotero.Promise.delay(20);
 		}
@@ -179,8 +179,8 @@ describe("PDF Recognition", function() {
 		assert.lengthOf(modifiedIDs, 2);
 		
 		// Wait for status to show as complete
-		var progressWindow = getWindows("chrome://zotero/content/recognizePDFDialog.xul")[0];
-		var completeStr = Zotero.getString("recognizePDF.complete.label");
+		var progressWindow = getWindows("chrome://zotero/content/progressQueueDialog.xul")[0];
+		var completeStr = Zotero.getString("general.finished");
 		while (progressWindow.document.getElementById("label").value != completeStr) {
 			await Zotero.Promise.delay(20);
 		}
@@ -209,8 +209,8 @@ describe("PDF Recognition", function() {
 		assert.lengthOf(modifiedIDs, 2);
 		
 		// Wait for status to show as complete
-		var progressWindow = getWindows("chrome://zotero/content/recognizePDFDialog.xul")[0];
-		var completeStr = Zotero.getString("recognizePDF.complete.label");
+		var progressWindow = getWindows("chrome://zotero/content/progressQueueDialog.xul")[0];
+		var completeStr = Zotero.getString("general.finished");
 		while (progressWindow.document.getElementById("label").value != completeStr) {
 			await Zotero.Promise.delay(20);
 		}

--- a/test/tests/server_connectorTest.js
+++ b/test/tests/server_connectorTest.js
@@ -843,7 +843,7 @@ describe("Connector Server", function () {
 			
 			var progressWindow = await recognizerPromise;
 			progressWindow.close();
-			Zotero.ProgressQueues.getQueue('recognize').cancel();
+			Zotero.ProgressQueues.get('recognize').cancel();
 			assert.isFalse(item.isTopLevelItem());
 			
 			stub.restore();

--- a/test/tests/server_connectorTest.js
+++ b/test/tests/server_connectorTest.js
@@ -843,7 +843,7 @@ describe("Connector Server", function () {
 			
 			var progressWindow = await recognizerPromise;
 			progressWindow.close();
-			Zotero.RecognizePDF.cancel();
+			Zotero.ProgressQueues.getQueue('recognize').cancel();
 			assert.isFalse(item.isTopLevelItem());
 			
 			stub.restore();


### PR DESCRIPTION
Any number of progress queues can be created at Zotero client initialization time with `Zotero.ProgressQueues.createQueue`. Queues can only be used with items. `Zotero_ProgressQueue_Dialogs` creates a dialog for each queue  and zoteroPane adds a toolbar button for each queue too. Queues are also waiting for internet connection.