### PR TITLE
Hide tab bar for single tab case on Windows and Linux

### DIFF
--- a/chrome/content/zotero/tabs.js
+++ b/chrome/content/zotero/tabs.js
@@ -65,6 +65,7 @@ var Zotero_Tabs = new function () {
 		})));
 		var { tab } = this._getTab(this._selectedID);
 		document.title = (tab.title.length ? tab.title + ' - ' : '') + 'Zotero';
+		this._updateTabBar();
 	};
 
 	this.init = function () {
@@ -93,8 +94,6 @@ var Zotero_Tabs = new function () {
 	 * @return {{ id: string, container: XULElement}} id - tab id, container - a new tab container created in the deck
 	 */
 	this.add = function ({ type, title, index, select, onClose, notifierData }) {
-		//this.showTabBar();
-		
 		if (typeof type != 'string') {
 			throw new Error(`'type' should be a string (was ${typeof type})`);
 		}
@@ -163,10 +162,6 @@ var Zotero_Tabs = new function () {
 		}
 		Zotero.Notifier.trigger('close', 'tab', [tab.id], true);
 		this._update();
-		
-		/*if (this._tabs.length == 1) {
-			this.hideTabBar();
-		}*/
 	};
 
 	/**
@@ -232,25 +227,46 @@ var Zotero_Tabs = new function () {
 		var { tabIndex } = this._getTab(this._selectedID);
 		this.select((this._tabs[tabIndex + 1] || this._tabs[0]).id);
 	};
+
+	/**
+	 * Update state of the tab bar.
+	 * Only used on Windows and Linux. On macOS, the tab bar is always shown.
+	 */
+	this._updateTabBar = function () {
+		if (Zotero.isMac) {
+			return;
+		}
+		if (this._tabs.length == 1) {
+			this._hideTabBar();
+		}
+		else {
+			this._showTabBar();
+		}
+	};
 	
-	// Unused
-	this.showTabBar = function () {
-		document.documentElement.setAttribute('drawintitlebar', true);
-		document.documentElement.setAttribute('tabsintitlebar', true);
-		document.documentElement.setAttribute('chromemargin', '0,-1,-1,-1');
+	/**
+	 * Show the tab bar.
+	 * Only used on Windows and Linux. On macOS, the tab bar is always shown.
+	 */
+	this._showTabBar = function () {
+		if (Zotero.isMac) {
+			return;
+		}
 		document.getElementById('titlebar').hidden = false;
 		document.getElementById('tab-bar-container').hidden = false;
-		document.getElementById('main-window').removeAttribute('legacytoolbar')
+		document.getElementById('main-window').removeAttribute('legacytoolbar');
 	};
 	
-	// Unused
-	this.hideTabBar = function () {
-		document.documentElement.removeAttribute('drawintitlebar');
-		document.documentElement.removeAttribute('tabsintitlebar');
-		document.documentElement.removeAttribute('chromemargin');
-		document.getElementById('titlebar').hidden = true
+	/**
+	 * Hide the tab bar.
+	 * Only used on Windows and Linux. On macOS, the tab bar is always shown.
+	 */
+	this._hideTabBar = function () {
+		if (Zotero.isMac) {
+			return;
+		}
+		document.getElementById('titlebar').hidden = true;
 		document.getElementById('tab-bar-container').hidden = true;
-		document.getElementById('main-window').setAttribute('legacytoolbar', 'true')
+		document.getElementById('main-window').setAttribute('legacytoolbar', 'true');
 	};
-
 };


### PR DESCRIPTION
This hides the tab bar on Windows and Linux, where it currently takes up a lot of vertical space below the menu bar. On macOS, the tab bar remains always shown since we don't have the menu bar and can move tabs in the window there.

![hide-tab-bar](https://user-images.githubusercontent.com/279572/116934041-53554d00-ac5c-11eb-97ff-f7dcfcdca3e8.gif)

Fixes https://github.com/zotero/zotero/issues/2019