### PR TITLE
Add per library linked attachment base directory support

### DIFF
--- a/chrome/content/zotero/preferences/libraryAttachmentBaseDirs.xul
+++ b/chrome/content/zotero/preferences/libraryAttachmentBaseDirs.xul
@@ -1,0 +1,67 @@
+<?xml version="1.0"?>
+<!--
+    ***** BEGIN LICENSE BLOCK *****
+
+    Copyright © 2007 Center for History and New Media
+                     George Mason University, Fairfax, Virginia, USA
+                     http://zotero.org
+
+    This file is part of Zotero.
+
+    Zotero is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Zotero is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
+
+    ***** END LICENSE BLOCK *****
+-->
+
+<?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
+<?xml-stylesheet href="chrome://zotero/skin/preferences.css"?>
+
+
+<!DOCTYPE window [
+  <!ENTITY % prefWindow SYSTEM "chrome://zotero/locale/preferences.dtd">
+  %prefWindow;
+  <!ENTITY % common SYSTEM "chrome://zotero/locale/zotero.dtd">
+  %common;
+]>
+
+<dialog xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
+	title="" buttons="accept"
+	id="zotero-libraryAttachmentBaseDirs"
+	onload="Zotero_Preferences.Attachment_Base_Directory.initLibraryAttachmentBaseDirs(); sizeToContent()" >
+
+	<script src="chrome://zotero/content/include.js"/>
+	<script src="preferences.js"/>
+	<script src="preferences_advanced.js"/>
+
+	<groupbox>
+		<caption label="Library Attachment Base Directories"/>
+
+		<tree id="library-attachment-base-dirs-tree" flex="1" width="515" hidecolumnpicker="true" rows="10" seltype="single" editable="true"
+			ondblclick="Zotero_Preferences.Attachment_Base_Directory.dblClickLibraryAttachmentBaseDir(event);"
+            onclick="Zotero_Preferences.Attachment_Base_Directory.clickLibraryAttachmentBaseDir(event);">
+            <treecols>
+                <treecol editable="true" type="checkbox" id="library-attachment-base-dirs-checked" label="Enable"/>
+                <treecol editable="false" id="library-attachment-base-dirs-name" flex="1" label="&zotero.preferences.sync.librariesToSync.library;"/>
+                <treecol editable="false" id="library-attachment-base-dirs-path" flex="5" label="Base Directory"/>
+            </treecols>
+			<treechildren id="library-attachment-base-dirs-rows"/>
+		</tree>
+	</groupbox>
+
+	<script>
+	<![CDATA[
+		var io = window.arguments[0];
+	]]>
+	</script>
+</dialog>

--- a/chrome/content/zotero/preferences/preferences_advanced.js
+++ b/chrome/content/zotero/preferences/preferences_advanced.js
@@ -24,6 +24,7 @@
 */
 
 Components.utils.import("resource://gre/modules/Services.jsm");
+Components.utils.import("resource://gre/modules/osfile.jsm");
 import FilePicker from 'zotero/filePicker';
 
 Zotero_Preferences.Advanced = {

--- a/chrome/content/zotero/preferences/preferences_advanced.xul
+++ b/chrome/content/zotero/preferences/preferences_advanced.xul
@@ -40,7 +40,6 @@
 			<preference id="pref-automaticScraperUpdates" name="extensions.zotero.automaticScraperUpdates" type="bool"/>
 			<preference id="pref-reportTranslationFailure" name="extensions.zotero.reportTranslationFailure" type="bool"/>
 			
-			<preference id="pref-baseAttachmentPath" name="extensions.zotero.baseAttachmentPath" type="string"/>
 			<preference id="pref-useDataDir" name="extensions.zotero.useDataDir" type="bool"/>
 			<preference id="pref-dataDir" name="extensions.zotero.dataDir" type="string"/>
 			<preference id="pref-debug-output-enableAfterRestart" name="extensions.zotero.debug.store" type="bool"/>
@@ -156,23 +155,9 @@
 						</vbox>
 						
 						<hbox align="center">
-							<label value="&zotero.preferences.attachmentBaseDir.basePath;"/>
-							<filefield id="baseAttachmentPath"
-								preference="pref-baseAttachmentPath"
-								onsyncfrompreference="Zotero_Preferences.Attachment_Base_Directory.updateUI()"
-								preference-editable="true"
-								readonly="true"
-								flex="1"
-								tabindex="-1"/>
-							<button id="baseAttachmentPathButton"
+							<button id="attachmentBaseDirButton"
 								label="&zotero.preferences.attachmentBaseDir.selectBasePath;"
-								oncommand="Zotero_Preferences.Attachment_Base_Directory.choosePath()"/>
-						</hbox>
-						
-						<hbox>
-							<button id="resetBasePath"
-								label="&zotero.preferences.attachmentBaseDir.resetBasePath;"
-								oncommand="Zotero_Preferences.Attachment_Base_Directory.clearPath()"/>
+								oncommand="Zotero_Preferences.Attachment_Base_Directory.manageBaseDirs()"/>
 						</hbox>
 						
 					</groupbox>

--- a/chrome/content/zotero/preferences/preferences_sync.js
+++ b/chrome/content/zotero/preferences/preferences_sync.js
@@ -220,7 +220,7 @@ Zotero_Preferences.Sync = {
 	}),
 	
 	
