### PR TITLE
HTML Tree: make find as you type a virtualized table functionality

### DIFF
--- a/chrome/content/zotero/locateManager.jsx
+++ b/chrome/content/zotero/locateManager.jsx
@@ -51,6 +51,7 @@ function init() {
 				multiSelect={true}
 				columns={columns}
 				disableFontSizeScaling={true}
+				getRowString={index => getRowData(index).name}
 				onActivate={handleActivate}
 			/>
 		</IntlProvider>

--- a/chrome/content/zotero/preferences/preferences_cite.jsx
+++ b/chrome/content/zotero/preferences/preferences_cite.jsx
@@ -129,6 +129,7 @@ Zotero_Preferences.Cite = {
 						disableFontSizeScaling={true}
 						onSelectionChange={() => document.getElementById('styleManager-delete').disabled = undefined}
 						onKeyDown={handleKeyDown}
+						getRowString={index => styles[index].title}
 					/>
 				</IntlProvider>
 			);

--- a/chrome/content/zotero/preferences/preferences_export.jsx
+++ b/chrome/content/zotero/preferences/preferences_export.jsx
@@ -316,6 +316,7 @@ Zotero_Preferences.Export = {
 						disableFontSizeScaling={true}
 						onSelectionChange={handleSelectionChange}
 						onKeyDown={handleKeyDown}
+						getRowString={index => this._rows[index].domain}
 						onActivate={(event, indices) => Zotero_Preferences.Export.showQuickCopySiteEditor()}
 					/>
 				</IntlProvider>

--- a/chrome/content/zotero/preferences/preferences_sync.jsx
+++ b/chrome/content/zotero/preferences/preferences_sync.jsx
@@ -322,6 +322,7 @@ Zotero_Preferences.Sync = {
 					showHeader={true}
 					columns={columns}
 					staticColumns={true}
+					getRowString={index => this._rows[index].name}
 					disableFontSizeScaling={true}
 					onKeyDown={handleKeyDown}
 				/>


### PR DESCRIPTION
Closes #2168, closes #2169.
Adds find-as-you-type to locate, preference style and export
formats managers.

To enable find as you type you need to specify the getRowString(index) prop
on the VirtualizedTable. See prop comment for more info.