### PR TITLE
Scaffold: Add action to open test URL in internal browser

### DIFF
--- a/chrome/content/scaffold/scaffold.js
+++ b/chrome/content/scaffold/scaffold.js
@@ -1110,7 +1110,7 @@ var Scaffold = new function() {
 	/**
 	 * Open the url of the first selected test in the browser (Browser tab or
 	 * the system's default browser).
-	 * @param {boolean} openExternally whether to open in the user's default browser
+	 * @param {boolean} openExternally whether to open in the default browser
 	**/
 	this.openURL = function (openExternally) {
 		var listbox = document.getElementById("testing-listbox");

--- a/chrome/content/scaffold/scaffold.js
+++ b/chrome/content/scaffold/scaffold.js
@@ -1107,14 +1107,26 @@ var Scaffold = new function() {
 		Zotero.Utilities.Internal.copyTextToClipboard(urlOrData);
 	}
 	
-	/*
-	 * Open the url of the first selected test in the browser.
-	 */	
-	this.openURL = function() {
+	/**
+	 * Open the url of the first selected test in the browser (Browser tab or
+	 * the system's default browser).
+	 * @param {boolean} openExternally whether to open in the user's default browser
+	**/
+	this.openURL = function (openExternally) {
 		var listbox = document.getElementById("testing-listbox");
 		var item = listbox.selectedItems[0];
 		var url = item.getElementsByTagName("listcell")[0].getAttribute("label");
-		Zotero.launchURL(url);
+		if (openExternally) {
+			Zotero.launchURL(url);
+		}
+		else {
+			var tabs = document.getElementById('tabs');
+			_browser.loadURIWithFlags(
+				url,
+				Components.interfaces.nsIWebNavigation.LOAD_FLAGS_BYPASS_CACHE
+			);
+			tabs.selectedItem = document.getElementById('tab-browser');
+		}
 	}
 	
 	/*

--- a/chrome/content/scaffold/scaffold.xul
+++ b/chrome/content/scaffold/scaffold.xul
@@ -52,7 +52,12 @@
 		<menupopup id="testing-context-menue">
 			<menuitem label="&scaffold.testing.edit.import;" tooltiptext="Edit the input data for the current test" oncommand="Scaffold.editImportFromTest()"/>
 			<menuitem label="&scaffold.testing.copyToClipboard;" tooltiptext="Copy the URL or data for the current test to the clipboard" oncommand="Scaffold.copyToClipboard()"/>
-			<menuitem label="&scaffold.testing.openUrl;" tooltiptext="Open the URL for the current test in the browser" oncommand="Scaffold.openURL()"/>
+			<menu label="&scaffold.testing.openUrl;">
+				<menupopup>
+					<menuitem label="&scaffold.testing.openUrl.internally;" tooltiptext="Open the URL for the current test in the Scaffold browser" oncommand="Scaffold.openURL(false)"/>
+					<menuitem label="&scaffold.testing.openUrl.externally;" tooltiptext="Open the URL for the current test in your default browser" oncommand="Scaffold.openURL(true)"/>
+				</menupopup>
+			</menu>
 		</menupopup>
 	</popupset>
 

--- a/chrome/locale/en-US/scaffold/scaffold.dtd
+++ b/chrome/locale/en-US/scaffold/scaffold.dtd
@@ -74,5 +74,5 @@
 <!ENTITY scaffold.testing.edit.import			"Edit Import">
 <!ENTITY scaffold.testing.copyToClipboard			"Copy to Clipboard">
 <!ENTITY scaffold.testing.openUrl			"Open URL">
-<!ENTITY scaffold.testing.openUrl.externally			"In default browser">
-<!ENTITY scaffold.testing.openUrl.internally			"Here">
+<!ENTITY scaffold.testing.openUrl.internally			"In Browser Tab">
+<!ENTITY scaffold.testing.openUrl.externally			"In External Browser">

--- a/chrome/locale/en-US/scaffold/scaffold.dtd
+++ b/chrome/locale/en-US/scaffold/scaffold.dtd
@@ -74,3 +74,5 @@
 <!ENTITY scaffold.testing.edit.import			"Edit Import">
 <!ENTITY scaffold.testing.copyToClipboard			"Copy to Clipboard">
 <!ENTITY scaffold.testing.openUrl			"Open URL">
+<!ENTITY scaffold.testing.openUrl.externally			"In default browser">
+<!ENTITY scaffold.testing.openUrl.internally			"Here">


### PR DESCRIPTION
The dropdown in the Browser tab is fine, but I find it more natural to work from the Testing tab. This makes that an option.