### PR TITLE
Handle handingindent return from citeproc-js as boolean

### DIFF
--- a/chrome/content/zotero/xpcom/cite.js
+++ b/chrome/content/zotero/xpcom/cite.js
@@ -206,7 +206,7 @@ Zotero.Cite = {
 				}
 				// If only one field, apply hanging indent on root
 				else if (!multiField) {
-					style += "margin-left: " + hangingIndent + "em; text-indent:-" + hangingIndent + "em;";
+					style += "margin-left: 2em; text-indent:-2em;";
 				}
 			}
 			
@@ -259,7 +259,7 @@ Zotero.Cite = {
 				divStyle = "margin: 0 .4em 0 " + (secondFieldAlign ? maxOffset + rightPadding : "0") + "em;";
 				
 				if (hangingIndent) {
-					divStyle += "padding-left: " + hangingIndent + "em; text-indent:-" + hangingIndent + "em;";
+					divStyle += "padding-left: 2em; text-indent:-2em;";
 				}
 				
 				div.setAttribute("style", divStyle);


### PR DESCRIPTION
This PR addresses an issue raised by Derek Sifford a couple of years ago that I've been slow to move on, concerning a spec violation by the processor:

* **citeproc-js issue:** https://github.com/Juris-M/citeproc-js/issues/15
* **CSL spec language:** http://docs.citationstyles.org/en/1.0.1/specification.html#whitespace


