### PR TITLE
Export CSL JSON with title-short rather than shortTitle

### DIFF
--- a/chrome/content/zotero/xpcom/utilities.js
+++ b/chrome/content/zotero/xpcom/utilities.js
@@ -82,7 +82,8 @@ var CSL_TEXT_MAPPINGS = {
 	"number":["number"],
 	"chapter-number":["session"],
 	"references":["history", "references"],
-	"shortTitle":["shortTitle"],
+	"shortTitle":["shortTitle"], /* preserved to read legacy data */
+	"title-short":["shortTitle"],
 	"journalAbbreviation":["journalAbbreviation"],
 	"status":["legalStatus"],
 	"language":["language"]
@@ -1588,6 +1589,7 @@ Zotero.Utilities = {
 		
 		// get all text variables (there must be a better way)
 		for(var variable in CSL_TEXT_MAPPINGS) {
+			if (variable === "shortTitle") continue; // read both title-short and shortTitle, but write only title-short
 			var fields = CSL_TEXT_MAPPINGS[variable];
 			for(var i=0, n=fields.length; i<n; i++) {
 				var field = fields[i],

--- a/test/tests/data/citeProcJSExport.js
+++ b/test/tests/data/citeProcJSExport.js
@@ -37,7 +37,7 @@
 		"language": "en-US",
 		"medium": "Medium",
 		"note": "Extra",
-		"shortTitle": "Short title",
+		"title-short": "Short title",
 		"source": "Library catalog",
 		"title": "Title",
 		"type": "graphic"
@@ -92,7 +92,7 @@
 		"number-of-volumes": "7",
 		"publisher": "Publisher",
 		"publisher-place": "Place",
-		"shortTitle": "Short title",
+		"title-short": "Short title",
 		"source": "Library catalog",
 		"title": "Title",
 		"type": "song",
@@ -138,7 +138,7 @@
 		"page": "1-10",
 		"references": "History",
 		"section": "Section",
-		"shortTitle": "Short title",
+		"title-short": "Short title",
 		"title": "Title",
 		"type": "bill",
 		"volume": "6"
@@ -178,7 +178,7 @@
 		},
 		"language": "en-US",
 		"note": "Extra",
-		"shortTitle": "Short title",
+		"title-short": "Short title",
 		"title": "Title",
 		"type": "post-weblog"
 	},
@@ -239,7 +239,7 @@
 		"number-of-volumes": "7",
 		"publisher": "Publisher",
 		"publisher-place": "Place",
-		"shortTitle": "Short title",
+		"title-short": "Short title",
 		"source": "Library catalog",
 		"title": "Title",
 		"translator": [
@@ -315,7 +315,7 @@
 		"page": "1-10",
 		"publisher": "Publisher",
 		"publisher-place": "Place",
-		"shortTitle": "Short title",
+		"title-short": "Short title",
 		"source": "Library catalog",
 		"title": "Title",
 		"translator": [
@@ -365,7 +365,7 @@
 		"number": "3",
 		"page": "1-10",
 		"references": "History",
-		"shortTitle": "Short title",
+		"title-short": "Short title",
 		"title": "Title",
 		"type": "legal_case",
 		"volume": "6"
@@ -412,7 +412,7 @@
 		"note": "Extra",
 		"publisher": "Publisher",
 		"publisher-place": "Place",
-		"shortTitle": "Short title",
+		"title-short": "Short title",
 		"source": "Library catalog",
 		"title": "Title",
 		"type": "book",
@@ -475,7 +475,7 @@
 		"page": "1-10",
 		"publisher": "Publisher",
 		"publisher-place": "Place",
-		"shortTitle": "Short title",
+		"title-short": "Short title",
 		"source": "Library catalog",
 		"title": "Title",
 		"translator": [
@@ -545,7 +545,7 @@
 		"page": "1-10",
 		"publisher": "Publisher",
 		"publisher-place": "Place",
-		"shortTitle": "Short title",
+		"title-short": "Short title",
 		"source": "Library catalog",
 		"title": "Title",
 		"translator": [
@@ -606,7 +606,7 @@
 				"given": "reviewedAuthorFirst"
 			}
 		],
-		"shortTitle": "Short title",
+		"title-short": "Short title",
 		"source": "Library catalog",
 		"title": "Title",
 		"translator": [
@@ -656,7 +656,7 @@
 				"given": "recipientFirst"
 			}
 		],
-		"shortTitle": "Short title",
+		"title-short": "Short title",
 		"title": "Title",
 		"type": "personal_communication"
 	},
@@ -718,7 +718,7 @@
 		"page": "1-10",
 		"publisher": "Publisher",
 		"publisher-place": "Place",
-		"shortTitle": "Short title",
+		"title-short": "Short title",
 		"source": "Library catalog",
 		"title": "Title",
 		"translator": [
@@ -770,7 +770,7 @@
 		"medium": "Medium",
 		"note": "Extra",
 		"publisher": "Publisher",
-		"shortTitle": "Short title",
+		"title-short": "Short title",
 		"source": "Library catalog",
 		"title": "Title",
 		"type": "motion_picture"
@@ -810,7 +810,7 @@
 		},
 		"language": "en-US",
 		"note": "Extra",
-		"shortTitle": "Short title",
+		"title-short": "Short title",
 		"title": "Title",
 		"type": "post"
 	},
@@ -857,7 +857,7 @@
 		"publisher-place": "Place",
 		"references": "History",
 		"section": "Committee",
-		"shortTitle": "Short title",
+		"title-short": "Short title",
 		"title": "Title",
 		"type": "bill"
 	},
