### PR TITLE
Mendeley import institutional login fix

### DIFF
--- a/chrome/content/zotero/fileInterface.js
+++ b/chrome/content/zotero/fileInterface.js
@@ -857,7 +857,7 @@ var Zotero_File_Interface = new function() {
 
 	this.authenticateMendeleyOnlinePoll = function (win) {
 		if (win && win[0] && win[0].location) {
-			const matchResult = win[0].location.toString().match(/(?:\?|&)code=(.*?)(?:&|$)/i);
+			const matchResult = win[0].location.toString().match(/mendeley_oauth_redirect.html(?:.*?)(?:\?|&)code=(.*?)(?:&|$)/i);
 			if (matchResult) {
 				const mendeleyCode = matchResult[1];
 				Zotero.getMainWindow().setTimeout(() => this.showImportWizard({ mendeleyCode }), 0);

--- a/chrome/content/zotero/standalone/basicViewer.xul
+++ b/chrome/content/zotero/standalone/basicViewer.xul
@@ -155,7 +155,7 @@
 	
 	<hbox flex="1" id="browser">
 		<vbox id="appcontent" flex="1">
-			<browser id="my-browser" type="content-primary" flex="1"/>
+			<browser id="my-browser" type="content" flex="1"/>
 		</vbox>
 	</hbox>
 </window>


### PR DESCRIPTION
There are two commits: first one tweaks the URL regexp to be more precise - not really needed, just a precaution since there are arbitrary pages involved in institutional login and some of them might have URL that matched the old regex.

Second commit changes browser `type` attribute in `basicViewer`. Documentation that I've found isn't very clear on what's the difference but it seems to resolve the issue with loaded pages accessing `window.top`. I've run a sanity spot check on few places that use `basicViewer` and it seemed fine but we may want to make this configurable/copy if we're concerned?