### PR TITLE
Ensure the integration window appears on the same screen as Zotero

### DIFF
--- a/chrome/content/zotero/bibliography.js
+++ b/chrome/content/zotero/bibliography.js
@@ -129,6 +129,7 @@ var Zotero_File_Interface_Bibliography = new function() {
 				Zotero.debug("No styles to select", 2);
 				return;
 			}
+			Zotero.Utilities.Internal.centerWindow(window);
 			Zotero_File_Interface_Bibliography.styleChanged();
 		}, 0);
 		

--- a/chrome/content/zotero/integration/addCitationDialog.js
+++ b/chrome/content/zotero/integration/addCitationDialog.js
@@ -73,16 +73,7 @@ var Zotero_Citation_Dialog = new function () {
 	this.load = Zotero.Promise.coroutine(function* () {
 		// make sure we are visible
 		window.setTimeout(function() {
-			var screenX = window.screenX;
-			var screenY = window.screenY;
-			var xRange = [window.screen.availLeft, window.screen.width-window.outerWidth];
-			var yRange = [window.screen.availTop, window.screen.height-window.outerHeight];
-			if(screenX < xRange[0] || screenX > xRange[1] || screenY < yRange[0] || screenY > yRange[1]) {
-				var targetX = Math.max(Math.min(screenX, xRange[1]), xRange[0]);
-				var targetY = Math.max(Math.min(screenY, yRange[1]), yRange[0]);
-				Zotero.debug("Moving window to "+targetX+", "+targetY);
-				window.moveTo(targetX, targetY);
-			}
+			Zotero.Utilities.Internal.centerWindow(window);
 		}, 0);
 		
 		document.documentElement.getButton("extra1").label = Zotero.getString("citation.multipleSources");

--- a/chrome/content/zotero/integration/quickFormat.js
+++ b/chrome/content/zotero/integration/quickFormat.js
@@ -157,18 +157,8 @@ var Zotero_QuickFormat = new function () {
 			if (event.target !== document) return;
 			// make sure we are visible
 			let resizePromise = (async function () {
-				await Zotero.Promise.delay();
-				window.resizeTo(window.outerWidth, qfb.clientHeight);
-				var screenX = window.screenX;
-				var screenY = window.screenY;
-				var xRange = [window.screen.availLeft, window.screen.width - window.outerWidth];
-				var yRange = [window.screen.availTop, window.screen.height - window.outerHeight];
-				if (screenX < xRange[0] || screenX > xRange[1] || screenY < yRange[0] || screenY > yRange[1]) {
-					var targetX = Math.max(Math.min(screenX, xRange[1]), xRange[0]);
-					var targetY = Math.max(Math.min(screenY, yRange[1]), yRange[0]);
-					Zotero.debug(`Moving window to ${targetX}, ${targetY}`);
-					window.moveTo(targetX, targetY);
-				}
+				_resize();
+				Zotero.Utilities.Internal.centerWindow(window);
 				qfGuidance = document.querySelector('.citation-dialog.guidance');
 				qfGuidance && qfGuidance.show();
 				_refocusQfe();
@@ -189,7 +179,6 @@ var Zotero_QuickFormat = new function () {
 				var node = qfe.firstChild;
 				node.nodeValue = "";
 				_showCitation(node);
-				_resize();
 			}
 		}
 		catch (e) {

--- a/chrome/content/zotero/xpcom/integration.js
+++ b/chrome/content/zotero/xpcom/integration.js
@@ -388,10 +388,10 @@ Zotero.Integration = new function() {
 		await Zotero.Integration.currentDoc.cleanup();
 		Zotero.Integration.currentSession && await Zotero.Integration.currentSession.progressBar.hide(true);
 		
-		var allOptions = 'chrome,centerscreen';
+		var allOptions = `chrome`;
 		// without this, Firefox gets raised with our windows under Compiz
-		if(Zotero.isLinux) allOptions += ',dialog=no';
-		if(options) allOptions += ','+options;
+		if (Zotero.isLinux) allOptions += ',dialog=no';
+		if (options) allOptions += ',' + options;
 		
 		var window = Components.classes["@mozilla.org/embedcomp/window-watcher;1"]
 			.getService(Components.interfaces.nsIWindowWatcher)

--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -1831,6 +1831,19 @@ Zotero.Utilities.Internal = {
 		return win;
 	},
 	
+	centerWindow: function (win, parent) {
+		if (!win) {
+			Zotero.logError(new Error('Called centerWindow() without a window to center'));
+			return;
+		}
+		parent = parent || win.opener || Zotero.getMainWindow();
+
+		var left = parent.screen.left + (parent.screen.width / 2) - (win.outerWidth / 2);
+		var top = parent.screen.top + (parent.screen.height / 2) - (win.outerHeight / 2);
+
+		win.moveTo(left, top);
+	},
+	
 	
 	filterStack: function (stack) {
 		return stack.split(/\n/)


### PR DESCRIPTION
See https://forums.zotero.org/discussion/93398/position-of-quick-format-citation

This has actually bothered me for a while. Maybe it's an issue just on Linux, but for some reason on multi-screen setup integration windows appear all over the place, usually seems like on the second screen, regardless of where the Zotero window is. Ideally they would appear on the same screen as the user cursor (i.e. over the word processor), but I cannot find any information about gecko APIs to retrieve pointer coordinates outside of a mouse event. This centers the window on the same screen as the parent window.

This is like 99% fine, but I'd like someone to test with a macOS multi-screen setup since I don't have one in case it breaks something there.