### PR TITLE
Fix React icons only using 2x image once

### DIFF
--- a/chrome/content/zotero/components/icons.jsx
+++ b/chrome/content/zotero/components/icons.jsx
@@ -23,25 +23,22 @@ Icon.propTypes = {
 module.exports = { Icon }
 
 
-function i(name, svgOrSrc, hasHiDPI=true) {
+function i(name, svgOrSrc, hasHiDPI = true) {
+	if (typeof svgOrSrc == 'string' && hasHiDPI && window.devicePixelRatio >= 1.25) {
+		// N.B. In Electron we can use css-image-set
+		let parts = svgOrSrc.split('.');
+		parts[parts.length - 2] = parts[parts.length - 2] + '@2x';
+		svgOrSrc = parts.join('.');
+	}
+
 	const icon = class extends PureComponent {
 		render() {
 			let props = Object.assign({}, this.props);
 			props.name = name.toLowerCase();
 			
 			if (typeof svgOrSrc == 'string') {
-				let finalSrc = svgOrSrc;
-				// N.B. In Electron we can use css-image-set
-				// Also N.B. this modifies svgOrSrc and hasHiDPI for all future invocations
-				// of this function
-				if (hasHiDPI && window.devicePixelRatio >= 1.25) {
-					let parts = svgOrSrc.split('.');
-					parts[parts.length - 2] = parts[parts.length - 2] + '@2x';
-					finalSrc = parts.join('.');
-					hasHiDPI = false;
-				}
 				if (!("style" in props)) props.style = {};
-				props.style.backgroundImage = `url(${finalSrc})`;
+				props.style.backgroundImage = `url(${svgOrSrc})`;
 				props.className = props.className || "";
 				props.className += " icon-bg";
 				// We use css background-image.


### PR DESCRIPTION
a1267bc fixed repeated re-appending of `'@2x'` by moving the modified URL to a local variable, but it still set `hasHiDPI` to false permanently; this meant that icons displayed repeatedly in the same window, like the tab close button, would only use their 2x versions the first time they were displayed (in the case of tabs, this is the library tab's invisible close button, so *no* tabs got visible 2x buttons).

This commit moves the HiDPI check and URL modification out of the render function and instead runs it a single time when `i()` is first called.

Before (upscaled 1x tab close button):
<img width="554" alt="Screen Shot 2022-02-02 at 4 59 35 PM" src="https://user-images.githubusercontent.com/1770299/152263786-89824d3c-9451-49e0-a0bf-6db776d00296.png">

After:
<img width="554" alt="Screen Shot 2022-02-02 at 5 00 42 PM" src="https://user-images.githubusercontent.com/1770299/152263788-7f8a10f1-2f05-4f19-9ebd-fbda51737270.png">
