### PR TITLE
Fix Input component doesn't work if autoComplete=false

### DIFF
--- a/chrome/content/zotero/components/form/input.jsx
+++ b/chrome/content/zotero/components/form/input.jsx
@@ -69,7 +69,7 @@ class Input extends React.PureComponent {
 	}
 
 	handleChange({ target }, { newValue } = {}) {
-		var newValue = newValue || target.value;
+		newValue = newValue || target.value;
 		this.setState({
 			value: newValue,
 		});

--- a/chrome/content/zotero/components/form/input.jsx
+++ b/chrome/content/zotero/components/form/input.jsx
@@ -69,7 +69,7 @@ class Input extends React.PureComponent {
 	}
 
 	handleChange({ target }, options) {
-		var newValue = options.newValue || target.value;
+		var newValue = options && options.newValue || target.value;
 		this.setState({
 			value: newValue,
 		});

--- a/chrome/content/zotero/components/form/input.jsx
+++ b/chrome/content/zotero/components/form/input.jsx
@@ -68,8 +68,8 @@ class Input extends React.PureComponent {
 		}
 	}
 
-	handleChange({ target }, options) {
-		var newValue = options && options.newValue || target.value;
+	handleChange({ target }, { newValue } = {}) {
+		var newValue = newValue || target.value;
 		this.setState({
 			value: newValue,
 		});


### PR DESCRIPTION
The Input component doesn't work if its autoComplete prop is set to false, as described here: https://groups.google.com/g/zotero-dev/c/vKdxvZJL8UQ/m/VLqu-3VGBQAJ
The commit proposed seems to solve the issue.