### PR TITLE
Individual sync preferences for groups

### DIFF
--- a/chrome/content/zotero/preferences/groupFilesToSync.html
+++ b/chrome/content/zotero/preferences/groupFilesToSync.html
@@ -1,0 +1,40 @@
+<!--
+    ***** BEGIN LICENSE BLOCK *****
+
+    Copyright © 2021 Corporation for Digital Scholarship
+                     Vienna, Virginia, USA
+                     https://digitalscholar.org
+
+    This file is part of Zotero.
+
+    Zotero is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Zotero is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
+
+    ***** END LICENSE BLOCK *****
+-->
+
+<html>
+	<head>
+		<title>Customize Group Library File Syncing</title>
+
+		<link href="chrome://zotero-platform/content/zotero-react-client.css" rel="stylesheet"/>
+	</head>
+
+	<body>
+		<div id="root"></div>
+	</body>
+
+	<script src="chrome://zotero/content/include.js"></script>
+	<script src="groupFilesToSync.js"></script>
+
+</html>

--- a/chrome/content/zotero/preferences/groupFilesToSync.jsx
+++ b/chrome/content/zotero/preferences/groupFilesToSync.jsx
@@ -1,0 +1,371 @@
+/*
+    ***** BEGIN LICENSE BLOCK *****
+
+    Copyright © 2021 Corporation for Digital Scholarship
+                     Vienna, Virginia, USA
+                     https://digitalscholar.org
+
+    This file is part of Zotero.
+
+    Zotero is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Zotero is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
+
+    ***** END LICENSE BLOCK *****
+*/
+
+'use strict';
+
+import React, { memo, useState, useEffect } from 'react';
+import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
+import { IntlProvider, FormattedMessage, useIntl } from 'react-intl';
+
+const customPreferences = (id) => {
+	const pref = 'sync.storage.groups.' + id;
+
+	return {
+		enabled: Zotero.Prefs.get(pref + '.custom') || false,
+		sync: Zotero.Prefs.get(pref + '.sync') || false,
+		downloadMode: Zotero.Prefs.get(pref + '.downloadMode') || 'on-sync',
+		ttl: Zotero.Prefs.get(pref + '.ttl') || false,
+		ttlValue: Zotero.Prefs.get(pref + '.ttl.value') || '30'
+	};
+};
+
+const Group = memo(({ id, name, prefs, onChangeEnabled, onChangeSync, onChangeMode, onChangeTTLEnabled, onChangeTTLValue }) => {
+	const intl = useIntl();
+
+	return (
+		<div className="group">
+			<div className="group-header">
+				<div className="group-header-label">
+					{ name }
+				</div>
+
+				<input
+					id={ 'custom-' + id }
+					type="checkbox"
+					checked={ prefs.enabled }
+					onChange={ onChangeEnabled }
+				/>
+				<label htmlFor={ 'custom-' + id }>
+					{ intl.formatMessage({ id: 'zotero.preferences.sync.fileSyncing.groups.custom' }) }
+				</label>
+			</div>
+
+			{ prefs.enabled && <div className="group-settings">
+				<input
+					id={ 'enabled-' + id }
+					type="checkbox"
+					className="setting-enabled"
+					checked={ prefs.sync }
+					onChange={ onChangeSync }
+				/>
+				<label htmlFor={ 'enabled-' + id }>
+					{ intl.formatMessage({ id: 'zotero.preferences.sync.fileSyncing.groups.sync' }) }
+				</label>
+
+				<div className="setting-downloadMode-box">
+					<label htmlFor={ 'downloadMode-' + id }>
+						{ intl.formatMessage({ id: 'zotero.preferences.sync.fileSyncing.download' }) }
+					</label>
+					<select
+						id={ 'downloadMode-' + id }
+						value={ prefs.downloadMode }
+						disabled={ !prefs.sync }
+						onChange={ onChangeMode }
+					>
+						<option value="on-demand">
+							{ intl.formatMessage({ id: 'zotero.preferences.sync.fileSyncing.download.onDemand' }) }
+						</option>
+						<option value="on-sync">
+							{ intl.formatMessage({ id: 'zotero.preferences.sync.fileSyncing.download.atSyncTime' }) }
+						</option>
+					</select>
+				</div>
+
+				{ prefs.downloadMode === 'on-demand' && <div className="setting-ttl-box">
+					<input
+						id={ 'ttl-' + id }
+						type="checkbox"
+						checked={ prefs.ttl }
+						disabled={ !prefs.sync }
+						onChange={ onChangeTTLEnabled }
+					/>
+					<label htmlFor={ 'ttl-' + id }>
+						{ intl.formatMessage({ id: 'zotero.preferences.sync.fileSyncing.remove' }) }
+					</label>
+					<select
+						id={ 'ttl-value-' + id }
+						value={ prefs.ttlValue }
+						disabled={ !prefs.sync || !prefs.ttl }
+						className="setting-ttl-value"
+						onChange={ onChangeTTLValue }
+					>
+						<option value="1">1</option>
+						<option value="7">7</option>
+						<option value="30">30</option>
+					</select>
+					<label htmlFor={ 'ttl-value-' + id }>
+						{ intl.formatMessage({ id: 'zotero.preferences.sync.fileSyncing.remove.suffix' }) }
+					</label>
+				</div> }
+			</div> }
+		</div>
+	);
+});
+
+Group.propTypes = {
+	id: PropTypes.number,
+	name: PropTypes.string,
+	prefs: PropTypes.object,
+	onChangeEnabled: PropTypes.func,
+	onChangeSync: PropTypes.func,
+	onChangeMode: PropTypes.func,
+	onChangeTTLEnabled: PropTypes.func,
+	onChangeTTLValue: PropTypes.func
+};
+
+const GroupCustomSettings = memo(() => {
+	const intl = useIntl();
+
+	const [groups, setGroups] = useState([]);
+
+	// Global settings
+	const globalSyncEnabled = Zotero.Prefs.get('sync.storage.groups.enabled');
+	const globalDownloadMode = Zotero.Prefs.get('sync.storage.downloadMode.groups');
+
+	// If the global setting is on-sync for downloadMode then we
+	// might not have a set a TTL for global yet so we need default values
+	const globalTTLEnabled = Zotero.Prefs.get('sync.storage.groups.ttl') || false;
+	const globalTTLValue = Zotero.Prefs.get('sync.storage.groups.ttl.value') || 30;
+
+	// Simply turn off custom settings for all groups
+	const revertAllGroups = () => {
+		const newGroups = groups.map((group) => {
+			Zotero.Prefs.set('sync.storage.groups.' + group.id + '.custom', false);
+			group.prefs.enabled = false;
+			return group;
+		});
+
+		setGroups(newGroups);
+	};
+
+	// Asynchronously load all group libraries
+	useEffect(() => {
+		(async () => {
+			let apiKey = await Zotero.Sync.Data.Local.getAPIKey();
+			let client = Zotero.Sync.Runner.getAPIClient({ apiKey });
+			let groups = [];
+			try {
+				// Load up remote groups
+				let keyInfo = await Zotero.Sync.Runner.checkAccess(client, { timeout: 5000 });
+				groups = await client.getGroups(keyInfo.userID);
+			}
+			catch (e) {
+				// Connection problems
+				if ((e instanceof Zotero.HTTP.UnexpectedStatusException)
+					|| (e instanceof Zotero.HTTP.TimeoutException)
+					|| (e instanceof Zotero.HTTP.BrowserOfflineException)) {
+					Zotero.alert(
+						window,
+						Zotero.getString('general.error'),
+						Zotero.getString('sync.error.checkConnection', Zotero.clientName)
+					);
+				}
+				else {
+					throw e;
+				}
+				window.close();
+			}
+
+			let librariesToSkip = JSON.parse(Zotero.Prefs.get('sync.librariesToSkip') || '[]');
+
+			// Sort groups
+			let collation = Zotero.getLocaleCollation();
+			groups.sort((a, b) => collation.compareString(1, a.data.name, b.data.name));
+
+			// Put them into state
+			setGroups(
+				groups
+					.filter(group => librariesToSkip.indexOf("G" + group.id) === -1)
+					.map(group => ({
+						name: group.data.name,
+						id: group.id,
+						prefs: customPreferences(group.id)
+					}))
+			);
+		})();
+	}, []);
+
+	// Update the given pref and change the state
+	const updatePrefInGroups = (id, pref, value) => {
+		const newGroups = groups.map((group) => {
+			if (group.id === id) {
+				group.prefs[pref] = value;
+			}
+
+			return group;
+		});
+
+		setGroups(newGroups);
+	};
+
+	// Change listeners for each custom settings section
+	const onChangeEnabled = (e, id) => {
+		Zotero.Prefs.set('sync.storage.groups.' + id + '.custom', e.target.checked);
+		updatePrefInGroups(id, 'enabled', e.target.checked);
+	};
+
+	const onChangeSync = (e, id) => {
+		Zotero.Prefs.set('sync.storage.groups.' + id + '.sync', e.target.checked);
+		updatePrefInGroups(id, 'sync', e.target.checked);
+	};
+
+	const onChangeMode = (e, id) => {
+		Zotero.Prefs.set('sync.storage.groups.' + id + '.downloadMode', e.target.value);
+		updatePrefInGroups(id, 'downloadMode', e.target.value);
+	};
+
+	const onChangeTTLEnabled = (e, id) => {
+		Zotero.Prefs.set('sync.storage.groups.' + id + '.ttl', e.target.checked);
+		updatePrefInGroups(id, 'ttl', e.target.checked);
+	};
+
+	const onChangeTTLValue = (e, id) => {
+		Zotero.Prefs.set('sync.storage.groups.' + id + '.ttl.value', e.target.value);
+		updatePrefInGroups(id, 'ttlValue', e.target.value);
+	};
+
+	return (
+		<div className="group-files-sync-container">
+			<label
+				className="global-settings-label"
+				htmlFor="global-settings"
+			>
+				{ intl.formatMessage({ id: 'zotero.preferences.sync.fileSyncing.groups.global' }) }
+			</label>
+
+			<div className="global-settings">
+				<input
+					type="checkbox"
+					className="setting-enabled"
+					disabled="disabled"
+					checked={ globalSyncEnabled }
+				/>
+				<label htmlFor="global-enabled">
+					<FormattedMessage id="zotero.preferences.sync.fileSyncing.groups"/>
+				</label>
+
+				<div>
+					<div className="setting-downloadMode-box">
+						<label>
+							<FormattedMessage id="zotero.preferences.sync.fileSyncing.download"/>
+						</label>
+						<select
+							id="global-downloadMode"
+							disabled="disabled"
+							className="storage-mode"
+							value={ globalDownloadMode }
+						>
+							<option value="on-demand">
+								{ intl.formatMessage({ id: 'zotero.preferences.sync.fileSyncing.download.onDemand' }) }
+							</option>
+							<option value="on-sync">
+								{ intl.formatMessage({ id: 'zotero.preferences.sync.fileSyncing.download.atSyncTime' }) }
+							</option>
+						</select>
+					</div>
+
+					{ globalDownloadMode === 'on-demand' && <div className="setting-ttl-box">
+						<input
+							type="checkbox"
+							id="global-ttl"
+							disabled="disabled"
+							checked={ globalTTLEnabled }
+						/>
+						<label htmlFor="global-ttl">
+							{ intl.formatMessage({ id: 'zotero.preferences.sync.fileSyncing.remove' }) }
+						</label>
+						<select
+							id="global-ttl-value"
+							disabled="disabled"
+							className="storage-mode"
+							value={ globalTTLValue }
+						>
+							<option value="1">1</option>
+							<option value="7">7</option>
+							<option value="30">30</option>
+						</select>
+						<label htmlFor="global-ttl-value">
+							{ intl.formatMessage({ id: 'zotero.preferences.sync.fileSyncing.remove.suffix' }) }
+						</label>
+					</div> }
+
+				</div>
+
+				<div className="reset-container">
+					<button
+						className="button-native"
+						onClick={ revertAllGroups }
+					>
+						{ intl.formatMessage({ id: 'zotero.preferences.sync.fileSyncing.groups.revert' }) }
+					</button>
+				</div>
+			</div>
+
+			<div className="groups-file-sync-groups">
+				{ groups.length === 0 && <div className="group">
+					{ Zotero.getString('zotero.preferences.sync.librariesToSync.loadingLibraries') }
+				</div> }
+				{ groups.map((group) => {
+					return (
+						<Group
+							key={ group.id }
+							name={ group.name }
+							id={ group.id }
+							prefs={ group.prefs }
+							onChangeEnabled={ e => onChangeEnabled(e, group.id) }
+							onChangeSync={ e => onChangeSync(e, group.id) }
+							onChangeMode={ e => onChangeMode(e, group.id) }
+							onChangeTTLEnabled={ e => onChangeTTLEnabled(e, group.id) }
+							onChangeTTLValue={ e => onChangeTTLValue(e, group.id) }
+						/>
+					);
+				}) }
+			</div>
+
+			<div className="dialog-buttons">
+				<button
+					default="noop"
+					className="button-native"
+					onClick={ () => window.close() }
+				>
+					{ intl.formatMessage({ id: 'zotero.general.ok' }) }
+				</button>
+			</div>
+		</div>
+	);
+});
+
+ReactDOM.render(
+	<IntlProvider
+		locale={ Zotero.locale }
+		messages={ Zotero.Intl.strings }
+	>
+		<GroupCustomSettings />
+	</IntlProvider>,
+	document.getElementById('root')
+);
+
+document.title = Zotero.getString('zotero.preferences.sync.groups.title');

