### PR TITLE
Update install.rdf

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -7,7 +7,8 @@
     <em:id>zotero@chnm.gmu.edu</em:id>
     <em:name>Zotero</em:name>
     <em:version>5.0.97.SOURCE</em:version>
-    <em:creator>Center for History and New Media<br/>George Mason University</em:creator>
+    <em:creator>Center for History and New Media
+George Mason University</em:creator>
     <em:contributor>Dan Cohen</em:contributor>
     <em:contributor>Sean Takats</em:contributor>
     <em:developer>Simon Kornblith</em:developer>


### PR DESCRIPTION
You can use `rapper` (it comes bundled with [raptor](http://librdf.org/raptor) which is part of the librdf umbrella) to easily check for mistakes in the RDF file. Just convert it to turtle (the ["RDF syntax for those with taste" according to David Robillard](http://www.drobilla.net/pages/software.html)) and it's easy to check by hand whether there are any mistakes left.

```
rapper -o turtle https://github.com/zotero/zotero/raw/master/install.rdf
```

You'll easily notice a bogus `em:creator` link in the output. This PR fixes the issue.

I only fixed this one error. I haven't checked whether the same `<br/>` tag mistake is present in other XML files from this repository.