### PR TITLE
Update SingleFile for bug fixes

### DIFF
--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -869,6 +869,15 @@ Zotero.Attachments = new function(){
 		if (parentItemID && collections) {
 			throw new Error("parentItemID and parentCollectionIDs cannot both be provided");
 		}
+
+		// If no title was provided, pull it from the document
+		if (!title) {
+			let parser = Components.classes["@mozilla.org/xmlextras/domparser;1"]
+				.createInstance(Components.interfaces.nsIDOMParser);
+			parser.init(null, Services.io.newURI(url));
+			let doc = parser.parseFromString(snapshotContent, 'text/html');
+			title = doc.title;
+		}
 		
 		let tmpDirectory = (await this.createTemporaryStorageDirectory()).path;
 		let destDirectory;

--- a/chrome/content/zotero/xpcom/translation/translate_item.js
+++ b/chrome/content/zotero/xpcom/translation/translate_item.js
@@ -364,6 +364,7 @@ Zotero.Translate.ItemSaver.prototype = {
 	 */
 	saveSnapshotAttachments: Zotero.Promise.coroutine(function* (pendingAttachments, snapshotContent, attachmentCallback) {
 		for (let [parentItemID, attachment] of pendingAttachments) {
+			Zotero.debug('Saving pending attachment: ' + JSON.stringify(attachment));
 			if (snapshotContent) {
 				attachment.snapshotContent = snapshotContent;
 			}

--- a/scripts/babel-worker.js
+++ b/scripts/babel-worker.js
@@ -48,18 +48,6 @@ async function babelWorker(ev) {
 				.replace('document.body.removeChild(scrollDiv)', 'document.documentElement.removeChild(scrollDiv)');
 		}
 
-		// Patch content-frame-tree
-		// In Chrome sometimes frames would not have access to the browser object. I could
-		// not replicate this in firefox so is possibly a bug with injected content_scripts
-		// in Chrome that was easier to work around than track down. SingleFile has this
-		// backup mechanism for message so we simply remove the check that implies that if
-		// the top window has the browser object the frame will as well.
-		else if (sourcefile === 'resource/SingleFile/lib/single-file/processors/frame-tree/content/content-frame-tree.js') {
-			transformed = contents
-				.replace('} else if ((!browser || !browser.runtime) && message.method == INIT_RESPONSE_MESSAGE) {',
-					'} else if (message.method == INIT_RESPONSE_MESSAGE) {');
-		}
-
 		// Patch single-file
 		else if (sourcefile === 'resource/SingleFile/lib/single-file/single-file.js') {
 			// We need to add this bit that is done for the cli implementation of singleFile

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -37,7 +37,6 @@ const symlinkFiles = [
 	'!resource/SingleFile/**/*',
 	'resource/SingleFile/lib/**/*',
 	'resource/SingleFile/extension/lib/single-file/fetch/content/content-fetch.js',
-	'!resource/SingleFile/lib/single-file/processors/frame-tree/content/content-frame-tree.js',
 	'!resource/SingleFile/lib/single-file/single-file.js',
 	'update.rdf'
 ];
@@ -91,7 +90,6 @@ const jsFiles = [
 	'resource/react.js',
 	'resource/react-dom.js',
 	'resource/react-virtualized.js',
-	'resource/SingleFile/lib/single-file/processors/frame-tree/content/content-frame-tree.js',
 	'resource/SingleFile/lib/single-file/single-file.js'
 ];
 


### PR DESCRIPTION
- Using `sandboxPrototype` properly uses window as prototype
- This commit removes the need for our patch in babel-worker.js
https://github.com/gildas-lormeau/SingleFile/commit/3d0bc4cf9fd23e4fe8f5b684a89c69521c306b60

This fixes #1908 and other similar issues like it.

@dstillman I also turned off `removeFrames` and included an extra commit that properly injects scripts to retrieve frame contents in the client. So frames should be working in both the connector and the client without the 10 second delay we saw before.

Here are two forum posts which both now work with these commits:
https://forums.zotero.org/discussion/85726/error-report-zetero-connector-failed-to-upload-webpage-snapshot
https://forums.zotero.org/discussion/85603/bug-in-zotero-beta-video-iframe-image-not-saved-in-snapshot
