### PR TITLE
Improve tree screen reader accessibility

### DIFF
--- a/chrome/content/zotero/collectionTree.jsx
+++ b/chrome/content/zotero/collectionTree.jsx
@@ -357,7 +357,7 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 				toggleOpenState: this.toggleOpenState,
 				getRowString: this.getRowString.bind(this),
 				
-				onItemContextMenu: (e) => this.props.onContextMenu && this.props.onContextMenu(e),
+				onItemContextMenu: (...args) => this.props.onContextMenu && this.props.onContextMenu(...args),
 
 				onKeyDown: this.handleKeyDown,
 				onActivate: this.handleActivate,

--- a/chrome/content/zotero/collectionTree.jsx
+++ b/chrome/content/zotero/collectionTree.jsx
@@ -299,6 +299,22 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 		cell.appendChild(icon);
 		cell.appendChild(label);
 		div.appendChild(cell);
+		
+		// Accessibility
+		div.setAttribute('aria-level', depth+1);
+		if (!this.isContainerEmpty(index)) {
+			div.setAttribute('aria-expanded', this.isContainerOpen(index));
+		}
+		div.setAttribute('role', 'treeitem');
+		if (treeRow.isSeparator()) {
+			div.setAttribute('role', 'none');
+		}
+		let children = [];
+		for (let i = index + 1; ; i++) {
+			let row = this.getRow(i);
+			if (!row || treeRow.level >= row.level) break;
+			children.push(this.id + '-row-' + i);
+		}
 
 		// Drag-and-drop stuff
 		if (this.props.dragAndDrop) {
@@ -346,6 +362,7 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 				onKeyDown: this.handleKeyDown,
 				onActivate: this.handleActivate,
 
+				role: 'tree',
 				label: Zotero.getString('pane.collections.title')
 			}
 		);
@@ -2152,12 +2169,7 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 			return false;
 		}
 		
