### PR TITLE
Customizable renaming rules #1413

### DIFF
--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -2376,6 +2376,7 @@ Zotero.Attachments = new function () {
 		};
 
 		const itemType = args => common(Zotero.ItemTypes.getLocalizedString(item.itemType), args);
+		const itemTypeRaw = item.itemType;
 
 		const creatorFields = ['authors', 'editors', 'creators'].reduce((obj, name) => {
 			obj[name] = (args) => {
@@ -2390,7 +2391,7 @@ Zotero.Attachments = new function () {
 			item.getField('firstCreator', false, true).replaceAll('\u2068', '').replaceAll('\u2069', ''), args
 		);
 
-		const vars = { ...fields, ...creatorFields, firstCreator, itemType, year };
+		const vars = { ...fields, ...creatorFields, firstCreator, itemType, itemTypeRaw, year };
 
 		formatString = Zotero.Utilities.Internal.generateHTMLFromTemplate(formatString, vars);
 		formatString = Zotero.Utilities.cleanTags(formatString);

--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -2327,11 +2327,11 @@ Zotero.Attachments = new function () {
 			return value;
 		};
 
-		const initializeFn = (name, shouldInitialize, initializewith) => (shouldInitialize ? name.slice(0, 1).toUpperCase() + initializewith : name);
+		const initializeFn = (name, shouldInitialize, initializeWith) => (shouldInitialize ? name.slice(0, 1).toUpperCase() + initializeWith : name);
 
-		const transformName = (creator, { name, namepartseparator, initialize, initializewith } = {}) => {
+		const transformName = (creator, { name, namePartSeparator, initialize, initializeWith } = {}) => {
 			if (creator.name) {
-				return initializeFn(creator.name, ['full', 'name'].includes(initialize), initializewith);
+				return initializeFn(creator.name, ['full', 'name'].includes(initialize), initializeWith);
 			}
 
 			const firstLast = ['full', 'given-family', 'first-last'];
@@ -2340,21 +2340,21 @@ Zotero.Attachments = new function () {
 			const last = ['family', 'last'];
 
 			if (firstLast.includes(name)) {
-				return initializeFn(creator.firstName, ['full', ...first].includes(initialize), initializewith) + namepartseparator + initializeFn(creator.lastName, ['full', ...last].includes(initialize), initializewith);
+				return initializeFn(creator.firstName, ['full', ...first].includes(initialize), initializeWith) + namePartSeparator + initializeFn(creator.lastName, ['full', ...last].includes(initialize), initializeWith);
 			}
 			else if (lastFirst.includes(name)) {
-				return initializeFn(creator.lastName, ['full', ...last].includes(initialize), initializewith) + namepartseparator + initializeFn(creator.firstName, ['full', ...first].includes(initialize), initializewith);
+				return initializeFn(creator.lastName, ['full', ...last].includes(initialize), initializeWith) + namePartSeparator + initializeFn(creator.firstName, ['full', ...first].includes(initialize), initializeWith);
 			}
 			else if (first.includes(name)) {
-				return initializeFn(creator.firstName, ['full', ...first].includes(initialize), initializewith);
+				return initializeFn(creator.firstName, ['full', ...first].includes(initialize), initializeWith);
 			}
 
-			return initializeFn(creator.lastName, ['full', ...last].includes(initialize), initializewith);
+			return initializeFn(creator.lastName, ['full', ...last].includes(initialize), initializeWith);
 		};
 
-		const commonCreators = (value, { max = Infinity, order = 'asc', name = 'family', namepartseparator = ' ', join = ', ', initialize = '', initializewith = '.' } = {}) => {
+		const commonCreators = (value, { max = Infinity, order = 'asc', name = 'family', namePartSeparator = ' ', join = ', ', initialize = '', initializeWith = '.' } = {}) => {
 			return getSlicedCreatorsOfType(value, order === "desc" ? -max : max)
-				.map(c => transformName(c, { name, namepartseparator, initialize, initializewith }))
+				.map(c => transformName(c, { name, namePartSeparator, initialize, initializeWith }))
 				.join(join);
 		};
 

--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -2312,9 +2312,9 @@ Zotero.Attachments = new function () {
 					value = value.slice(0, 1).toUpperCase() + value.slice(1);
 					break;
 				case 'title':
-					value = value.split(' ').map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()).join(' ');
+					value = Zotero.Utilities.capitalizeTitle(value, true);
 					break;
-				case 'dash':
+				case 'hyphen':
 					value = value.toLowerCase().replace(/\s+/g, '-');
 					break;
 				case 'snake':

--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -2291,6 +2291,8 @@ Zotero.Attachments = new function () {
 			A: slice => getSlicedCreatorsOfType(
 				primaryCreator, slice
 			).map(a => (a.lastName || a.name).slice(0, 1)).join(' '),
+			e: 'issue',
+			f: 'pages',
 			d: slice => getSlicedCreatorsOfType(
 				editorCreators, slice
 			).map(a => a.lastName || a.name).join(' '),
@@ -2301,15 +2303,23 @@ Zotero.Attachments = new function () {
 				primaryCreator, slice
 			).map(a => a.name && a.name || a.lastName + (a.firstName).slice(0, 1)).join(' '),
 			c: 'firstCreator',
+			i: 'assignee',
 			I: slice => getSlicedCreatorsOfType(
 				primaryCreator, slice
 			).map(a => a.name && (a.name).slice(0, 1) || (a.firstName).slice(0, 1) + (a.lastName).slice(0, 1)).join(' '),
+			j: 'publicationTitle',
 			l: slice => getSlicedCreatorsOfType(
 				editorCreators, slice
 			).map(a => a.name && (a.name).slice(0, 1) || (a.firstName).slice(0, 1) + (a.lastName).slice(0, 1)).join(' '),
 			L: slice => getSlicedCreatorsOfType(
 				editorCreators, slice
 			).map(a => a.name && a.name || a.lastName + (a.firstName).slice(0, 1)).join(' '),
+			n: 'number',
+			p: 'publisher',
+			s: 'journalAbbreviation',
+			t: 'title',
+			v: 'volume',
+			T: () => Zotero.ItemTypes.getLocalizedString(item.itemType),
 			y: () => {
 				let value = item.getField('date', true, true);
 				if (value) {
@@ -2320,7 +2330,6 @@ Zotero.Attachments = new function () {
 				}
 				return value;
 			},
-			t: 'title'
 		};
 
 		// Regexp contains 4 capture groups all wrapped in {}:

--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -2352,8 +2352,8 @@ Zotero.Attachments = new function () {
 			return initializeFn(creator.lastName, ['full', ...last].includes(initialize), initializeWith);
 		};
 
-		const commonCreators = (value, { max = Infinity, order = 'asc', name = 'family', namePartSeparator = ' ', join = ', ', initialize = '', initializeWith = '.' } = {}) => {
-			return getSlicedCreatorsOfType(value, order === "desc" ? -max : max)
+		const commonCreators = (value, { max = Infinity, name = 'family', namePartSeparator = ' ', join = ', ', initialize = '', initializeWith = '.' } = {}) => {
+			return getSlicedCreatorsOfType(value, max)
 				.map(c => transformName(c, { name, namePartSeparator, initialize, initializeWith }))
 				.join(join);
 		};

--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -2401,35 +2401,6 @@ Zotero.Attachments = new function () {
 		formatString = Zotero.File.getValidFileName(formatString);
 		return formatString;
 	};
-
-	this.convertLegacyFormatString = function (formatString) {
-		const markers = {
-			c: 'firstCreator',
-			y: 'year',
-			t: 'title'
-		};
-
-		// Regexp contains 4 capture groups all wrapped in {}:
-		// 		* Prefix before the wildcard, can be empty string
-		// 		* Any recognized marker. % sign marks a wildcard and is required for a match but is
-		// 		  not part of the capture group. Recognized markers are specified in a `markers`
-		// 		  lookup.
-		// 		* Optionally a maximum number of characters to truncate the value to
-		// 		* Suffix after the wildcard, can be empty string
-		const re = new RegExp(`{([^%{}]*)%(${Object.keys(markers).join('|')})({[0-9]+})?([^%{}]*)}`, 'ig');
-
-		return formatString.replace(re, (match, prefix, marker, truncate, suffix) => {
-			const field = markers[marker];
-			truncate = truncate ? truncate.replace(/[^0-9]+/g, '') : false;
-			prefix = prefix ? `prefix="${prefix}"` : null;
-			suffix = suffix ? `suffix="${suffix}"` : null;
-			truncate = truncate ? `truncate="${truncate}"` : null;
-
-			Zotero.debug({ match, field, truncate, prefix, suffix });
-
-			return `{{ ${[field, truncate, prefix, suffix].filter(f => f !== null).join(' ')} }}`;
-		});
-	};
 	
 	
 	this.shouldAutoRenameFile = function (isLink) {

--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -2289,6 +2289,9 @@ Zotero.Attachments = new function () {
 
 
 		const common = (value, { truncate = false, prefix = '', suffix = '', case: textCase = '' } = {}) => {
+			if (value === '' || value === null || typeof value === 'undefined') {
+				return '';
+			}
 			if (truncate) {
 				value = value.substr(0, truncate);
 			}

--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -2378,8 +2378,9 @@ Zotero.Attachments = new function () {
 			return common(value, args);
 		};
 
-		const itemType = args => common(Zotero.ItemTypes.getLocalizedString(item.itemType), args);
-		const itemTypeRaw = item.itemType;
+		const itemType = ({ localize = false, ...rest }) => common(
+			localize ? Zotero.ItemTypes.getLocalizedString(item.itemType) : item.itemType, rest
+		);
 
 		const creatorFields = ['authors', 'editors', 'creators'].reduce((obj, name) => {
 			obj[name] = (args) => {
@@ -2394,7 +2395,7 @@ Zotero.Attachments = new function () {
 			item.getField('firstCreator', false, true).replaceAll('\u2068', '').replaceAll('\u2069', ''), args
 		);
 
-		const vars = { ...fields, ...creatorFields, firstCreator, itemType, itemTypeRaw, year };
+		const vars = { ...fields, ...creatorFields, firstCreator, itemType, year };
 
 		formatString = Zotero.Utilities.Internal.generateHTMLFromTemplate(formatString, vars);
 		formatString = Zotero.Utilities.cleanTags(formatString);

--- a/chrome/content/zotero/xpcom/prefs.js
+++ b/chrome/content/zotero/xpcom/prefs.js
@@ -112,7 +112,7 @@ Zotero.Prefs = new function() {
 					// Convert "attachment rename format string" from old format (e.g. {%c - }{%y - }{%t{50}})
 					// to a new format that uses the template engine
 					case 8:
-						this.set('attachmentRenameFormatString', this.convertLegacyFormatString(
+						this.set('attachmentRenameFormatString', this.convertLegacyAttachmentRenameFormatString(
 							this.get('attachmentRenameFormatString') || ''
 						));
 				}
@@ -562,12 +562,13 @@ Zotero.Prefs = new function() {
 	};
 
 	/**
-	 * Converts a legacy format string to a new format that uses a template engine
+	 * Converts a value of a `attachmentRenameFormatString` pref from a legacy format string
+	 * with % markers to a new format that uses the template engine
 	 *
 	 * @param {string} formatString - The legacy format string to convert.
 	 * @returns {string} The new format string.
 	 */
-	this.convertLegacyFormatString = function (formatString) {
+	this.convertLegacyAttachmentRenameFormatString = function (formatString) {
 		const markers = {
 			c: 'firstCreator',
 			y: 'year',

--- a/chrome/content/zotero/xpcom/prefs.js
+++ b/chrome/content/zotero/xpcom/prefs.js
@@ -112,9 +112,11 @@ Zotero.Prefs = new function() {
 					// Convert "attachment rename format string" from old format (e.g. {%c - }{%y - }{%t{50}})
 					// to a new format that uses the template engine
 					case 8:
-						this.set('attachmentRenameFormatString', this.convertLegacyAttachmentRenameFormatString(
-							this.get('attachmentRenameFormatString') || ''
-						));
+						if (this.prefHasUserValue('attachmentRenameFormatString')) {
+							this.set('attachmentRenameFormatString', this.convertLegacyAttachmentRenameFormatString(
+								this.get('attachmentRenameFormatString') || ''
+							));
+						}
 				}
 			}
 			this.set('prefVersion', toVersion);

--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -2125,29 +2125,31 @@ Zotero.Utilities.Internal = {
 		let html = '';
 		let parts = template.split(/{{|}}/);
 
+		const dashToCamel = varName => varName.replace(/-(.)/g, (_, g1) => g1.toUpperCase());
+
 		const getAttributes = (part) => {
-			let attrsRegexp = new RegExp(/((\w*) *=+ *(['"])((\\\3|[^\3])*?)\3)|((\w*) *=+ *(\w*))/g);
+			let attrsRegexp = new RegExp(/(([\w-]*) *=+ *(['"])((\\\3|[^\3])*?)\3)|(([\w-]*) *=+ *(\w*))/g);
 			let attrs = {};
 			let match;
 			while ((match = attrsRegexp.exec(part))) {
 				if (match[1]) { // if first alternative (i.e. argument with value wrapped in " or ') matched, even if value is empty
-					attrs[match[2]] = match[4];
+					attrs[dashToCamel(match[2])] = match[4];
 				}
 				else {
-					attrs[match[7]] = match[8];
+					attrs[dashToCamel(match[7])] = match[8];
 				}
 			}
 			return attrs;
 		};
 
 		const evaluateIdentifier = (ident, args) => {
-			if (Array.isArray(vars[ident])) {
-				return vars[ident].length;
+			if (Array.isArray(vars[dashToCamel(ident)])) {
+				return vars[dashToCamel(ident)].length;
 			}
-			if (typeof vars[ident] === 'function') {
-				return vars[ident](args);
+			if (typeof vars[dashToCamel(ident)] === 'function') {
+				return vars[dashToCamel(ident)](args);
 			}
-			return vars[ident];
+			return vars[dashToCamel(ident)];
 		};
 
 		
@@ -2223,7 +2225,8 @@ Zotero.Utilities.Internal = {
 				if (level.condition) {
 					// Get attributes i.e. join=" #"
 					let attrs = getAttributes(part);
-					html += (typeof vars[operator] === 'function' ? vars[operator](attrs) : vars[operator]) ?? '';
+					const identifier = vars[dashToCamel(operator)];
+					html += (typeof identifier === 'function' ? identifier(attrs) : identifier) ?? '';
 				}
 			}
 			else if (level.condition) {

--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -2180,14 +2180,14 @@ Zotero.Utilities.Internal = {
 					let attrsRegexp = new RegExp(/((\w*) *=+ *(['"])((\\\3|[^\3])*?)\3)|((\w*) *=+ *(\w*))/g);
 					let attrs = {};
 					while ((match = attrsRegexp.exec(part))) {
-						if (match[4]) {
+						if (match[1]) { // if first alternative (i.e. argument with value wrapped in " or ') matched, even if value is empty
 							attrs[match[2]] = match[4];
 						}
 						else {
 							attrs[match[7]] = match[8];
 						}
 					}
-					html += (typeof vars[operator] === 'function' ? vars[operator](attrs) : vars[operator]) || '';
+					html += (typeof vars[operator] === 'function' ? vars[operator](attrs) : vars[operator]) ?? '';
 				}
 			}
 			else if (level.condition) {

--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -2157,7 +2157,7 @@ Zotero.Utilities.Internal = {
 	 * @returns {String} HTML
 	 */
 	generateHTMLFromTemplate: function (template, vars) {
-		const dashToCamel = varName => varName.replace(/-(.)/g, (_, g1) => g1.toUpperCase());
+		const hyphenToCamel = varName => varName.replace(/-(.)/g, (_, g1) => g1.toUpperCase());
 
 		const getAttributes = (part) => {
 			let attrsRegexp = new RegExp(/(([\w-]*) *=+ *(['"])((\\\3|[^\3])*?)\3)/g);
@@ -2165,7 +2165,7 @@ Zotero.Utilities.Internal = {
 			let match;
 			while ((match = attrsRegexp.exec(part))) {
 				if (match[1]) { // if first alternative (i.e. argument with value wrapped in " or ') matched, even if value is empty
-					attrs[dashToCamel(match[2])] = match[4];
+					attrs[hyphenToCamel(match[2])] = match[4];
 				}
 			}
 			return attrs;
@@ -2173,7 +2173,7 @@ Zotero.Utilities.Internal = {
 
 		
 		const evaluateIdentifier = (ident, args = {}) => {
-			ident = dashToCamel(ident);
+			ident = hyphenToCamel(ident);
 
 			if (!(ident in vars)) {
 				return '';

--- a/defaults/preferences/zotero.js
+++ b/defaults/preferences/zotero.js
@@ -36,7 +36,7 @@ pref("extensions.zotero.autoRecognizeFiles", true);
 pref("extensions.zotero.autoRenameFiles", true);
 pref("extensions.zotero.autoRenameFiles.linked", false);
 pref("extensions.zotero.autoRenameFiles.fileTypes", "application/pdf");
-pref("extensions.zotero.attachmentRenameFormatString", "{%c - }{%y - }{%t{50}}");
+pref("extensions.zotero.attachmentRenameFormatString", "{{ firstCreator suffix=\" - \" }}{{ year suffix=\" - \" }}{{ title truncate=\"50\" }}");
 pref("extensions.zotero.capitalizeTitles", false);
 pref("extensions.zotero.launchNonNativeFiles", false);
 pref("extensions.zotero.sortNotesChronologically", false);

--- a/test/tests/attachmentsTest.js
+++ b/test/tests/attachmentsTest.js
@@ -1293,7 +1293,7 @@ describe("Zotero.Attachments", function() {
 	});
 	
 	describe("#getFileBaseNameFromItem()", function () {
-		var item, itemManyAuthors, itemPatent, itemIncomplete;
+		var item, itemManyAuthors, itemPatent, itemIncomplete, itemBookSection;
 
 		before(() => {
 			item = createUnsavedDataObject('item', { title: 'Lorem Ipsum', itemType: 'journalArticle' });
@@ -1332,6 +1332,8 @@ describe("Zotero.Attachments", function() {
 			itemPatent.setField('number', 'HBK-8539b');
 			itemPatent.setField('assignee', 'Fast FooBar');
 			itemIncomplete = createUnsavedDataObject('item', { title: 'Incomplete', itemType: 'preprint' });
+			itemBookSection = createUnsavedDataObject('item', { title: 'Book Section', itemType: 'bookSection' });
+			itemBookSection.setField('bookTitle', 'Book Title');
 		});
 
 		
@@ -1364,7 +1366,7 @@ describe("Zotero.Attachments", function() {
 			);
 		});
 
-		it('should offer a range of options for composing creaotrs', function () {
+		it('should offer a range of options for composing creators', function () {
 			assert.equal(
 				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ authors max="1" }}'),
 				'Barius'
@@ -1461,6 +1463,14 @@ describe("Zotero.Attachments", function() {
 				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ authors max="2" }}'),
 				'Author, Creator'
 			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ creators max="3" join=" " name="given" }}'),
+				'First Second Third'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ creators max="3" join=" " name="given" order="desc" }}'),
+				'Last Other Some'
+			);
 		});
 
 		it('should accept case parameter', async function () {
@@ -1477,7 +1487,7 @@ describe("Zotero.Attachments", function() {
 				'Best Publications Place'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ publicationTitle case="dash" }}'),
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ publicationTitle case="hyphen" }}'),
 				'best-publications-place'
 			);
 			assert.equal(
@@ -1530,7 +1540,7 @@ describe("Zotero.Attachments", function() {
 		});
 
 		it("should support simple logic in template syntax", function () {
-			const template = '{{ if itemTypeRaw == "journalArticle" }}j-{{ publicationTitle case="dash" }}{{ elseif itemTypeRaw == "patent" }}p-{{ number case="dash" }}{{ else }}o-{{ title case="dash" }}{{ endif }}';
+			const template = '{{ if itemTypeRaw == "journalArticle" }}j-{{ publicationTitle case="hyphen" }}{{ elseif itemTypeRaw == "patent" }}p-{{ number case="hyphen" }}{{ else }}o-{{ title case="hyphen" }}{{ endif }}';
 			assert.equal(
 				Zotero.Attachments.getFileBaseNameFromItem(item, template), 'j-best-publications-place'
 			);
@@ -1544,13 +1554,23 @@ describe("Zotero.Attachments", function() {
 
 		it("should skip missing fields", function () {
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemIncomplete, '{{ authors prefix = "a" suffix="-" }}{{ publicationTitle case="dash" suffix="-" }}{{ title }}'),
+				Zotero.Attachments.getFileBaseNameFromItem(itemIncomplete, '{{ authors prefix = "a" suffix="-" }}{{ publicationTitle case="hyphen" suffix="-" }}{{ title }}'),
 				'Incomplete'
 			);
 		});
 
-		it("should conver formatString attachmentRenameFormatString to use template syntax", function () {
+		it("should recognized base-mapped fields", function () {
 			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemBookSection, '{{ bookTitle case="snake" }}'),
+				'book_title'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemBookSection, '{{ publicationTitle case="snake" }}'),
+				'book_title'
+			);
+		});
+
+		it("should convert formatString attachmentRenameFormatString to use template syntax", function () {
 			assert.equal(
 				Zotero.Prefs.convertLegacyFormatString('{%c - }{%y - }{%t{50}}'),
 				'{{ firstCreator suffix=" - " }}{{ year suffix=" - " }}{{ title truncate="50" }}'

--- a/test/tests/attachmentsTest.js
+++ b/test/tests/attachmentsTest.js
@@ -1542,6 +1542,13 @@ describe("Zotero.Attachments", function() {
 			);
 		});
 
+		it("should skip missing fields", function () {
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemIncomplete, '{{ authors prefix = "a" suffix="-" }}{{ publicationTitle case="dash" suffix="-" }}{{ title }}'),
+				'Incomplete'
+			);
+		});
+
 		it("should conver formatString attachmentRenameFormatString to use template syntax", function () {
 			assert.equal(
 				Zotero.Attachments.convertLegacyFormatString('{%c - }{%y - }{%t{50}}'),

--- a/test/tests/attachmentsTest.js
+++ b/test/tests/attachmentsTest.js
@@ -1551,35 +1551,36 @@ describe("Zotero.Attachments", function() {
 
 		it("should conver formatString attachmentRenameFormatString to use template syntax", function () {
 			assert.equal(
-				Zotero.Attachments.convertLegacyFormatString('{%c - }{%y - }{%t{50}}'),
+			assert.equal(
+				Zotero.Prefs.convertLegacyFormatString('{%c - }{%y - }{%t{50}}'),
 				'{{ firstCreator suffix=" - " }}{{ year suffix=" - " }}{{ title truncate="50" }}'
 			);
 			assert.equal(
-				Zotero.Attachments.convertLegacyFormatString('{ - %y - }'),
+				Zotero.Prefs.convertLegacyFormatString('{ - %y - }'),
 				'{{ year prefix=" - " suffix=" - " }}'
 			);
 			assert.equal(
-				Zotero.Attachments.convertLegacyFormatString('{%y{2}00}'),
+				Zotero.Prefs.convertLegacyFormatString('{%y{2}00}'),
 				'{{ year truncate="2" suffix="00" }}'
 			);
 			assert.equal(
-				Zotero.Attachments.convertLegacyFormatString('{%c5 - }'),
+				Zotero.Prefs.convertLegacyFormatString('{%c5 - }'),
 				'{{ firstCreator suffix="5 - " }}'
 			);
 			assert.equal(
-				Zotero.Attachments.convertLegacyFormatString('{%c-2 - }'),
+				Zotero.Prefs.convertLegacyFormatString('{%c-2 - }'),
 				'{{ firstCreator suffix="-2 - " }}'
 			);
 			assert.equal(
-				Zotero.Attachments.convertLegacyFormatString('{%t5 - }'),
+				Zotero.Prefs.convertLegacyFormatString('{%t5 - }'),
 				'{{ title suffix="5 - " }}'
 			);
 			assert.equal(
-				Zotero.Attachments.convertLegacyFormatString('{++%t{10}--}'),
+				Zotero.Prefs.convertLegacyFormatString('{++%t{10}--}'),
 				'{{ title truncate="10" prefix="++" suffix="--" }}'
 			);
 			assert.equal(
-				Zotero.Attachments.convertLegacyFormatString('foo{%c}-{%t{10}}-{%y{2}00}'),
+				Zotero.Prefs.convertLegacyFormatString('foo{%c}-{%t{10}}-{%y{2}00}'),
 				'foo{{ firstCreator }}-{{ title truncate="10" }}-{{ year truncate="2" suffix="00" }}'
 			);
 		});

--- a/test/tests/attachmentsTest.js
+++ b/test/tests/attachmentsTest.js
@@ -1572,35 +1572,35 @@ describe("Zotero.Attachments", function() {
 
 		it("should convert formatString attachmentRenameFormatString to use template syntax", function () {
 			assert.equal(
-				Zotero.Prefs.convertLegacyFormatString('{%c - }{%y - }{%t{50}}'),
+				Zotero.Prefs.convertLegacyAttachmentRenameFormatString('{%c - }{%y - }{%t{50}}'),
 				'{{ firstCreator suffix=" - " }}{{ year suffix=" - " }}{{ title truncate="50" }}'
 			);
 			assert.equal(
-				Zotero.Prefs.convertLegacyFormatString('{ - %y - }'),
+				Zotero.Prefs.convertLegacyAttachmentRenameFormatString('{ - %y - }'),
 				'{{ year prefix=" - " suffix=" - " }}'
 			);
 			assert.equal(
-				Zotero.Prefs.convertLegacyFormatString('{%y{2}00}'),
+				Zotero.Prefs.convertLegacyAttachmentRenameFormatString('{%y{2}00}'),
 				'{{ year truncate="2" suffix="00" }}'
 			);
 			assert.equal(
-				Zotero.Prefs.convertLegacyFormatString('{%c5 - }'),
+				Zotero.Prefs.convertLegacyAttachmentRenameFormatString('{%c5 - }'),
 				'{{ firstCreator suffix="5 - " }}'
 			);
 			assert.equal(
-				Zotero.Prefs.convertLegacyFormatString('{%c-2 - }'),
+				Zotero.Prefs.convertLegacyAttachmentRenameFormatString('{%c-2 - }'),
 				'{{ firstCreator suffix="-2 - " }}'
 			);
 			assert.equal(
-				Zotero.Prefs.convertLegacyFormatString('{%t5 - }'),
+				Zotero.Prefs.convertLegacyAttachmentRenameFormatString('{%t5 - }'),
 				'{{ title suffix="5 - " }}'
 			);
 			assert.equal(
-				Zotero.Prefs.convertLegacyFormatString('{++%t{10}--}'),
+				Zotero.Prefs.convertLegacyAttachmentRenameFormatString('{++%t{10}--}'),
 				'{{ title truncate="10" prefix="++" suffix="--" }}'
 			);
 			assert.equal(
-				Zotero.Prefs.convertLegacyFormatString('foo{%c}-{%t{10}}-{%y{2}00}'),
+				Zotero.Prefs.convertLegacyAttachmentRenameFormatString('foo{%c}-{%t{10}}-{%y{2}00}'),
 				'foo{{ firstCreator }}-{{ title truncate="10" }}-{{ year truncate="2" suffix="00" }}'
 			);
 		});

--- a/test/tests/attachmentsTest.js
+++ b/test/tests/attachmentsTest.js
@@ -1334,13 +1334,13 @@ describe("Zotero.Attachments", function() {
 		});
 
 		
-		it('should strip HTML tags from title', async function () {
+		it('should strip HTML tags from title', function () {
 			var htmlItem = createUnsavedDataObject('item', { title: 'Foo <i>Bar</i> Foo<br><br/><br />Bar' });
 			var str = Zotero.Attachments.getFileBaseNameFromItem(htmlItem, '{{ title }}');
 			assert.equal(str, 'Foo Bar Foo Bar');
 		});
 
-		it('should accept basic formating options', async function () {
+		it('should accept basic formating options', function () {
 			assert.equal(
 				Zotero.Attachments.getFileBaseNameFromItem(item, 'FOO{{year}}BAR'),
 				'FOO1975BAR'
@@ -1363,7 +1363,7 @@ describe("Zotero.Attachments", function() {
 			);
 		});
 
-		it('should offer a range of options for composing creaotrs', async function () {
+		it('should offer a range of options for composing creaotrs', function () {
 			assert.equal(
 				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ authors max="1" }}'),
 				'Barius'
@@ -1489,7 +1489,7 @@ describe("Zotero.Attachments", function() {
 			);
 		});
 
-		it('should accept itemType or any other field', async function () {
+		it('should accept itemType or any other field', function () {
 			assert.equal(
 				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ itemType }}'),
 				'Journal Article'
@@ -1525,6 +1525,41 @@ describe("Zotero.Attachments", function() {
 			assert.equal(
 				Zotero.Attachments.getFileBaseNameFromItem(itemPatent, '{{ assignee }}'),
 				'Fast FooBar'
+			);
+		});
+
+		it("should conver formatString attachmentRenameFormatString to use template syntax", function () {
+			assert.equal(
+				Zotero.Attachments.convertLegacyFormatString('{%c - }{%y - }{%t{50}}'),
+				'{{ firstCreator suffix=" - " }}{{ year suffix=" - " }}{{ title truncate="50" }}'
+			);
+			assert.equal(
+				Zotero.Attachments.convertLegacyFormatString('{ - %y - }'),
+				'{{ year prefix=" - " suffix=" - " }}'
+			);
+			assert.equal(
+				Zotero.Attachments.convertLegacyFormatString('{%y{2}00}'),
+				'{{ year truncate="2" suffix="00" }}'
+			);
+			assert.equal(
+				Zotero.Attachments.convertLegacyFormatString('{%c5 - }'),
+				'{{ firstCreator suffix="5 - " }}'
+			);
+			assert.equal(
+				Zotero.Attachments.convertLegacyFormatString('{%c-2 - }'),
+				'{{ firstCreator suffix="-2 - " }}'
+			);
+			assert.equal(
+				Zotero.Attachments.convertLegacyFormatString('{%t5 - }'),
+				'{{ title suffix="5 - " }}'
+			);
+			assert.equal(
+				Zotero.Attachments.convertLegacyFormatString('{++%t{10}--}'),
+				'{{ title truncate="10" prefix="++" suffix="--" }}'
+			);
+			assert.equal(
+				Zotero.Attachments.convertLegacyFormatString('foo{%c}-{%t{10}}-{%y{2}00}'),
+				'foo{{ firstCreator }}-{{ title truncate="10" }}-{{ year truncate="2" suffix="00" }}'
 			);
 		});
 	});

--- a/test/tests/attachmentsTest.js
+++ b/test/tests/attachmentsTest.js
@@ -1334,161 +1334,189 @@ describe("Zotero.Attachments", function() {
 		});
 
 		
-		it("should strip HTML tags from title", async function () {
+		it('should strip HTML tags from title', async function () {
 			var htmlItem = createUnsavedDataObject('item', { title: 'Foo <i>Bar</i> Foo<br><br/><br />Bar' });
 			var str = Zotero.Attachments.getFileBaseNameFromItem(htmlItem);
 			assert.equal(str, 'Foo Bar Foo Bar');
 		});
 
-		it("should accept basic wildcards for formatString", async function () {
+		it('should accept basic wildcards for formatString', async function () {
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, "{FOO%yBAR}"),
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{FOO%yBAR}'),
 				'FOO1975BAR'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, "{%c - }{%y - }{%t}"),
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{%c - }{%y - }{%t}'),
 				'Barius and Pixelus - 1975 - Lorem Ipsum'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, "{%y-}{%c{10}-}{%t{5}}"),
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{%y-}{%c{10}-}{%t{5}}'),
 				'1975-Barius and-Lorem'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, "foo {%y} bar {++%y{2}++}"),
+				Zotero.Attachments.getFileBaseNameFromItem(item, 'foo {%y} bar {++%y{2}++}'),
 				'foo 1975 bar ++19++'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, "{%c - }{%y - }{%t}"),
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{%c - }{%y - }{%t}'),
 				'Author et al. - 2000 - Has Many Authors'
 			);
 		});
 
-		it("should accept advanced wildcards for primary creators for formatString", async function () {
+		it('should accept advanced wildcards for primary creators for formatString', async function () {
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, "{%a}"),
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{%a}'),
 				'Barius'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, "{%a-1}"),
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{%a-1}'),
 				'Pixelus'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, "{%a-1{5}}"),
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{%a-1{5}}'),
 				'Pixel'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, "{%a5}"),
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{%a5}'),
 				'Barius Pixelus'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, "{%a-5}"),
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{%a-5}'),
 				'Pixelus Barius'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, "{%a3}"),
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{%a3}'),
 				'Author Creator Person'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemPatent, "{%a}"),
+				Zotero.Attachments.getFileBaseNameFromItem(itemPatent, '{%a}'),
 				'AcmeCorp'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, "{%A2}"),
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{%A2}'),
 				'A C'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemPatent, "{%A2}"),
+				Zotero.Attachments.getFileBaseNameFromItem(itemPatent, '{%A2}'),
 				'A'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, "{%I}"),
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{%I}'),
 				'FB'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, "{%I-1}"),
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{%I-1}'),
 				'BP'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, "{%I-3}"),
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{%I-3}'),
 				'FW TP SC'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, "{%F}"),
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{%F}'),
 				'BariusF'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, "{%F2}"),
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{%F2}'),
 				'AuthorF CreatorS'
 			);
 		});
 
-		it("should accept advanced wildcards for editors form formatString", async function () {
+		it('should accept advanced wildcards for editors form formatString', async function () {
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, "{%d}test"),
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{%d}test'),
 				'test'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, "{%d}"),
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{%d}'),
 				'Editor1'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, "{%d5}"),
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{%d5}'),
 				'Editor1 ProEditor2 SuperbEditor3'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, "{%D2}"),
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{%D2}'),
 				'E P'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, "{%D-1}"),
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{%D-1}'),
 				'S'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, "{%l}"),
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{%l}'),
 				'SE'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, "{%L}"),
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{%L}'),
 				'Editor1S'
 			);
 		});
 
-		it("should accept other advanced wildcards for formatString", async function () {
+		it('should accept other advanced wildcards for formatString', async function () {
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, "{%T}"),
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{%T}'),
 				'Journal Article'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, "{%j}"),
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{%j}'),
 				'Best Publications Place'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, "{%s}"),
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{%s}'),
 				'BPP'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, "{%p}"),
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{%p}'),
 				'Awesome House'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, "{%v}"),
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{%v}'),
 				'3'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, "{%e}"),
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{%e}'),
 				'42'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, "{%f}"),
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{%f}'),
 				'321'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemPatent, "{%n}"),
+				Zotero.Attachments.getFileBaseNameFromItem(itemPatent, '{%n}'),
 				'HBK-8539b'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemPatent, "{%i}"),
+				Zotero.Attachments.getFileBaseNameFromItem(itemPatent, '{%i}'),
 				'Fast FooBar'
+			);
+		});
+
+		it("should be backwards-compatible", async function () {
+			var justTitleItem = createUnsavedDataObject('item', { title: 'lorem ipsum' });
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(justTitleItem, '{%c - }{%y - }{%t{50}}'),
+				'lorem ipsum'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{%y - }'),
+				'1975 - '
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{%y{2}00}'),
+				'1900'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{%c5 - }'),
+				'Barius and Pixelus5 - '
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{%c-2 - }'),
+				'Author et al.-2 - '
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{%t5 - }'),
+				'Lorem Ipsum5 - '
 			);
 		});
 	});

--- a/test/tests/attachmentsTest.js
+++ b/test/tests/attachmentsTest.js
@@ -1302,7 +1302,12 @@ describe("Zotero.Attachments", function() {
 				{ firstName: 'Bazius', lastName: 'Pixelus', creatorType: 'author' }
 			]);
 			item.setField('date', "1975-10-15");
+			item.setField('publicationTitle', 'Best Publications Place');
+			item.setField('journalAbbreviation', 'BPP');
+			item.setField('issue', '42');
+			item.setField('pages', '321');
 
+			
 			itemManyAuthors = createUnsavedDataObject('item', { title: 'Has Many Authors', itemType: 'book' });
 			itemManyAuthors.setCreators([
 				{ firstName: 'First', lastName: 'Author', creatorType: 'author' },
@@ -1314,6 +1319,8 @@ describe("Zotero.Attachments", function() {
 				{ firstName: 'Last', lastName: 'SuperbEditor3', creatorType: 'editor' },
 			]);
 			itemManyAuthors.setField('date', "2000-01-02");
+			itemManyAuthors.setField('publisher', 'Awesome House');
+			itemManyAuthors.setField('volume', '3');
 
 			itemPatent = createUnsavedDataObject('item', { title: 'Retroencabulator', itemType: 'patent' });
 			itemPatent.setCreators([
@@ -1321,7 +1328,9 @@ describe("Zotero.Attachments", function() {
 				{ firstName: 'Wile', lastName: 'E', creatorType: 'contributor' },
 				{ firstName: 'Road', lastName: 'R', creatorType: 'contributor' },
 			]);
-			itemPatent.setField('date', "1952-05-10");
+			itemPatent.setField('date', '1952-05-10');
+			itemPatent.setField('number', 'HBK-8539b');
+			itemPatent.setField('assignee', 'Fast FooBar');
 		});
 
 		
@@ -1354,7 +1363,7 @@ describe("Zotero.Attachments", function() {
 			);
 		});
 
-		it("should accept advanced wildcards for formating primary creators", async function () {
+		it("should accept advanced wildcards for primary creators for formatString", async function () {
 			assert.equal(
 				Zotero.Attachments.getFileBaseNameFromItem(item, "{%a}"),
 				'Barius'
@@ -1413,7 +1422,7 @@ describe("Zotero.Attachments", function() {
 			);
 		});
 
-		it("should accept advanced wildcards for formating editors", async function () {
+		it("should accept advanced wildcards for editors form formatString", async function () {
 			assert.equal(
 				Zotero.Attachments.getFileBaseNameFromItem(item, "{%d}test"),
 				'test'
@@ -1441,6 +1450,45 @@ describe("Zotero.Attachments", function() {
 			assert.equal(
 				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, "{%L}"),
 				'Editor1S'
+			);
+		});
+
+		it("should accept other advanced wildcards for formatString", async function () {
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, "{%T}"),
+				'Journal Article'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, "{%j}"),
+				'Best Publications Place'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, "{%s}"),
+				'BPP'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, "{%p}"),
+				'Awesome House'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, "{%v}"),
+				'3'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, "{%e}"),
+				'42'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, "{%f}"),
+				'321'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemPatent, "{%n}"),
+				'HBK-8539b'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemPatent, "{%i}"),
+				'Fast FooBar'
 			);
 		});
 	});

--- a/test/tests/attachmentsTest.js
+++ b/test/tests/attachmentsTest.js
@@ -1396,31 +1396,31 @@ describe("Zotero.Attachments", function() {
 				'AcmeCorp'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ authors max="2" name="family" initialize="family" join=" " initializewith="" }}'),
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ authors max="2" name="family" initialize="family" join=" " initialize-with="" }}'),
 				'A C'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemPatent, '{{ authors max="2" name="family" initialize="family" initializewith="" }}'),
+				Zotero.Attachments.getFileBaseNameFromItem(itemPatent, '{{ authors max="2" name="family" initialize="family" initialize-with="" }}'),
 				'A'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ authors max="1" name="full" initialize="full" namepartseparator="" initializewith="" }}'),
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ authors max="1" name="full" initialize="full" name-part-separator="" initialize-with="" }}'),
 				'FB'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ authors max="1" order="desc" name="full" initialize="full" namepartseparator="" initializewith="" }}'),
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ authors max="1" order="desc" name="full" initialize="full" name-part-separator="" initialize-with="" }}'),
 				'BP'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ authors max="3" order="desc" name="full" initialize="full" namepartseparator="" join=" " initializewith="" }}'),
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ authors max="3" order="desc" name="full" initialize="full" name-part-separator="" join=" " initialize-with="" }}'),
 				'FW TP SC'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ authors max="1" name="family-given" initialize="given" namepartseparator="" initializewith="" }}'),
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ authors max="1" name="family-given" initialize="given" name-part-separator="" initialize-with="" }}'),
 				'BariusF'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ authors max="2" name="family-given" initialize="given" join=" " namepartseparator="" initializewith="" }}'),
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ authors max="2" name="family-given" initialize="given" join=" " name-part-separator="" initialize-with="" }}'),
 				'AuthorF CreatorS'
 			);
 			assert.equal(
@@ -1436,19 +1436,19 @@ describe("Zotero.Attachments", function() {
 				'Editor1 ProEditor2 SuperbEditor3'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ editors max="2" name="family" initialize="family" join=" " initializewith="" }}'),
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ editors max="2" name="family" initialize="family" join=" " initialize-with="" }}'),
 				'E P'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ editors max="1" order="desc" name="family" initialize="family" initializewith="" }}'),
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ editors max="1" order="desc" name="family" initialize="family" initialize-with="" }}'),
 				'S'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ editors max="1" name="full" initialize="full" namepartseparator="" initializewith="" }}'),
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ editors max="1" name="full" initialize="full" name-part-separator="" initialize-with="" }}'),
 				'SE'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ editors max="1" name="family-given" initialize="given" namepartseparator="" initializewith="" }}'),
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ editors max="1" name="family-given" initialize="given" name-part-separator="" initialize-with="" }}'),
 				'Editor1S'
 			);
 			assert.equal(

--- a/test/tests/attachmentsTest.js
+++ b/test/tests/attachmentsTest.js
@@ -1293,15 +1293,35 @@ describe("Zotero.Attachments", function() {
 	});
 	
 	describe("#getFileBaseNameFromItem()", function () {
-		var item;
+		var item, itemManyAuthors, itemPatent;
 
 		before(() => {
-			item = createUnsavedDataObject('item', { title: 'Lorem Ipsum' });
+			item = createUnsavedDataObject('item', { title: 'Lorem Ipsum', itemType: 'journalArticle' });
 			item.setCreators([
 				{ firstName: 'Foocius', lastName: 'Barius', creatorType: 'author' },
 				{ firstName: 'Bazius', lastName: 'Pixelus', creatorType: 'author' }
 			]);
 			item.setField('date', "1975-10-15");
+
+			itemManyAuthors = createUnsavedDataObject('item', { title: 'Has Many Authors', itemType: 'book' });
+			itemManyAuthors.setCreators([
+				{ firstName: 'First', lastName: 'Author', creatorType: 'author' },
+				{ firstName: 'Second', lastName: 'Creator', creatorType: 'author' },
+				{ firstName: 'Third', lastName: 'Person', creatorType: 'author' },
+				{ firstName: 'Final', lastName: 'Writer', creatorType: 'author' },
+				{ firstName: 'Some', lastName: 'Editor1', creatorType: 'editor' },
+				{ firstName: 'Other', lastName: 'ProEditor2', creatorType: 'editor' },
+				{ firstName: 'Last', lastName: 'SuperbEditor3', creatorType: 'editor' },
+			]);
+			itemManyAuthors.setField('date', "2000-01-02");
+
+			itemPatent = createUnsavedDataObject('item', { title: 'Retroencabulator', itemType: 'patent' });
+			itemPatent.setCreators([
+				{ name: 'AcmeCorp', creatorType: 'inventor' },
+				{ firstName: 'Wile', lastName: 'E', creatorType: 'contributor' },
+				{ firstName: 'Road', lastName: 'R', creatorType: 'contributor' },
+			]);
+			itemPatent.setField('date', "1952-05-10");
 		});
 
 		
@@ -1327,6 +1347,100 @@ describe("Zotero.Attachments", function() {
 			assert.equal(
 				Zotero.Attachments.getFileBaseNameFromItem(item, "foo {%y} bar {++%y{2}++}"),
 				'foo 1975 bar ++19++'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, "{%c - }{%y - }{%t}"),
+				'Author et al. - 2000 - Has Many Authors'
+			);
+		});
+
+		it("should accept advanced wildcards for formating primary creators", async function () {
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, "{%a}"),
+				'Barius'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, "{%a-1}"),
+				'Pixelus'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, "{%a-1{5}}"),
+				'Pixel'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, "{%a5}"),
+				'Barius Pixelus'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, "{%a-5}"),
+				'Pixelus Barius'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, "{%a3}"),
+				'Author Creator Person'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemPatent, "{%a}"),
+				'AcmeCorp'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, "{%A2}"),
+				'A C'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemPatent, "{%A2}"),
+				'A'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, "{%I}"),
+				'FB'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, "{%I-1}"),
+				'BP'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, "{%I-3}"),
+				'FW TP SC'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, "{%F}"),
+				'BariusF'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, "{%F2}"),
+				'AuthorF CreatorS'
+			);
+		});
+
+		it("should accept advanced wildcards for formating editors", async function () {
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, "{%d}test"),
+				'test'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, "{%d}"),
+				'Editor1'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, "{%d5}"),
+				'Editor1 ProEditor2 SuperbEditor3'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, "{%D2}"),
+				'E P'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, "{%D-1}"),
+				'S'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, "{%l}"),
+				'SE'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, "{%L}"),
+				'Editor1S'
 			);
 		});
 	});

