### PR TITLE
Fix babel worker file-specific fixes check on Windows

### DIFF
--- a/scripts/babel-worker.js
+++ b/scripts/babel-worker.js
@@ -7,6 +7,7 @@ const babel = require('@babel/core');
 const multimatch = require('multimatch');
 const options = JSON.parse(fs.readFileSync('.babelrc'));
 const cluster = require('cluster');
+const { comparePaths } = require('./utils');
 
 /* exported onmessage */
 async function babelWorker(ev) {
@@ -30,18 +31,18 @@ async function babelWorker(ev) {
 	try {
 		let contents = await fs.readFile(sourcefile, 'utf8');
 		// Patch react
-		if (sourcefile === 'resource/react.js') {
+		if (comparePaths(sourcefile, 'resource/react.js')) {
 			transformed = contents.replace('instanceof Error', '.constructor.name == "Error"')
 		}
 		// Patch react-dom
-		else if (sourcefile === 'resource/react-dom.js') {
+		else if (comparePaths(sourcefile, 'resource/react-dom.js')) {
 			transformed = contents.replace(/ ownerDocument\.createElement\((.*?)\)/gi, 'ownerDocument.createElementNS(HTML_NAMESPACE, $1)')
 				.replace('element instanceof win.HTMLIFrameElement',
 					'typeof element != "undefined" && element.tagName.toLowerCase() == "iframe"')
 				.replace("isInputEventSupported = false", 'isInputEventSupported = true');
 		}
 		// Patch react-virtualized
-		else if (sourcefile === 'resource/react-virtualized.js') {
+		else if (comparePaths(sourcefile, 'resource/react-virtualized.js')) {
 			transformed = contents.replace('scrollDiv = document.createElement("div")', 'scrollDiv = document.createElementNS("http://www.w3.org/1999/xhtml", "div")')
 				.replace('document.body.appendChild(scrollDiv)', 'document.documentElement.appendChild(scrollDiv)')
 				.replace('document.body.removeChild(scrollDiv)', 'document.documentElement.removeChild(scrollDiv)');

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -111,16 +111,22 @@ const formatDirsForMatcher = dirs => {
 	return dirs.length > 1 ? `{${dirs.join(',')}}` : dirs[0];
 };
 
+function comparePaths(actualPath, testedPath) {
+	// compare paths after normalizing os-specific path separator
+	return path.normalize(actualPath) === path.normalize(testedPath);
+}
+
 module.exports = {
+	cleanUp,
+	comparePaths,
+	compareSignatures,
+	formatDirsForMatcher,
+	getFileSignature,
+	getPathRelativeTo,
+	getSignatures,
 	isWindows,
 	onError,
 	onProgress,
 	onSuccess,
-	cleanUp,
-	getSignatures,
-	getFileSignature,
-	compareSignatures,
 	writeSignatures,
-	getPathRelativeTo,
-	formatDirsForMatcher
 };


### PR DESCRIPTION
Everywhere else we use `glob` for paths which deals with forward/backward slash apart from `babel-worker.js` where paths were compared verbatim, hence file-specific fixes weren't applied during the build on windows. This PR resolves this issue by using regex check instead.