### PR TITLE
Display a more user-friendly error for integration errors

### DIFF
--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -873,6 +873,7 @@ integration.error.styleNotFound = The citation style %S could not be found.
 integration.error.macWordSBPermissionsMissing.title = Missing Permission
 integration.error.macWordSBPermissionsMissing = Zotero does not have permission to control Word. To grant this permission:\n\n1) Open System Preferences\n2) Click on “Security & Privacy”\n3) Select the “Privacy” tab\n4) Find and select “Automation” on the left\n5) Check the checkbox for “Microsoft Word” under “Zotero”\n6) Restart Word
 integration.error.macWordSBPermissionsMissing.pre2016 = If “Microsoft Word” does not appear under “Automation”, make sure you are running Word 2011 version 14.7.7 or later.
+integration.error.seeTroubleshootingInfo	= Would you like to see the troubleshooting instructions?
 
 integration.replace						= Replace this Zotero field?
 integration.missingItem.single			= The highlighted citation no longer exists in your Zotero database. Do you want to select a substitute item?


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5899315/55089788-a5f3d080-50b6-11e9-967a-63ccb018df82.png)

We cannot use Zotero to display prompts because those tend to not focus the Zotero window properly. We cannot display prompts with options other than Yes/No/Ok/Cancel in Word and LibreOffice, so no "More Info" buttons either. To test add 

```
throw new Error("test");
```
at https://github.com/adomasven/zotero/blob/0cb056c994ccd4fa493a60d473d36638781afe0b/chrome/content/zotero/xpcom/integration.js#L248

Closes #1666