@@ -900,7 +900,7 @@
 				"given": "recipientFirst"
 			}
 		],
-		"shortTitle": "Short title",
+		"title-short": "Short title",
 		"title": "Title",
 		"type": "personal_communication"
 	},
@@ -947,7 +947,7 @@
 		"language": "en-US",
 		"medium": "Medium",
 		"note": "Extra",
-		"shortTitle": "Short title",
+		"title-short": "Short title",
 		"source": "Library catalog",
 		"title": "Title",
 		"translator": [
@@ -1013,7 +1013,7 @@
 				"given": "reviewedAuthorFirst"
 			}
 		],
-		"shortTitle": "Short title",
+		"title-short": "Short title",
 		"source": "Library catalog",
 		"title": "Title",
 		"translator": [
@@ -1068,7 +1068,7 @@
 				"given": "recipientFirst"
 			}
 		],
-		"shortTitle": "Short title",
+		"title-short": "Short title",
 		"source": "Library catalog",
 		"title": "Title",
 		"type": "personal_communication"
@@ -1119,7 +1119,7 @@
 				"given": "reviewedAuthorFirst"
 			}
 		],
-		"shortTitle": "Short title",
+		"title-short": "Short title",
 		"source": "Library catalog",
 		"title": "Title",
 		"translator": [
@@ -1171,7 +1171,7 @@
 		"note": "Extra",
 		"number-of-pages": "4",
 		"publisher-place": "Place",
-		"shortTitle": "Short title",
+		"title-short": "Short title",
 		"source": "Library catalog",
 		"title": "Title",
 		"translator": [
@@ -1232,7 +1232,7 @@
 		"publisher": "Publisher",
 		"publisher-place": "Place",
 		"scale": "Scale",
-		"shortTitle": "Short title",
+		"title-short": "Short title",
 		"source": "Library catalog",
 		"title": "Title",
 		"type": "map"
@@ -1286,7 +1286,7 @@
 			}
 		],
 		"section": "Section",
