### PR TITLE
Fix item tree jumping to top on focus without selection

### DIFF
--- a/chrome/content/zotero/components/virtualized-table.jsx
+++ b/chrome/content/zotero/components/virtualized-table.jsx
@@ -116,9 +116,10 @@ class TreeSelection {
 	 * Selects an item, updates focused item to index.
 	 * @param index {Number} The index is 0-clamped.
 	 * @param shouldDebounce {Boolean} Whether the update to the tree should be debounced
+	 * @param {Boolean} [shouldScroll=true] Whether to scroll the item into view
 	 * @returns {boolean} False if nothing to select and select handlers won't be called
 	 */
-	select(index, shouldDebounce) {
+	select(index, shouldDebounce, shouldScroll = true) {
 		if (!this._tree.props.isSelectable(index)) return;
 		index = Math.max(0, index);
 		if (this.selected.size == 1 && this._focused == index && this.pivot == index) {
@@ -134,7 +135,7 @@ class TreeSelection {
 
 		if (this.selectEventsSuppressed) return true;
 
-		this._tree.scrollToRow(index);
+		if (shouldScroll) this._tree.scrollToRow(index);
 		this._updateTree(shouldDebounce);
 		if (this._tree.invalidate) {
 			toInvalidate.forEach(this._tree.invalidateRow.bind(this._tree));

--- a/chrome/content/zotero/components/virtualized-table.jsx
+++ b/chrome/content/zotero/components/virtualized-table.jsx
@@ -116,10 +116,9 @@ class TreeSelection {
 	 * Selects an item, updates focused item to index.
 	 * @param index {Number} The index is 0-clamped.
 	 * @param shouldDebounce {Boolean} Whether the update to the tree should be debounced
-	 * @param {Boolean} [shouldScroll=true] Whether to scroll the item into view
 	 * @returns {boolean} False if nothing to select and select handlers won't be called
 	 */
-	select(index, shouldDebounce, shouldScroll = true) {
+	select(index, shouldDebounce) {
 		if (!this._tree.props.isSelectable(index)) return;
 		index = Math.max(0, index);
 		if (this.selected.size == 1 && this._focused == index && this.pivot == index) {
@@ -135,7 +134,7 @@ class TreeSelection {
 
 		if (this.selectEventsSuppressed) return true;
 
-		if (shouldScroll) this._tree.scrollToRow(index);
+		this._tree.scrollToRow(index);
 		this._updateTree(shouldDebounce);
 		if (this._tree.invalidate) {
 			toInvalidate.forEach(this._tree.invalidateRow.bind(this._tree));
@@ -359,6 +358,7 @@ class VirtualizedTable extends React.Component {
 		// If you want to perform custom key handling it should be in this function
 		// if it returns false then virtualized-table's own key handler won't run
 		onKeyDown: () => true,
+		onKeyUp: noop,
 
 		onDragOver: noop,
 		onDrop: noop,
@@ -421,6 +421,7 @@ class VirtualizedTable extends React.Component {
 		// If you want to perform custom key handling it should be in this function
 		// if it returns false then virtualized-table's own key handler won't run
 		onKeyDown: PropTypes.func,
+		onKeyUp: PropTypes.func,
 
 		onDragOver: PropTypes.func,
 		onDrop: PropTypes.func,
@@ -1146,6 +1147,7 @@ class VirtualizedTable extends React.Component {
 		}
 		let props = {
 			onKeyDown: this._onKeyDown,
+			onKeyUp: e => this.props.onKeyUp && this.props.onKeyUp(e),
 			onDragOver: this._onDragOver,
 			onDrop: e => this.props.onDrop && this.props.onDrop(e),
 			onFocus: e => this.props.onFocus && this.props.onFocus(e),

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -830,7 +830,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 			return false;
 		}
 		if (this.selection.count == 0) {
-			this.selection.select(this.selection.pivot);
+			this.selection.select(this.selection.pivot, false, false);
 		}
 	}
 	

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -825,15 +825,6 @@ var ItemTree = class ItemTree extends LibraryTree {
 		}
 	}
 	
-	handleFocus = (event) => {
-		if (Zotero.locked) {
-			return false;
-		}
-		if (this.selection.count == 0) {
-			this.selection.select(this.selection.pivot, false, false);
-		}
-	}
-	
 	handleActivate = (event, indices) => {
 		// Ignore double-clicks in duplicates view on everything except attachments
 		let items = indices.map(index => this.getRow(index).ref);
@@ -905,6 +896,15 @@ var ItemTree = class ItemTree extends LibraryTree {
 		}
 		return true;
 	}
+
+	/**
+	 * Select the first row when the tree is focused by the keyboard.
+	 */
+	handleKeyUp = (event) => {
+		if (!Zotero.locked && event.code === 'Tab' && this.selection.count == 0) {
+			this.selection.select(this.selection.pivot);
+		}
+	};
 	
 	render() {
 		const itemsPaneMessageHTML = this._itemsPaneMessage || this.props.emptyMessage;
@@ -969,8 +969,8 @@ var ItemTree = class ItemTree extends LibraryTree {
 					onDragOver: e => this.props.dragAndDrop && this.onDragOver(e, -1),
 					onDrop: e => this.props.dragAndDrop && this.onDrop(e, -1),
 					onKeyDown: this.handleKeyDown,
+					onKeyUp: this.handleKeyUp,
 					onActivate: this.handleActivate,
-					onFocus: this.handleFocus,
 
 					onItemContextMenu: (...args) => this.props.onContextMenu(...args),
 					


### PR DESCRIPTION
This fixes a bug that caused the item tree to scroll to the very top if you focused it without selecting an item, e.g. by clicking on an item's twisty while focus is outside the tree.