### PR TITLE
Allow session history in a hidden browser

### DIFF
--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -2053,7 +2053,7 @@ Zotero.Browser = new function() {
 		// Create a hidden browser
 		var hiddenBrowser = win.document.createElement("browser");
 		hiddenBrowser.setAttribute('type', 'content');
-		hiddenBrowser.setAttribute('disablehistory', 'true');
+		hiddenBrowser.setAttribute('disableglobalhistory', 'true');
 		win.document.documentElement.appendChild(hiddenBrowser);
 		// Disable some features
 		hiddenBrowser.docShell.allowAuth = false;


### PR DESCRIPTION
Currently loading any page that uses history object `window.history` triggers `NS_ERROR_FAILURE`. Many single-page apps, including the new web-library, depend on availability of `window.history` and will crash without rendering anything if unexpectedly `NS_ERROR_FAILURE` is thrown when accessing `window.history`. 

This small change ensures that page loaded in the hidden browser can access `window.history`. However I'm not familiar enough with the codebase to say how would this affect other translators and other parts of Zotero that use `Zotero.Browser`. 
