### PR TITLE
Mendeley Import: improve handling of attachment files

### DIFF
--- a/chrome/content/zotero/import/mendeley/mendeleyImport.js
+++ b/chrome/content/zotero/import/mendeley/mendeleyImport.js
@@ -706,7 +706,7 @@ Zotero_Import_Mendeley.prototype._getDocumentFilesAPI = async function (document
 	for (let doc of documents) {
 		const files = [];
 		for (let file of (doc.files || [])) {
-			const fileName = file.file_name || 'file';
+			const fileName = Zotero.File.getValidFileName(file.file_name || 'file');
 			const tmpFile = OS.Path.join(Zotero.getTempDirectory().path, `m-api-${this.timestamp}-${file.id}`, fileName);
 			this._tmpFilesToDelete.push(tmpFile);
 			caller.add(this._fetchFile.bind(this, file.id, tmpFile));

--- a/chrome/content/zotero/import/mendeley/mendeleyImport.js
+++ b/chrome/content/zotero/import/mendeley/mendeleyImport.js
@@ -707,7 +707,7 @@ Zotero_Import_Mendeley.prototype._getDocumentFilesAPI = async function (document
 		const files = [];
 		for (let file of (doc.files || [])) {
 			const fileName = file.file_name || 'file';
-			const tmpFile = OS.Path.join(Zotero.getTempDirectory().path, `mendeley-online-import-${this.timestamp}-${file.id}`, fileName);
+			const tmpFile = OS.Path.join(Zotero.getTempDirectory().path, `m-api-${this.timestamp}-${file.id}`, fileName);
 			this._tmpFilesToDelete.push(tmpFile);
 			caller.add(this._fetchFile.bind(this, file.id, tmpFile));
 			files.push({
@@ -1468,7 +1468,7 @@ Zotero_Import_Mendeley.prototype._isDownloadedFile = function (path) {
 
 Zotero_Import_Mendeley.prototype._isTempDownloadedFile = function (path) {
 	var parentDir = OS.Path.dirname(path);
-	return parentDir.startsWith(OS.Path.join(Zotero.getTempDirectory().path, 'mendeley-online-import'));
+	return parentDir.startsWith(OS.Path.join(Zotero.getTempDirectory().path, 'm-api'));
 };
 
 /**

--- a/chrome/content/zotero/import/mendeley/mendeleyImport.js
+++ b/chrome/content/zotero/import/mendeley/mendeleyImport.js
@@ -708,7 +708,8 @@ Zotero_Import_Mendeley.prototype._getDocumentFilesAPI = async function (document
 		for (let file of (doc.files || [])) {
 			var fileName = Zotero.File.truncateFileName(Zotero.File.getValidFileName(file.file_name || 'file'), 255); // most filesystems limit filename to 255 characters
 			var tmpFile = OS.Path.join(Zotero.getTempDirectory().path, `m-api-${this.timestamp}-${file.id}`, fileName);
-			if (tmpFile.length >= 260) {
+			// Limit path length on Windows
+			if (Zotero.isWin && tmpFile.length >= 260) {
 				const surplus = tmpFile.length - 260;
 				if (surplus >= fileName.length) {
 					Zotero.logError(`File ${fileName} will be skipped due to path exceeding filesystem limits: ${tmpFile}`);

--- a/chrome/content/zotero/xpcom/file.js
+++ b/chrome/content/zotero/xpcom/file.js
@@ -1230,6 +1230,12 @@ Zotero.File = new function(){
 			ext = '.' + ext;
 		}
 
+		if (ext.length >= maxLength) {
+			// Improve resulting truncated filename by dropping extension if it wouldn't fit within
+			// the limit. e.g. for (lorem.json, 5) it returns "lorem", instead of ".json"
+			ext = '';
+		}
+
 		return fn.substr(0,maxLength-ext.length) + ext;
 	}
 	


### PR DESCRIPTION
Few changes to improve handling of attachment files during import via Mendeley API:

* Sanitize filenames and shorten to 255 characters
* If temporary path length would exceed 260 characters, shorten the filename to ensure that length is not exceeded. This is designed to work around limitation present in [some (probably most?) windows systems](https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=cmd). I did not limit this behaviour to be windows only but we may do that if we think it would have significant impact on imports.
* Reduce the overall length of the temporary path by using shorter prefix (`m-api` instead of `mendeley-online-import`)