### PR TITLE
Fix error when connector requests translators

### DIFF
--- a/chrome/content/zotero/xpcom/connector/server_connector.js
+++ b/chrome/content/zotero/xpcom/connector/server_connector.js
@@ -431,7 +431,7 @@ Zotero.Server.Connector.GetTranslators.prototype = {
 			}).catch(function(e) {
 				sendResponseCallback(500);
 				throw e;
-			}).done();
+			});
 		}
 	},
 	


### PR DESCRIPTION
The call to `done()` resulted in a 500 response and prevented the connector from fetching the list of available translators.

Fixes #2134.