--- a/test/tests/attachmentsTest.js
+++ b/test/tests/attachmentsTest.js
@@ -1336,187 +1336,195 @@ describe("Zotero.Attachments", function() {
 		
 		it('should strip HTML tags from title', async function () {
 			var htmlItem = createUnsavedDataObject('item', { title: 'Foo <i>Bar</i> Foo<br><br/><br />Bar' });
-			var str = Zotero.Attachments.getFileBaseNameFromItem(htmlItem);
+			var str = Zotero.Attachments.getFileBaseNameFromItem(htmlItem, '{{ title }}');
 			assert.equal(str, 'Foo Bar Foo Bar');
 		});
 
-		it('should accept basic wildcards for formatString', async function () {
+		it('should accept basic formating options', async function () {
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, '{FOO%yBAR}'),
+				Zotero.Attachments.getFileBaseNameFromItem(item, 'FOO{{year}}BAR'),
 				'FOO1975BAR'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, '{%c - }{%y - }{%t}'),
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{{firstCreator suffix=" - "}}{{year suffix=" - "}}{{title truncate="50" }}'),
 				'Barius and Pixelus - 1975 - Lorem Ipsum'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, '{%y-}{%c{10}-}{%t{5}}'),
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{{year suffix="-"}}{{firstCreator truncate="10" suffix="-"}}{{title truncate="5" }}'),
 				'1975-Barius and-Lorem'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, 'foo {%y} bar {++%y{2}++}'),
+				Zotero.Attachments.getFileBaseNameFromItem(item, 'foo {{year}} bar {{year prefix="++" truncate="2" suffix="++"}}'),
 				'foo 1975 bar ++19++'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{%c - }{%y - }{%t}'),
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{firstCreator suffix=" - "}}{{year suffix=" - "}}{{title}}'),
 				'Author et al. - 2000 - Has Many Authors'
 			);
 		});
 