-	showLibrariesToSyncDialog: function() {
+	showLibrariesToSyncDialog: function () {
 		var io = {};
 		window.openDialog('chrome://zotero/content/preferences/librariesToSync.xul',
 			"zotero-preferences-librariesToSyncDialog", "chrome,modal,centerscreen", io);
@@ -263,7 +263,7 @@ Zotero_Preferences.Sync = {
 		var row = treechildren.childNodes[index];
 		var val = row.firstChild.childNodes[1].getAttribute('value');
 		if (!val) {
-			return
+			return;
 		}
 		
 		var librariesToSkip = JSON.parse(Zotero.Prefs.get('sync.librariesToSkip') || '[]');

--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -23,7 +23,7 @@
  ***** END LICENSE BLOCK *****
 */
 
-Zotero.Attachments = new function(){
+Zotero.Attachments = new function () {
 	// Keep in sync with Zotero.Schema.integrityCheck()
 	this.LINK_MODE_IMPORTED_FILE = 0;
 	this.LINK_MODE_IMPORTED_URL = 1;
@@ -53,10 +53,10 @@ Zotero.Attachments = new function(){
 	this.importFromFile = Zotero.Promise.coroutine(function* (options) {
 		Zotero.debug('Importing attachment from file');
 		
-		var libraryID = options.libraryID;
 		var file = Zotero.File.pathToFile(options.file);
 		var path = file.path;
 		var leafName = file.leafName;
+		var libraryID = options.libraryID;
 		var parentItemID = options.parentItemID;
 		var title = options.title;
 		var collections = options.collections;
@@ -85,13 +85,18 @@ Zotero.Attachments = new function(){
 			yield Zotero.DB.executeTransaction(function* () {
 				// Create a new attachment
 				attachmentItem = new Zotero.Item('attachment');
-				if (parentItemID) {
+				if (libraryID) {
+					attachmentItem.libraryID = libraryID;
+				}
+				else if (parentItemID) {
 					let {libraryID: parentLibraryID, key: parentKey} =
 						Zotero.Items.getLibraryAndKeyFromID(parentItemID);
-					attachmentItem.libraryID = parentLibraryID;
-				}
-				else if (libraryID) {
-					attachmentItem.libraryID = libraryID;
+					if (parentLibraryID) {
+						attachmentItem.libraryID = parentLibraryID;
+					}
+					else {
+						Zotero.debug(`parentItemID '${parentItemID}' does not have a libraryID`);
+					}
 				}
 				attachmentItem.setField('title', title != undefined ? title : newName);
 				attachmentItem.parentID = parentItemID;
@@ -151,7 +156,9 @@ Zotero.Attachments = new function(){
 	
 	
 	/**
+	 * @param {Object} options
 	 * @param {nsIFile|String} options.file - File to add
+	 * @param {Integer} [options.libraryID] - Library ID to add item to
 	 * @param {Integer[]|String[]} [options.parentItemID] - Parent item to add item to
 	 * @param {String} [options.title]
 	 * @param {Integer[]} [options.collections] - Collection keys or ids to add new item to
@@ -164,6 +171,7 @@ Zotero.Attachments = new function(){
 		Zotero.debug('Linking attachment from file');
 		
 		var file = Zotero.File.pathToFile(options.file);
+		var libraryID = options.libraryID;
 		var parentItemID = options.parentItemID;
 		var title = options.title;
 		var collections = options.collections;
@@ -177,13 +185,14 @@ Zotero.Attachments = new function(){
 		
 		var item = yield _addToDB({
 			file,
+			libraryID,
 			title: title != undefined ? title : file.leafName,
 			linkMode: this.LINK_MODE_LINKED_FILE,
 			contentType,
 			charset,
 			parentItemID,
 			collections,
-			saveOptions
+			saveOptions,
 		});
 		try {
 			yield _postProcessFile(item, file, contentType);
@@ -196,7 +205,9 @@ Zotero.Attachments = new function(){
 	
 	
 	/**
+	 * @param {Object} options
 	 * @param {String} options.path - Relative path to file
+	 * @param {Integer} options.libraryID
 	 * @param {String} options.title
 	 * @param {String} options.contentType
 	 * @param {Integer[]|String[]} [options.parentItemID] - Parent item to add item to
@@ -208,6 +219,7 @@ Zotero.Attachments = new function(){
 		Zotero.debug('Linking attachment from file in base directory');
 		
 		var path = options.path;
+		var libraryID = options.libraryID;
 		var title = options.title;
 		var contentType = options.contentType;
 		var parentItemID = options.parentItemID;
@@ -237,6 +249,7 @@ Zotero.Attachments = new function(){
 		path = Zotero.Attachments.BASE_PATH_PLACEHOLDER + path;
 		var item = await _addToDB({
 			file: path,
+			libraryID,
 			title,
 			linkMode: this.LINK_MODE_LINKED_FILE,
 			contentType,
@@ -245,9 +258,10 @@ Zotero.Attachments = new function(){
 			saveOptions
 		});
 		
+		// At this point, item is guaranteed to have a libraryID because .save() was called on it
 		// If the file is found (which requires a base directory being set and the file existing),
 		// index it
-		var file = this.resolveRelativePath(path);
+		var file = this.resolveRelativePath(item.libraryID, path);
 		if (file && await OS.File.exists(file)) {
 			try {
 				await _postProcessFile(item, file, contentType);
@@ -264,6 +278,13 @@ Zotero.Attachments = new function(){
 	/**
 	 * @param {Object} options - 'file', 'url', 'title', 'contentType', 'charset', 'parentItemID', 'singleFile'
 	 * @param {Object} [options.saveOptions] - Options to pass to Zotero.Item::save()
+	 * @param {String} options.file
+	 * @param {String} options.url
+	 * @param {String} options.title
+	 * @param {String} options.contentType
+	 * @param {String} options.charset
+	 * @param {Integer[]|String[]} [options.parentItemID] - Parent item to add item to
+	 * @param {Boolean} options.singleFile
 	 * @return {Promise<Zotero.Item>}
 	 */
 	this.importSnapshotFromFile = Zotero.Promise.coroutine(function* (options) {
@@ -292,7 +313,12 @@ Zotero.Attachments = new function(){
 				// Create a new attachment
 				attachmentItem = new Zotero.Item('attachment');
 				let {libraryID, key: parentKey} = Zotero.Items.getLibraryAndKeyFromID(parentItemID);
-				attachmentItem.libraryID = libraryID;
+				if (libraryID) {
+					attachmentItem.libraryID = libraryID;
+				}
+				else {
+					Zotero.debug(`parentItemID '${parentItemID}' does not have a libraryID`);
+				}
 				attachmentItem.setField('title', title);
 				attachmentItem.setField('url', url);
 				attachmentItem.parentID = parentItemID;
@@ -526,7 +552,7 @@ Zotero.Attachments = new function(){
 	 *
 	 * @param {Object} options
 	 * @param {String} options.directory
-	 * @param {Number} options.libraryID
+	 * @param {Integer} options.libraryID
 	 * @param {String} options.filename
 	 * @param {String} options.url
 	 * @param {Number} [options.parentItemID]
@@ -554,7 +580,12 @@ Zotero.Attachments = new function(){
 			else if (options.parentItemID) {
 				let {libraryID: parentLibraryID, key: parentKey} =
 					Zotero.Items.getLibraryAndKeyFromID(options.parentItemID);
-				attachmentItem.libraryID = parentLibraryID;
+				if (parentLibraryID) {
+					attachmentItem.libraryID = parentLibraryID;
+				}
+				else {
+					Zotero.debug(`parentItemID '${options.parentItemID}' does not have a libraryID`);
+				}
 			}
 			attachmentItem.setField('title', options.title != undefined ? options.title : options.filename);
 			attachmentItem.setField('url', options.url);
@@ -598,6 +629,12 @@ Zotero.Attachments = new function(){
 	 *
 	 * @param {Object} options - 'url', 'parentItemID', 'contentType', 'title', 'collections'
 	 * @param {Object} [options.saveOptions] - Options to pass to Zotero.Item::save()
+	 * @param {Object} options
+	 * @param {String} options.url
+	 * @param {Number} options.parentItemID
+	 * @param {String} options.contentType
+	 * @param {String} options.title
+	 * @param {String[]} options.collections
 	 * @return {Promise<Zotero.Item>} - A promise for the created attachment item
 	 */
 	this.linkFromURL = Zotero.Promise.coroutine(function* (options) {
@@ -609,6 +646,10 @@ Zotero.Attachments = new function(){
 		var title = options.title;
 		var collections = options.collections;
 		var saveOptions = options.saveOptions;
+
+		if (parentItemID && collections) {
+			throw new Error("parentItemID and collections cannot both be provided");
+		}
 		
 		var schemeRE = /^([a-z][a-z0-9+.-]+):/;
 		var matches = url.match(schemeRE);
@@ -793,7 +834,12 @@ Zotero.Attachments = new function(){
 				else if (parentItemID) {
 					let {libraryID: parentLibraryID, key: parentKey} =
 						Zotero.Items.getLibraryAndKeyFromID(parentItemID);
-					attachmentItem.libraryID = parentLibraryID;
+					if (parentLibraryID) {
+						attachmentItem.libraryID = parentLibraryID;
+					}
+					else {
+						Zotero.debug(`parentItemID '${parentItemID}' does not have a libraryID`);
+					}
 				}
 				attachmentItem.setField('title', title);
 				attachmentItem.setField('url', url);
@@ -1835,9 +1881,9 @@ Zotero.Attachments = new function(){
 		Zotero.debug("Zotero.Attachments.cleanAttachmentURI() is deprecated -- use Zotero.Utilities.cleanURL");
 		return Zotero.Utilities.cleanURL(uri, tryHttp);
 	}
-	
-	
-	/*
+
+
+	/**
 	 * Returns a formatted string to use as the basename of an attachment
 	 * based on the metadata of the specified item and a format string
 	 *
@@ -2039,60 +2085,176 @@ Zotero.Attachments = new function(){
 		});
 		return tmpDir;
 	});
-	
-	
+
+
 	/**
-	 * If path is within the attachment base directory, return a relative
-	 * path prefixed by BASE_PATH_PLACEHOLDER. Otherwise, return unchanged.
+	 * If ``path`` is within the attachment base directory, return a relative path
+	 * prefixed by *BASE_PATH_PLACEHOLDER*. Otherwise, return ``path`` unchanged.
+	 *
+	 * @param {Integer} libraryID
+	 * @param {String} path
+	 * @return {String}
 	 */
-	this.getBaseDirectoryRelativePath = function (path) {
+	this.getBaseDirectoryRelativePath = function (libraryID, path) {
 		if (!path || path.startsWith(this.BASE_PATH_PLACEHOLDER)) {
 			return path;
 		}
-		
-		var basePath = Zotero.Prefs.get('baseAttachmentPath');
-		if (!basePath) {
+
+		var baseDir = Zotero.Attachments.getBaseDirByLibrary(libraryID);
+		if (!baseDir) {
 			return path;
 		}
-		
-		if (Zotero.File.directoryContains(basePath, path)) {
+
+		if (Zotero.File.directoryContains(baseDir, path)) {
 			// Since stored paths can be synced to other platforms, use forward slashes for consistency.
 			// resolveRelativePath() will convert to the appropriate platform-specific slash on use.
-			basePath = OS.Path.normalize(basePath).replace(/\\/g, "/");
+			baseDir = baseDir.replace(/\\/g, "/");
 			path = OS.Path.normalize(path).replace(/\\/g, "/");
 			// Normalize D:\ vs. D:\foo
-			if (!basePath.endsWith('/')) {
-				basePath += '/';
+			if (!baseDir.endsWith('/')) {
+				baseDir += '/';
 			}
-			path = this.BASE_PATH_PLACEHOLDER + path.substr(basePath.length)
+			path = this.BASE_PATH_PLACEHOLDER + path.substr(baseDir.length)
 		}
-		
+
 		return path;
 	};
-	
-	
+
+
 	/**
-	 * Get an absolute path from this base-dir relative path, if we can
+	 * Get an absolute path from this base directory relative ``path``, if we can
 	 *
-	 * @param {String} path - Absolute path or relative path prefixed by BASE_PATH_PLACEHOLDER
-	 * @return {String|false} - Absolute path, or FALSE if no path
+	 * @param {Integer} libraryID
+	 * @param {String} path - Absolute path or relative path prefixed by *BASE_PATH_PLACEHOLDER*
+	 * @return {String|false} Absolute path, or FALSE if no path
 	 */
-	this.resolveRelativePath = function (path) {
+	this.resolveRelativePath = function (libraryID, path) {
 		if (!path.startsWith(Zotero.Attachments.BASE_PATH_PLACEHOLDER)) {
 			return false;
 		}
-		
-		var basePath = Zotero.Prefs.get('baseAttachmentPath');
-		if (!basePath) {
-			Zotero.debug("No base attachment path set -- can't resolve '" + path + "'", 2);
+
+		var baseDir = Zotero.Attachments.getBaseDirByLibrary(libraryID, path);
+		if (!baseDir) {
+			Zotero.debug(`No attachment base directory set -- can't resolve '${path}' in library '${libraryID}'`, 2);
 			return false;
 		}
-		
+
 		return this.fixPathSlashes(OS.Path.join(
-			OS.Path.normalize(basePath),
-			path.substr(Zotero.Attachments.BASE_PATH_PLACEHOLDER.length)
+			baseDir, path.substr(Zotero.Attachments.BASE_PATH_PLACEHOLDER.length)
 		));
-	}
+	};
+
+
+	/**
+	 * Get the attachment base directory for ``libraryID``, if its set
+	 *
+	 * @param {Integer} libraryID
+	 * @return {String|false} Normalized attachment base directory, or FALSE if no path is found for ``libraryID``
+	 */
+	this.getBaseDirByLibrary = function (libraryID) {
+		// Upgrade and clear out the old preference first
+		var prefValue = Zotero.Prefs.get("baseAttachmentPath");
+		if (prefValue) {
+			Zotero.debug(`Upgrading old user library attachment base directory preference: '${prefValue}'`);
+			this.setBaseDirByLibrary(Zotero.Libraries.userLibraryID, prefValue);
+			Zotero.Prefs.clear("baseAttachmentPath");
+		}
+
+		prefValue = JSON.parse(Zotero.Prefs.get("libraryAttachmentBaseDirs") || "{}");
+		if (libraryID in prefValue) {
+			var baseDir = prefValue[libraryID];
+			if (baseDir) {
+				try {
+					baseDir = OS.Path.normalize(baseDir);
+					Zotero.debug(`Attachment base directory found for library '${libraryID}': '${baseDir}'`);
+					return baseDir;
+				}
+				catch (e) {
+					Zotero.logError(e);
+				}
+			}
+		}
+
+		Zotero.debug(`Attachment base directory not found for library '${libraryID}'`);
+		return false
+	};
+
+
+	/**
+	 * Set the attachment base directory for ``libraryID``.  ``libraryID``s attachment
+	 * base directory can be cleared by passing a falsy value for ``newBaseDir``.
+	 *
+	 * @param {Integer} libraryID
+	 * @param {String|false} newBaseDir - New attachment base directory for ``libraryID`` or clear it if falsy
+	 * @return {Boolean}
+	 */
+	this.setBaseDirByLibrary = function(libraryID, newBaseDir) {
+		var prefValue = JSON.parse(Zotero.Prefs.get("libraryAttachmentBaseDirs") || "{}");
+		if (newBaseDir) {
+			Zotero.debug(`Setting attachment base directory for library '${libraryID}': '${newBaseDir}'`);
+			prefValue[libraryID] = newBaseDir;
+		}
+		else {
+			Zotero.debug(`Clearing attachment base directory for library '${libraryID}'`);
+			delete prefValue[libraryID];
+		}
+
+		Zotero.Prefs.set("libraryAttachmentBaseDirs", JSON.stringify(prefValue));
+		return true;
+	};
+
+
+	/**
+	 * Get whether attachments within ``libraryID``'s attachment base directory
+	 * should be saved as relative paths.
+	 *
+	 * @param {Integer} libraryID
+	 * @return {String|false}
+	 */
+	this.getSaveRelativePathByLibrary = function (libraryID) {
+		// Upgrade and clear out the old preference first
+		var prefValue = Zotero.Prefs.get("saveRelativeAttachmentPath");
+		if (prefValue) {
+			Zotero.debug(`Upgrading old user library relative path preference: '${prefValue}'`);
+			this.setSaveRelativePathByLibrary(Zotero.Libraries.userLibraryID, prefValue);
+			Zotero.Prefs.clear("saveRelativeAttachmentPath");
+		}
+
+		prefValue = JSON.parse(Zotero.Prefs.get("librarySaveRelativeAttachmentPaths") || "{}");
+		if (libraryID in prefValue) {
+			var saveRelative = prefValue[libraryID];
+			Zotero.debug(`Save relative path preference found for library '${libraryID}': '${saveRelative}'`);
+			return saveRelative;
+		}
+
+		Zotero.debug(`Save relative path preference not found for library '${libraryID}'`);
+		return false;
+	};
+
+
+	/**
+	 * Set whether attachments within ``libraryID``'s attachment base directory
+	 * should be saved as relative paths.  ``libraryID`` can be cleared by passing
+	 * a falsy value for ``saveRelative``.
+	 *
+	 * @param {Integer} libraryID
+	 * @param {String|false} saveRelative - New attachment base directory for ``libraryID`` or clear it if falsy
+	 * @return {Boolean}
+	 */
+	this.setSaveRelativePathByLibrary = function (libraryID, saveRelative) {
+		var prefValue = JSON.parse(Zotero.Prefs.get("librarySaveRelativeAttachmentPaths") || "{}");
+		if (saveRelative) {
+			Zotero.debug(`Setting save relative path for library '${libraryID}': '${saveRelative}'`);
+			prefValue[libraryID] = saveRelative;
+		}
+		else {
+			Zotero.debug(`Clearing save relative path for library '${libraryID}'`);
+			delete prefValue[libraryID];
+		}
+
+		Zotero.Prefs.set("librarySaveRelativeAttachmentPaths", JSON.stringify(prefValue));
+		return true;
+	};
 	
 	
 	this.fixPathSlashes = function (path) {
@@ -2489,6 +2651,7 @@ Zotero.Attachments = new function(){
 	 * @param {Object} options
 	 * @param {nsIFile|String} [file]
 	 * @param {String} [url]
+	 * @param {Integer} [libraryID]
 	 * @param {String} title
 	 * @param {Number} linkMode
 	 * @param {String} contentType
@@ -2501,6 +2664,7 @@ Zotero.Attachments = new function(){
 	function _addToDB(options) {
 		var file = options.file;
 		var url = options.url;
+		var libraryID = options.libraryID;
 		var title = options.title;
 		var linkMode = options.linkMode;
 		var contentType = options.contentType;
@@ -2510,15 +2674,28 @@ Zotero.Attachments = new function(){
 		var saveOptions = options.saveOptions;
 		
 		return Zotero.DB.executeTransaction(function* () {
+			// Create a new attachment
 			var attachmentItem = new Zotero.Item('attachment');
-			if (parentItemID) {
-				let {libraryID: parentLibraryID, key: parentKey} =
-					Zotero.Items.getLibraryAndKeyFromID(parentItemID);
-				if (parentLibraryID != Zotero.Libraries.userLibraryID
+			if (libraryID) {
+				if (libraryID != Zotero.Libraries.userLibraryID
 						&& linkMode == Zotero.Attachments.LINK_MODE_LINKED_FILE) {
 					throw new Error("Cannot save linked file in non-local library");
 				}
-				attachmentItem.libraryID = parentLibraryID;
+				attachmentItem.libraryID = libraryID;
+			}
+			else if (parentItemID) {
+				let {libraryID: parentLibraryID, key: parentKey} =
+					Zotero.Items.getLibraryAndKeyFromID(parentItemID);
+				if (parentLibraryID) {
+					if (parentLibraryID != Zotero.Libraries.userLibraryID
+							&& linkMode == Zotero.Attachments.LINK_MODE_LINKED_FILE) {
+						throw new Error("Cannot save linked file in non-local library");
+					}
+					attachmentItem.libraryID = parentLibraryID;
+				}
+				else {
+					Zotero.debug(`parentItemID '${parentItemID}' does not have a libraryID`);
+				}
 			}
 			attachmentItem.setField('title', title);
 			if (linkMode == self.LINK_MODE_IMPORTED_URL || linkMode == self.LINK_MODE_LINKED_URL) {
@@ -2530,12 +2707,13 @@ Zotero.Attachments = new function(){
 			attachmentItem.attachmentLinkMode = linkMode;
 			attachmentItem.attachmentContentType = contentType;
 			attachmentItem.attachmentCharset = charset;
-			if (file) {
-				attachmentItem.attachmentPath = typeof file == 'string' ? file : file.path;
-			}
 			
 			if (collections) {
 				attachmentItem.setCollections(collections);
+			}
+
+			if (file) {
+				attachmentItem.attachmentPath = typeof file == 'string' ? file : file.path;
 			}
 			yield attachmentItem.save(saveOptions);
 			

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -124,6 +124,9 @@ errorReport.repoCannotBeContacted	= Repository cannot be contacted
 
 
 attachmentBasePath.selectDir                                   = Choose Base Directory
+attachmentBasePath.libraryAttachmentBasePaths.label            = Library Attachment Base Directories
+attachmentBasePath.libraryAttachmentBasePaths.relative         = Relative
+attachmentBasePath.libraryAttachmentBasePaths.path             = Path
 attachmentBasePath.chooseNewPath.title                         = Confirm New Base Directory
 attachmentBasePath.chooseNewPath.message                       = Linked file attachments below this directory will be saved using relative paths.
 attachmentBasePath.chooseNewPath.existingAttachments.singular  = One existing attachment was found within the new base directory.

--- a/defaults/preferences/zotero.js
+++ b/defaults/preferences/zotero.js
@@ -6,8 +6,8 @@
 pref("extensions.zotero.firstRun2", true);
 pref("extensions.zotero@chnm.gmu.edu.description", "chrome://zotero/locale/zotero.properties");
 
-pref("extensions.zotero.saveRelativeAttachmentPath", false);
-pref("extensions.zotero.baseAttachmentPath", "");
+pref("extensions.zotero.librarySaveRelativeAttachmentPaths", "{}");
+pref("extensions.zotero.libraryAttachmentBaseDirs", "{}");
 pref("extensions.zotero.useDataDir", false);
 pref("extensions.zotero.dataDir", "");
 pref("extensions.zotero.warnOnUnsafeDataDir", true);

--- a/test/tests/attachmentsTest.js
+++ b/test/tests/attachmentsTest.js
@@ -115,11 +115,11 @@ describe("Zotero.Attachments", function() {
 	
 	describe("#linkFromFileWithRelativePath()", function () {
 		afterEach(function () {
-			Zotero.Prefs.clear('baseAttachmentPath');
+			Zotero.Prefs.clear('libraryAttachmentBaseDirs');
 		});
 		
 		it("should link to a file using a relative path with no base directory set", async function () {
-			Zotero.Prefs.clear('baseAttachmentPath');
+			Zotero.Prefs.clear('libraryAttachmentBaseDirs');
 			
 			var item = await createDataObject('item');
 			var spy = sinon.spy(Zotero.Fulltext, 'indexPDF');
@@ -143,8 +143,8 @@ describe("Zotero.Attachments", function() {
 		
 		it("should link to a file using a relative path within the base directory", async function () {
 			var baseDir = await getTempDirectory();
-			Zotero.Prefs.set('baseAttachmentPath', baseDir);
-			Zotero.Prefs.set('saveRelativeAttachmentPath', true);
+			Zotero.Attachments.setBaseDirByLibrary(Zotero.Libraries.userLibraryID, baseDir);
+			Zotero.Attachments.setSaveRelativePathByLibrary(Zotero.Libraries.userLibraryID, true);
 			
 			var subDir = OS.Path.join(baseDir, 'foo');
 			await OS.File.makeDir(subDir);
@@ -176,8 +176,8 @@ describe("Zotero.Attachments", function() {
 		
 		it("should link to a nonexistent file using a relative path within the base directory", async function () {
 			var baseDir = await getTempDirectory();
-			Zotero.Prefs.set('baseAttachmentPath', baseDir);
-			Zotero.Prefs.set('saveRelativeAttachmentPath', true);
+			Zotero.Attachments.setBaseDirByLibrary(Zotero.Libraries.userLibraryID, baseDir);
+			Zotero.Attachments.setSaveRelativePathByLibrary(Zotero.Libraries.userLibraryID, true);
 			
 			var subDir = OS.Path.join(baseDir, 'foo');
 			await OS.File.makeDir(subDir);
@@ -981,14 +981,14 @@ describe("Zotero.Attachments", function() {
 	
 	describe("#getBaseDirectoryRelativePath()", function () {
 		it("should handle base directory at Windows drive root", function () {
-			Zotero.Prefs.set('baseAttachmentPath', "C:\\");
-			var path = Zotero.Attachments.getBaseDirectoryRelativePath("C:\\file.txt");
+			Zotero.Attachments.setBaseDirByLibrary(Zotero.Libraries.userLibraryID, "C:\\");
+			var path = Zotero.Attachments.getBaseDirectoryRelativePath(Zotero.Libraries.userLibraryID, "C:\\file.txt");
 			assert.equal(path, Zotero.Attachments.BASE_PATH_PLACEHOLDER + "file.txt");
 		});
 		
 		it("should convert backslashes to forward slashes", function () {
-			Zotero.Prefs.set('baseAttachmentPath', "C:\\foo\\bar");
-			var path = Zotero.Attachments.getBaseDirectoryRelativePath("C:\\foo\\bar\\test\\file.txt");
+			Zotero.Attachments.setBaseDirByLibrary(Zotero.Libraries.userLibraryID, "C:\\foo\\bar");
+			var path = Zotero.Attachments.getBaseDirectoryRelativePath(Zotero.Libraries.userLibraryID, "C:\\foo\\bar\\test\\file.txt");
 			assert.equal(path, Zotero.Attachments.BASE_PATH_PLACEHOLDER + "test/file.txt");
 		});
 	});

--- a/test/tests/itemTest.js
+++ b/test/tests/itemTest.js
@@ -932,8 +932,9 @@ describe("Zotero.Item", function () {
 			var dir = getTestDataDirectory().path;
 			var dirname = OS.Path.basename(dir);
 			var baseDir = OS.Path.dirname(dir);
-			Zotero.Prefs.set('saveRelativeAttachmentPath', true)
-			Zotero.Prefs.set('baseAttachmentPath', baseDir)
+
+			Zotero.Attachments.setBaseDirByLibrary(Zotero.Libraries.userLibraryID, baseDir);
+			Zotero.Attachments.setSaveRelativePathByLibrary(Zotero.Libraries.userLibraryID, true);
 			
 			var file = OS.Path.join(dir, 'test.png');
 			
@@ -943,16 +944,16 @@ describe("Zotero.Item", function () {
 			
 			assert.equal(item.attachmentPath, "attachments:data/test.png");
 			
-			Zotero.Prefs.set('saveRelativeAttachmentPath', false)
-			Zotero.Prefs.clear('baseAttachmentPath')
+			Zotero.Attachments.setSaveRelativePathByLibrary(Zotero.Libraries.userLibraryID, false);
+			Zotero.Attachments.setBaseDirByLibrary(Zotero.Libraries.userLibraryID, null);
 		})
 		
 		it("should return a prefixed path for a linked attachment within the defined base directory", function* () {
 			var dir = getTestDataDirectory().path;
 			var dirname = OS.Path.basename(dir);
 			var baseDir = OS.Path.dirname(dir);
-			Zotero.Prefs.set('saveRelativeAttachmentPath', true)
-			Zotero.Prefs.set('baseAttachmentPath', baseDir)
+			Zotero.Attachments.setSaveRelativePathByLibrary(Zotero.Libraries.userLibraryID, true);
+			Zotero.Attachments.setBaseDirByLibrary(Zotero.Libraries.userLibraryID, baseDir);
 			
 			var file = OS.Path.join(dir, 'test.png');
 			
@@ -962,8 +963,8 @@ describe("Zotero.Item", function () {
 			
 			assert.equal(item.attachmentPath, "attachments:data/test.png");
 			
-			Zotero.Prefs.set('saveRelativeAttachmentPath', false)
-			Zotero.Prefs.clear('baseAttachmentPath')
+			Zotero.Attachments.setSaveRelativePathByLibrary(Zotero.Libraries.userLibraryID, false);
+			Zotero.Attachments.setBaseDirByLibrary(Zotero.Libraries.userLibraryID, null);
 		})
 	})
 	


### PR DESCRIPTION
Basically the two preferences that related to base directory attachment paths were changed to stringified objects that use the `libraryID` as the key and store a unique value per library.  The same `BASE_ATTACHMENT_PATH` prefix is used.
The logic for changing or clearing base directories now only modifies the `attachment.attachmentPath` for an `attachment` who's `attachment.libraryID` matches the specified `libraryID`.

The attachment base directory selection window UI is based off the *Libraries to Sync UI*.

I tested the following additional use cases (for which unit tests need to be created):
- Set attachment base paths for two libraries to two different paths, then checked that all attachments still open.
- Set attachment base paths for two libraries to the same path, then checked that all attachments still open.
- Set attachment base paths for two libraries, then removed one of them and checked that all attachments still open and that the other library still uses the linked files.
- Others I can't think of right now...

| Old | New |
| --- | --- |
| `Zotero_Preferences.Attachment_Base_Directory.getPath` | `Zotero.Attachments.getBaseDirByLibrary` |
| `Zotero_Preferences.Attachment_Base_Directory.choosePath` | `Zotero_Preferences.Attachment_Base_Directory.getNewBaseDir` `Zotero_Preferences.Attachment_Base_Directory.manageBaseDirs` |
| `Zotero_Preferences.Attachment_Base_Directory.changePath` | `Zotero_Preferences.Attachment_Base_Directory.changeBaseDirByLibrary` |
| `Zotero_Preferences.Attachment_Base_Directory.clearPath` | `Zotero_Preferences.Attachment_Base_Directory.clearBaseDirByLibrary` |

### To Do
- [ ] Reactify (Blocked by #1674)
- [x] Only set attachment base paths for user and group libraries
- [x] Get all tests to pass
- [ ] Add new tests for group specific base paths - should only change files in specified library
- [ ] _Assistance Needed:_ Add localization support for new UI window


### Unanticipated Changes
- `item.js`: Added a default `libraryID` of `Zotero.Libraries.userLibraryID` if the `linkMode` is `LINK_MODE_LINKED_FILE`.  This was an assumption being made by *many* tests and has the same effect as if the attachment had first been `.save()`'d and had its `libraryID` defaulted there.  The tests could all be updated to pass an explicit `libraryID`, but the other issue is generally that the many test parent items also don't have a `libraryID` set.
- Added additional optional parameter `libraryID` to several functions in `attachments.js`.


### Related Issues / Commits / PRs
- #1674 - Reactify preferences
- #1675 - Show X for unsynced libraries
- #1338 - Don't recommend "Attach Link to File" for file: URIs in group libraries
- zotero#51 - Relative paths to linked files
- https://forums.zotero.org/discussion/comment/317328#Comment_317328
- https://forums.zotero.org/discussion/36857/group-sharing-through-webdav-and-linked-base-directories
- https://forums.zotero.org/discussion/55253/attach-link-to-file-grayed-out

### Screenshots
![image](https://user-images.githubusercontent.com/1417401/56471499-686a3500-6421-11e9-911b-f5ce7e1b978f.png)
![image](https://user-images.githubusercontent.com/1417401/56471503-6bfdbc00-6421-11e9-842e-00e908e61ea7.png)