--- a/chrome/content/zotero/preferences/groupFilesToSync.jsx
+++ b/chrome/content/zotero/preferences/groupFilesToSync.jsx
@@ -285,12 +285,12 @@ const GroupCustomSettings = memo(() => {
 
 	const onChangeTTLValue = (e, id) => {
 		if (id) {
-			Zotero.Prefs.set('sync.storage.groups.' + id + '.ttl.value', e.target.value);
+			Zotero.Prefs.set('sync.storage.groups.' + id + '.ttl.value', parseInt(e.target.value));
 		}
 		else {
-			Zotero.Prefs.set('sync.storage.groups.ttl.value', e.target.value);
+			Zotero.Prefs.set('sync.storage.groups.ttl.value', parseInt(e.target.value));
 		}
-		updatePrefInGroups(id, 'ttlValue', e.target.value);
+		updatePrefInGroups(id, 'ttlValue', parseInt(e.target.value));
 	};
 
 	return (

--- a/chrome/content/zotero/preferences/preferences_sync.js
+++ b/chrome/content/zotero/preferences/preferences_sync.js
@@ -33,6 +33,8 @@ Zotero_Preferences.Sync = {
 	noChar: '\uD83D\uDEAB',
 	
 	init: Zotero.Promise.coroutine(function* () {
+		this.checkCustomTTL(false);
+		this.checkCustomTTL(true);
 		this.updateStorageSettingsUI();
 		this.updateStorageSettingsGroupsUI();
 
@@ -71,6 +73,30 @@ Zotero_Preferences.Sync = {
 		
 		this.initResetPane();
 	}),
+
+	checkCustomTTL: function (groups) {
+		let id = groups ? 'storage-groups-download-ttl-custom' : 'storage-user-download-ttl-custom';
+		let value = Zotero.Prefs.get(
+			groups ? 'sync.storage.groups.ttl.value' : 'sync.storage.personal.ttl.value'
+		);
+
+		let customItem = document.getElementById(id);
+		if (![1, 7, 30, 90].includes(value)) {
+			customItem.setAttribute('label',
+				Zotero.getString(
+					'zotero.preferences.sync.fileSyncing.ttl.custom',
+					value,
+					value
+				)
+			);
+			customItem.value = value;
+			customItem.hidden = false;
+			customItem.parentNode.parentNode.selectedIndex = 0;
+		}
+		else {
+			customItem.hidden = true;
+		}
+	},
 	
 	displayFields: function (username) {
 		document.getElementById('sync-unauthorized').hidden = !!username;
@@ -420,6 +446,8 @@ Zotero_Preferences.Sync = {
 		var io = {};
 		window.openDialog('chrome://zotero/content/preferences/groupFilesToSync.html',
 			"zotero-preferences-groupFilesToSyncDialog", "chrome,modal,centerscreen", io);
+		// Group preferences may have changed so run our updates
+		this.updateStorageSettingsGroupsUI();
 	},
 	
 	updateStorageTerms: function () {

--- a/chrome/content/zotero/preferences/preferences_sync.js
+++ b/chrome/content/zotero/preferences/preferences_sync.js
@@ -380,20 +380,47 @@ Zotero_Preferences.Sync = {
 		}
 		
 		document.getElementById('storage-user-download-mode').disabled = !enabled;
+		document.getElementById('storage-user-download-ttl').disabled = !enabled;
+		document.getElementById('storage-user-download-ttl-value').disabled
+			= !(enabled && document.getElementById('storage-user-download-ttl').checked);
 		this.updateStorageTerms();
 		
 		window.sizeToContent();
 	}),
 	
 	
+	updateStorageSettingsTTLUI: function () {
+		document.getElementById('storage-user-download-ttl-box').hidden
+			= document.getElementById('storage-user-download-mode').value !== 'on-demand';
+	},
+
+
 	updateStorageSettingsGroupsUI: function () {
 		setTimeout(() => {
 			var enabled = document.getElementById('pref-storage-groups-enabled').value;
 			document.getElementById('storage-groups-download-mode').disabled = !enabled;
+			document.getElementById('storage-groups-download-ttl-box').hidden
+				= document.getElementById('storage-groups-download-mode').value !== 'on-demand';
+			document.getElementById('storage-groups-download-ttl').disabled = !enabled;
+			document.getElementById('storage-groups-download-ttl-value').disabled
+				= !(enabled && document.getElementById('storage-groups-download-ttl').checked);
 			this.updateStorageTerms();
 		});
 	},
+
+	updatePersonalTTLUI: function (event) {
+		document.getElementById('storage-user-download-ttl-value').disabled = !event.target.checked;
+	},
 	
+	updateGroupsTTLUI: function (event) {
+		document.getElementById('storage-groups-download-ttl-value').disabled = !event.target.checked;
+	},
+
+	customizeGroups: function () {
+		var io = {};
+		window.openDialog('chrome://zotero/content/preferences/groupFilesToSync.html',
+			"zotero-preferences-groupFilesToSyncDialog", "chrome,modal,centerscreen", io);
+	},
 	
 	updateStorageTerms: function () {
 		var terms = document.getElementById('storage-terms');

--- a/chrome/content/zotero/preferences/preferences_sync.xul
+++ b/chrome/content/zotero/preferences/preferences_sync.xul
@@ -41,10 +41,10 @@
 			<preference id="pref-storage-downloadMode-personal" name="extensions.zotero.sync.storage.downloadMode.personal" type="string"/>
 			<preference id="pref-storage-downloadMode-groups" name="extensions.zotero.sync.storage.downloadMode.groups" type="string"/>
 			<preference id="pref-storage-groups-enabled" name="extensions.zotero.sync.storage.groups.enabled" type="bool"/>
-			<preference id="pref-storage-groups-TTL" name="extensions.zotero.sync.storage.groups.ttl" type="bool"/>
-			<preference id="pref-storage-groups-TTL-value" name="extensions.zotero.sync.storage.groups.ttl.value" type="int"/>
 			<preference id="pref-storage-personal-TTL" name="extensions.zotero.sync.storage.personal.ttl" type="bool"/>
 			<preference id="pref-storage-personal-TTL-value" name="extensions.zotero.sync.storage.personal.ttl.value" type="int"/>
+			<preference id="pref-storage-groups-TTL" name="extensions.zotero.sync.storage.groups.ttl" type="bool"/>
+			<preference id="pref-storage-groups-TTL-value" name="extensions.zotero.sync.storage.groups.ttl.value" type="int"/>
 		</preferences>
 		
 		<tabbox>
@@ -263,12 +263,13 @@
 											  preference="pref-storage-personal-TTL-value"
 											  style="margin-left: 0">
 										<menupopup>
-											<menuitem label="1" value="1"/>
-											<menuitem label="7" value="7"/>
-											<menuitem label="30" value="30"/>
+											<menuitem id="storage-user-download-ttl-custom" value="0" hidden="true"/>
+											<menuitem label="&zotero.preferences.sync.fileSyncing.ttl.day;" value="1"/>
+											<menuitem label="&zotero.preferences.sync.fileSyncing.ttl.week;" value="7"/>
+											<menuitem label="&zotero.preferences.sync.fileSyncing.ttl.month;" value="30"/>
+											<menuitem label="&zotero.preferences.sync.fileSyncing.ttl.multipleMonths;" value="90"/>
 										</menupopup>
 									</menulist>
-									<label value="&zotero.preferences.sync.fileSyncing.remove.suffix;" />
 								</hbox>
 							</vbox>
 
@@ -307,12 +308,13 @@
 											  preference="pref-storage-groups-TTL-value"
 											  style="margin-left: 0">
 										<menupopup>
-											<menuitem label="1" value="1"/>
-											<menuitem label="7" value="7"/>
-											<menuitem label="30" value="30"/>
+											<menuitem id="storage-groups-download-ttl-custom" value="0" hidden="true"/>
+											<menuitem label="&zotero.preferences.sync.fileSyncing.ttl.day;" value="1"/>
+											<menuitem label="&zotero.preferences.sync.fileSyncing.ttl.week;" value="7"/>
+											<menuitem label="&zotero.preferences.sync.fileSyncing.ttl.month;" value="30"/>
+											<menuitem label="&zotero.preferences.sync.fileSyncing.ttl.multipleMonths;" value="90"/>
 										</menupopup>
 									</menulist>
-									<label value="&zotero.preferences.sync.fileSyncing.remove.suffix;" />
 								</hbox>
 
 								<box>

--- a/chrome/content/zotero/preferences/preferences_sync.xul
+++ b/chrome/content/zotero/preferences/preferences_sync.xul
@@ -41,6 +41,10 @@
 			<preference id="pref-storage-downloadMode-personal" name="extensions.zotero.sync.storage.downloadMode.personal" type="string"/>
 			<preference id="pref-storage-downloadMode-groups" name="extensions.zotero.sync.storage.downloadMode.groups" type="string"/>
 			<preference id="pref-storage-groups-enabled" name="extensions.zotero.sync.storage.groups.enabled" type="bool"/>
+			<preference id="pref-storage-groups-TTL" name="extensions.zotero.sync.storage.groups.ttl" type="bool"/>
+			<preference id="pref-storage-groups-TTL-value" name="extensions.zotero.sync.storage.groups.ttl.value" type="int"/>
+			<preference id="pref-storage-personal-TTL" name="extensions.zotero.sync.storage.personal.ttl" type="bool"/>
+			<preference id="pref-storage-personal-TTL-value" name="extensions.zotero.sync.storage.personal.ttl.value" type="int"/>
 		</preferences>
 		
 		<tabbox>
@@ -231,18 +235,42 @@
 
 							</stack>
 
-							<hbox class="storage-settings-download-options" align="center">
-								<label value="&zotero.preferences.sync.fileSyncing.download;"/>
-								<menulist id="storage-user-download-mode"
-										class="storage-mode"
-										preference="pref-storage-downloadMode-personal"
-										style="margin-left: 0">
-									<menupopup>
-										<menuitem label="&zotero.preferences.sync.fileSyncing.download.onDemand;" value="on-demand"/>
-										<menuitem label="&zotero.preferences.sync.fileSyncing.download.atSyncTime;" value="on-sync"/>
-									</menupopup>
-								</menulist>
-							</hbox>
+							<vbox class="storage-settings-download-options">
+								<hbox align="center">
+									<label value="&zotero.preferences.sync.fileSyncing.download;"/>
+									<menulist id="storage-user-download-mode"
+											class="storage-mode"
+											preference="pref-storage-downloadMode-personal"
+											oncommand="Zotero_Preferences.Sync.updateStorageSettingsTTLUI();"
+											style="margin-left: 0">
+										<menupopup>
+											<menuitem label="&zotero.preferences.sync.fileSyncing.download.onDemand;" value="on-demand"/>
+											<menuitem label="&zotero.preferences.sync.fileSyncing.download.atSyncTime;" value="on-sync"/>
+										</menupopup>
+									</menulist>
+								</hbox>
+
+								<hbox id="storage-user-download-ttl-box"
+									  align="center">
+									<checkbox
+										id="storage-user-download-ttl"
+										label="&zotero.preferences.sync.fileSyncing.remove;"
+										preference="pref-storage-personal-TTL"
+										oncommand="Zotero_Preferences.Sync.updatePersonalTTLUI(event)"
+									/>
+									<menulist id="storage-user-download-ttl-value"
+											  class="storage-mode"
+											  preference="pref-storage-personal-TTL-value"
+											  style="margin-left: 0">
+										<menupopup>
+											<menuitem label="1" value="1"/>
+											<menuitem label="7" value="7"/>
+											<menuitem label="30" value="30"/>
+										</menupopup>
+									</menulist>
+									<label value="&zotero.preferences.sync.fileSyncing.remove.suffix;" />
+								</hbox>
+							</vbox>
 
 							<separator id="storage-separator" class="thin"/>
 
@@ -251,18 +279,49 @@
 									preference="pref-storage-groups-enabled"
 										oncommand="Zotero_Preferences.Sync.updateStorageSettingsGroupsUI()"/>
 
-							<hbox class="storage-settings-download-options" align="center">
-								<label value="&zotero.preferences.sync.fileSyncing.download;"/>
-								<menulist id="storage-groups-download-mode"
-										class="storage-mode"
-										preference="pref-storage-downloadMode-groups"
-										style="margin-left: 0">
-									<menupopup>
-										<menuitem label="&zotero.preferences.sync.fileSyncing.download.onDemand;" value="on-demand"/>
-										<menuitem label="&zotero.preferences.sync.fileSyncing.download.atSyncTime;" value="on-sync"/>
-									</menupopup>
-								</menulist>
-							</hbox>
+							<vbox class="storage-settings-download-options">
+								<hbox align="center">
+									<label value="&zotero.preferences.sync.fileSyncing.download;"/>
+									<menulist id="storage-groups-download-mode"
+											class="storage-mode"
+											preference="pref-storage-downloadMode-groups"
+											oncommand="Zotero_Preferences.Sync.updateStorageSettingsGroupsUI()"
+											style="margin-left: 0">
+										<menupopup>
+											<menuitem label="&zotero.preferences.sync.fileSyncing.download.onDemand;" value="on-demand"/>
+											<menuitem label="&zotero.preferences.sync.fileSyncing.download.atSyncTime;" value="on-sync"/>
+										</menupopup>
+									</menulist>
+								</hbox>
+
+								<hbox id="storage-groups-download-ttl-box"
+									  align="center">
+									<checkbox
+										id="storage-groups-download-ttl"
+										label="&zotero.preferences.sync.fileSyncing.remove;"
+										preference="pref-storage-groups-TTL"
+										oncommand="Zotero_Preferences.Sync.updateGroupsTTLUI(event)"
+									/>
+									<menulist id="storage-groups-download-ttl-value"
+											  class="storage-mode"
+											  preference="pref-storage-groups-TTL-value"
+											  style="margin-left: 0">
+										<menupopup>
+											<menuitem label="1" value="1"/>
+											<menuitem label="7" value="7"/>
+											<menuitem label="30" value="30"/>
+										</menupopup>
+									</menulist>
+									<label value="&zotero.preferences.sync.fileSyncing.remove.suffix;" />
+								</hbox>
+
+								<box>
+									<button
+										label="&zotero.preferences.sync.fileSyncing.groups.customize;"
+										oncommand="Zotero_Preferences.Sync.customizeGroups()"
+									/>
+								</box>
+							</vbox>
 
 							<separator class="thin"/>
 

--- a/chrome/content/zotero/xpcom/data/group.js
+++ b/chrome/content/zotero/xpcom/data/group.js
@@ -236,6 +236,9 @@ Zotero.Group.prototype._finalizeErase = Zotero.Promise.coroutine(function* (env)
 	
 	Zotero.Groups.unregister(this.groupID);
 	
+	// Clear custom preferences for this group
+	Zotero.Prefs.resetBranch([], 'extensions.zotero.sync.storage.groups.' + this.groupID + '.');
+
 	yield Zotero.Group._super.prototype._finalizeErase.call(this, env);
 });
 

--- a/chrome/content/zotero/xpcom/intl.js
+++ b/chrome/content/zotero/xpcom/intl.js
@@ -76,7 +76,7 @@ Zotero.Intl = new function () {
 		Zotero.rtl = (Zotero.dir === 'rtl');
 		
 		this.strings = {};
-		const intlFiles = ['zotero.dtd'];
+		const intlFiles = ['zotero.dtd', 'preferences.dtd'];
 		for (let intlFile of intlFiles) {
 			let localeXML = Zotero.File.getContentsFromURL(`chrome://zotero/locale/${intlFile}`);
 			let regexp = /<!ENTITY ([^\s]+)\s+"([^"]+)/g;

--- a/chrome/content/zotero/xpcom/storage/storageLocal.js
+++ b/chrome/content/zotero/xpcom/storage/storageLocal.js
@@ -49,6 +49,12 @@ Zotero.Sync.Storage.Local = {
 			return true;
 		
 		case 'group':
+			// Check for custom group settings first
+			if (Zotero.Prefs.get('sync.storage.groups.' + libraryID + '.custom')) {
+				return Zotero.Prefs.get('sync.storage.groups.' + libraryID + '.sync');
+			}
+
+			// Fall back to global settings
 			return Zotero.Prefs.get("sync.storage.groups.enabled");
 		
 		case 'feed':
@@ -138,9 +144,13 @@ Zotero.Sync.Storage.Local = {
 		if (libraryID == Zotero.Libraries.userLibraryID) {
 			return 'sync.storage.downloadMode.personal';
 		}
-		// TODO: Library-specific settings
 		
-		// Group library
+		// Group library custom settings, if enabled
+		if (Zotero.Prefs.get('sync.storage.groups.' + libraryID + '.custom')) {
+			return 'sync.storage.groups.' + libraryID + '.downloadMode';
+		}
+
+		// Fall back to global group settings
 		return 'sync.storage.downloadMode.groups';
 	},
 	

--- a/chrome/content/zotero/xpcom/storage/storageLocal.js
+++ b/chrome/content/zotero/xpcom/storage/storageLocal.js
@@ -50,8 +50,9 @@ Zotero.Sync.Storage.Local = {
 		
 		case 'group':
 			// Check for custom group settings first
-			if (Zotero.Prefs.get('sync.storage.groups.' + libraryID + '.custom')) {
-				return Zotero.Prefs.get('sync.storage.groups.' + libraryID + '.sync');
+			let groupID = Zotero.Groups.getGroupIDFromLibraryID(libraryID);
+			if (Zotero.Prefs.get('sync.storage.groups.' + groupID + '.custom')) {
+				return Zotero.Prefs.get('sync.storage.groups.' + groupID + '.sync');
 			}
 
 			// Fall back to global settings

--- a/chrome/content/zotero/xpcom/sync/syncLocal.js
+++ b/chrome/content/zotero/xpcom/sync/syncLocal.js
@@ -144,9 +144,9 @@ Zotero.Sync.Data.Local = {
 			if (io.accept) {
 				var resetDataDirFile = OS.Path.join(Zotero.DataDirectory.dir, 'reset-data-directory');
 				yield Zotero.File.putContentsAsync(resetDataDirFile, '');
-				
+
+				Zotero.Prefs.resetBranch([], 'extensions.zotero.sync.storage.groups.');
 				Zotero.Prefs.clear('sync.storage.downloadMode.groups');
-				Zotero.Prefs.clear('sync.storage.groups.enabled');
 				Zotero.Prefs.clear('sync.storage.downloadMode.personal');
 				Zotero.Prefs.clear('sync.storage.username');
 				Zotero.Prefs.clear('sync.storage.url');

--- a/chrome/locale/en-US/zotero/preferences.dtd
+++ b/chrome/locale/en-US/zotero/preferences.dtd
@@ -61,15 +61,19 @@
 <!ENTITY zotero.preferences.sync.fileSyncing.myLibrary				"Sync attachment files in My Library using">
 <!ENTITY zotero.preferences.sync.fileSyncing.groups				"Sync attachment files in group libraries using Zotero storage">
 <!ENTITY zotero.preferences.sync.fileSyncing.groups.global			"Global Settings">
-<!ENTITY zotero.preferences.sync.fileSyncing.groups.custom			"Use Custom Settings">
+<!ENTITY zotero.preferences.sync.fileSyncing.groups.custom			"Group-Specific Settings">
+<!ENTITY zotero.preferences.sync.fileSyncing.groups.custom.use		"Use Custom Settings">
 <!ENTITY zotero.preferences.sync.fileSyncing.groups.sync			"Sync attachment files">
-<!ENTITY zotero.preferences.sync.fileSyncing.groups.customize		"Customize...">
-<!ENTITY zotero.preferences.sync.fileSyncing.groups.revert			"Revert All Groups to Global Settings">
+<!ENTITY zotero.preferences.sync.fileSyncing.groups.customize		"Customize Group Settings…">
+<!ENTITY zotero.preferences.sync.fileSyncing.groups.revert			"Use Global Settings for All Groups">
 <!ENTITY zotero.preferences.sync.fileSyncing.download				"Download files">
 <!ENTITY zotero.preferences.sync.fileSyncing.download.atSyncTime	"at sync time">
 <!ENTITY zotero.preferences.sync.fileSyncing.download.onDemand		"as needed">
+<!ENTITY zotero.preferences.sync.fileSyncing.ttl.day				"1 day">
+<!ENTITY zotero.preferences.sync.fileSyncing.ttl.week				"1 week">
+<!ENTITY zotero.preferences.sync.fileSyncing.ttl.month				"1 month">
+<!ENTITY zotero.preferences.sync.fileSyncing.ttl.multipleMonths		"3 months">
 <!ENTITY zotero.preferences.sync.fileSyncing.remove				    "Remove downloaded files if not opened for">
-<!ENTITY zotero.preferences.sync.fileSyncing.remove.suffix			"day(s)">
 <!ENTITY zotero.preferences.sync.fileSyncing.verifyServer         "Verify Server">
 <!ENTITY zotero.preferences.sync.fileSyncing.tos1					"By using Zotero storage, you agree to become bound by its">
 <!ENTITY zotero.preferences.sync.fileSyncing.tos2					"terms and conditions">

--- a/chrome/locale/en-US/zotero/preferences.dtd
+++ b/chrome/locale/en-US/zotero/preferences.dtd
@@ -60,9 +60,16 @@
 <!ENTITY zotero.preferences.sync.fileSyncing.url					"URL:">
 <!ENTITY zotero.preferences.sync.fileSyncing.myLibrary				"Sync attachment files in My Library using">
 <!ENTITY zotero.preferences.sync.fileSyncing.groups				"Sync attachment files in group libraries using Zotero storage">
+<!ENTITY zotero.preferences.sync.fileSyncing.groups.global			"Global Settings">
+<!ENTITY zotero.preferences.sync.fileSyncing.groups.custom			"Use Custom Settings">
+<!ENTITY zotero.preferences.sync.fileSyncing.groups.sync			"Sync attachment files">
+<!ENTITY zotero.preferences.sync.fileSyncing.groups.customize		"Customize...">
+<!ENTITY zotero.preferences.sync.fileSyncing.groups.revert			"Revert All Groups to Global Settings">
 <!ENTITY zotero.preferences.sync.fileSyncing.download				"Download files">
 <!ENTITY zotero.preferences.sync.fileSyncing.download.atSyncTime	"at sync time">
 <!ENTITY zotero.preferences.sync.fileSyncing.download.onDemand		"as needed">
+<!ENTITY zotero.preferences.sync.fileSyncing.remove				    "Remove downloaded files if not opened for">
+<!ENTITY zotero.preferences.sync.fileSyncing.remove.suffix			"day(s)">
 <!ENTITY zotero.preferences.sync.fileSyncing.verifyServer         "Verify Server">
 <!ENTITY zotero.preferences.sync.fileSyncing.tos1					"By using Zotero storage, you agree to become bound by its">
 <!ENTITY zotero.preferences.sync.fileSyncing.tos2					"terms and conditions">

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -668,6 +668,7 @@ zotero.preferences.sync.reset.restoreToServer          = %1$S will replace data 
 zotero.preferences.sync.reset.restoreToServer.button   = Replace Data in Online Library
 zotero.preferences.sync.reset.fileSyncHistory          = On the next sync, %1$S will check all attachment files in “%2$S” against the storage service. Any remote attachment files that are missing locally will be downloaded, and local attachment files missing remotely will be uploaded.\n\nThis option is not necessary during normal usage.
 zotero.preferences.sync.reset.fileSyncHistory.cleared  = The file sync history for “%S” has been cleared.
+zotero.preferences.sync.groups.title                    = Customize Group Library File Syncing
 
 zotero.preferences.search.rebuildIndex						= Rebuild Index
 zotero.preferences.search.rebuildWarning					= Do you want to rebuild the entire index? This may take a while.\n\nTo index only items that haven't been indexed, use %S.

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -668,7 +668,8 @@ zotero.preferences.sync.reset.restoreToServer          = %1$S will replace data 
 zotero.preferences.sync.reset.restoreToServer.button   = Replace Data in Online Library
 zotero.preferences.sync.reset.fileSyncHistory          = On the next sync, %1$S will check all attachment files in “%2$S” against the storage service. Any remote attachment files that are missing locally will be downloaded, and local attachment files missing remotely will be uploaded.\n\nThis option is not necessary during normal usage.
 zotero.preferences.sync.reset.fileSyncHistory.cleared  = The file sync history for “%S” has been cleared.
-zotero.preferences.sync.groups.title                    = Customize Group Library File Syncing
+zotero.preferences.sync.fileSyncing.groups.title       = Customize Group Library File Syncing
+zotero.preferences.sync.fileSyncing.ttl.custom         = %1$S day;%1$S days
 
 zotero.preferences.search.rebuildIndex						= Rebuild Index
 zotero.preferences.search.rebuildWarning					= Do you want to rebuild the entire index? This may take a while.\n\nTo index only items that haven't been indexed, use %S.

--- a/defaults/preferences/zotero.js
+++ b/defaults/preferences/zotero.js
@@ -162,6 +162,10 @@ pref("extensions.zotero.sync.storage.groups.enabled", true);
 pref("extensions.zotero.sync.storage.downloadMode.personal", "on-sync");
 pref("extensions.zotero.sync.storage.downloadMode.groups", "on-sync");
 pref("extensions.zotero.sync.fulltext.enabled", true);
+pref("extensions.zotero.sync.storage.groups.ttl", false);
+pref("extensions.zotero.sync.storage.groups.ttl.value", 30);
+pref("extensions.zotero.sync.storage.personal.ttl", false);
+pref("extensions.zotero.sync.storage.personal.ttl.value", 30);
 
 // Proxy
 pref("extensions.zotero.proxies.autoRecognize", true);

--- a/defaults/preferences/zotero.js
+++ b/defaults/preferences/zotero.js
@@ -162,10 +162,10 @@ pref("extensions.zotero.sync.storage.groups.enabled", true);
 pref("extensions.zotero.sync.storage.downloadMode.personal", "on-sync");
 pref("extensions.zotero.sync.storage.downloadMode.groups", "on-sync");
 pref("extensions.zotero.sync.fulltext.enabled", true);
-pref("extensions.zotero.sync.storage.groups.ttl", false);
-pref("extensions.zotero.sync.storage.groups.ttl.value", 30);
 pref("extensions.zotero.sync.storage.personal.ttl", false);
 pref("extensions.zotero.sync.storage.personal.ttl.value", 30);
+pref("extensions.zotero.sync.storage.groups.ttl", false);
+pref("extensions.zotero.sync.storage.groups.ttl.value", 30);
 
 // Proxy
 pref("extensions.zotero.proxies.autoRecognize", true);

--- a/scss/_zotero-react-client.scss
+++ b/scss/_zotero-react-client.scss
@@ -25,6 +25,7 @@
 @import "components/createParent";
 @import "components/editable";
 @import "components/icons";
+@import "components/preferences";
 @import "components/progressMeter";
 @import "components/search";
 @import "components/tagsBox";

--- a/scss/components/_preferences.scss
+++ b/scss/components/_preferences.scss
@@ -1,0 +1,98 @@
+.group-files-sync-container {
+	height: 500px;
+	width: 500px;
+	font-size: 13px;
+	margin: 1em;
+
+	select {
+		margin-left: 0.25em;
+		margin-right: 0.25em;
+	}
+
+	input[type='checkbox'] {
+		height: 15px;
+		width: 15px;
+	}
+
+	input[type='checkbox'] {
+		margin-left: 0;
+	}
+
+	.global-settings-label {
+		padding-bottom: 0.5em;
+		padding-left: 0.5em;
+	}
+
+	.global-settings {
+		background-color: $shade-2;
+		border-radius: 5px;
+		border: solid 1px $shade-3;
+		padding: 0.75em;
+
+		.reset-container {
+			margin-top: 0.75em;
+			display: flex;
+			justify-content: flex-end;
+		}
+	}
+
+	.setting-enabled {
+		margin-bottom: 0.75em;
+	}
+
+	.setting-downloadMode-box {
+		margin-left: 1.5em;
+		margin-bottom: 0.5em;
+		display: flex;
+		align-items: center;
+	}
+
+	.setting-ttl-box {
+		margin-left: 1.5em;
+		display: flex;
+		align-items: center;
+	}
+
+	.groups-file-sync-groups {
+		max-height: 250px;
+		height: 250px;
+		overflow-y: scroll;
+		overflow-x: visible;
+		background-color: white;
+		margin: 1em 0;
+		padding: 1.5em;
+
+		.group
+		{
+			padding-bottom: 1em;
+			margin-bottom: 1em;
+			border-bottom: solid 1px #ccc;
+		}
+
+		.group:last-child {
+			border-bottom: none;
+			margin-bottom: 0;
+		}
+
+		.group-header {
+			display: flex;
+			align-items: center;
+			margin-bottom: 0.5em;
+		}
+
+		.group-header-label {
+			flex: 1;
+		}
+
+		.group-settings {
+			padding: 1em;
+			background-color: $shade-1;
+			border: solid 1px $shade-2;
+		}
+	}
+
+	.dialog-buttons {
+		display: flex;
+		justify-content: flex-end;
+	}
+}

--- a/scss/components/_preferences.scss
+++ b/scss/components/_preferences.scss
@@ -4,45 +4,36 @@
 	font-size: 13px;
 	margin: 1em;
 
-	select {
-		margin-left: 0.25em;
-		margin-right: 0.25em;
-	}
-
 	input[type='checkbox'] {
-		height: 15px;
-		width: 15px;
-	}
-
-	input[type='checkbox'] {
-		margin-left: 0;
+		height: 16px;
+		width: 16px;
 	}
 
 	.global-settings-label {
 		padding-bottom: 0.5em;
-		padding-left: 0.5em;
 	}
 
 	.global-settings {
-		background-color: $shade-2;
+		background-color: $shade-3;
 		border-radius: 5px;
-		border: solid 1px $shade-3;
+		border: solid 1px $shade-4;
 		padding: 0.75em;
+		margin-bottom: 1em;
 
 		.reset-container {
-			margin-top: 0.75em;
 			display: flex;
 			justify-content: flex-end;
 		}
 	}
 
-	.setting-enabled {
-		margin-bottom: 0.75em;
+	.setting-enabled-box {
+		display: flex;
+		align-items: flex-start;
 	}
 
 	.setting-downloadMode-box {
 		margin-left: 1.5em;
-		margin-bottom: 0.5em;
+		//margin-bottom: 0.5em;
 		display: flex;
 		align-items: center;
 	}
@@ -53,20 +44,23 @@
 		align-items: center;
 	}
 
+	.custom-settings-label {
+		padding-top: 1em !important;
+	}
+
 	.groups-file-sync-groups {
 		max-height: 250px;
 		height: 250px;
 		overflow-y: scroll;
 		overflow-x: visible;
-		background-color: white;
-		margin: 1em 0;
+		background-color: $shade-0;
 		padding: 1.5em;
 
 		.group
 		{
 			padding-bottom: 1em;
 			margin-bottom: 1em;
-			border-bottom: solid 1px #ccc;
+			border-bottom: solid 1px $shade-4;
 		}
 
 		.group:last-child {
@@ -82,12 +76,6 @@
 
 		.group-header-label {
 			flex: 1;
-		}
-
-		.group-settings {
-			padding: 1em;
-			background-color: $shade-1;
-			border: solid 1px $shade-2;
 		}
 	}
 

--- a/scss/mac/_global.scss
+++ b/scss/mac/_global.scss
@@ -1,0 +1,22 @@
+html > body, select, input {
+	font-family: Lucida Grande, Lucida Sans Unicode, Lucida Sans, Geneva, -apple-system, sans-serif;
+}
+
+label {
+	cursor: default;
+	margin-top: 1px;
+	margin-bottom: 2px;
+	margin-inline-start: 6px;
+	margin-inline-end: 5px;
+}
+
+input[type='checkbox'] + label {
+	margin: 1px 0 !important;
+}
+
+input[type='checkbox'] {
+	margin: 1px 3px 0 1px;
+	vertical-align: top;
+	width: 1.3em;
+	height: 1.3em;
+}

--- a/scss/mac/_preferences.scss
+++ b/scss/mac/_preferences.scss
@@ -1,14 +1,18 @@
 .group-files-sync-container {
-	font-family: Lucida Grande, Lucida Sans Unicode, Lucida Sans, Geneva, -apple-system, sans-serif;
-	
 	select {
-		font-family: Lucida Grande, Lucida Sans Unicode, Lucida Sans, Geneva, -apple-system, sans-serif;
 		font-size: 13px;
+		margin: 5px 2px 3px;
+		padding: 1px 3px !important;
 	}
-	
-	input {
-		font-family: Lucida Grande, Lucida Sans Unicode, Lucida Sans, Geneva, -apple-system, sans-serif;
-		font-size: 13px;
+
+	.setting-enabled-box {
+		margin-bottom: 4px;
+	}
+
+	.setting-downloadMode-box {
+		label {
+			margin-inline-start: 2px;
+		}
 	}
 
 	// .button-native comes from: chrome://global/skin/button.css

--- a/scss/mac/_preferences.scss
+++ b/scss/mac/_preferences.scss
@@ -1,0 +1,52 @@
+.group-files-sync-container {
+	font-family: Lucida Grande, Lucida Sans Unicode, Lucida Sans, Geneva, -apple-system, sans-serif;
+	
+	select {
+		font-family: Lucida Grande, Lucida Sans Unicode, Lucida Sans, Geneva, -apple-system, sans-serif;
+		font-size: 13px;
+	}
+	
+	input {
+		font-family: Lucida Grande, Lucida Sans Unicode, Lucida Sans, Geneva, -apple-system, sans-serif;
+		font-size: 13px;
+	}
+
+	// .button-native comes from: chrome://global/skin/button.css
+	// For some reason those styles are overriden in the react world
+	// Note we changed the attribute selectors default="true" to just default
+	// because I couldn't figure out how to get react to pass the string "true"
+	.button-native {
+		font: {
+			family: inherit;
+			size: inherit;
+		}
+		line-height: 17.5px; // Added this after copy
+		// -moz-appearance: button;
+		/* The horizontal margin used here come from the Aqua Human Interface
+		   Guidelines, there should be 12 pixels between two buttons. */
+		margin: 5px 6px 3px;
+		min-width: 79px;
+	}
+
+	.button-native:not([disabled]):hover:active {
+		color: -moz-mac-buttonactivetext;
+	}
+
+	/* When the window isn't focused, the default button background isn't drawn,
+	 * so don't change the text color then: */
+	.button-native[default]:not([disabled]):not(:-moz-window-inactive) {
+		color: -moz-mac-defaultbuttontext;
+	}
+
+	/* Likewise, when active (mousedown) but not hovering, the default button
+	 * background isn't drawn, override the previous selector for that case: */
+	.button-native[default]:not(:hover):active {
+		color: ButtonText;
+	}
+
+	/* .......... disabled state .......... */
+
+	.button-native[disabled] {
+		color: GrayText;
+	}
+}

--- a/scss/zotero-react-client-mac.scss
+++ b/scss/zotero-react-client-mac.scss
@@ -7,6 +7,7 @@
 @import "mac/button";
 @import "mac/createParent";
 @import "mac/editable";
+@import "mac/global";
 @import "mac/preferences";
 @import "mac/search";
 @import "mac/tag-selector";

--- a/scss/zotero-react-client-mac.scss
+++ b/scss/zotero-react-client-mac.scss
@@ -7,5 +7,6 @@
 @import "mac/button";
 @import "mac/createParent";
 @import "mac/editable";
+@import "mac/preferences";
 @import "mac/search";
 @import "mac/tag-selector";


### PR DESCRIPTION
Moving this discussion over from #1919.

Here is the same concept as the preferences discussed there, but more polished, functional and the dialog is now all HTML.
I'm not exactly sure how we should combine the two pull requests, but probably the best way to to temporarily hide the time to live settings.

![Screen Shot 2021-01-22 at 4 24 35 PM](https://user-images.githubusercontent.com/4305610/105559473-7de35180-5cce-11eb-8211-0dfbdc21adb0.png)
![Screen Shot 2021-01-22 at 4 25 11 PM](https://user-images.githubusercontent.com/4305610/105559477-7fad1500-5cce-11eb-8fdf-581367c9a715.png)
