### PR TITLE
Fix unescapeHTML on node.js

### DIFF
--- a/chrome/content/zotero/xpcom/utilities.js
+++ b/chrome/content/zotero/xpcom/utilities.js
@@ -546,17 +546,9 @@ Zotero.Utilities = {
 				node.innerHTML = str;
 				return node.textContent.replace(/ {2,}/g, " ");
 			} else if(Zotero.isNode) {
-				/*var doc = require('jsdom').jsdom(str, null, {
-					"features":{
-						"FetchExternalResources":false,
-						"ProcessExternalResources":false,
-						"MutationEvents":false,
-						"QuerySelector":false
-					}
-				});
-				if(!doc.documentElement) return str;
-				return doc.documentElement.textContent;*/
-				return Zotero.Utilities.cleanTags(str);
+				let {JSDOM} = require('jsdom');
+				let document = (new JSDOM(str)).window.document;
+				return document.documentElement.textContent.replace(/ {2,}/g, " ");
 			} else {
 				if(!node) node = document.createElement("div");
 				node.innerHTML = str;


### PR DESCRIPTION
Solves zotero/translation-server#88.

Although it's not very elegant to put multi platform code to Zotero client, but this is what we are doing already.