### PR TITLE
Scaffold: Run/delete tests with the keyboard

### DIFF
--- a/chrome/content/scaffold/scaffold.js
+++ b/chrome/content/scaffold/scaffold.js
@@ -604,6 +604,16 @@ var Scaffold = new function() {
 		}
 	}
 
+	this.runTranslatorOrTests = async function () {
+		var tabs = document.getElementById('tabs');
+		if (tabs.selectedItem.id == 'tab-testing') {
+			this.runSelectedTests();
+		}
+		else {
+			this.run('do');
+		}
+	}
+
 	/*
 	 * generate translator GUID
 	 */

--- a/chrome/content/scaffold/scaffold.xul
+++ b/chrome/content/scaffold/scaffold.xul
@@ -39,7 +39,7 @@
 	<script src="scaffold.js"/>
 	
 	<keyset>
-		<key id="run-do-web" modifiers="accel" key="R" oncommand="Scaffold.run('do')"/>
+		<key id="run-do-web" modifiers="accel" key="R" oncommand="Scaffold.runTranslatorOrTests()"/>
 		<key id="detect-web" modifiers="accel" key="T" oncommand="Scaffold.run('detect')"/>
 		<key id="save" modifiers="accel" key="S" oncommand="Scaffold.save()"/>
 		<key id="increase-font-size" modifiers="accel" key="+" oncommand="Scaffold.increaseFontSize()"/>
@@ -205,6 +205,10 @@
 						<iframe src="chrome://zotero/content/ace/ace.html" id="editor-tests" flex="1"/>
 					</tabpanel>
 					<tabpanel flex="1" id="tabpanel-testing">
+						<keyset>
+							<key id="key-delete-tests" keycode="VK_BACK" oncommand="Scaffold.deleteSelectedTests()"/>
+						</keyset>
+
 						<vbox flex="1"><hbox><description>&scaffold.testing.description;</description></hbox>
 							<hbox flex="1" context="testing-context-menue">
 								<listbox id="testing-listbox" flex="1" seltype="multiple">

--- a/chrome/content/scaffold/templates/shortcuts.txt
+++ b/chrome/content/scaffold/templates/shortcuts.txt
@@ -3,8 +3,8 @@ Keyboard Shortcuts
 
 Ctrl/Cmd  S	:	Save
 
-Ctrl/Cmd  R	:	Run doWeb/doImport
-Ctrl/Cmd  T	:	DetectWeb/detectImport
+Ctrl/Cmd  R	:	Run doWeb/doImport or selected tests
+Ctrl/Cmd  T	:	Run detectWeb/detectImport
 
 Ctrl/Cmd  +	:	Increase Font Size
 Ctrl/Cmd  -	:	Decrease Font Size


### PR DESCRIPTION
This remaps a couple keyboard shortcuts on the testing tab: Cmd/Ctrl-R will now run selected tests and backspace will delete them.