### PR TITLE
Fix UnhandledPromiseRejection in translators

### DIFF
--- a/chrome/content/zotero/xpcom/translation/translate.js
+++ b/chrome/content/zotero/xpcom/translation/translate.js
@@ -1359,9 +1359,8 @@ Zotero.Translate.Base.prototype = {
 				// doImport can return a promise to allow for incremental saves (via promise-returning
 				// item.complete() calls)
 				if (maybePromise) {
-					maybePromise
-						.then(() => this.decrementAsyncProcesses("Zotero.Translate#translate()"))
-					return;
+					return maybePromise
+						.then(() => this.decrementAsyncProcesses("Zotero.Translate#translate()"));
 				}
 			} catch (e) {
 				this.complete(false, e);

--- a/chrome/content/zotero/xpcom/translation/translate.js
+++ b/chrome/content/zotero/xpcom/translation/translate.js
@@ -1344,7 +1344,7 @@ Zotero.Translate.Base.prototype = {
 			return loadPromise.then(() => rest.apply(this, arguments))
 		}
 		
-		function rest() {
+		async function rest() {
 			Zotero.debug("Translate: Beginning translation with " + this.translator[0].label);
 
 			this.incrementAsyncProcesses("Zotero.Translate#translate()");
@@ -1359,8 +1359,9 @@ Zotero.Translate.Base.prototype = {
 				// doImport can return a promise to allow for incremental saves (via promise-returning
 				// item.complete() calls)
 				if (maybePromise) {
-					return maybePromise
+					await maybePromise
 						.then(() => this.decrementAsyncProcesses("Zotero.Translate#translate()"));
+          return;
 				}
 			} catch (e) {
 				this.complete(false, e);


### PR DESCRIPTION
If `maybePromise` resolves, `this.decrementAsyncProcesses` is run which returns `undefined`, so no different behaviour. If `maybePromise` rejects, it now bubbles up through the call stack instead of becoming unhandled.