### PR TITLE
Fix for the centering issue for the logo on the Quick Format window.

### DIFF
--- a/chrome/skin/default/zotero/integration.css
+++ b/chrome/skin/default/zotero/integration.css
@@ -51,7 +51,6 @@
 }
 
 #add[disabled="true"] {
-	list-style-image: url('chrome://zotero/skin/citation-down.png');
 	list-style-image: url('chrome://zotero/skin/citation-add-gray.png');
 }
 

--- a/chrome/skin/default/zotero/integration.css
+++ b/chrome/skin/default/zotero/integration.css
@@ -38,19 +38,7 @@
 }
 
 #down {
-	list-style-image: url('chrome://zotero/skin/citation-down.png');
-}
-
-#down[disabled="true"] {
-	list-style-image: url('chrome://zotero/skin/citation-down-gray.png');
-}
-
-
-#add {
-	list-style-image: url('chrome://zotero/skin/citation-add.png');
-}
-
-#add[disabled="true"] {
+	list-style-image: url('chrome://zotero/skin/citation-down.png');git clone --recursive https://github.com/zotero/zotero-standalone-build
 	list-style-image: url('chrome://zotero/skin/citation-add-gray.png');
 }
 
@@ -210,7 +198,7 @@ richlistitem[selected="true"] {
 	width: 16px;
 	height: 16px;
 	padding: 0;
-	margin: 0;
+	margin: 0px 0px 0px 15px;
 }
 
 #citation-properties #suppress-author {

--- a/chrome/skin/default/zotero/integration.css
+++ b/chrome/skin/default/zotero/integration.css
@@ -38,7 +38,20 @@
 }
 
 #down {
-	list-style-image: url('chrome://zotero/skin/citation-down.png');git clone --recursive https://github.com/zotero/zotero-standalone-build
+	list-style-image: url('chrome://zotero/skin/citation-down.png');
+}
+
+#down[disabled="true"] {
+	list-style-image: url('chrome://zotero/skin/citation-down-gray.png');
+}
+
+
+#add {
+	list-style-image: url('chrome://zotero/skin/citation-add.png');
+}
+
+#add[disabled="true"] {
+	list-style-image: url('chrome://zotero/skin/citation-down.png');
 	list-style-image: url('chrome://zotero/skin/citation-add-gray.png');
 }
 


### PR DESCRIPTION
A fix for [zotero/zotero#1842](https://github.com/zotero/zotero/issues/1842)

The original issue on the forums stated that it looked like the logo was off-centered on a white background. Upon further investigation, I found that the white background wasn't part of the logo or background but rather the toolbarbutton used for the dropdown menu to navigate to Classic View. I increased the left margin on the icon slightly to put it at the exact center of the white box.

**Before:**
![](https://snipboard.io/GLQUIP.jpg)

**After:**
![](https://snipboard.io/VNBWuk.jpg)