### PR TITLE
Exclude unmergeable types by name, not by ID

### DIFF
--- a/chrome/content/zotero/duplicatesMerge.js
+++ b/chrome/content/zotero/duplicatesMerge.js
@@ -46,7 +46,7 @@ var Zotero_Duplicates_Pane = new function () {
 				otherItems.push(item);
 			}
 			
-			if (!item.isRegularItem() || [1,14].indexOf(item.itemTypeID) != -1) {
+			if (!item.isRegularItem() || ['annotation', 'attachment', 'note'].includes(item.itemType)) {
 				var msg = Zotero.getString('pane.item.duplicates.onlyTopLevel');
 				ZoteroPane_Local.setItemPaneMessage(msg);
 				return false;


### PR DESCRIPTION
Excluding by ID obscured which types were being excluded. IDs drifted and we ended up blacklisting `artwork` and `encyclopediaArticle`.

Fixes #2136.