-		it('should accept advanced wildcards for primary creators for formatString', async function () {
+		it('should offer a range of options for composing creaotrs', async function () {
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, '{%a}'),
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ authors max="1" }}'),
 				'Barius'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, '{%a-1}'),
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ authors max="1" order="desc" }}'),
 				'Pixelus'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, '{%a-1{5}}'),
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ authors max="1" order="desc" truncate="5" }}'),
 				'Pixel'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, '{%a5}'),
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ authors max="5" join=" " }}'),
 				'Barius Pixelus'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, '{%a-5}'),
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ authors max="5" order="desc" join=" " }}'),
 				'Pixelus Barius'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{%a3}'),
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ authors max="3" join=" " }}'),
 				'Author Creator Person'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemPatent, '{%a}'),
+				Zotero.Attachments.getFileBaseNameFromItem(itemPatent, '{{ authors }}'),
 				'AcmeCorp'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{%A2}'),
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ authors max="2" name="family" initialize="family" join=" " initializewith="" }}'),
 				'A C'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemPatent, '{%A2}'),
+				Zotero.Attachments.getFileBaseNameFromItem(itemPatent, '{{ authors max="2" name="family" initialize="family" initializewith="" }}'),
 				'A'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, '{%I}'),
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ authors max="1" name="full" initialize="full" namepartseparator="" initializewith="" }}'),
 				'FB'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, '{%I-1}'),
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ authors max="1" order="desc" name="full" initialize="full" namepartseparator="" initializewith="" }}'),
 				'BP'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{%I-3}'),
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ authors max="3" order="desc" name="full" initialize="full" namepartseparator="" join=" " initializewith="" }}'),
 				'FW TP SC'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, '{%F}'),
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ authors max="1" name="family-given" initialize="given" namepartseparator="" initializewith="" }}'),
 				'BariusF'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{%F2}'),
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ authors max="2" name="family-given" initialize="given" join=" " namepartseparator="" initializewith="" }}'),
 				'AuthorF CreatorS'
 			);
