### PR TITLE
Fix background color of the dropdown menu.

### DIFF
--- a/chrome/skin/default/zotero/integration.css
+++ b/chrome/skin/default/zotero/integration.css
@@ -197,7 +197,6 @@ richlistitem[selected="true"] {
 
 #zotero-icon {
 	list-style-image: url("chrome://zotero/skin/zotero-new-z-16px.png");
-	background-color: #fff;
 	padding: 0;
 	margin: 0;
 }


### PR DESCRIPTION
This is another go at issue #1842. I took your suggestion about fixing the color and found that this was a simple fix if you remove the hardcoded white color of the dropdown menu. This fixes the issue in dark theme in Linux without affecting the appearance of light mode, as shown below. There's also no noticeable difference when this change is applied to the Windows build.

Original appearance in dark theme:
![](https://snipboard.io/GLQUIP.jpg)

Fix in dark themed Linux:
![ZoteroDarkThemeFix](https://user-images.githubusercontent.com/44124160/111944737-b32dd500-8aae-11eb-9d2b-014f011f9e34.JPG)

Fix in light themed Linux:
![ZoteroLightThemeFix](https://user-images.githubusercontent.com/44124160/111944759-c0e35a80-8aae-11eb-8976-c4a55d203c75.JPG)

