### PR TITLE
Copy related items between libraries

### DIFF
--- a/chrome/content/zotero/collectionTree.jsx
+++ b/chrome/content/zotero/collectionTree.jsx
@@ -1690,7 +1690,7 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 					}
 				}
 			}
-			
+
 			return newItemID;
 		};
 		
@@ -1804,7 +1804,7 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 					// No transaction, because most time is spent traversing urls
 					promises.push(item.translate(targetLibraryID, targetCollectionID))
 				}
-				return Zotero.Promise.all(promises);	
+				return Zotero.Promise.all(promises);
 			}
 			
 			if (targetTreeRow.isPublications()) {
@@ -1826,7 +1826,7 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 			let newIDs = [];
 			let toMove = [];
 			// TODO: support items coming from different sources?
-			let sameLibrary = items[0].libraryID == targetLibraryID
+			let sameLibrary = items[0].libraryID == targetLibraryID;
 			
 			for (let item of items) {
 				if (!item.isTopLevelItem()) {
@@ -1842,6 +1842,15 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 			}
 			
 			if (!sameLibrary) {
+				let relatedKeys = window.ZoteroPane.showCopyRelatedPrompt(items, Zotero.Libraries.get(targetLibraryID).name);
+				if (relatedKeys) {
+					let relatedItems = (await Promise.all(
+						[...relatedKeys].map(key => Zotero.Items.getByLibraryAndKeyAsync(items[0].libraryID, key))
+					)).filter(Boolean);
+					items.push(...relatedItems);
+					newItems.push(...relatedItems);
+				}
+
 				let toReconcile = [];
 				
 				await Zotero.Utilities.Internal.forEachChunkAsync(
@@ -1850,7 +1859,7 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 					function (chunk) {
 						return Zotero.DB.executeTransaction(async function () {
 							for (let item of chunk) {
-								var id = await copyItem(item, targetLibraryID, copyOptions)
+								var id = await copyItem(item, targetLibraryID, copyOptions);
 								// Standalone attachments might not get copied
 								if (!id) {
 									continue;
@@ -1893,6 +1902,28 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 						for (let obj of io.dataOut) {
 							await obj.ref.save();
 						}
+					});
+				}
+
+				if (relatedKeys) {
+					await Zotero.DB.executeTransaction(async () => {
+						let savePromises = [];
+						for (let [i, oldItem] of items.entries()) {
+							if (!oldItem.relatedItems.length) continue;
+							let newItem = Zotero.Items.get(newIDs[i]);
+							for (let oldRelatedKey of oldItem.relatedItems) {
+								let newRelatedID = newIDs[items.findIndex(item => item.key === oldRelatedKey)];
+								if (newRelatedID) {
+									newItem.addRelation(Zotero.Relations.relatedItemPredicate,
+										Zotero.URI.getItemURI(Zotero.Items.get(newRelatedID)));
+									savePromises.push(newItem.save());
+								}
+								else {
+									Zotero.debug(`No match for related item ${oldRelatedKey} of ${oldItem.key}`);
+								}
+							}
+						}
+						await Promise.all(savePromises);
 					});
 				}
 			}

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -4166,6 +4166,35 @@ var ZoteroPane = new function()
 		window.openDialog('chrome://zotero/content/publicationsDialog.xul','','chrome,modal', io);
 		return io.license ? io : false;
 	};
+
+
+	this.showCopyRelatedPrompt = function (items, targetCollectionName) {
+		let originalKeys = new Set(items.map(item => item.key));
+		let newKeys = new Set();
+		for (let item of items) {
+			for (let key of item.relatedItems) {
+				if (!originalKeys.has(key)) {
+					newKeys.add(key);
+				}
+			}
+		}
+
+		if (!newKeys.size) {
+			return newKeys;
+		}
+
+		let ps = Services.prompt;
+		let buttonFlags = ps.BUTTON_POS_1_DEFAULT + ps.STD_YES_NO_BUTTONS;
+		let index = ps.confirmEx(
+			null,
+			Zotero.getString('pane.collections.copyRelatedItems.title'),
+			Zotero.getString('pane.collections.copyRelatedItems.text', [newKeys.size, targetCollectionName], newKeys.size),
+			buttonFlags,
+			null, null, null, null, {}
+		);
+
+		return index === 0 && newKeys;
+	};
 	
 	
 	/**

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -287,6 +287,9 @@ pane.collections.menu.generateReport.feed	= Generate Report from Feed…
 
 pane.collections.menu.refresh.feed			= Refresh Feed
 
+pane.collections.copyRelatedItems.title = Copy Related Items
+pane.collections.copyRelatedItems.text  = Copy %1$S additional related item?\n\nIf the related item is not copied, the relation will be lost in “%2$S”.;Copy %1$S additional related items?\n\nIf related items are not copied, relations will be lost in “%2$S”.
+
 pane.tagSelector.rename.title					= Rename Tag
 pane.tagSelector.rename.message					= Please enter a new name for this tag.\n\nThe tag will be changed in all associated items.
 pane.tagSelector.delete.title					= Delete Tag

--- a/test/tests/collectionTreeTest.js
+++ b/test/tests/collectionTreeTest.js
@@ -982,6 +982,82 @@ describe("Zotero.CollectionTree", function() {
 				
 				assert.isTrue(droppedItem.deleted);
 			})
+
+			it("should copy related item relations unprompted when all related items are dragged", async function () {
+				let item1 = await createDataObject('item');
+				let item2 = await createDataObject('item');
+				item1.addRelatedItem(item2);
+				item2.addRelatedItem(item1);
+				await item1.saveTx();
+				await item2.saveTx();
+				let group = await createGroup();
+				
+				await cv.selectLibrary(group.libraryID);
+				await waitForItemsLoad(win);
+				
+				await onDrop('item', 'L' + group.libraryID, [item1.id, item2.id]);
+				
+				let groupItem1 = await item1.getLinkedItem(group.libraryID);
+				let groupItem2 = await item2.getLinkedItem(group.libraryID);
+				assert.ok(groupItem1);
+				assert.ok(groupItem2);
+
+				assert.include(groupItem1.relatedItems, groupItem2.key);
+				assert.include(groupItem2.relatedItems, groupItem1.key);
+				
+				await group.eraseTx();
+			});
+
+			it("should prompt when a related item is excluded and copy all when user selects Yes", async function () {
+				let item1 = await createDataObject('item');
+				let item2 = await createDataObject('item');
+				item1.addRelatedItem(item2);
+				item2.addRelatedItem(item1);
+				await item1.saveTx();
+				await item2.saveTx();
+				let group = await createGroup();
+				
+				await cv.selectLibrary(group.libraryID);
+				await waitForItemsLoad(win);
+				
+				let dialog = waitForDialog(null, 'accept');
+				let drop = onDrop('item', 'L' + group.libraryID, [item1.id]);
+				await Promise.all([dialog, drop]);
+				
+				let groupItem1 = await item1.getLinkedItem(group.libraryID);
+				let groupItem2 = await item2.getLinkedItem(group.libraryID);
+				assert.ok(groupItem1);
+				assert.ok(groupItem2);
+				assert.include(groupItem1.relatedItems, groupItem2.key);
+				assert.include(groupItem2.relatedItems, groupItem1.key);
+
+				await group.eraseTx();
+			});
+
+			it("should prompt when a related item is excluded and not copy when user selects No", async function () {
+				let item1 = await createDataObject('item');
+				let item2 = await createDataObject('item');
+				item1.addRelatedItem(item2);
+				item2.addRelatedItem(item1);
+				await item1.saveTx();
+				await item2.saveTx();
+				let group = await createGroup();
+				
+				await cv.selectLibrary(group.libraryID);
+				await waitForItemsLoad(win);
+				
+				let dialog = waitForDialog(null, 'cancel');
+				let drop = onDrop('item', 'L' + group.libraryID, [item1.id]);
+				await Promise.all([dialog, drop]);
+				
+				let groupItem1 = await item1.getLinkedItem(group.libraryID);
+				let groupItem2 = await item2.getLinkedItem(group.libraryID);
+				assert.ok(groupItem1);
+				assert.notOk(groupItem2);
+				assert.isEmpty(groupItem1.relatedItems);
+
+				await group.eraseTx();
+			});
 		})
 		
 		


### PR DESCRIPTION
If all related item relations are within the drag set, relations are copied without prompting the user. But if items in the drag set are related to items outside the drag set, the user is asked whether to additionally copy the related items and preserve the relations in the target library.

The wording of the dialog text could use some work.

Fixes #1713.