-		});
-
-		it('should accept advanced wildcards for editors form formatString', async function () {
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, '{%d}test'),
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ editors }}test'),
 				'test'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{%d}'),
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ editors max="1" }}'),
 				'Editor1'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{%d5}'),
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ editors max="5" join=" " }}'),
 				'Editor1 ProEditor2 SuperbEditor3'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{%D2}'),
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ editors max="2" name="family" initialize="family" join=" " initializewith="" }}'),
 				'E P'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{%D-1}'),
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ editors max="1" order="desc" name="family" initialize="family" initializewith="" }}'),
 				'S'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{%l}'),
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ editors max="1" name="full" initialize="full" namepartseparator="" initializewith="" }}'),
 				'SE'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{%L}'),
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ editors max="1" name="family-given" initialize="given" namepartseparator="" initializewith="" }}'),
 				'Editor1S'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ authors max="3" name="full" initialize="given" }}'),
+				'F. Barius, B. Pixelus'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ creators case="upper" }}'),
+				'BARIUS, PIXELUS'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ authors max="2" }}'),
+				'Author, Creator'
 			);
 		});
 
-		it('should accept other advanced wildcards for formatString', async function () {
+		it('should accept case parameter', async function () {
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, '{%T}'),
-				'Journal Article'
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ publicationTitle case="upper" }}'),
+				'BEST PUBLICATIONS PLACE'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, '{%j}'),
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ publicationTitle case="lower" }}'),
+				'best publications place'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ publicationTitle case="title" }}'),
 				'Best Publications Place'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, '{%s}'),
