### PR TITLE
Blur active field in switchCreatorMode. Fix #2087

### DIFF
--- a/chrome/content/zotero/bindings/itembox.xml
+++ b/chrome/content/zotero/bindings/itembox.xml
@@ -1068,7 +1068,12 @@
 						fields.fieldMode = fieldMode;
 						this.modifyCreator(index, fields);
 						if (this.saveOnEdit) {
-							this.item.saveTx();
+							let activeField = this._dynamicFields.querySelector('textbox');
+							if (activeField !== null && activeField !== firstName && activeField !== lastName) {
+								this.blurOpenField();
+							} else {
+								this.item.saveTx();
+							}
 						}
 					}
 				]]>


### PR DESCRIPTION
After this change `activeField` is blurred just before item is saved to preserve the value entered by the user, `switchCreatorMode()` has been converted to async to allow for this.