### PR TITLE
Fixed dark theme on "About Zotero" page

### DIFF
--- a/chrome/skin/default/zotero/about.css
+++ b/chrome/skin/default/zotero/about.css
@@ -7,7 +7,6 @@ dialog
 
 #aboutcontent
 {
-	background: white;
 	padding: 10px;
 }
 

--- a/chrome/skin/default/zotero/about.css
+++ b/chrome/skin/default/zotero/about.css
@@ -7,22 +7,14 @@ dialog
 
 #aboutcontent
 {
-	padding: 10px;
+	background: white;
+	padding: 10px 16px;
+	font-size: 13px;
+	margin-bottom: 10px;
 }
 
-#column1 {
-	width: 23em;
-	padding-right: 2em;
-}
-
-#column2 {
-	margin-right: 1em;
-}
-
-#name
-{
-	font-size: large;
-	font-weight: bold;
+#logo {
+	margin: 7px 0 0 7px;
 }
 
 #version

--- a/chrome/skin/default/zotero/about.css
+++ b/chrome/skin/default/zotero/about.css
@@ -7,6 +7,7 @@ dialog
 
 #aboutcontent
 {
+	background: white;
 	padding: 10px;
 }
 

--- a/chrome/skin/default/zotero/about.css
+++ b/chrome/skin/default/zotero/about.css
@@ -7,7 +7,6 @@ dialog
 
 #aboutcontent
 {
-	background: white;
 	padding: 10px 16px;
 	font-size: 13px;
 	margin-bottom: 10px;


### PR DESCRIPTION
[Report: 1517701677](https://forums.zotero.org/discussion/88473/zotero-linux-dark-theme-issues)

Under the help tab, the "About Zotero" page background now reacts to the Linux theme instead of being hard coded to have a white background.

Before:
![Before](https://user-images.githubusercontent.com/55896360/112732874-02429280-8f13-11eb-9042-09c86ee187c1.PNG)

After:
![After](https://user-images.githubusercontent.com/55896360/112732884-0cfd2780-8f13-11eb-896c-fa97386fee4f.PNG)