### PR TITLE
Update zotero.dtd

### DIFF
--- a/chrome/locale/fr-FR/zotero/zotero.dtd
+++ b/chrome/locale/fr-FR/zotero/zotero.dtd
@@ -61,7 +61,7 @@
 <!ENTITY zotero.items.creator_column "Créateur">
 <!ENTITY zotero.items.date_column "Date">
 <!ENTITY zotero.items.year_column "Année">
-<!ENTITY zotero.items.publisher_column "Éditeur">
+<!ENTITY zotero.items.publisher_column "Maison d'édition">
 <!ENTITY zotero.items.publication_column "Publication">
 <!ENTITY zotero.items.journalAbbr_column "Abrév. de revue">
 <!ENTITY zotero.items.language_column "Langue">


### PR DESCRIPTION
I changed the translation "éditeur" to "maison d'édition" which is the exact translation of publisher in French. In French, there is a confusion between editor/publisher because "éditeur" can be both. With this translation, the two roles are more clear.