### PR TITLE
Fix build on Windows 

### DIFF
--- a/scripts/symlinks.js
+++ b/scripts/symlinks.js
@@ -38,7 +38,7 @@ async function getSymlinks(source, options, signatures) {
 		const dest = path.join('build', f);
 		try {
 			if (isWindows) {
-				await fs.copy(f, dest);
+				await fs.copy(f, dest, { dereference: true });
 			} else {
 				await fs.ensureSymlink(f, dest);
 			}


### PR DESCRIPTION
On Windows, to avoid problems with symlinks, files are copied during the build instead. However source symlinks are not currently dereferenced during the copy leading to invalid symlinks being placed in the build folder and ultimately breaking the build. This PR adds dereferencing.