### PR TITLE
Fix dark theme on Item Type

### DIFF
--- a/chrome/skin/default/zotero/bindings/itembox.css
+++ b/chrome/skin/default/zotero/bindings/itembox.css
@@ -104,7 +104,6 @@ row > vbox > description
 #item-type-menu
 {
 	-moz-appearance: none;
-	color: black;
 	height: 1.5em !important;
 	min-height: 1.5em !important;
 	padding: 0 0 0 2px !important;


### PR DESCRIPTION
[Report: 1517701677](https://forums.zotero.org/discussion/88473/zotero-linux-dark-theme-issues)
Number 1, The item type was hard coded to black therefore it did not look well when used in dark mode. I removed the hard code so now it should look nicer when using dark mode.

Before fix:
![Item Type pre fix](https://user-images.githubusercontent.com/49535429/112733176-5f871580-8f0c-11eb-888d-6aafc1b94a33.PNG)

After fix:
![Item Type color fix](https://user-images.githubusercontent.com/49535429/112733203-7c234d80-8f0c-11eb-967d-32a787ab16cb.PNG)
