### PR TITLE
Restore tabs state

### DIFF
--- a/chrome/content/zotero/tabs.js
+++ b/chrome/content/zotero/tabs.js
@@ -107,13 +107,15 @@ var Zotero_Tabs = new function () {
 				this.rename('zotero-pane', tab.title);
 			}
 			else if (tab.type === 'reader') {
-				Zotero.Reader.open(tab.data.itemID,
-					null,
-					{
-						title: tab.title,
-						openInBackground: !tab.selected
-					}
-				);
+				if (Zotero.Items.exists(tab.data.itemID)) {
+					Zotero.Reader.open(tab.data.itemID,
+						null,
+						{
+							title: tab.title,
+							openInBackground: !tab.selected
+						}
+					);
+				}
 			}
 		}
 	};

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -841,7 +841,7 @@ class Reader {
 	async init() {
 		await Zotero.uiReadyPromise;
 		Zotero.Session.state.windows
-			.filter(x => x.type == 'reader')
+			.filter(x => x.type == 'reader' && Zotero.Items.exists(x.itemID))
 			.forEach(x => this.open(x.itemID, null, { title: x.title, openInWindow: true }));
 	}
 	
@@ -963,9 +963,6 @@ class Reader {
 	}
 
 	async open(itemID, location, { title, openInBackground, openInWindow } = {}) {
-		if (!Zotero.Items.exists(itemID)) {
-			return;
-		}
 		this._loadSidebarOpenState();
 		this.triggerAnnotationsImportCheck(itemID);
 		let reader;

--- a/chrome/content/zotero/xpcom/session.js
+++ b/chrome/content/zotero/xpcom/session.js
@@ -1,0 +1,71 @@
+/*
+    ***** BEGIN LICENSE BLOCK *****
+    
+    Copyright © 2021 Corporation for Digital Scholarship
+                     Vienna, Virginia, USA
+                     http://digitalscholar.org/
+    
+    This file is part of Zotero.
+    
+    Zotero is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    
+    Zotero is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+    
+    You should have received a copy of the GNU Affero General Public License
+    along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
+    
+    ***** END LICENSE BLOCK *****
+*/
+
+Zotero.Session = new function () {
+	const SESSION_FILE_NAME = 'session.json';
+
+	let _state = {
+		windows: []
+	};
+
+	Zotero.defineProperty(this, 'state', {
+		get: () => {
+			return _state;
+		}
+	});
+
+	this.init = async function () {
+		try {
+			let sessionFile = OS.Path.join(Zotero.Profile.dir, SESSION_FILE_NAME);
+			let state = await Zotero.File.getContentsAsync(sessionFile);
+			_state = JSON.parse(state);
+		}
+		catch (e) {
+			Zotero.logError(e);
+		}
+	};
+	
+	this.setLastClosedZoteroPaneState = function (state) {
+		_state.windows = [state];
+	};
+
+	this.save = async function () {
+		try {
+			// Save is triggered when application receives quit event,
+			// but if it was triggered by closing window, ZoteroPane might
+			// be already destroyed
+			let panes = Zotero.getZoteroPanes();
+			if (panes.length) {
+				_state.windows = panes.map(x => x.getState());
+			}
+
+			let sessionFile = OS.Path.join(Zotero.Profile.dir, SESSION_FILE_NAME);
+			await Zotero.File.putContentsAsync(sessionFile, JSON.stringify(_state));
+		}
+		catch (e) {
+			Zotero.logError(e);
+		}
+	};
+};

--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -380,6 +380,12 @@ Services.scriptloader.loadSubScript("resource://zotero/polyfill.js");
 		// Make sure data directory isn't in Dropbox, etc.
 		yield Zotero.DataDirectory.checkForUnsafeLocation(dataDir);
 		
+		Services.obs.addObserver({
+			observe: function () {
+				Zotero.Session.save();
+			}
+		}, "quit-application-granted", false);
+		
 		// Register shutdown handler to call Zotero.shutdown()
 		var _shutdownObserver = {observe:function() { Zotero.shutdown().done() }};
 		Services.obs.addObserver(_shutdownObserver, "quit-application", false);
@@ -689,6 +695,8 @@ Services.scriptloader.loadSubScript("resource://zotero/polyfill.js");
 			yield Zotero.FileTypes.init();
 			yield Zotero.CharacterSets.init();
 			yield Zotero.RelationPredicates.init();
+			
+			yield Zotero.Session.init();
 			
 			Zotero.locked = false;
 			

--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -735,6 +735,7 @@ Services.scriptloader.loadSubScript("resource://zotero/polyfill.js");
 			yield Zotero.Retractions.init();
 			yield Zotero.NoteBackups.init();
 			yield Zotero.Dictionaries.init();
+			Zotero.Reader.init();
 			
 			// Migrate fields from Extra that can be moved to item fields after a schema update
 			yield Zotero.Schema.migrateExtraFields();

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -252,7 +252,7 @@ var ZoteroPane = new function()
 		
 		// Restore pane state
 		try {
-			let state = Zotero.Session.state.windows[0];
+			let state = Zotero.Session.state.windows.find(x => x.type == 'pane');
 			if (state) {
 				Zotero_Tabs.restoreState(state.tabs);
 			}
@@ -4875,6 +4875,7 @@ var ZoteroPane = new function()
 	
 	this.getState = function () {
 		return {
+			type: 'pane',
 			tabs: Zotero_Tabs.getState()
 		};
 	};

--- a/components/zotero-service.js
+++ b/components/zotero-service.js
@@ -120,6 +120,7 @@ const xpcomFilesLocal = [
 	'router',
 	'schema',
 	'server',
+	'session',
 	'streamer',
 	'style',
 	'sync',


### PR DESCRIPTION
- Saves all panes state when quit is triggered (even though it's not necessary to save multiple Zotero panes at the moment).
- Saves last Zotero pane state when closing it.
- Restores last Zotero pane when Zotero application is reopened.
- Restores state when Zotero pane is reopened on macOS.
- Fixes failed-to-initialize context pane's item pane when reopening Zotero pane on macOS.

Let's see if everything looks good.