### PR TITLE
Add color and tag selector to annotations sidebar

### DIFF
--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -560,6 +560,28 @@ class ReaderInstance {
 		popup.openPopup(element, 'after_start', 0, 0, true);
 	}
 
+	_openSelectorPopup(data) {
+		let popup = this._window.document.createElement('menupopup');
+		this._popupset.appendChild(popup);
+		popup.addEventListener('popuphidden', function () {
+			popup.remove();
+		});
+		let menuitem;
+		// Clear Selection
+		menuitem = this._window.document.createElement('menuitem');
+		menuitem.setAttribute('label', Zotero.getString('general.clearSelection'));
+		menuitem.setAttribute('disabled', !data.enableClearSelection);
+		menuitem.addEventListener('command', () => {
+			this._postMessage({
+				action: 'popupCmd',
+				cmd: 'clearSelector',
+				ids: data.ids
+			});
+		});
+		popup.appendChild(menuitem);
+		popup.openPopupAtScreen(data.x, data.y, true);
+	}
+
 	async _postMessage(message, transfer) {
 		await this._waitForReader();
 		this._iframeWindow.postMessage({ itemID: this._itemID, message }, this._iframeWindow.origin, transfer);
@@ -654,6 +676,10 @@ class ReaderInstance {
 				}
 				case 'openColorPopup': {
 					this._openColorPopup(message.data);
+					return;
+				}
+				case 'openSelectorPopup': {
+					this._openSelectorPopup(message.data);
 					return;
 				}
 				case 'openURL': {

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -366,6 +366,7 @@ class ReaderInstance {
 
 	_openTagsPopup(x, y, item) {
 		let menupopup = this._window.document.createElement('menupopup');
+		menupopup.className = 'tags-popup';
 		menupopup.style.minWidth = '300px';
 		menupopup.setAttribute('ignorekeys', true);
 		let tagsbox = this._window.document.createElement('tagsbox');
@@ -678,8 +679,14 @@ class ReaderInstance {
 					this._openColorPopup(message.data);
 					return;
 				}
-				case 'openSelectorPopup': {
-					this._openSelectorPopup(message.data);
+				case 'closePopup': {
+					// Note: This currently only closes tags popup when annotations are
+					// disappearing from pdf-reader sidebar
+					for (let child of Array.from(this._popupset.children)) {
+						if (child.classList.contains('tags-popup')) {
+							child.hidePopup();
+						}
+					}
 					return;
 				}
 				case 'openURL': {

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -89,6 +89,7 @@ general.default                    = Default
 general.custom                     = Custom
 general.loading                    = Loading…
 general.richText = Rich Text
+general.clearSelection = Clear Selection
 
 general.yellow = Yellow
 general.red = Red


### PR DESCRIPTION
The tag and color selector can be tested now. Some issues to discuss:

1) There is no a convenient way to clear the filter. A separate button would be good, but I'm not sure where to put it. Alternatively it could be in context menu as it is in the original tag selector.
2) When filtering is active, some actions like annotation creation or selection become complicated because you no longer see it in the sidebar. Maybe a better indication that filtering is active would be useful, especially in those cases when only a color is selected, because it might be difficult to notice.
3) The final element that is necessary for this workflow is "Select all annotations" button. Or should it also be in context menu?