-				'BPP'
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ publicationTitle case="dash" }}'),
+				'best-publications-place'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{%p}'),
-				'Awesome House'
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ publicationTitle case="camel" }}'),
+				'bestPublicationsPlace'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{%v}'),
-				'3'
-			);
-			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, '{%e}'),
-				'42'
-			);
-			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, '{%f}'),
-				'321'
-			);
-			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemPatent, '{%n}'),
-				'HBK-8539b'
-			);
-			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemPatent, '{%i}'),
-				'Fast FooBar'
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ publicationTitle case="snake" }}'),
+				'best_publications_place'
 			);
 		});
 
-		it("should be backwards-compatible", async function () {
-			var justTitleItem = createUnsavedDataObject('item', { title: 'lorem ipsum' });
+		it('should accept itemType or any other field', async function () {
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(justTitleItem, '{%c - }{%y - }{%t{50}}'),
-				'lorem ipsum'
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ itemType }}'),
+				'Journal Article'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, '{%y - }'),
-				'1975 - '
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ publicationTitle }}'),
+				'Best Publications Place'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, '{%y{2}00}'),
-				'1900'
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ journalAbbreviation }}'),
+				'BPP'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, '{%c5 - }'),
-				'Barius and Pixelus5 - '
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ publisher }}'),
+				'Awesome House'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{%c-2 - }'),
-				'Author et al.-2 - '
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ volume }}'),
+				'3'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, '{%t5 - }'),
-				'Lorem Ipsum5 - '
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ issue }}'),
+				'42'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ pages }}'),
+				'321'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemPatent, '{{ number }}'),
+				'HBK-8539b'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemPatent, '{{ assignee }}'),
+				'Fast FooBar'
 			);
 		});
 	});

