### PR TITLE
Test for bibliography sort update on change to item

### DIFF
--- a/test/tests/integrationTest.js
+++ b/test/tests/integrationTest.js
@@ -485,6 +485,35 @@ describe("Zotero.Integration", function () {
 
 				getCiteprocBibliographySpy.restore();
 			});
+
+			it('should update bibliography sort order on change to item', function* () {
+				yield insertMultipleCitations.call(this);
+				var docID = this.test.fullTitle();
+				var doc = applications[docID].doc;
+
+				let getCiteprocBibliographySpy =
+					sinon.spy(Zotero.Integration.Bibliography.prototype, 'getCiteprocBibliography');
+
+				yield execCommand('addEditBibliography', docID);
+				assert.isTrue(getCiteprocBibliographySpy.calledOnce);
+
+				assert.equal(getCiteprocBibliographySpy.lastCall.returnValue[0].entry_ids.length, 3);
+				getCiteprocBibliographySpy.reset();
+
+				sinon.stub(doc, 'cursorInField').resolves(doc.fields[1]);
+				sinon.stub(doc, 'canInsertField').resolves(false);
+
+				testItems[1].setCreator(0, {creatorType: 'author', name: 'Aaaaa'});
+				testItems[1].setField('title', 'Bbbbb');
+
+				setAddEditItems(testItems.slice(1, 3));
+				yield execCommand('addEditCitation', docID);
+
+				assert.equal(getCiteprocBibliographySpy.lastCall.returnValue[0].entry_ids.length, 3);
+				assert.equal(getCiteprocBibliographySpy.lastCall.returnValue[1][0], "Aaaaa Bbbbb.");
+
+				getCiteprocBibliographySpy.restore();
+			});
 			
 			describe('when original citation text has been modified', function() {
 				var displayAlertStub;


### PR DESCRIPTION
This pull request adds a test for the behavior noted in https://github.com/zotero/zotero/issues/1631, which led to the 1.1.215 update to `citeproc-js`. The test will fail with the current 1.1.212 processor version, but will pass when https://github.com/zotero/zotero/pull/1638 is merged and the 1.1.215 version of the processor is installed.