### PR TITLE
Mendeley import: Add "★" tag for favourite items

### DIFF
--- a/chrome/content/zotero/import/mendeley/mendeleyImport.js
+++ b/chrome/content/zotero/import/mendeley/mendeleyImport.js
@@ -1042,7 +1042,7 @@ Zotero_Import_Mendeley.prototype._documentToAPIJSON = async function (map, docum
 	}
 	parent.tags = [];
 	// Add star tag for favorites
-	if (documentRow.favourite == 'true') {
+	if (documentRow.favourite === 'true' || documentRow.favourite === true) {
 		parent.tags.push('\u2605');
 	}
 	if (tags) {
@@ -1239,6 +1239,11 @@ Zotero_Import_Mendeley.prototype._saveItems = async function (libraryID, json) {
 				// online importer
 				if (itemJSON.publicationTitle && !item.getField('publicationTitle')) {
 					item.setField('publicationTitle', itemJSON.publicationTitle);
+				}
+
+				// Add "★" tag if not present, since it was previously missed in the online importer
+				if ((itemJSON.tags || []).includes('\u2605') && !item.hasTag('\u2605')) {
+					item.addTag('\u2605');
 				}
 				
 				// Update any child items to point to the existing item's key instead of the

--- a/chrome/content/zotero/import/mendeley/mendeleyOnlineMappings.js
+++ b/chrome/content/zotero/import/mendeley/mendeleyOnlineMappings.js
@@ -50,6 +50,7 @@ var mendeleyOnlineMappings = {
 		short_title: 'shortTitle',
 		source: 'publication',
 		source_type: 'sourceType',
+		starred: 'favourite',
 		tags: false, // tags handled separately
 		translators: false, // all author types handled separately
 		user_context: 'userContext',


### PR DESCRIPTION
This import feature was missing for Mendeley online import. Also ensure that "★" tag is added to an existing item on re-import where appropriate.