### PR TITLE
Show full tab title on hover

### DIFF
--- a/chrome/content/zotero/components/tabBar.jsx
+++ b/chrome/content/zotero/components/tabBar.jsx
@@ -106,6 +106,9 @@ const TabBar = forwardRef(function (props, ref) {
 			<div
 				key={id}
 				className={cx('tab', { selected })}
+				/* Fix 'title' not working for HTML-in-XUL */
+				onMouseOver={() => window.Zotero_Tooltip.start(title)}
+				onMouseOut={() => window.Zotero_Tooltip.stop()}
 				onMouseDown={(event) => handleMouseDown(event, id, index)}
 			>
 				<div className="tab-name">{title}</div>


### PR DESCRIPTION
<img width="681" alt="image" src="https://user-images.githubusercontent.com/279572/117003485-d28a6580-acdc-11eb-80c3-1278668df236.png">

Fixes https://github.com/zotero/zotero/issues/2033