-		"shortTitle": "Short title",
+		"title-short": "Short title",
 		"source": "Library catalog",
 		"title": "Title",
 		"translator": [
@@ -1338,7 +1338,7 @@
 		"page": "1-10",
 		"publisher-place": "Place",
 		"references": "References",
-		"shortTitle": "Short title",
+		"title-short": "Short title",
 		"status": "Legal status",
 		"submitted": {
 			"date-parts": [
@@ -1380,7 +1380,7 @@
 		"medium": "Medium",
 		"note": "Extra",
 		"number": "3",
-		"shortTitle": "Short title",
+		"title-short": "Short title",
 		"title": "Title",
 		"type": "broadcast"
 	},
@@ -1421,7 +1421,7 @@
 		"language": "en-US",
 		"note": "Extra",
 		"publisher-place": "Place",
-		"shortTitle": "Short title",
+		"title-short": "Short title",
 		"title": "Title",
 		"type": "speech"
 	},
@@ -1468,7 +1468,7 @@
 		"number": "3",
 		"publisher": "Publisher",
 		"publisher-place": "Place",
-		"shortTitle": "Short title",
+		"title-short": "Short title",
 		"source": "Library catalog",
 		"title": "Title",
 		"type": "broadcast"
@@ -1522,7 +1522,7 @@
 		"page": "1-10",
 		"publisher": "Publisher",
 		"publisher-place": "Place",
-		"shortTitle": "Short title",
+		"title-short": "Short title",
 		"source": "Library catalog",
 		"title": "Title",
 		"translator": [
@@ -1572,7 +1572,7 @@
 		"page": "1-10",
 		"references": "History",
 		"section": "Section",
-		"shortTitle": "Short title",
+		"title-short": "Short title",
 		"title": "Title",
 		"type": "legislation",
 		"volume": "Code number"
@@ -1618,7 +1618,7 @@
 		"number-of-pages": "4",
 		"publisher": "Publisher",
 		"publisher-place": "Place",
-		"shortTitle": "Short title",
+		"title-short": "Short title",
 		"source": "Library catalog",
 		"title": "Title",
 		"type": "thesis"
@@ -1666,7 +1666,7 @@
 		"number": "3",
 		"publisher": "Publisher",
 		"publisher-place": "Place",
-		"shortTitle": "Short title",
+		"title-short": "Short title",
 		"source": "Library catalog",
 		"title": "Title",
 		"type": "broadcast"
@@ -1715,7 +1715,7 @@
 		"number-of-volumes": "7",
 		"publisher": "Publisher",
 		"publisher-place": "Place",
-		"shortTitle": "Short title",
+		"title-short": "Short title",
 		"source": "Library catalog",
 		"title": "Title",
 		"type": "motion_picture",
@@ -1756,7 +1756,7 @@
 		},
 		"language": "en-US",
 		"note": "Extra",
-		"shortTitle": "Short title",
+		"title-short": "Short title",
 		"title": "Title",
 		"translator": [
 			{

--- a/test/tests/utilitiesTest.js
+++ b/test/tests/utilitiesTest.js
@@ -418,6 +418,23 @@ describe("Zotero.Utilities", function() {
 			}
 			
 		});
+		it("should recognize the legacy shortTitle key", function* () {
+			this.timeout(20000);
+
+			let data = loadSampleData('citeProcJSExport');
+
+			var json = data.artwork;
+			var canonicalKeys = Object.keys(json);
+			json.shortTitle = json["title-short"];
+			delete json["title-short"];
+
+			let item = new Zotero.Item();
+			Zotero.Utilities.itemFromCSLJSON(item, json);
+			yield item.saveTx();
+
+			let newJSON = Zotero.Utilities.itemToCSLJSON(item);
+			assert.hasAllKeys(newJSON, canonicalKeys);
+		});
 		it("should import exported standalone note", function* () {
 			let note = new Zotero.Item('note');
 			note.setNote('Some note longer than 50 characters, which will become the title.');


### PR DESCRIPTION
Although we've been using it for years, the `shortTitle` variable is not part of the [CSL Specification](http://docs.citationstyles.org/en/1.0.1/specification.html#standard-variables). In a [recent discussion](https://discourse.citationstyles.org/t/title-short-vs-shorttitle/1515), a developer queried why we weren't using `title-short` in the CSL test suite, @adam3smith suggested that Zotero be aligned with the spec, and although the processor is meant to handle both, it's a bit easier to work with the canonical name in code.

This PR would read both `shortTitle` and `title-short`, but write only the latter on export.