### PR TITLE
Fix arXiv ID not imported. 

### DIFF
--- a/chrome/content/zotero/import/mendeley/mendeleyOnlineMappings.js
+++ b/chrome/content/zotero/import/mendeley/mendeleyOnlineMappings.js
@@ -25,6 +25,7 @@ var mendeleyOnlineMappings = {
 		working_paper: 'WorkingPaper'
 	},
 	apiFieldToDBField: {
+		arxiv: 'arxivId',
 		accessed: 'dateAccessed',
 		authors: false, // all author types handled separately
 		citation_key: 'citationKey',

--- a/test/tests/data/mendeleyMock/items-simple.json
+++ b/test/tests/data/mendeleyMock/items-simple.json
@@ -11,6 +11,12 @@
         "profile_id": "8dbf0832-8723-4c48-b532-20c0b7f6e01a",
         "read": false,
         "source": "lorem ipsum",
+        "identifiers":
+        {
+            "doi": "10.1111",
+            "pmid": "11111111",
+            "arxiv": "1111.2222"
+        },
         "starred": false,
         "title": "Foo Bar",
         "type": "journal",

--- a/test/tests/mendeleyImport.js
+++ b/test/tests/mendeleyImport.js
@@ -102,6 +102,11 @@ describe('Zotero_Import_Mendeley', function () {
 			assert.equal(journal.itemTypeID, Zotero.ItemTypes.getID('journalArticle'));
 			assert.equal(report.getField('title'), 'Sample Report');
 			assert.equal(report.itemTypeID, Zotero.ItemTypes.getID('report'));
+
+			// test identifiers
+			assert.equal(journal.getField('DOI'), '10.1111');
+			assert.include(journal.getField('extra'), 'PMID: 11111111');
+			assert.include(journal.getField('extra'), 'arXiv: 1111.2222');
 			
 			const parentCollection = await Zotero.Collections.getAsync(
 				journal.getCollections().pop()


### PR DESCRIPTION
This is a fix for #2236. Mendeley online schema uses "arxiv", local DB uses "arxivId" hence it was skipped. This commit adds missing mapping and a test.