### PR TITLE
Expose ViewOptions from Zotero_LocateMenu

### DIFF
--- a/chrome/content/zotero/locateMenu.js
+++ b/chrome/content/zotero/locateMenu.js
@@ -584,4 +584,7 @@ var Zotero_LocateMenu = new function() {
 			ZoteroPane_Local.loadURI(urls, event);
 		});
 	};
+	
+	// Expose ViewOptions for external use
+	this.ViewOptions = ViewOptions;
 }


### PR DESCRIPTION
There have been some recent requests to add shortcut functions to Zutilo for items from the locate menu. Would it be okay to expose ViewOptions like this so it is easy to create the shortcuts? Without this, the easiest way I saw to make the shortcuts is to create a dummy menu element, run `Zotero_LocateMenu.buildContextMenu` on it, and then use `dispatchEvent(new Event("command")` on the appropriate menu item. That is pretty convoluted compared to calling `handleItems()` on the currently selected items.