-		if (isLibrary) {
-			var collections = Zotero.Collections.getByLibrary(libraryID);
-		}
-		else if (isCollection) {
-			var collections = Zotero.Collections.getByParent(treeRow.ref.id);
-		}
+		var collections = treeRow.getChildren();
 		
 		if (isLibrary) {
 			var savedSearches = await Zotero.Searches.getAll(libraryID);

--- a/chrome/content/zotero/components/icons.jsx
+++ b/chrome/content/zotero/components/icons.jsx
@@ -98,8 +98,8 @@ i('BulletBlueEmpty', "chrome://zotero/skin/bullet_blue_empty.png");
 // TreeItems
 i('TreeitemArtwork', 'chrome://zotero/skin/treeitem-artwork.png');
 i('TreeitemAttachmentLink', 'chrome://zotero/skin/treeitem-attachment-link.png');
-i('TreeitemAttachmentPdf', 'chrome://zotero/skin/treeitem-attachment-pdf.png');
-i('TreeitemAttachmentPdfLink', 'chrome://zotero/skin/treeitem-attachment-pdf-link.png');
+i('TreeitemAttachmentPDF', 'chrome://zotero/skin/treeitem-attachment-pdf.png');
+i('TreeitemAttachmentPDFLink', 'chrome://zotero/skin/treeitem-attachment-pdf-link.png');
 i('TreeitemAttachmentSnapshot', 'chrome://zotero/skin/treeitem-attachment-snapshot.png');
 i('TreeitemAttachmentWebLink', 'chrome://zotero/skin/treeitem-attachment-web-link.png');
 i('TreeitemAudioRecording', 'chrome://zotero/skin/treeitem-audioRecording.png');

--- a/chrome/content/zotero/components/virtualized-table.jsx
+++ b/chrome/content/zotero/components/virtualized-table.jsx
@@ -423,6 +423,8 @@ class VirtualizedTable extends React.Component {
 
 		// Enter, double-clicking
 		onActivate: PropTypes.func,
+		
+		onFocus: PropTypes.func,
 
 		onItemContextMenu: PropTypes.func,
 	};
@@ -1076,6 +1078,7 @@ class VirtualizedTable extends React.Component {
 			onKeyDown: this._onKeyDown,
 			onDragOver: this._onDragOver,
 			onDrop: e => this.props.onDrop && this.props.onDrop(e),
+			onFocus: e => this.props.onFocus && this.props.onFocus(e),
 			className: cx(["virtualized-table", { resizing: this.state.resizing }]),
 			id: this.props.id,
 			ref: ref => this._topDiv = ref,

--- a/chrome/content/zotero/components/virtualized-table.jsx
+++ b/chrome/content/zotero/components/virtualized-table.jsx
@@ -579,6 +579,11 @@ class VirtualizedTable extends React.Component {
 			}
 			break;
 		}
+		
+		if (e.key == 'ContextMenu' || (e.key == 'F10' && e.shiftKey)) {
+			this.props.onItemContextMenu(e);
+			return;
+		}
 
 		if (this.props.getRowString && !(e.ctrlKey || e.metaKey) && e.key.length == 1) {
 			this._handleTyping(e.key);
@@ -673,9 +678,7 @@ class VirtualizedTable extends React.Component {
 			if (!modifierClick && !this.selection.isSelected(index)) {
 				this._onSelection(index, false, false);
 			}
-			if (this.props.onItemContextMenu) {
-				this.props.onItemContextMenu(e);
-			}
+			this.props.onItemContextMenu(e);
 		}
 		// All modifier clicks handled in mouseUp per mozilla itemtree convention
 		if (!modifierClick && !this.selection.isSelected(index)) {

--- a/chrome/content/zotero/components/virtualized-table.jsx
+++ b/chrome/content/zotero/components/virtualized-table.jsx
@@ -581,7 +581,9 @@ class VirtualizedTable extends React.Component {
 		}
 		
 		if (e.key == 'ContextMenu' || (e.key == 'F10' && e.shiftKey)) {
-			this.props.onItemContextMenu(e);
+			let selectedElem = document.querySelector(`#${this._jsWindowID} [aria-selected=true]`);
+			let boundingRect = selectedElem.getBoundingClientRect();
+			this.props.onItemContextMenu(e, boundingRect.left + 50, boundingRect.bottom);
 			return;
 		}
 
@@ -678,7 +680,7 @@ class VirtualizedTable extends React.Component {
 			if (!modifierClick && !this.selection.isSelected(index)) {
 				this._onSelection(index, false, false);
 			}
-			this.props.onItemContextMenu(e);
+			this.props.onItemContextMenu(e, e.clientX, e.clientY);
 		}
 		// All modifier clicks handled in mouseUp per mozilla itemtree convention
 		if (!modifierClick && !this.selection.isSelected(index)) {

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -970,7 +970,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 					onActivate: this.handleActivate,
 					onFocus: this.handleFocus,
 
-					onItemContextMenu: e => this.props.onContextMenu(e),
+					onItemContextMenu: (...args) => this.props.onContextMenu(...args),
 					
 					role: 'treegrid',
 					label: Zotero.getString('pane.items.title'),

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -2550,12 +2550,13 @@ var ItemTree = class ItemTree extends LibraryTree {
 			retractedAriaLabel = Zotero.getString('retraction.banner');
 		}
 
-		let tagAriaLabel = ''
-		let tagSpans = ''
+		let tagAriaLabel = '';
+		let tagSpans = '';
 		let coloredTags = item.getColoredTags();
 		if (coloredTags.length) {
 			tagSpans = coloredTags.map(x => this._getTagSwatch(x.tag, x.color));
-			tagAriaLabel = Zotero.getString('itemFields.tags') + ' ' + coloredTags.map(x => x.tag).join(',') + '.';;
+			tagAriaLabel = tagSpans.length == 1 ? Zotero.getString('searchConditions.tag') : Zotero.getString('itemFields.tags');
+			tagAriaLabel += ' ' + coloredTags.map(x => x.tag).join(', ') + '.';
 		}
 
 		let itemTypeAriaLabel;
@@ -2569,7 +2570,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 		}
 		
 		let textWithFullStop = data;
-		if (textWithFullStop.length != textWithFullStop.lastIndexOf('.') + 1) {
+		if (!textWithFullStop.match(/\.$/)) {
 			textWithFullStop += '.';
 		}
 		let textSpanAriaLabel = [textWithFullStop, itemTypeAriaLabel, tagAriaLabel, retractedAriaLabel].join(' ');
@@ -2719,7 +2720,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 		if (!this.isContainerEmpty(index)) {
 			div.setAttribute('aria-expanded', this.isContainerOpen(index));
 		}
-		if (!!rowData.contextRow) {
+		if (!rowData.contextRow) {
 			div.setAttribute('aria-disabled', true);
 		}
 
@@ -3588,10 +3589,10 @@ var ItemTree = class ItemTree extends LibraryTree {
 			
 			if (item.attachmentContentType == 'application/pdf' && item.isFileAttachment()) {
 				if (linkMode == Zotero.Attachments.LINK_MODE_LINKED_FILE) {
-					itemType += 'PdfLink';
+					itemType += 'PDFLink';
 				}
 				else {
-					itemType += 'Pdf';
+					itemType += 'PDF';
 				}
 			}
 			else if (linkMode == Zotero.Attachments.LINK_MODE_IMPORTED_FILE) {

--- a/chrome/content/zotero/xpcom/collectionTreeRow.js
+++ b/chrome/content/zotero/xpcom/collectionTreeRow.js
@@ -245,6 +245,15 @@ Zotero.CollectionTreeRow.prototype.getName = function()
 	}
 }
 
+Zotero.CollectionTreeRow.prototype.getChildren = function () {
+	if (this.isLibrary(true)) {
+		return Zotero.Collections.getByLibrary(this.ref.libraryID);
+	}
+	else if (this.isCollection()) {
+		return Zotero.Collections.getByParent(this.ref.id);
+	}
+}
+
 Zotero.CollectionTreeRow.prototype.getItems = Zotero.Promise.coroutine(function* ()
 {
 	switch (this.type) {

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -1084,7 +1084,7 @@ var ZoteroPane = new function()
 				persistColumns: true,
 				columnPicker: true,
 				onSelectionChange: selection => ZoteroPane.itemSelected(selection),
-				onContextMenu: event => ZoteroPane.onItemsContextMenuOpen(event),
+				onContextMenu: (...args) => ZoteroPane.onItemsContextMenuOpen(...args),
 				onActivate: (event, items) => ZoteroPane.onItemTreeActivate(event, items),
 				emptyMessage: Zotero.getString('pane.items.loading')
 			});
@@ -1103,7 +1103,7 @@ var ZoteroPane = new function()
 			var collectionsTree = document.getElementById('zotero-collections-tree');
 			ZoteroPane.collectionsView = await CollectionTree.init(collectionsTree, {
 				onSelectionChange: prevSelection => ZoteroPane.onCollectionSelected(prevSelection),
-				onContextMenu: e => ZoteroPane.onCollectionsContextMenuOpen(e),
+				onContextMenu: (...args) => ZoteroPane.onCollectionsContextMenuOpen(...args),
 				dragAndDrop: true
 			});
 		}
@@ -2297,20 +2297,24 @@ var ZoteroPane = new function()
 	/**
 	 * Show context menu once it's ready
 	 */
-	this.onCollectionsContextMenuOpen = async function (event) {
+	this.onCollectionsContextMenuOpen = async function (event, x, y) {
 		await ZoteroPane.buildCollectionContextMenu();
+		x = x || event.clientX;
+		y = y || event.clientY;
 		document.getElementById('zotero-collectionmenu').openPopup(
-			null, null, event.clientX + 1, event.clientY + 1);
+			null, null, x + 1, y + 1);
 	};
 	
 	
 	/**
 	 * Show context menu once it's ready
 	 */
-	this.onItemsContextMenuOpen = async function (event) {
+	this.onItemsContextMenuOpen = async function (event, x, y) {
 		await ZoteroPane.buildItemContextMenu();
+		x = x || event.clientX;
+		y = y || event.clientY;
 		document.getElementById('zotero-itemmenu').openPopup(
-			null, null, event.clientX + 1, event.clientY + 1);
+			null, null, x + 1, y + 1);
 	};
 	
 	

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -2308,10 +2308,9 @@ var ZoteroPane = new function()
 	 * Show context menu once it's ready
 	 */
 	this.onItemsContextMenuOpen = async function (event) {
-		await ZoteroPane.buildItemContextMenu()
+		await ZoteroPane.buildItemContextMenu();
 		document.getElementById('zotero-itemmenu').openPopup(
-			null, null, event.clientX + 1, event.clientY + 1, true, false, event
-		);
+			null, null, event.clientX + 1, event.clientY + 1);
 	};
 	
 	

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -573,7 +573,7 @@ itemFields.issuingAuthority		= Issuing Authority
 itemFields.filingDate			= Filing Date
 itemFields.genre				= Genre
 itemFields.archive				= Archive
-itemFields.attachmentPDF		= PDF Attachment
+itemFields.attachmentPdf		= PDF Attachment
 
 creatorTypes.author				= Author
 creatorTypes.contributor		= Contributor

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -573,7 +573,7 @@ itemFields.issuingAuthority		= Issuing Authority
 itemFields.filingDate			= Filing Date
 itemFields.genre				= Genre
 itemFields.archive				= Archive
-itemFields.attachmentPdf		= PDF Attachment
+itemFields.attachmentPDF		= PDF Attachment
 
 creatorTypes.author				= Author
 creatorTypes.contributor		= Contributor

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -402,6 +402,7 @@ pane.item.attachments.delete.confirm  = Are you sure you want to delete this att
 pane.item.attachments.count.zero      = %S attachments:
 pane.item.attachments.count.singular  = %S attachment:
 pane.item.attachments.count.plural    = %S attachments:
+pane.item.attachments.has             = Has attachments
 pane.item.attachments.select			= Select a File
 pane.item.attachments.PDF.installTools.title	= PDF Tools Not Installed
 pane.item.attachments.PDF.installTools.text		= To use this feature, you must first install the PDF tools in the Search pane of the Zotero preferences.
@@ -572,6 +573,7 @@ itemFields.issuingAuthority		= Issuing Authority
 itemFields.filingDate			= Filing Date
 itemFields.genre				= Genre
 itemFields.archive				= Archive
+itemFields.attachmentPDF		= PDF Attachment
 
 creatorTypes.author				= Author
 creatorTypes.contributor		= Contributor


### PR DESCRIPTION
Addresses all points of #2261

Some notes:
> 4\. When a list is selected, it says "table" instead of "tree view".

I've set the roles for the trees where appropriate to either 'tree' or 'treegrid'. 'treegrid' is announced as table, tree, grid or others depending on screen reading software

> 6\. The item type, colored tags, and non-matching (gray) rows aren't indicated in any way. They should probably be read before or after the title. E.g., "book The Great Gatsby", "non-matching book The Great Gatsby", "book The Great Gatsby tag Class". We'll talk to some people to figure out the best approach here, but getting them into the row would be a good start.

I've added something to address this, but it's not ideal. If you have Item Type column, the item type is read twice, even though i set aria-hidden=true on the Item Type column cell. (coloured) Tags are read at the start and multiple tags are read as "Tag One, Tag Two", etc. 

There doesn't seem to be a good way to make the screen reader make pauses between stuff that is read, although this is probably down to preference and accustomization of screen reader users.

I've tested this on Ubuntu with Orca and it works although it seems to read every selected row twice for some reason. VoiceOver works fairly well, however it does not read level and row information, although maybe that can be changed in the preferences.