### PR TITLE
Improve `directoryContains()`

### DIFF
--- a/chrome/content/zotero/xpcom/file.js
+++ b/chrome/content/zotero/xpcom/file.js
@@ -1094,8 +1094,12 @@ Zotero.File = new function(){
 		if (typeof dir != 'string') throw new Error("dir must be a string");
 		if (typeof file != 'string') throw new Error("file must be a string");
 		
-		dir = OS.Path.normalize(dir);
-		file = OS.Path.normalize(file);
+		dir = OS.Path.normalize(dir).replace(/\\/g, "/");
+		file = OS.Path.normalize(file).replace(/\\/g, "/");
+		// Normalize D:\ vs. D:\foo
+		if (!dir.endsWith('/')) {
+			dir += '/';
+		}
 		
 		return file.startsWith(dir);
 	};

--- a/chrome/content/zotero/xpcom/file.js
+++ b/chrome/content/zotero/xpcom/file.js
@@ -1097,7 +1097,7 @@ Zotero.File = new function(){
 		dir = OS.Path.normalize(dir).replace(/\\/g, "/");
 		file = OS.Path.normalize(file).replace(/\\/g, "/");
 		// Normalize D:\ vs. D:\foo
-		if (!dir.endsWith('/')) {
+		if (dir != file && !dir.endsWith('/')) {
 			dir += '/';
 		}
 		


### PR DESCRIPTION
This PR should fix an issue with relative paths of linked file attachments in the latest Zotero beta.

## Steps to reproduce the issue

- (These steps are for Windows, but this can be reproduced on Linux if adapted.)
- Set the Linked Attachment Base Directory: `C:\Temp`
- Add a linked file attachment: `C:\TempABC\123.pdf`
- Try to open it.
- This results in a "File Not Found" prompt:

> The attached file could not be found at the following path:
> 
> C:\Temp\BC\123.pdf
> 
> It may have been moved or deleted outside of Zotero, or a Linked Attachment Base Directory may be set incorrectly on one of your computers.

## Background

Within `Zotero.Attachments.getBaseDirectoryRelativePath(path)` ([here](https://github.com/zotero/zotero/blob/b865ee8b65c0f24eaad6d3123706b14e3dfff65e/chrome/content/zotero/xpcom/attachments.js#L2401-L2428)), the function `Zotero.File.directoryContains(dir, file)` ([here](https://github.com/zotero/zotero/blob/b865ee8b65c0f24eaad6d3123706b14e3dfff65e/chrome/content/zotero/xpcom/file.js#L1090-L1101)) is called, which appears to be problematic.

## Proposed fix

```js
	this.directoryContains = function (dir, file) {
		if (typeof dir != 'string') throw new Error("dir must be a string");
		if (typeof file != 'string') throw new Error("file must be a string");
		
		dir = OS.Path.normalize(dir).replace(/\\/g, "/");
		file = OS.Path.normalize(file).replace(/\\/g, "/");
		// Normalize D:\ vs. D:\foo
		if (!dir.endsWith('/')) {
			dir += '/';
		}

		return file.startsWith(dir);
	};
```

This reuses code from the `getBaseDirectoryRelativePath()` function. Forward slashes are used for consistency. A path separator at the end of the `dir` string fixes the issue with folders such as `Zotero.Prefs.get('baseAttachmentPath') + 'ABC'`.

I saw that `directoryContains()` is also used for two directories ([here](https://github.com/zotero/zotero/blob/b865ee8b65c0f24eaad6d3123706b14e3dfff65e/chrome/content/zotero/preferences/preferences_advanced.js#L714)). In the proposed form, it will return `true` for true subfolders only, e.g., `directoryContains('/abc', '/abc/def')`. If `directoryContains('/abc', '/abc')` should return `true` as well, this could be checked for directly before adding a slash. _Edited_: I'd propose `if (dir != file && !dir.endsWith('/')) {` in order to preserve current behavior.

## Alternative code considered

```js
	this.directoryContains = function (dir, file) {
		if (typeof dir != 'string') throw new Error("dir must be a string");
		if (typeof file != 'string') throw new Error("file must be a string");
		
		dir = OS.Path.normalize(dir);
		file = OS.Path.normalize(file);

		if (!file.startsWith(dir)) {
			return false;
		} else {
			dir = JSON.stringify(OS.Path.split(dir).components).slice(1,-1);
			file = JSON.stringify(OS.Path.split(file).components).slice(1,-1);
			return file.startsWith(dir);
		}
	};
```

The proposed fix seems to be simpler than this.

## Related issues

https://forums.zotero.org/discussion/94250/opening-retrieving-and-saving-linked-files

https://github.com/wshanks/Zutilo/issues/214