--- a/test/tests/attachmentsTest.js
+++ b/test/tests/attachmentsTest.js
@@ -1293,7 +1293,7 @@ describe("Zotero.Attachments", function() {
 	});
 	
 	describe("#getFileBaseNameFromItem()", function () {
-		var item, itemManyAuthors, itemPatent;
+		var item, itemManyAuthors, itemPatent, itemIncomplete;
 
 		before(() => {
 			item = createUnsavedDataObject('item', { title: 'Lorem Ipsum', itemType: 'journalArticle' });
@@ -1331,6 +1331,7 @@ describe("Zotero.Attachments", function() {
 			itemPatent.setField('date', '1952-05-10');
 			itemPatent.setField('number', 'HBK-8539b');
 			itemPatent.setField('assignee', 'Fast FooBar');
+			itemIncomplete = createUnsavedDataObject('item', { title: 'Incomplete', itemType: 'preprint' });
 		});
 
 		
@@ -1525,6 +1526,19 @@ describe("Zotero.Attachments", function() {
 			assert.equal(
 				Zotero.Attachments.getFileBaseNameFromItem(itemPatent, '{{ assignee }}'),
 				'Fast FooBar'
+			);
+		});
+
+		it("should support simple logic in template syntax", function () {
+			const template = '{{ if itemTypeRaw == "journalArticle" }}j-{{ publicationTitle case="dash" }}{{ elseif itemTypeRaw == "patent" }}p-{{ number case="dash" }}{{ else }}o-{{ title case="dash" }}{{ endif }}';
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, template), 'j-best-publications-place'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemPatent, template), 'p-hbk-8539b'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, template), 'o-has-many-authors'
 			);
 		});
 

