### PR TITLE
Decouple progress queue table from progress window

### DIFF
--- a/chrome/content/zotero/components/progressQueueTable.jsx
+++ b/chrome/content/zotero/components/progressQueueTable.jsx
@@ -1,0 +1,123 @@
+/*
+	***** BEGIN LICENSE BLOCK *****
+	
+	Copyright © 2022 Corporation for Digital Scholarship
+					 Vienna, Virginia, USA
+					 https://digitalscholar.org
+	
+	This file is part of Zotero.
+	
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+	
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+	
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
+	
+	***** END LICENSE BLOCK *****
+*/
+import React, { memo, useCallback, useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+import { getDOMElement } from 'components/icons';
+import { IntlProvider } from 'react-intl';
+
+import VirtualizedTable, { renderCell } from 'components/virtualized-table';
+import { noop } from './utils';
+
+
+function getImageByStatus(status) {
+	if (status === Zotero.ProgressQueue.ROW_PROCESSING) {
+		return getDOMElement('IconArrowRefresh');
+	}
+	else if (status === Zotero.ProgressQueue.ROW_FAILED) {
+		return getDOMElement('IconCross');
+	}
+	else if (status === Zotero.ProgressQueue.ROW_SUCCEEDED) {
+		return getDOMElement('IconTick');
+	}
+	return document.createElementNS("http://www.w3.org/1999/xhtml", 'span');
+}
+
+const ProgressQueueTable = ({ onActivate = noop, progressQueue }) => {
+	const treeRef = useRef(null);
+	
+	const getRowCount = useCallback(() => progressQueue.getRows().length, [progressQueue]);
+	
+	const rowToTreeItem = useCallback((index, selection, oldDiv = null, columns) => {
+		let rows = progressQueue.getRows();
+		let row = rows[index];
+		
+		let div;
+		if (oldDiv) {
+			div = oldDiv;
+			div.innerHTML = "";
+		}
+		else {
+			div = document.createElementNS("http://www.w3.org/1999/xhtml", 'div');
+			div.className = "row";
+		}
+
+		div.classList.toggle('selected', selection.isSelected(index));
+
+		for (let column of columns) {
+			if (column.dataKey === 'success') {
+				let span = document.createElementNS("http://www.w3.org/1999/xhtml", 'span');
+				span.className = `cell icon ${column.className}`;
+				span.appendChild(getImageByStatus(row.status));
+				div.appendChild(span);
+			}
+			else {
+				div.appendChild(renderCell(index, row[column.dataKey], column));
+			}
+		}
+		return div;
+	}, [progressQueue]);
+
+	const columns = progressQueue.getColumns();
+
+	const tableColumns = [
+		{ dataKey: 'success', fixedWidth: true, width: "26" },
+		{ dataKey: 'fileName', label: Zotero.getString(columns[0]) },
+		{ dataKey: 'message', label: Zotero.getString(columns[1]) },
+	];
+
+	const refreshTree = useCallback(() => treeRef.current.invalidate(), []);
+
+	useEffect(() => {
+		progressQueue.addListener('rowadded', refreshTree);
+		progressQueue.addListener('rowupdated', refreshTree);
+		progressQueue.addListener('rowdeleted', refreshTree);
+		return () => {
+			progressQueue.removeListener('rowadded', refreshTree);
+			progressQueue.removeListener('rowupdated', refreshTree);
+			progressQueue.removeListener('rowdeleted', refreshTree);
+		};
+	}, []); // eslint-disable-line react-hooks/exhaustive-deps
+	
+	return (
+		<IntlProvider locale={ Zotero.locale } messages={ Zotero.Intl.strings }>
+			<VirtualizedTable
+				getRowCount={ getRowCount }
+				ref={ treeRef }
+				id="progress-queue-table"
+				renderItem={ rowToTreeItem }
+				showHeader={ true }
+				columns={ tableColumns }
+				onActivate={ onActivate }
+			/>
+		</IntlProvider>
+	);
+};
+
+ProgressQueueTable.propTypes = {
+	onActivate: PropTypes.func,
+	progressQueue: PropTypes.object.isRequired
+};
+
+export default memo(ProgressQueueTable);

--- a/chrome/content/zotero/progressQueueDialog.jsx
+++ b/chrome/content/zotero/progressQueueDialog.jsx
@@ -26,86 +26,24 @@
 Components.utils.import("resource://gre/modules/Services.jsm");
 import React from 'react';
 import ReactDOM from 'react-dom';
-import VirtualizedTable from 'components/virtualized-table';
-const { IntlProvider } = require('react-intl');
-const { getDOMElement } = require('components/icons');
-const { renderCell } = VirtualizedTable;
+import ProgressQueueTable from 'components/progressQueueTable';
 
-let _progressIndicator = null;
 let _progressQueue;
-let _tree;
-
-function _getImageByStatus(status) {
-	if (status === Zotero.ProgressQueue.ROW_PROCESSING) {
-		return getDOMElement('IconArrowRefresh');
-	}
-	else if (status === Zotero.ProgressQueue.ROW_FAILED) {
-		return getDOMElement('IconCross');
-	}
-	else if (status === Zotero.ProgressQueue.ROW_SUCCEEDED) {
-		return getDOMElement('IconTick');
-	}
-	return document.createElementNS("http://www.w3.org/1999/xhtml", 'span');
-}
-	
-function _rowToTreeItem(index, selection, oldDiv=null, columns) {
-	let rows = _progressQueue.getRows();
-	let row = rows[index];
-	
-	let div;
-	if (oldDiv) {
-		div = oldDiv;
-		div.innerHTML = "";
-	}
-	else {
-		div = document.createElementNS("http://www.w3.org/1999/xhtml", 'div');
-		div.className = "row";
-	}
-
-	div.classList.toggle('selected', selection.isSelected(index));
-
-	for (let column of columns) {
-		if (column.dataKey === 'success') {
-			let span = document.createElementNS("http://www.w3.org/1999/xhtml", 'span');
-			span.className = `cell icon ${column.className}`;
-			span.appendChild(_getImageByStatus(row.status));
-			div.appendChild(span);
-		}
-		else {
-			div.appendChild(renderCell(index, row[column.dataKey], column));
-		}
-	}
-	return div;
-}
 	
 function _init() {
 	var io = window.arguments[0];
 	_progressQueue = io.progressQueue;
 	document.title = Zotero.getString(_progressQueue.getTitle());
-
-	let columns = _progressQueue.getColumns();
-
-	const tableColumns = [
-		{ dataKey: 'success', fixedWidth: true, width: "26" },
-		{ dataKey: 'fileName', label: Zotero.getString(columns[0]) },
-		{ dataKey: 'message', label: Zotero.getString(columns[1]) },
-	];
 	
 	const domEl = document.querySelector('#tree');
-	let elem = (
-		<IntlProvider locale={Zotero.locale} messages={Zotero.Intl.strings}>
-			<VirtualizedTable
-				getRowCount={() => _progressQueue.getRows().length}
-				id="locateManager-table"
-				ref={ref => io.tree = _tree = ref}
-				renderItem={_rowToTreeItem}
-				showHeader={true}
-				columns={tableColumns}
-				onActivate={_handleActivate}
-			/>
-		</IntlProvider>
+	
+	ReactDOM.render(
+		<ProgressQueueTable
+			onActivate={ _handleActivate }
+			progressQueue={ _progressQueue }
+		/>,
+		domEl
 	);
-	ReactDOM.render(elem, domEl);
 }
 	
 /**

--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -1478,6 +1478,7 @@ Zotero.Attachments = new function(){
 	this.addAvailablePDFs = async function (items, options = {}) {
 		const MAX_CONSECUTIVE_DOMAIN_FAILURES = 5;
 		const SAME_DOMAIN_REQUEST_DELAY = options.sameDomainRequestDelay || 1000;
+		var queue;
 		
 		var domains = new Map();
 		function getDomainInfo(domain) {
@@ -1502,8 +1503,10 @@ Zotero.Attachments = new function(){
 					'general.pdf'
 				]
 			});
+			progressQueue.addListener('cancel', () => queue = []);
 		}
-		var queue = _findPDFQueue;
+
+		queue = _findPDFQueue;
 		
 		for (let item of items) {
 			// Skip items that aren't eligible. This is sort of weird, because it means some
@@ -1570,11 +1573,6 @@ Zotero.Attachments = new function(){
 		var queueResolve;
 		_findPDFQueuePromise = new Zotero.Promise((resolve) => {
 			queueResolve = resolve;
-		});
-		
-		// Only one listener can be added, so we just add each time
-		progressQueue.addListener('cancel', () => {
-			queue = [];
 		});
 		
 		//

--- a/chrome/content/zotero/xpcom/progressQueueDialog.js
+++ b/chrome/content/zotero/xpcom/progressQueueDialog.js
@@ -113,29 +113,18 @@ Zotero.ProgressQueueDialog = function (progressQueue) {
 		});
 		
 		_progressWindow.addEventListener('unload', function () {
-			_progressQueue.removeListener('rowadded');
-			_progressQueue.removeListener('rowupdated');
-			_progressQueue.removeListener('rowdeleted');
+			_progressQueue.removeListener('rowadded', _updateProgress);
+			_progressQueue.removeListener('rowupdated', _updateProgress);
+			_progressQueue.removeListener('rowdeleted', _updateProgress);
 			_progressWindow = null;
 			_progressIndicator = null;
 			_status = null;
 			_showMinimize = true;
 		});
 		
-		_progressQueue.addListener('rowadded', function (row) {
-			_io.tree.invalidate();
-			_updateProgress();
-		});
-		
-		_progressQueue.addListener('rowupdated', function (row) {
-			_io.tree.invalidate();
-			_updateProgress();
-		});
-		
-		_progressQueue.addListener('rowdeleted', function (row) {
-			_io.tree.invalidate();
-			_updateProgress();
-		});
+		_progressQueue.addListener('rowadded', _updateProgress);
+		_progressQueue.addListener('rowupdated', _updateProgress);
+		_progressQueue.addListener('rowdeleted', _updateProgress);
 		
 		_updateProgress();
 	}


### PR DESCRIPTION
This PR decouples progress queue table into a separate React component. It also tweaks progress queue so that it supports  multiple listeners. Few places that used `removeListener` on progressQueue have been updated to specify which listener should be removed and I've added a deprecation note.

I've came up with this as part of #2311 but I think it's a good PR on it's own. Merging it now will also help avoid potential future conflicts.