### PR TITLE
Made About page text visible across default Linux themes

### DIFF
--- a/chrome/content/zotero/about.xul
+++ b/chrome/content/zotero/about.xul
@@ -2,6 +2,7 @@
 <?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
 <?xml-stylesheet href="chrome://zotero/skin/zotero.css" type="text/css"?>
 <?xml-stylesheet href="chrome://zotero/skin/about.css" type="text/css"?>
+<?xml-stylesheet href="chrome://zotero-platform/content/zotero-react-client.css" type="text/css"?>
 <!DOCTYPE window SYSTEM "chrome://zotero/locale/about.dtd">
 
 <dialog

--- a/scss/linux/_about.scss
+++ b/scss/linux/_about.scss
@@ -1,0 +1,4 @@
+#aboutcontent
+{
+	color: #3e3e3e;
+}

--- a/scss/zotero-react-client-unix.scss
+++ b/scss/zotero-react-client-unix.scss
@@ -8,3 +8,4 @@
 @import "linux/editable";
 @import "linux/search";
 @import "linux/tagsBox";
+@import "linux/about";


### PR DESCRIPTION
Fix for issue in Report [1517701677](https://forums.zotero.org/discussion/88473/zotero-linux-dark-theme-issues)

I was unable to change the dark theme background since since XUL doesn't support prefers-color-scheme, so I made a Linux specific fix to ensure the text was visible across themes. 

Dark Theme Before/After:
![Zotero About - Dark Before-After](https://user-images.githubusercontent.com/6352998/114588716-fbc35300-9c54-11eb-95ab-12e3eaa63637.png)

Light Theme Before/After:
![Zotero About - Light Before-After](https://user-images.githubusercontent.com/6352998/114588730-ff56da00-9c54-11eb-9f9b-3f8e35e9c53b.png)

