### PR TITLE
Fix for c[0] bug

### DIFF
--- a/chrome/content/zotero/xpcom/integration.js
+++ b/chrome/content/zotero/xpcom/integration.js
@@ -1223,7 +1223,7 @@ Zotero.Integration.Fields.prototype.addEditCitation = async function (field) {
 		var [citations, fieldToCitationIdxMapping, citationToFieldIdxMapping] = this._session.getCiteprocLists();
 		if (citations.length === 0) {
 			await this._session.init(true, false)
-			this._session.reload = true;
+			this._session.reload = !this._session.data.prefs.delayCitationUpdates;
 			await this.updateSession(FORCE_CITATIONS_REGENERATE)
 			await this.updateDocument(FORCE_CITATIONS_REGENERATE, true, false);
 			[citations, fieldToCitationIdxMapping, citationToFieldIdxMapping] = this._session.getCiteprocLists();

--- a/chrome/content/zotero/xpcom/integration.js
+++ b/chrome/content/zotero/xpcom/integration.js
@@ -1220,7 +1220,15 @@ Zotero.Integration.Fields.prototype.addEditCitation = async function (field) {
 		await citationsByItemIDPromise;
 		var fields = await this.get();
 
-		var [citations, fieldToCitationIdxMapping, citationToFieldIdxMapping] = this._session.getCiteprocLists(true);
+		var [citations, fieldToCitationIdxMapping, citationToFieldIdxMapping] = this._session.getCiteprocLists();
+		if (citations.length === 0) {
+			await this._session.init(true, false)
+			this._session.reload = true;
+			await this.updateSession(FORCE_CITATIONS_REGENERATE)
+			await this.updateDocument(FORCE_CITATIONS_REGENERATE, true, false);
+			[citations, fieldToCitationIdxMapping, citationToFieldIdxMapping] = this._session.getCiteprocLists();
+		}
+
 		for (var prevIdx = idx-1; prevIdx >= 0; prevIdx--) {
 			if (prevIdx in fieldToCitationIdxMapping) break;
 		}
@@ -1654,7 +1662,7 @@ Zotero.Integration.Session.prototype.getCiteprocLists = function() {
 			continue;
 		}
 		citations.push([this.citationsByIndex[idx].citationID, this.citationsByIndex[idx].properties.noteIndex]);
-		fieldToCitationIdxMapping[i] = idx;
+		fieldToCitationIdxMapping[i] = parseInt(idx, 10);
 		citationToFieldIdxMapping[idx] = i++;
 	}
 	return [citations, fieldToCitationIdxMapping, citationToFieldIdxMapping];

--- a/chrome/content/zotero/xpcom/integration.js
+++ b/chrome/content/zotero/xpcom/integration.js
@@ -1221,7 +1221,8 @@ Zotero.Integration.Fields.prototype.addEditCitation = async function (field) {
 		var fields = await this.get();
 
 		var [citations, fieldToCitationIdxMapping, citationToFieldIdxMapping] = this._session.getCiteprocLists();
-		if (citations.length === 0) {
+		if (citations.length === 0 && !this._session.citeprocInit) {
+			this._session.citeprocInit = true;
 			await this._session.init(true, false)
 			this._session.reload = !this._session.data.prefs.delayCitationUpdates;
 			await this.updateSession(FORCE_CITATIONS_REGENERATE)
@@ -1487,6 +1488,8 @@ Zotero.Integration.Session.prototype.setData = async function (data, resetStyle)
 			// We're changing the citeproc instance, so we'll have to reinsert all citations into the registry
 			this.reload = true;
 			this.styleID = data.style.styleID;
+			// To assure client/processor data reconcilitation in previewFn
+			this.citeprocInit = false;
 		} catch (e) {
 			Zotero.logError(e);
 			throw new Zotero.Exception.Alert("integration.error.invalidStyle");


### PR DESCRIPTION
There were several facets to this. This PR should be tested with citeproc-js tag 1.1.236.

* When `previewFn` was run via the Classic dialog before updating citations **[1]**, the `citations` array returned by `getCiteprocLists` was of zero length, but the function would process index positions (`idx`) based on the field position within the document. The preview operation would succeed, and could be canceled without error, but that left the processor initialized with an empty registry, and subsequent operations crashed on attempts to access unregistered citationIDs.

* Performing an implicit hard refresh in `previewFn` when an empty array is encountered cleared the issue above, but exposed a crashing bug in citeproc-js preview mode, which erroneously assumed that the previewed citation would always be present in the registry, which is not the case.

* Addressing the citation registry bug above exposed a further problem in rendering context. There seem to have been two issues here, one in the processor and one in Zotero.

  - In the processor, it seems that previewing a citation under a citationID already in the registry erroneously caused the processor to trigger an ibid citation for the preview. I'm not clear on the details, but removing the citationID from the previewed citation and allowing citeproc-js to cut a fresh citationID for it seemed to remedy all but one "ibid" failure condition. That brings us to the last item in the journey.

  - In Zotero, the values in the second array returned from `getCiteprocLists` (`fieldToCitationIdxMapping`) were set as numeric strings drawn from a walk over the keys in the `citationsByIndex` object. In `previewFn`, the index of the predecessor to the previewed citation is set by adding one to the array value. For the string value we were getting things like "0" -&nbsp;> "01" and "3" -&nbsp;> "31". As a result, extra citationID tuples were included in `citationsPre`, many of which would be prior to the current citation note position, and were repeated in `citationsPost`. Processor behavior under those conditions is undefined, but in preview mode it seems to have been relatively harmless, apart from messing up the context of the preview. A consistent failure was to render the last citation in the document always as ibid in preview (because all citations, including the last, were included in `citationsPre`).

(**Edit:** Changed the description of `idx` in the first bullet-point. The original falsely stated that the value was returned by `getCiteprocLists`, but it is derived from a separate promise that delivers the document field position. The mismatch between the promise and the function return was the ultimate cause of the crash condition.)

(**Edit:** Added the following note.)

[1] I see that `previewFn` is run from the Quick Format dialog also, in styles that sort citations. There is a possibility that the same bug might be triggered when inserting a citation into an open document immediately after restarting Zotero. As with the [STR for the Classic dialog](https://forums.zotero.org/discussion/76780/steps-to-reproduce-the-c-0-bug-d312361246), the bug would manifest immediately *after* the preview/cancel (or possibly preview/insert - I haven't checked the latter).