### PR TITLE
error report page dark theme compatible

### DIFF
--- a/chrome/content/zotero/errorReport.xul
+++ b/chrome/content/zotero/errorReport.xul
@@ -2,6 +2,7 @@
 
 <?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
 <?xml-stylesheet href="chrome://zotero/skin/errorReport.css" type="text/css"?>
+<?xml-stylesheet href="chrome://zotero-platform/content/zotero-react-client.css"?>
 
 <!DOCTYPE window SYSTEM "chrome://zotero/locale/zotero.dtd">
 

--- a/chrome/skin/default/zotero/errorReport.css
+++ b/chrome/skin/default/zotero/errorReport.css
@@ -5,7 +5,6 @@ description {
 /* Intro pane */
 #zotero-error-message {
 	background: #FFF;
-	color: rgb(61, 61, 61);
 }
 
 #zotero-error-message .textbox-textarea {

--- a/chrome/skin/default/zotero/errorReport.css
+++ b/chrome/skin/default/zotero/errorReport.css
@@ -5,6 +5,7 @@ description {
 /* Intro pane */
 #zotero-error-message {
 	background: #FFF;
+	color: rgb(61, 61, 61);
 }
 
 #zotero-error-message .textbox-textarea {

--- a/scss/linux/_errorReport.scss
+++ b/scss/linux/_errorReport.scss
@@ -1,0 +1,3 @@
+#zotero-error-message {
+    color: rgb(61, 61, 61);
+}

--- a/scss/zotero-react-client-unix.scss
+++ b/scss/zotero-react-client-unix.scss
@@ -8,3 +8,4 @@
 @import "linux/editable";
 @import "linux/search";
 @import "linux/tagsBox";
+@import "linux/errorReport"


### PR DESCRIPTION
Report [1517701677](https://forums.zotero.org/discussion/88473/zotero-linux-dark-theme-issues):

Originally, if the user used the dark theme on Linux with Zotero, the error report page would display extremely light gray text on a white background.  I set the text to match the default text color of the light and standard themes. This keeps the already correct windows from being changed while making the dark theme readable. By keeping the window the error message is displayed in white with a darker text, it makes it easier for the user to see the error window, separating the message from the surrounding UI.

Here are some comparison screenshots (before on the left and after on the right):

Dark Theme:
![CompareDark](https://user-images.githubusercontent.com/55896360/113015479-95fea380-914b-11eb-8245-b2684d7002c0.png)

Light Theme:
![CompareLight](https://user-images.githubusercontent.com/55896360/113015382-7d8e8900-914b-11eb-9eac-72dc9398c107.png)

Standard Theme:
![CompareStandard](https://user-images.githubusercontent.com/55896360/113015409-85e6c400-914b-11eb-828a-c3d2c98f6a22.png)