### PR TITLE
Retrieve metadata from identifier alert

### DIFF
--- a/chrome/content/zotero/bindings/itembox.xml
+++ b/chrome/content/zotero/bindings/itembox.xml
@@ -292,6 +292,17 @@
 					}
 					
 					this.updateRetracted();
+
+					// Hide the set identifier button
+					document.getElementById('set-identifier-box').style.display = 'none	';
+					// If the appropriate conditions are met, show it
+					if (!(this.item instanceof Zotero.FeedItem) && this.item.itemTypeID === 12) {
+						let timeAdded = Zotero.Date.sqlToDate(this.item.dateAdded, true).getTime();
+						let timeModified = Zotero.Date.sqlToDate(this.item.dateModified, true).getTime();
+						if (Math.abs(timeAdded - timeModified) < 2) {
+							document.getElementById('set-identifier-box').style.display = 'flex';
+						}
+					}
 					
 					if (this.clickByItem) {
 						var itemBox = document.getAnonymousNodes(this)[0];
@@ -1099,6 +1110,25 @@
 				<![CDATA[
 					var sbo = document.getAnonymousNodes(this)[0].boxObject;
 					sbo.ensureElementIsVisible(elem);
+				]]>
+				</body>
+			</method>
+			
+			
+			<method name="openIdentifierWindow">
+				<parameter name="e"/>
+				<body>
+				<![CDATA[
+						if (!ZoteroPane.canEdit()) {
+							ZoteroPane.displayCannotEditLibraryMessage();
+							return;
+						}
+
+						let io = { dataIn: { item: this.item }, dataOut: null };
+						window.openDialog('chrome://zotero/content/identifyItemDialog.xul', '', 'chrome,modal,centerscreen', io);
+						if (!io.dataOut) {
+							return;
+						}
 				]]>
 				</body>
 			</method>
@@ -2662,6 +2692,18 @@
 						<p id="retraction-credit"/>
 						<div id="retraction-hide"><button/></div>
 					</div>
+				</div>
+				<div xmlns="http://www.w3.org/1999/xhtml"
+					 id="set-identifier-box"
+					 class="set-identifier-box">
+					<button class="text"
+							onclick="document.getBindingParent(this).openIdentifierWindow();">
+						Retrieve Metadata from Identifier
+					</button>
+					<button class="close"
+							onclick="document.getElementById('set-identifier-box').style.display = 'none';">
+						<span class="close-x">x</span>
+					</button>
 				</div>
 				<grid flex="1">
 					<columns>

--- a/chrome/content/zotero/components/createParent/createParent.jsx
+++ b/chrome/content/zotero/components/createParent/createParent.jsx
@@ -49,12 +49,12 @@ function CreateParent({ loading, item, toggleAccept }) {
 		>
 			<div className="create-parent-container">
 				<span className="title">
-					{ item.attachmentFilename }
+					{ item.isAttachment() ? item.attachmentFilename : item.getField('title') }
 				</span>
 				<div className="body">
 					<input
 						id="parent-item-identifier"
-						placeholder={ Zotero.getString('createParent.prompt') }
+						placeholder={ Zotero.getString(item.isAttachment() ? 'createParent.prompt' : 'identifyItem.prompt') }
 						size="50"
 						disabled={ loading }
 						onChange={ handleInput }

--- a/chrome/content/zotero/identifyItemDialog.js
+++ b/chrome/content/zotero/identifyItemDialog.js
@@ -1,0 +1,80 @@
+/*
+    ***** BEGIN LICENSE BLOCK *****
+
+    Copyright © 2009 Center for History and New Media
+                     George Mason University, Fairfax, Virginia, USA
+                     http://zotero.org
+
+    This file is part of Zotero.
+
+    Zotero is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Zotero is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
+
+    ***** END LICENSE BLOCK *****
+*/
+
+"use strict";
+
+var io;
+let createParent;
+
+function toggleAccept(enabled) {
+	document.documentElement.getButton("accept").disabled = !enabled;
+}
+
+function doLoad() {
+	// Set font size from pref
+	let sbc = document.getElementById('zotero-create-parent-container');
+	Zotero.setFontSize(sbc);
+
+	io = window.arguments[0];
+
+	createParent = document.getElementById('create-parent');
+	Zotero.CreateParent.render(createParent, {
+		loading: false,
+		item: io.dataIn.item,
+		toggleAccept
+	});
+}
+
+function doUnload() {
+	Zotero.CreateParent.destroy(createParent);
+}
+
+async function doAccept() {
+	let textBox = document.getElementById('parent-item-identifier');
+	let childItem = io.dataIn.item;
+	let newItems = await Zotero_Lookup.addItemsFromIdentifier(
+		textBox,
+		childItem,
+		(on) => {
+			// Render react again with correct loading value
+			Zotero.CreateParent.render(createParent, {
+				loading: on,
+				item: childItem,
+				toggleAccept
+			});
+		}
+	);
+
+	// If we successfully created a parent, return it
+	if (newItems) {
+		io.dataOut = { parent: newItems[0] };
+		window.close();
+	}
+}
+
+function doManualEntry() {
+	io.dataOut = { parent: false };
+	window.close();
+}

--- a/chrome/content/zotero/identifyItemDialog.xul
+++ b/chrome/content/zotero/identifyItemDialog.xul
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
+<?xml-stylesheet href="chrome://zotero/skin/zotero.css" type="text/css"?>
+<?xml-stylesheet href="chrome://zotero/skin/overlay.css" type="text/css"?>
+<?xml-stylesheet href="chrome://zotero-platform/content/overlay.css" type="text/css"?>
+<?xml-stylesheet href="chrome://zotero-platform/content/zotero-react-client.css"?>
+
+<!DOCTYPE window SYSTEM "chrome://zotero/locale/zotero.dtd">
+
+<dialog
+	id="zotero-parent-dialog"
+	title="Retrieve Metadata From Identifier"
+	orient="vertical"
+	buttons="cancel,accept"
+	buttondisabledaccept="true"
+	buttonlabelaccept="Retrieve Metadata"
+	ondialogaccept="doAccept();return false;"
+	onload="doLoad();"
+	onunload="doUnload();"
+	xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
+	xmlns:html="http://www.w3.org/1999/xhtml"
+	style="padding:20px 15px;width:400px;">
+
+	<script src="include.js"/>
+	<script src="lookup.js"/>
+	<script src="identifyItemDialog.js"/>
+	<script src="components/createParent/createParent.js"/>
+
+	<vbox id="zotero-create-parent-container" flex="1">
+		<html:div id="create-parent" />
+	</vbox>
+</dialog>

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -4512,7 +4512,7 @@ var ZoteroPane = new function()
 		
 		let item = this.getSelectedItems()[0];
 		if (!item.isAttachment() || !item.isTopLevelItem()) {
-			throw new Error('Item ' + itemID + ' is not a top-level attachment');
+			throw new Error('Item ' + item.id + ' is not a top-level attachment');
 		}
 
 		let io = { dataIn: { item }, dataOut: null };

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -1150,6 +1150,7 @@ lookup.failureToID.description		= Zotero could not find any identifiers in your 
 lookup.failureTooMany.description	= Too many identifiers. Please enter one identifier and try again.
 
 createParent.prompt					= Enter a DOI, ISBN, PMID, or arXiv ID to identify this file
+identifyItem.prompt					= Enter a DOI, ISBN, PMID, or arXiv ID to identify this item
 
 locate.online.label					= View Online
 locate.online.tooltip				= Go to this item online

--- a/scss/_zotero-react-client.scss
+++ b/scss/_zotero-react-client.scss
@@ -25,6 +25,7 @@
 @import "components/createParent";
 @import "components/editable";
 @import "components/icons";
+@import "components/itemDetails";
 @import "components/progressMeter";
 @import "components/search";
 @import "components/tagsBox";

--- a/scss/components/_itemDetails.scss
+++ b/scss/components/_itemDetails.scss
@@ -1,0 +1,44 @@
+.set-identifier-box {
+	display: flex;
+	cursor: pointer;
+	margin-bottom: 1em;
+	background: $clicky-hover-bg-color;
+	border: 1px solid $clicky-border-color;
+	
+	button {
+		font-family: Lucida Grande, Lucida Sans Unicode, Lucida Sans, Geneva, -apple-system, sans-serif !important;
+	}
+
+	.text {
+		cursor: pointer;
+		background: none;
+		border: none;
+		text-align: left;
+		padding: 3px 0.5em;
+		flex: 1;
+	}
+
+	.close {
+		cursor: pointer;
+		background: none;
+		border: none;
+		padding: 3px 1.5em 3px 1.5em;
+		position: relative;
+		
+		.close-x {
+			position: absolute;
+			cursor: pointer;
+			top: -2px;
+			right: 10px;
+			font-size: 18px;
+		}
+	}
+
+	.text, .close {
+		&:hover {
+			cursor: pointer;
+			color: white;
+			background: $blue;
+		}
+	}
+}


### PR DESCRIPTION
Inspired by: https://forums.zotero.org/discussion/comment/369979

First pass here to get feedback on UI design and flow. The code should be unified with createParent feature before this is merged.

- The alert currently only shows up when item type is `Document` and the `Date Added` and `Date Modified` are within 2 seconds of each other. What are the best heuristics to use here?
- Once you click on the `X` the `Date Modified` is touched in the database to bump it outside the 2 second window and we won't ever display the alert for this item again.
- For this dialog, I think allowing the use of URLs via translator-service makes more sense.
- What do we want to happen when we `Retrieve Metadata`? This should overwrite everything? That seems reasonable as long as we add a warning to the dialog. Or we could do a checkbox below the text box that allows you to overwrite?

![Screen Shot 2020-12-15 at 8 46 43 AM](https://user-images.githubusercontent.com/4305610/102238532-1823ce80-3eb3-11eb-91fd-d7b97af97dbf.png)

![Screen Shot 2020-12-15 at 8 47 28 AM](https://user-images.githubusercontent.com/4305610/102238547-1b1ebf00-3eb3-11eb-983d-ab3f1c090740.png)
