### PR TITLE
Fix integration for citeproc 1.1.215

### DIFF
--- a/chrome/content/zotero/xpcom/integration.js
+++ b/chrome/content/zotero/xpcom/integration.js
@@ -1661,7 +1661,7 @@ Zotero.Integration.Session.prototype._updateCitations = async function () {
 	
 	var [citations, fieldToCitationIdxMapping, citationToFieldIdxMapping] = this.getCiteprocLists();
 
-	var updateIndices = {};
+	var updateIndices = Object.assign({}, this.updateIndices);
 	for (let indexList of [this.newIndices, this.updateIndices]) {
 		for (let index in indexList) {
 			// Jump to next event loop step for UI updates

--- a/chrome/content/zotero/xpcom/integration.js
+++ b/chrome/content/zotero/xpcom/integration.js
@@ -1212,8 +1212,12 @@ Zotero.Integration.Fields.prototype.addEditCitation = async function (field) {
 		for (var nextIdx = idx+1; nextIdx < fields.length; nextIdx++) {
 			if (nextIdx in fieldToCitationIdxMapping) break;
 		}
+		var nextMappedIdx = fieldToCitationIdxMapping[nextIdx];
+		if (nextMappedIdx === undefined) {
+			nextMappedIdx = fields.length;
+		}
 		let citationsPre = citations.slice(0, fieldToCitationIdxMapping[prevIdx]+1);
-		let citationsPost = citations.slice(fieldToCitationIdxMapping[nextIdx]);
+		let citationsPost = citations.slice(nextMappedIdx);
 		let citationID = citation.citationID;
 		try {
 			var result = this._session.style.previewCitationCluster(citation, citationsPre, citationsPost, "rtf");

--- a/chrome/content/zotero/xpcom/integration.js
+++ b/chrome/content/zotero/xpcom/integration.js
@@ -1600,7 +1600,7 @@ Zotero.Integration.Session.prototype.addCitation = Zotero.Promise.coroutine(func
 	}
 	
 	// We need a new ID if there's another citation with the same citation ID in this document
-	var duplicateIndex = this.documentCitationIDs[citation.citationID];
+	var duplicateIndex = this.documentCitationIDs[citation.citationID] != citation.properties.zoteroIndex ? this.documentCitationIDs[citation.citationID] : undefined;
 	var needNewID = !citation.citationID || duplicateIndex != undefined;
 	if(needNewID) {
 		if (duplicateIndex != undefined) {
@@ -1656,6 +1656,12 @@ Zotero.Integration.Session.prototype._updateCitations = async function () {
 	Zotero.debug(Object.keys(this.updateIndices));
 	
 	var [citations, fieldToCitationIdxMapping, citationToFieldIdxMapping] = this.getCiteprocLists();
+
+	for (var index in this.newIndices) {
+		if (this.updateIndices[index] !== undefined) {
+			delete this.updateIndices[index];
+		}
+	}
 	
 	for (let indexList of [this.newIndices, this.updateIndices]) {
 		for (let index in indexList) {

--- a/chrome/content/zotero/xpcom/integration.js
+++ b/chrome/content/zotero/xpcom/integration.js
@@ -1657,14 +1657,16 @@ Zotero.Integration.Session.prototype._updateCitations = async function () {
 	
 	var [citations, fieldToCitationIdxMapping, citationToFieldIdxMapping] = this.getCiteprocLists();
 
-	for (var index in this.newIndices) {
-		if (this.updateIndices[index] !== undefined) {
-			delete this.updateIndices[index];
-		}
-	}
-	
+	var outerLoopCounter = 0;
+	var newIndicesCopy = JSON.parse(JSON.stringify(this.newIndices));
 	for (let indexList of [this.newIndices, this.updateIndices]) {
+		outerLoopCounter++;
 		for (let index in indexList) {
+			if (outerLoopCounter === 2) {
+				if (newIndicesCopy[index]) {
+					continue;
+				}
+			}
 			// Jump to next event loop step for UI updates
 			await Zotero.Promise.delay();
 			index = parseInt(index);

--- a/chrome/content/zotero/xpcom/integration.js
+++ b/chrome/content/zotero/xpcom/integration.js
@@ -1657,16 +1657,9 @@ Zotero.Integration.Session.prototype._updateCitations = async function () {
 	
 	var [citations, fieldToCitationIdxMapping, citationToFieldIdxMapping] = this.getCiteprocLists();
 
-	var outerLoopCounter = 0;
-	var newIndicesCopy = JSON.parse(JSON.stringify(this.newIndices));
+	var updateIndices = {};
 	for (let indexList of [this.newIndices, this.updateIndices]) {
-		outerLoopCounter++;
 		for (let index in indexList) {
-			if (outerLoopCounter === 2) {
-				if (newIndicesCopy[index]) {
-					continue;
-				}
-			}
 			// Jump to next event loop step for UI updates
 			await Zotero.Promise.delay();
 			index = parseInt(index);
@@ -1693,12 +1686,13 @@ Zotero.Integration.Session.prototype._updateCitations = async function () {
 			
 			for (let citationInfo of newCitations) {
 				let idx = fieldToCitationIdxMapping[citationInfo[0]], text = citationInfo[1];
-				this.updateIndices[idx] = true;
+				updateIndices[idx] = true;
 				this.citationsByIndex[idx].text = text;
 			}
 			
 		}
 	}
+	this.updateIndices = updateIndices;
 }
 
 /**


### PR DESCRIPTION
This pull request addresses test suite failures triggered by `citeproc-js` version 1.1.215, and reported at https://github.com/Juris-M/citeproc-js/issues/98. The anomalies shown in the trace posted to the linked issue have two causes: the marking of an existing citation as a duplicate (it looks as though this affected all citation edits); and multiple iterations of `citeproc-js` on the same index and citation data. I don't fully understand the integration layer, but all integration tests pass with these changes:
* Mark citations as duplicates only if they are at a different index from the citation to be inserted.
* Skip citation indices present in `newIndices` when processing `updateIndices`, to avoid redundant runs of `citeproc-js`.

(**Edit:** changed "Remove" to "Skip" in the second bullet-point, with other edits. See further notes below.)