### PR TITLE
Hide tab title tooltips whenever the tab bar changes

### DIFF
--- a/chrome/content/zotero/components/tabBar.jsx
+++ b/chrome/content/zotero/components/tabBar.jsx
@@ -36,15 +36,15 @@ const TabBar = forwardRef(function (props, ref) {
 	const mouseMoveWaitUntil = useRef(0);
 
 	useEffect(() => {
-		window.addEventListener('mouseup', handleMouseUp);
+		window.addEventListener('mouseup', handleWindowMouseUp);
 		return () => {
-			window.removeEventListener('mouseup', handleMouseUp);
+			window.removeEventListener('mouseup', handleWindowMouseUp);
 		};
 	}, []);
 
 	useImperativeHandle(ref, () => ({ setTabs }));
 
-	function handleMouseDown(event, id, index) {
+	function handleTabMouseDown(event, id, index) {
 		if (event.target.closest('.tab-close')) {
 			return;
 		}
@@ -55,7 +55,7 @@ const TabBar = forwardRef(function (props, ref) {
 		event.stopPropagation();
 	}
 
-	function handleMouseMove(event) {
+	function handleTabBarMouseMove(event) {
 		if (!draggingID.current || mouseMoveWaitUntil.current > Date.now()) {
 			return;
 		}
@@ -91,7 +91,7 @@ const TabBar = forwardRef(function (props, ref) {
 		mouseMoveWaitUntil.current = Date.now() + 100;
 	}
 
-	function handleMouseUp(event) {
+	function handleWindowMouseUp(event) {
 		draggingID.current = null;
 		event.stopPropagation();
 	}
@@ -109,7 +109,7 @@ const TabBar = forwardRef(function (props, ref) {
 				/* Fix 'title' not working for HTML-in-XUL */
 				onMouseOver={() => window.Zotero_Tooltip.start(title)}
 				onMouseOut={() => window.Zotero_Tooltip.stop()}
-				onMouseDown={(event) => handleMouseDown(event, id, index)}
+				onMouseDown={(event) => handleTabMouseDown(event, id, index)}
 			>
 				<div className="tab-name">{title}</div>
 				<div
@@ -123,7 +123,7 @@ const TabBar = forwardRef(function (props, ref) {
 	}
 
 	return (
-		<div className="tabs" ref={tabsRef} onMouseMove={handleMouseMove}>
+		<div className="tabs" ref={tabsRef} onMouseMove={handleTabBarMouseMove}>
 			{tabs.map((tab, index) => renderTab(tab, index))}
 		</div>
 	);

--- a/chrome/content/zotero/components/tabBar.jsx
+++ b/chrome/content/zotero/components/tabBar.jsx
@@ -100,15 +100,26 @@ const TabBar = forwardRef(function (props, ref) {
 		props.onTabClose(id);
 		event.stopPropagation();
 	}
+	
+	function handleTabMouseMove(title) {
+		// Fix `title` not working for HTML-in-XUL. Using `mousemove` ensures we restart the tooltip
+		// after just a small movement even when the active tab has changed under the cursor, which
+		// matches behavior in Firefox.
+		window.Zotero_Tooltip.start(title);
+	}
+	
+	function handleTabBarMouseOut() {
+		// Hide any possibly open `title` tooltips when mousing out of any tab or the tab bar as a
+		// whole. `mouseout` bubbles up from element you moved out of, so it covers both cases.
+		window.Zotero_Tooltip.stop();
+	}
 
 	function renderTab({ id, title, selected }, index) {
 		return (
 			<div
 				key={id}
 				className={cx('tab', { selected })}
-				/* Fix 'title' not working for HTML-in-XUL */
-				onMouseOver={() => window.Zotero_Tooltip.start(title)}
-				onMouseOut={() => window.Zotero_Tooltip.stop()}
+				onMouseMove={() => handleTabMouseMove(title)}
 				onMouseDown={(event) => handleTabMouseDown(event, id, index)}
 			>
 				<div className="tab-name">{title}</div>
@@ -123,7 +134,12 @@ const TabBar = forwardRef(function (props, ref) {
 	}
 
 	return (
-		<div className="tabs" ref={tabsRef} onMouseMove={handleTabBarMouseMove}>
+		<div
+			ref={tabsRef}
+			className="tabs"
+			onMouseMove={handleTabBarMouseMove}
+			onMouseOut={handleTabBarMouseOut}
+		>
 			{tabs.map((tab, index) => renderTab(tab, index))}
 		</div>
 	);

--- a/chrome/content/zotero/tabs.js
+++ b/chrome/content/zotero/tabs.js
@@ -66,6 +66,8 @@ var Zotero_Tabs = new function () {
 		var { tab } = this._getTab(this._selectedID);
 		document.title = (tab.title.length ? tab.title + ' - ' : '') + 'Zotero';
 		this._updateTabBar();
+		// Hide any tab title tooltips that might be open
+		window.Zotero_Tooltip.stop();
 	};
 
 	this.init = function () {

--- a/chrome/content/zotero/tabs.js
+++ b/chrome/content/zotero/tabs.js
@@ -66,7 +66,7 @@ var Zotero_Tabs = new function () {
 		var { tab } = this._getTab(this._selectedID);
 		document.title = (tab.title.length ? tab.title + ' - ' : '') + 'Zotero';
 		this._updateTabBar();
-		// Hide any tab title tooltips that might be open
+		// Hide any tab `title` tooltips that might be open
 		window.Zotero_Tooltip.stop();
 	};
 


### PR DESCRIPTION
This hides tooltips (such as the tab title tooltip) whenever the tab bar state changes, such as when adding or removing a tab, to ensure we don't leave any tooltips behind that no longer match reality.

Additionally, this changes to `mousemove` to start the tab title tooltip, so that the behavior matches applications like Firefox more closely: you can always get the latest tooltip back after changing state by nudging the mouse (without having to exit and re-enter anything).

![tab-title-mousemove](https://user-images.githubusercontent.com/279572/118661985-8d3f5b00-b7e7-11eb-98a7-655d52c82831.gif)

Fixes https://github.com/zotero/zotero/issues/2060