### PR TITLE
Skip .scss files if build not required #1944

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -17,14 +17,15 @@ if (require.main === module) {
 				.concat(dirs.map(d => `${d}/**`))
 				.concat([`!${formatDirsForMatcher(dirs)}/**/*.js`])
 				.concat([`!${formatDirsForMatcher(dirs)}/**/*.jsx`])
-				.concat([`!${formatDirsForMatcher(copyDirs)}/**`])
+				.concat([`!${formatDirsForMatcher(dirs)}/**/*.scss`])
+				.concat([`!${formatDirsForMatcher(copyDirs)}/**`]);
 
 			const signatures = await getSignatures();
 			const results = await Promise.all([
 				getBrowserify(signatures),
 				getCopy(copyDirs.map(d => `${d}/**`), { ignore: ignoreMask }, signatures),
 				getJS(jsFiles, { ignore: ignoreMask }, signatures),
-				getSass(scssFiles, { ignore: ignoreMask }, signatures),
+				...scssFiles.map(scf => getSass(scf, { ignore: ignoreMask }, signatures)),
 				getSymlinks(symlinks, { nodir: true, ignore: ignoreMask }, signatures),
 				getSymlinks(symlinkDirs, { ignore: ignoreMask }, signatures),
 				cleanUp(signatures)

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -50,7 +50,8 @@ const symlinkFiles = [
 	'resource/ace/theme-chrome.js',
 	'resource/ace/theme-monokai.js',
 	'resource/ace/worker-javascript.js',
-	'update.rdf'
+	'update.rdf',
+	'!chrome/skin/default/zotero/**/*.scss'
 ];
 
 
@@ -89,7 +90,6 @@ const browserifyConfigs = [
 // exclude mask used for js, copy, symlink and sass tasks
 const ignoreMask = [
 	'**/#*',
-	'**/_*.scss',
 	'resource/schema/global/schema.json.gz'
 ];
 

--- a/scripts/sass.js
+++ b/scripts/sass.js
@@ -1,4 +1,4 @@
-'use strict';
+/* eslint-disable no-await-in-loop */
 
 const universalify = require('universalify');
 const sass = require('sass');
@@ -6,56 +6,59 @@ const globby = require('globby');
 const path = require('path');
 const fs = require('fs-extra');
 const { getSignatures, writeSignatures, cleanUp, compareSignatures, getFileSignature, onSuccess, onError, onProgress, getPathRelativeTo } = require('./utils');
-const { ignoreMask } = require('./config');
+const { scssFiles, ignoreMask } = require('./config');
 const sassRender = universalify.fromCallback(sass.render);
 
 const ROOT = path.resolve(__dirname, '..');
 
 async function getSass(source, options, signatures={}) {
 	const t1 = Date.now();
-	const files = await globby(source, Object.assign({ cwd: ROOT }, options ));
+	const files = await globby(source, Object.assign({ cwd: ROOT }, options));
 	const totalCount = files.length;
-	var count = 0;
-	var f;
+	var count = 0, shouldRebuild = false;
 
-	while ((f = files.pop()) != null) {
+	for (const f of files) {
+		// if any file changed, rebuild all onSuccess
 		let newFileSignature = await getFileSignature(f);
-		let destFile = getPathRelativeTo(f, 'scss');
-		destFile = path.join(path.dirname(destFile), path.basename(destFile, '.scss') + '.css');
-		let dest = path.join.apply(this, ['build', 'chrome', 'skin', 'default', 'zotero', destFile]);
-		if (['win', 'mac', 'unix'].some(platform => f.endsWith(`-${platform}.scss`))) {
-			let platform = f.slice(f.lastIndexOf('-')+1, f.lastIndexOf('.'));
-			destFile = destFile.slice(0, destFile.lastIndexOf('-'))
-				+ destFile.slice(destFile.lastIndexOf('-')+1+platform.length);
-			dest = path.join.apply(this, ['build', 'chrome', 'content', 'zotero-platform', platform, destFile]);
-		}
-
-		if (f in signatures) {
-			if (compareSignatures(newFileSignature, signatures[f])) {
-				try {
-					await fs.access(dest, fs.constants.F_OK);
-					// TODO: Doesn't recompile on partial scss file changes, so temporarily disabled
-					// continue;
-				} catch (_) {
-					// file does not exists in build, fallback to browserifing
-				}
-			}
-		}
-		try {
-			const sass = await sassRender({
-				file: f,
-				outFile: dest,
-				sourceMap: true,
-				outputStyle: 'compressed'
-			});
-
-			await fs.outputFile(dest, sass.css);
-			await fs.outputFile(`${dest}.map`, sass.map);
-			onProgress(f, dest, 'sass');
+		if (!compareSignatures(newFileSignature, signatures[f])) {
 			signatures[f] = newFileSignature;
-			count++;
-		} catch (err) {
-			throw new Error(`Failed on ${f}: ${err}`);
+			shouldRebuild = true;
+		}
+	}
+
+	var f;
+	if (shouldRebuild) {
+		const filesToBuild = files.filter(f => !path.basename(f).startsWith('_'));
+		while ((f = filesToBuild.pop())) {
+			let newFileSignature = await getFileSignature(f);
+			let destFile = getPathRelativeTo(f, 'scss');
+			destFile = path.join(path.dirname(destFile), path.basename(destFile, '.scss') + '.css');
+			let dest = path.join.apply(this, ['build', 'chrome', 'skin', 'default', 'zotero', destFile]);
+
+			if (['win', 'mac', 'unix'].some(platform => f.endsWith(`-${platform}.scss`))) {
+				let platform = f.slice(f.lastIndexOf('-') + 1, f.lastIndexOf('.'));
+				destFile = destFile.slice(0, destFile.lastIndexOf('-'))
+				+ destFile.slice(destFile.lastIndexOf('-') + 1 + platform.length);
+				dest = path.join.apply(this, ['build', 'chrome', 'content', 'zotero-platform', platform, destFile]);
+			}
+
+			try {
+				const sass = await sassRender({
+					file: f,
+					outFile: dest,
+					sourceMap: true,
+					outputStyle: 'compressed'
+				});
+
+				await fs.outputFile(dest, sass.css);
+				await fs.outputFile(`${dest}.map`, sass.map);
+				onProgress(f, dest, 'sass');
+				signatures[f] = newFileSignature;
+				count++;
+			}
+			catch (err) {
+				throw new Error(`Failed on ${f}: ${err}`);
+			}
 		}
 	}
 	
@@ -74,10 +77,13 @@ if (require.main === module) {
 	(async () => {
 		try {
 			const signatures = await getSignatures();
-			onSuccess(await getSass('scss/*.scss', { root: 'scss', ignore: ignoreMask }, signatures));
+			for (var i = 0; i < scssFiles.length; i++) {
+				onSuccess(await getSass(scssFiles[i], { ignore: ignoreMask }, signatures));
+			}
 			onSuccess(await cleanUp(signatures));
 			await writeSignatures(signatures);
-		} catch (err) {
+		}
+		catch (err) {
 			process.exitCode = 1;
 			global.isError = true;
 			onError(err);

--- a/scripts/symlinks.js
+++ b/scripts/symlinks.js
@@ -70,6 +70,8 @@ if (require.main === module) {
 			const source = symlinkFiles
 				.concat(dirs.map(d => `${d}/**`))
 				.concat([`!${formatDirsForMatcher(dirs)}/**/*.js`])
+				.concat([`!${formatDirsForMatcher(dirs)}/**/*.jsx`])
+				.concat([`!${formatDirsForMatcher(dirs)}/**/*.scss`])
 				.concat([`!${formatDirsForMatcher(copyDirs)}/**`]);
 
 			const signatures = await getSignatures();

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -17,7 +17,7 @@ function onError(err) {
 function onSuccess(result) {
 	var msg = `${green('Success:')} ${blue(`[${result.action}]`)} ${result.count} files processed`;
 	if (result.totalCount) {
-		msg += ` (out of total ${result.totalCount} matched)`; 
+		msg += ` | ${result.totalCount} checked`; 
 	}
 
 	msg += ` [${yellow(`${result.processingTime}ms`)}]`;	


### PR DESCRIPTION
This PR tweaks build so that scss won't rebuild unless one of the observed .scss files has changed and fixes for a potential issue where .scss files could have been symlinked into the build folder.
