### PR TITLE
Add test for ADS Bibcode extraction

### DIFF
--- a/chrome/locale/en-US/zotero/zotero.dtd
+++ b/chrome/locale/en-US/zotero/zotero.dtd
@@ -176,7 +176,7 @@
 <!ENTITY zotero.tagColorChooser.setColor       "Set Color">
 <!ENTITY zotero.tagColorChooser.removeColor    "Remove Color">
 
-<!ENTITY zotero.lookup.description				"Enter ISBNs, DOIs, PMIDs, arXiv IDs, or ADS bibcodes to add to your library:">
+<!ENTITY zotero.lookup.description				"Enter ISBNs, DOIs, PMIDs, arXiv IDs, or ADS Bibcodes to add to your library:">
 <!ENTITY zotero.lookup.button.search				"Search">
 
 <!ENTITY zotero.createParent.title				"Create Parent Item">

--- a/chrome/locale/en-US/zotero/zotero.dtd
+++ b/chrome/locale/en-US/zotero/zotero.dtd
@@ -176,7 +176,7 @@
 <!ENTITY zotero.tagColorChooser.setColor       "Set Color">
 <!ENTITY zotero.tagColorChooser.removeColor    "Remove Color">
 
-<!ENTITY zotero.lookup.description				"Enter ISBNs, DOIs, PMIDs, or arXiv IDs to add to your library:">
+<!ENTITY zotero.lookup.description				"Enter ISBNs, DOIs, PMIDs, arXiv IDs, or ADS bibcodes to add to your library:">
 <!ENTITY zotero.lookup.button.search				"Search">
 
 <!ENTITY zotero.createParent.title				"Create Parent Item">

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -1180,7 +1180,7 @@ lookup.failure.description			= Zotero could not find a record for the specified 
 lookup.failureToID.description		= Zotero could not find any identifiers in your input. Please verify your input and try again.
 lookup.failureTooMany.description	= Too many identifiers. Please enter one identifier and try again.
 
-createParent.prompt					= Enter a DOI, ISBN, PMID, or arXiv ID to identify this file
+createParent.prompt					= Enter a DOI, ISBN, PMID, arXiv ID, or ADS bibcode to identify this file
 
 locate.online.label					= View Online
 locate.online.tooltip				= Go to this item online

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -1180,7 +1180,7 @@ lookup.failure.description			= Zotero could not find a record for the specified 
 lookup.failureToID.description		= Zotero could not find any identifiers in your input. Please verify your input and try again.
 lookup.failureTooMany.description	= Too many identifiers. Please enter one identifier and try again.
 
-createParent.prompt					= Enter a DOI, ISBN, PMID, arXiv ID, or ADS bibcode to identify this file
+createParent.prompt					= Enter a DOI, ISBN, PMID, arXiv ID, or ADS Bibcode to identify this file
 
 locate.online.label					= View Online
 locate.online.tooltip				= Go to this item online

--- a/test/tests/utilities_internalTest.js
+++ b/test/tests/utilities_internalTest.js
@@ -382,6 +382,15 @@ describe("Zotero.Utilities.Internal", function () {
 			assert.propertyVal(identifiers[2], "arXiv", "hep-ex/9809001");
 			assert.propertyVal(identifiers[3], "arXiv", "math.GT/0309135");
 		});
+
+		it("should extract ADS bibcodes", async function () {
+			var identifiers = ZUI.extractIdentifiers("9 2021wfc..rept....8D, 2022MSSP..16208010Y.");
+			assert.lengthOf(identifiers, 2);
+			assert.lengthOf(Object.keys(identifiers[0]), 1);
+			assert.lengthOf(Object.keys(identifiers[1]), 1);
+			assert.propertyVal(identifiers[0], "adsBibcode", "2021wfc..rept....8D");
+			assert.propertyVal(identifiers[1], "adsBibcode", "2022MSSP..16208010Y");
+		});
 	});
 	
 	describe("#resolveLocale()", function () {


### PR DESCRIPTION
Completes zotero/translators#2529 by adding support for ADS bibcodes to the Add Item(s) by Identifier box. I suppose we should also change the label in the UI (`zotero.lookup.description` in the DTDs), but I don't know how to go about doing that (since I'm assuming it involves Transifex).