### PR TITLE
Add 'type' to variables list for extraToCSL

### DIFF
--- a/chrome/content/zotero/xpcom/cite.js
+++ b/chrome/content/zotero/xpcom/cite.js
@@ -387,6 +387,7 @@ Zotero.Cite = {
 			case 'title':
 			case 'title-short':
 			case 'translator':
+			case 'type':
 			case 'version':
 			case 'volume':
 			case 'year-suffix':


### PR DESCRIPTION
So that it can be stored in Extra as "Type:" instead of "type:"

Replaces https://github.com/zotero/zotero/pull/1688