### PR TITLE
Do not send back `saveSingleFile: true` if saving a PDF snapshot.

### DIFF
--- a/chrome/content/zotero/xpcom/connector/server_connector.js
+++ b/chrome/content/zotero/xpcom/connector/server_connector.js
@@ -1143,7 +1143,9 @@ Zotero.Server.Connector.SaveSnapshot.prototype = {
 			return 500;
 		}
 		
-		return [201, "application/json", JSON.stringify({ saveSingleFile: !data.skipSnapshot })];
+		return [201,
+			"application/json",
+			JSON.stringify({ saveSingleFile: !data.skipSnapshot && !data.pdf })];
 	},
 	
 	/*

--- a/test/tests/server_connectorTest.js
+++ b/test/tests/server_connectorTest.js
@@ -1359,7 +1359,7 @@ describe("Connector Server", function () {
 				});
 			});
 			
-			await Zotero.HTTP.request(
+			let response = await Zotero.HTTP.request(
 				'POST',
 				connectorServerPath + "/connector/saveSnapshot",
 				{
@@ -1368,10 +1368,13 @@ describe("Connector Server", function () {
 					},
 					body: JSON.stringify({
 						url: testServerPath + "/test.pdf",
-						pdf: true
+						pdf: true,
+						singleFile: true
 					})
 				}
 			);
+			let json = JSON.parse(response.responseText);
+			assert.propertyVal(json, 'saveSingleFile', false);
 			
 			var ids = await promise;
 			


### PR DESCRIPTION
Fixes and tests for https://github.com/zotero/zotero-connectors/issues/343