### PR TITLE
Async translators

### DIFF
--- a/chrome/content/zotero/xpcom/translation/translate.js
+++ b/chrome/content/zotero/xpcom/translation/translate.js
@@ -1712,17 +1712,18 @@ Zotero.Translate.Base.prototype = {
 	/**
 	 * Runs detect code for a translator
 	 */
-	"_detectTranslatorLoaded":function() {
+	_detectTranslatorLoaded: async function () {
 		this._prepareDetection();
 		
 		this.incrementAsyncProcesses("Zotero.Translate#getTranslators");
 		
-		try {
-			var returnValue = Function.prototype.apply.call(this._sandboxManager.sandbox["detect"+this._entryFunctionSuffix], null, this._getParameters());
-		} catch(e) {
-			this.complete(false, e);
-			return;
-		}
+		var maybePromise = Function.prototype.apply.call(
+			this._sandboxManager.sandbox["detect" + this._entryFunctionSuffix],
+			null,
+			this._getParameters()
+		);
+		// If detect* returns a promise, wait for it
+		var returnValue = (maybePromise && maybePromise.then) ? await maybePromise : maybePromise;
 		
 		if(returnValue !== undefined) this._returnValue = returnValue;
 		this.decrementAsyncProcesses("Zotero.Translate#getTranslators");

--- a/chrome/content/zotero/xpcom/translation/translate.js
+++ b/chrome/content/zotero/xpcom/translation/translate.js
@@ -352,7 +352,7 @@ Zotero.Translate.Sandbox = {
 			};
 			
 			var translatorsHandlerSet = false;
-			safeTranslator.getTranslators = function() {
+			safeTranslator.getTranslators = async function () {
 				if(!translation._handlers["translators"] || !translation._handlers["translators"].length) {
 					throw new Error('Translator must register a "translators" handler to '+
 						'call getTranslators() in this translation environment.');
@@ -367,7 +367,7 @@ Zotero.Translate.Sandbox = {
 			};
 			
 			var doneHandlerSet = false;
-			safeTranslator.translate = function() {
+			safeTranslator.translate = async function () {
 				translate.incrementAsyncProcesses("safeTranslator#translate()");
 				setDefaultHandlers(translate, translation);
 				if(!doneHandlerSet) {
@@ -378,7 +378,7 @@ Zotero.Translate.Sandbox = {
 					errorHandlerSet = true;
 					translation.setHandler("error", function(obj, error) { translate.complete(false, error) });
 				}
-				translation.translate(false);
+				return translation.translate(false);
 			};
 			
 			safeTranslator.getTranslatorObject = function(callback) {

--- a/chrome/content/zotero/xpcom/utilities_translate.js
+++ b/chrome/content/zotero/xpcom/utilities_translate.js
@@ -280,6 +280,18 @@ Zotero.Utilities.Translate.prototype.processDocuments = async function (urls, pr
 	translate.decrementAsyncProcesses("Zotero.Utilities.Translate#processDocuments");
 }
 
+Zotero.Utilities.Translate.prototype.request = async function (method, url, options = {}) {
+	options = Object.assign(
+		{},
+		options,
+		{
+			headers: Object.assign({}, this._translate.requestHeaders, options.headers),
+			cookieSandbox: this._translate.cookieSandbox
+		}
+	);
+	return Zotero.HTTP.request(method, url, options);
+};
+
 /**
 * Send an HTTP GET request via XMLHTTPRequest
 * 


### PR DESCRIPTION
This is a staging ground for full `async`/`await` support in translators. Both `detect*()` and `do*()` can now be marked as `async` and can use `await` to wait for promise-returning functions. (Import translators could already return a promise from `doImport()` and do incremental saving via promise-returning `item.complete()` functions, but it was hacky and unpleasant.)

This change is made possible by @adomasven's removal of the Mozilla sandbox in favor of a less-secure `eval()`-based sandbox like what we use in the connectors. We're comfortable doing that because 1) we now load remote pages with XHR/DOMParser rather using hidden browsers and running translators in those browsers, so we're not worried about untrusted JS on remote pages potentially getting access to privileged code and 2) we review translator code and can make sure translators are using only the translator API and aren't using `eval()`, so we don't need as strict isolation from globals or other Zotero code that might be accessible somehow. We might still want to do some initial page loads in hidden browsers, but if necessary we can always let the JS run and then reparse the DOM with DOMParser to get a safe static document, at the cost of some efficiency.

Currently, this exposes the promise-based `Zotero.HTTP.request()` as `ZU.request()`, which returns a promise for an XMLHttpRequest object. That may be a bit too verbose to expose directly to translators, so we need to figure out what request functionality translators really need and what it should look like. (CCing @adam3smith and @zuphilip for any thoughts they have on this.) Among other things:

  * `doGet()`/`doPost()` automatically fail translation on non-2xx status codes. We probably want to keep that in general, but some translators could possibly benefit from specifying that 403 or 404 isn't a fatal error. The main question is whether translators actually need a response object that allows them to check the response status code and content type. It may be enough 1) for 403/404 (when explicitly allowed?) to result in a promise resolution of `null` or to throw the promise with an `HTTP.UnexpectedStatusException` that lets you check `.status` without throwing translation and 2) for content type to be ignored or handled with string checks (e.g., does this look like RIS?).
  * We should simplify the `Zotero.HTTP.request()` signature in general (both for translators and for the rest of Zotero) to allow a URL in the first parameter, similar to `fetch()`, and do a GET if not specified in `options`. (Technically a `body` in `options` could even make it default to POST, though `method` would still be possible in `options` for other methods.)
  * `doGet()`/`doPost()` return raw text, which is useful for anything retrieving BibTeX/RIS/etc. It would be nice to be able to just do `var ris = await request(url);`.
  * We can probably stop using `processDocuments()` altogether, since `Zotero.HTTP.request()` supports `response: 'document'`. Instead you'd just do a loop and run the handler function on the `await`ed response. As above, if we didn't return a response object we'd need to decide how to convey that a response either couldn't be parsed as a document or was a 403/404. `null` is probably sufficient for the former, and the latter could be either `null` or a thrown promise. Maybe a translator doesn't care about the distinction and only cares whether it got 1) a 200 and an HTML document or 2) something else?

We won't be able to start using this in translators for probably a month after the first release that includes it, at which time we can cut off translator updates for older versions.

Down the line, it would be nice to get rid of the callback-based functions so that we can remove the horrible `incrementAsyncProcesses()`/etc. stuff in the translator framework.