### PR TITLE
Add a checks and prompts for retracted items within an existing doc

### DIFF
--- a/chrome/content/zotero/integration/addCitationDialog.js
+++ b/chrome/content/zotero/integration/addCitationDialog.js
@@ -624,6 +624,7 @@ var Zotero_Citation_Dialog = new function () {
 						}
 						return false;
 					}
+					item.ignoreRetraction = true;
 					break;
 				}
 			}

--- a/chrome/content/zotero/integration/quickFormat.js
+++ b/chrome/content/zotero/integration/quickFormat.js
@@ -742,6 +742,8 @@ var Zotero_QuickFormat = new function () {
 					Zotero_QuickFormat.showInLibrary(parseInt(citationItem.id));
 				}
 				return false;
+			} else {
+				citationItem.ignoreRetraction = true;
 			}
 		}
 		

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -1211,3 +1211,5 @@ retraction.details = More details:
 retraction.credit = Data from %S
 retraction.citeWarning.text1 = The item you are citing has been retracted. Do you still want to add it to your document?
 retraction.citeWarning.text2 = You can view the item in your library for further details on the retraction.
+retraction.citedItemWarning = A cited item in your document has been retracted:
+retraction.citedItemWarning.dontWarn = Don’t warn me about this item again


### PR DESCRIPTION
See #1703

Currently `Retractions.getRetractionsFromJSON()` fails with a HTTP 403 for me.