### PR TITLE
Fix autosuggestion background color in dark mode

### DIFF
--- a/scss/components/_autosuggest.scss
+++ b/scss/components/_autosuggest.scss
@@ -35,7 +35,7 @@
 	max-height: 10em;
 	overflow-y: auto;
 	border: 1px solid #aaa;
-	background-color: #fff;
+	background-color: -moz-field;
 	z-index: 2;
 	
 	margin-left: -3px;


### PR DESCRIPTION
Before:

![](https://user-images.githubusercontent.com/7223991/146156499-2ae8f46f-bbc3-4535-bf51-b3224e7403b2.png)

After:

![](https://user-images.githubusercontent.com/7223991/146156536-073fc3ab-928a-4e88-81ff-798c5bf886c7.png)