### PR TITLE
Run JavaScript: Improve `await` regex

### DIFF
--- a/chrome/content/zotero/runJS.js
+++ b/chrome/content/zotero/runJS.js
@@ -45,7 +45,7 @@ function handleInput() { // eslint-disable-line no-unused-vars
 	}
 	var code = codeEditor.getSession().getValue();
 	// If `await` is used, switch to async mode
-	if (/(^|[^=([]\s*)await\s/m.test(code)) {
+	if (/(^|\W)await\s/m.test(code)) {
 		checkbox.checked = true;
 		update();
 	}


### PR DESCRIPTION
The current regex doesn't seem right. Most likely there's a typo, see "intended?" below.

Here are some variants:
```
(^|[^=([]\s*)await\s  //current
(^|[=([]\s*)await\s   //intended?
(^|[=([{!]\s*)await\s //improved
(^|\W)await\s         //simpler, suggested in this PR
```

Tests: https://regex101.com/r/eQYCIp/1