### PR TITLE
Fix data type

### DIFF
--- a/chrome/content/zotero/xpcom/integration.js
+++ b/chrome/content/zotero/xpcom/integration.js
@@ -1654,7 +1654,7 @@ Zotero.Integration.Session.prototype.getCiteprocLists = function() {
 			continue;
 		}
 		citations.push([this.citationsByIndex[idx].citationID, this.citationsByIndex[idx].properties.noteIndex]);
-		fieldToCitationIdxMapping[i] = idx;
+		fieldToCitationIdxMapping[i] = parseInt(idx, 10);
 		citationToFieldIdxMapping[idx] = i++;
 	}
 	return [citations, fieldToCitationIdxMapping, citationToFieldIdxMapping];


### PR DESCRIPTION
I don't know whether this is related to the ``c[0]`` bug in some way, but it seems to need a tweak.

Values of `fieldToCitationIdxMapping` returned by `getCiteprocLists` are assumed to be numbers in some places. The `idx` value used in the function is an object key, this converts it to an integer so that adding to it produces a sane result.
