### PR TITLE
Allow to add/remove citations in notes

### DIFF
--- a/chrome/content/zotero/xpcom/editorInstance.js
+++ b/chrome/content/zotero/xpcom/editorInstance.js
@@ -589,11 +589,15 @@ class EditorInstance {
 					if (!item) {
 						return;
 					}
-					let attachments = Zotero.Items.get(item.getAttachments()).filter(x => x.isPDFAttachment());
-					if (citationItem.locator && attachments.length === 1) {
-						let zp = Zotero.getActiveZoteroPane();
-						if (zp) {
-							zp.viewPDF(attachments[0].id, { pageLabel: citationItem.locator });
+
+					if (citationItem.locator) {
+						let attachments = await item.getBestAttachments();
+						attachments = attachments.filter(x => x.isPDFAttachment());
+						if (attachments.length) {
+							let zp = Zotero.getActiveZoteroPane();
+							if (zp) {
+								zp.viewPDF(attachments[0].id, { pageLabel: citationItem.locator });
+							}
 						}
 					}
 					else {

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -1336,12 +1336,13 @@ noteEditor.unlink = Unlink
 noteEditor.set = Set
 noteEditor.edit = Edit
 noteEditor.addCitation = Add Citation
+noteEditor.removeCitation = Hide Citation
 noteEditor.findAndReplace = Find and Replace
 noteEditor.editInWindow = Edit in a Separate Window
-noteEditor.applyAnnotationColors = Apply Annotation Colors
-noteEditor.removeAnnotationColors = Remove Annotation Colors
-noteEditor.addCitations = Add Citations
-noteEditor.removeCitations = Remove Citations
+noteEditor.applyAnnotationColors = Show Annotation Colors
+noteEditor.removeAnnotationColors = Hide Annotation Colors
+noteEditor.addCitations = Show Annotation Citations
+noteEditor.removeCitations = Hide Annotation Citations
 
 pdfReader.annotations = Annotations
 pdfReader.showAnnotations = Show Annotations

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -1340,6 +1340,8 @@ noteEditor.findAndReplace = Find and Replace
 noteEditor.editInWindow = Edit in a Separate Window
 noteEditor.applyAnnotationColors = Apply Annotation Colors
 noteEditor.removeAnnotationColors = Remove Annotation Colors
+noteEditor.addCitations = Add Citations
+noteEditor.removeCitations = Remove Citations
 
 pdfReader.annotations = Annotations
 pdfReader.showAnnotations = Show Annotations


### PR DESCRIPTION
As discussed in #2284, this is an experimental PR that allows to add/remove citations that are immediately after annotation. Citations in other places or multi-item citations are untouched.

It now also shows a title with formatted citation when hovering a highlight or image annotation.

For now the default behavior (whether to show colors or citations, or not) is not changed and it also doesn't remember the last setting yet. Firstly let's try this out and make sure actually adding/removing citations is the right way to go.

It actually feels much cleaner without citations.