--- a/test/tests/attachmentsTest.js
+++ b/test/tests/attachmentsTest.js
@@ -1293,10 +1293,41 @@ describe("Zotero.Attachments", function() {
 	});
 	
 	describe("#getFileBaseNameFromItem()", function () {
+		var item;
+
+		before(() => {
+			item = createUnsavedDataObject('item', { title: 'Lorem Ipsum' });
+			item.setCreators([
+				{ firstName: 'Foocius', lastName: 'Barius', creatorType: 'author' },
+				{ firstName: 'Bazius', lastName: 'Pixelus', creatorType: 'author' }
+			]);
+			item.setField('date', "1975-10-15");
+		});
+
+		
 		it("should strip HTML tags from title", async function () {
-			var item = createUnsavedDataObject('item', { title: 'Foo <i>Bar</i> Foo<br><br/><br />Bar' });
-			var str = Zotero.Attachments.getFileBaseNameFromItem(item);
+			var htmlItem = createUnsavedDataObject('item', { title: 'Foo <i>Bar</i> Foo<br><br/><br />Bar' });
+			var str = Zotero.Attachments.getFileBaseNameFromItem(htmlItem);
 			assert.equal(str, 'Foo Bar Foo Bar');
+		});
+
+		it("should accept basic wildcards for formatString", async function () {
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, "{FOO%yBAR}"),
+				'FOO1975BAR'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, "{%c - }{%y - }{%t}"),
+				'Barius and Pixelus - 1975 - Lorem Ipsum'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, "{%y-}{%c{10}-}{%t{5}}"),
+				'1975-Barius and-Lorem'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, "foo {%y} bar {++%y{2}++}"),
+				'foo 1975 bar ++19++'
+			);
 		});
 	});
 	

