### PR TITLE
Implement custom keyboard navigation

### DIFF
--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -365,7 +365,7 @@ class ReaderInstance {
 		return `data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><rect shape-rendering="geometricPrecision" fill="${fill}" stroke-width="2" x="2" y="2" stroke="${stroke}" width="12" height="12" rx="3"/></svg>`;
 	}
 
-	_openTagsPopup(x, y, item) {
+	_openTagsPopup(item, selector) {
 		let menupopup = this._window.document.createElement('menupopup');
 		menupopup.className = 'tags-popup';
 		menupopup.style.minWidth = '300px';
@@ -374,7 +374,8 @@ class ReaderInstance {
 		menupopup.appendChild(tagsbox);
 		tagsbox.setAttribute('flex', '1');
 		this._popupset.appendChild(menupopup);
-		menupopup.openPopupAtScreen(x, y, false);
+		let element = this._iframeWindow.document.querySelector(selector);
+		menupopup.openPopup(element, 'overlap', 0, 0, true);
 		tagsbox.mode = 'edit';
 		tagsbox.item = item;
 		if (tagsbox.mode == 'edit' && tagsbox.count == 0) {
@@ -537,7 +538,14 @@ class ReaderInstance {
 			});
 		});
 		popup.appendChild(menuitem);
-		popup.openPopupAtScreen(data.x, data.y, true);
+
+		if (data.x) {
+			popup.openPopupAtScreen(data.x, data.y, true);
+		}
+		else if (data.selector) {
+			let element = this._iframeWindow.document.querySelector(data.selector);
+			popup.openPopup(element, 'after_start', 0, 0, true);
+		}
 	}
 
 	_openColorPopup(data) {
@@ -662,12 +670,12 @@ class ReaderInstance {
 					return;
 				}
 				case 'openTagsPopup': {
-					let { id: key, x, y } = message;
+					let { id: key, selector } = message;
 					let attachment = Zotero.Items.get(this._itemID);
 					let libraryID = attachment.libraryID;
 					let annotation = Zotero.Items.getByLibraryAndKey(libraryID, key);
 					if (annotation) {
-						this._openTagsPopup(x, y, annotation);
+						this._openTagsPopup(annotation, selector);
 					}
 					return;
 				}


### PR DESCRIPTION
As discussed in #1986.

It took a lot of time and there were many difficulties to implement this. Each focus zone has its own nuances. Basically a virtual focus layer was implemented. I tried to keep things as simple and as maintainable as possible, but the way how it works is still not perfect and will need a partial rewrite when we migrate to a newer PDF.js, or new UI elements will be introduced.

So this is what was implemented:
- Sidebar search input is now fixed to the top.
- Toolbar navigation.
- Findbar navigation.
- Sidebar view buttons navigation.
- Page thumbnails navigation.
- Outline navigation (Enter to fold/unfold)
- Annotations navigation and selection that respects the current filter.
- Annotation widget navigation.
- Page label updating popup navigation.
- Tag and color selector navigation.
- Annotations in PDF view navigation, which also allows to focus the first visible annotation when sidebar is closed.
- PDF view navigation that is native PDF.js navigation.
- Text selection popup navigation to pick highlight color (when text is selected, press Tab to focus to the first color).


We can consider slightly different variations of this navigation, especial for the part where focus becomes annotation selection. Maybe instead of automatically selecting annotation we only want to focus it and show an outline around it.


There is a high chance that there are bugs.

As soon as we approve the final version of this, I’ll do more code simplifications, cleanups and add comments to save time in future when I’ll need to get back to this complex thing.

EDIT: More points added.