### PR TITLE
Fix bug with async translate process never returning.

### DIFF
--- a/chrome/content/zotero/xpcom/translation/translate.js
+++ b/chrome/content/zotero/xpcom/translation/translate.js
@@ -1363,6 +1363,7 @@ Zotero.Translate.Base.prototype = {
 				if (maybePromise) {
 					maybePromise
 						.then(() => this.decrementAsyncProcesses("Zotero.Translate#translate()"))
+						.catch(e => this.complete(false, e));
 					return;
 				}
 			} catch (e) {


### PR DESCRIPTION
When using `doImport` a promise is returned, but was lacking a catch a
statement to ensure completion.

This fixes #1882