--- a/test/tests/attachmentsTest.js
+++ b/test/tests/attachmentsTest.js
@@ -1372,20 +1372,12 @@ describe("Zotero.Attachments", function() {
 				'Barius'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ authors max="1" order="desc" }}'),
-				'Pixelus'
-			);
-			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ authors max="1" order="desc" truncate="5" }}'),
-				'Pixel'
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ authors max="1" truncate="3" }}'),
+				'Bar'
 			);
 			assert.equal(
 				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ authors max="5" join=" " }}'),
 				'Barius Pixelus'
-			);
-			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ authors max="5" order="desc" join=" " }}'),
-				'Pixelus Barius'
 			);
 			assert.equal(
 				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ authors max="3" join=" " }}'),
@@ -1408,12 +1400,8 @@ describe("Zotero.Attachments", function() {
 				'FB'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ authors max="1" order="desc" name="full" initialize="full" name-part-separator="" initialize-with="" }}'),
-				'BP'
-			);
-			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ authors max="3" order="desc" name="full" initialize="full" name-part-separator="" join=" " initialize-with="" }}'),
-				'FW TP SC'
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ authors max="3" name="full" initialize="full" name-part-separator="" join=" " initialize-with="" }}'),
+				'FA SC TP'
 			);
 			assert.equal(
 				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ authors max="1" name="family-given" initialize="given" name-part-separator="" initialize-with="" }}'),
@@ -1440,10 +1428,6 @@ describe("Zotero.Attachments", function() {
 				'E P'
 			);
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ editors max="1" order="desc" name="family" initialize="family" initialize-with="" }}'),
-				'S'
-			);
-			assert.equal(
 				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ editors max="1" name="full" initialize="full" name-part-separator="" initialize-with="" }}'),
 				'SE'
 			);
@@ -1466,10 +1450,6 @@ describe("Zotero.Attachments", function() {
 			assert.equal(
 				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ creators max="3" join=" " name="given" }}'),
 				'First Second Third'
-			);
-			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{ creators max="3" join=" " name="given" order="desc" }}'),
-				'Last Other Some'
 			);
 		});
 

--- a/test/tests/attachmentsTest.js
+++ b/test/tests/attachmentsTest.js
@@ -1502,7 +1502,7 @@ describe("Zotero.Attachments", function() {
 
 		it('should accept itemType or any other field', function () {
 			assert.equal(
-				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ itemType }}'),
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{{ itemType localize="true" }}'),
 				'Journal Article'
 			);
 			assert.equal(
@@ -1540,7 +1540,7 @@ describe("Zotero.Attachments", function() {
 		});
 
 		it("should support simple logic in template syntax", function () {
-			const template = '{{ if itemTypeRaw == "journalArticle" }}j-{{ publicationTitle case="hyphen" }}{{ elseif itemTypeRaw == "patent" }}p-{{ number case="hyphen" }}{{ else }}o-{{ title case="hyphen" }}{{ endif }}';
+			const template = '{{ if itemType == "journalArticle" }}j-{{ publicationTitle case="hyphen" }}{{ elseif itemType == "patent" }}p-{{ number case="hyphen" }}{{ else }}o-{{ title case="hyphen" }}{{ endif }}';
 			assert.equal(
 				Zotero.Attachments.getFileBaseNameFromItem(item, template), 'j-best-publications-place'
 			);

--- a/test/tests/utilities_internalTest.js
+++ b/test/tests/utilities_internalTest.js
@@ -607,6 +607,15 @@ describe("Zotero.Utilities.Internal", function () {
 			}
 		});
 
+		it("should accept dash-case variables and attributes", function () {
+			const vars = {
+				fooBar: ({ isFoo }) => (isFoo === 'true' ? 'foo' : 'bar'),
+			};
+			const template = '{{ foo-bar is-foo="true" }}{{ if foo-bar is-foo="false" == "bar" }}{{ foo-bar is-foo="false" }}{{ endif }}';
+			const out = Zotero.Utilities.Internal.generateHTMLFromTemplate(template, vars);
+			assert.equal(out, 'foobar');
+		});
+
 
 		it("should support nested 'if' statements", function () {
 			var vars = {

--- a/test/tests/utilities_internalTest.js
+++ b/test/tests/utilities_internalTest.js
@@ -560,6 +560,15 @@ describe("Zotero.Utilities.Internal", function () {
 			assert.equal(html, '11 23 1,2yes');
 		});
 
+		it("should support empty string as attribute value and correctly render returned false-ish values (e.g. 0)", function () {
+			const vars = {
+				length: ({ string }) => string.length,
+			};
+			const template = `"" has a length of {{ length string="" }} and "hello" has a length of {{ length string="hello" }}`;
+			const out = Zotero.Utilities.Internal.generateHTMLFromTemplate(template, vars);
+			assert.equal(out, '"" has a length of 0 and "hello" has a length of 5');
+		});
+
 		it("should support nested 'if' statements", function () {
 			var vars = {
 				v1: '1',

--- a/test/tests/utilities_internalTest.js
+++ b/test/tests/utilities_internalTest.js
@@ -638,7 +638,7 @@ describe("Zotero.Utilities.Internal", function () {
 			assert.equal(out15, 'yes');
 		});
 
-		it("should accept dash-case variables and attributes", function () {
+		it("should accept hyphen-case variables and attributes", function () {
 			const vars = {
 				fooBar: ({ isFoo }) => (isFoo === 'true' ? 'foo' : 'bar'),
 			};


### PR DESCRIPTION
This PR includes multiple changes to extend capabilities of `getFileBaseNameFromItem` ~~but keeps it backwards-compatible~~ using template engine. See #1413.

(Removed details of previous implementation, current in comment below)