### PR TITLE
Don't reset isRead when feed item metadata changes

### DIFF
--- a/chrome/content/zotero/xpcom/data/feed.js
+++ b/chrome/content/zotero/xpcom/data/feed.js
@@ -475,9 +475,8 @@ Zotero.Feed.prototype._updateFeed = Zotero.Promise.coroutine(function* () {
 			
 			if (!feedItem.hasChanged()) {
 				Zotero.debug("Feed item " + feedItem.guid + " has not changed");
-				continue
+				continue;
 			}
-			feedItem.isRead = false;
 			toSave.push(feedItem);
 		}
 	}

--- a/test/tests/feedTest.js
+++ b/test/tests/feedTest.js
@@ -362,7 +362,7 @@ describe("Zotero.Feed", function() {
 			assert.isTrue(feed.lastCheck > Zotero.Date.dateToSQL(new Date(Date.now() - 1000*60), true), 'feed.lastCheck updated');
 			assert.isTrue(feed.lastUpdate > Zotero.Date.dateToSQL(new Date(Date.now() - 1000*60), true), 'feed.lastUpdate updated');
 		});
-		it('should update modified items and set unread', function* () {
+		it('should update modified items, preserving isRead', function* () {
 			let feedItem = yield Zotero.FeedItems.getAsyncByGUID("http://liftoff.msfc.nasa.gov/2003/06/03.html#item573");
 			feedItem.isRead = true;
 			yield feedItem.saveTx();
@@ -377,7 +377,7 @@ describe("Zotero.Feed", function() {
 			feedItem = yield Zotero.FeedItems.getAsyncByGUID("http://liftoff.msfc.nasa.gov/2003/06/03.html#item573");
 			
 			assert.notEqual(oldDateModified, feedItem.getField('date'));
-			assert.isFalse(feedItem.isRead)
+			assert.isTrue(feedItem.isRead);
 		});
 		it('should skip items that are not modified', function* () {
 			let save = sinon.spy(Zotero.FeedItem.prototype, 'save');
@@ -400,7 +400,7 @@ describe("Zotero.Feed", function() {
 			feed._feedUrl = modifiedFeedUrl;
 			yield feed.updateFeed();
 			
-			assert.equal(feed.unreadCount, 2);
+			assert.equal(feed.unreadCount, 1);
 		});
 		it('should add a link to enclosed pdfs from <enclosure/> elements', function* () {
 			let feedItem = yield Zotero.FeedItems.getAsyncByGUID("http://liftoff.msfc.nasa.gov/2003/06/03.html#item573");


### PR DESCRIPTION
This prevents metadata changes from clearing the `isRead` status of feed items as long as GUIDs remain constant. Previously, feed items with randomized properties (like URLs generated dynamically each time the feed is served) would be incorrectly marked as unread on every update.

Fixes #2213.