### PR TITLE
Print highlight colors in Reports

### DIFF
--- a/chrome/skin/default/zotero/report/detail_print.css
+++ b/chrome/skin/default/zotero/report/detail_print.css
@@ -13,8 +13,6 @@ h1, h2, h3, h4, h5, h6 {
 
 ul, ol, dl {
 	page-break-inside: avoid;
-	-webkit-print-color-adjust: exact;
-	printer-colors: exact;
 	color-adjust: exact;
 }
 

--- a/chrome/skin/default/zotero/report/detail_print.css
+++ b/chrome/skin/default/zotero/report/detail_print.css
@@ -13,6 +13,9 @@ h1, h2, h3, h4, h5, h6 {
 
 ul, ol, dl {
 	page-break-inside: avoid;
+	-webkit-print-color-adjust: exact;
+	printer-colors: exact;
+	color-adjust: exact;
 }
 
 h2 {


### PR DESCRIPTION
https://forums.zotero.org/discussion/72505/color-highlights-disappear-when-i-print-a-report#latest