### PR TITLE
Add sync reminders

### DIFF
--- a/chrome/content/zotero/xpcom/prefs.js
+++ b/chrome/content/zotero/xpcom/prefs.js
@@ -254,10 +254,10 @@ Zotero.Prefs = new function(){
 				Zotero.Sync.EventListeners.IdleListener.unregister();
 				Zotero.Prefs.set('sync.reminder.autoSync.enabled', true);
 				// We don't want to immediately display reminder so bump this value
-				Zotero.Prefs.set('sync.reminder.autoSync.lastDisplayed', String(Date.now()));
+				Zotero.Prefs.set('sync.reminder.autoSync.lastDisplayed', Date.now());
 			}
 			try {
-				Zotero.getActiveZoteroPane().setupSyncReminders(false);
+				Zotero.getActiveZoteroPane().initSyncReminders(false);
 			}
 			catch (e) {
 				Zotero.logError(e);

--- a/chrome/content/zotero/xpcom/prefs.js
+++ b/chrome/content/zotero/xpcom/prefs.js
@@ -252,6 +252,15 @@ Zotero.Prefs = new function(){
 			else {
 				Zotero.Sync.EventListeners.AutoSyncListener.unregister();
 				Zotero.Sync.EventListeners.IdleListener.unregister();
+				Zotero.Prefs.set('sync.reminder.autoSync.enabled', true);
+				// We don't want to immediately display reminder so bump this value
+				Zotero.Prefs.set('sync.reminder.autoSync.lastDisplayed', String(Date.now()));
+			}
+			try {
+				Zotero.getActiveZoteroPane().setupSyncReminders(false);
+			}
+			catch (e) {
+				Zotero.logError(e);
 			}
 		}],
 		[ "search.quicksearch-mode", function(val) {

--- a/chrome/content/zotero/xpcom/prefs.js
+++ b/chrome/content/zotero/xpcom/prefs.js
@@ -254,7 +254,7 @@ Zotero.Prefs = new function(){
 				Zotero.Sync.EventListeners.IdleListener.unregister();
 				Zotero.Prefs.set('sync.reminder.autoSync.enabled', true);
 				// We don't want to immediately display reminder so bump this value
-				Zotero.Prefs.set('sync.reminder.autoSync.lastDisplayed', Date.now());
+				Zotero.Prefs.set('sync.reminder.autoSync.lastDisplayed', Math.round(Date.now() / 1000));
 			}
 			try {
 				Zotero.getActiveZoteroPane().initSyncReminders(false);

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -2334,7 +2334,15 @@ var ZoteroPane = new function()
 		actionLink.textContent = Zotero.getString(`sync.reminder.${reminderType}.action`);
 		actionLink.onclick = function () {
 			closePanel();
-			Zotero.Utilities.Internal.openPreferences('zotero-prefpane-sync');
+
+			switch (reminderType) {
+				case 'autoSync':
+					Zotero.Prefs.set(`sync.autoSync`, true);
+					break;
+				case 'setup':
+					Zotero.Utilities.Internal.openPreferences('zotero-prefpane-sync');
+					break;
+			}
 		};
 
 		let dontShowAgainLink = document.getElementById('sync-reminder-disable');

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -229,7 +229,7 @@ var ZoteroPane = new function()
 		
 		setTimeout(function () {
 			ZoteroPane.showRetractionBanner();
-			ZoteroPane.setupSyncReminders(true);
+			ZoteroPane.initSyncReminders(true);
 		});
 		
 		// TEMP: Clean up extra files from Mendeley imports <5.0.51
@@ -2204,27 +2204,29 @@ var ZoteroPane = new function()
 
 
 	this._syncRemindersObserverID = null;
-	this.setupSyncReminders = function (startup) {
+	this.initSyncReminders = function (startup) {
 		if (startup) {
 			Zotero.Notifier.registerObserver(
-				{ notify: (event) => {
-					// When the API Key is deleted we need to add an observer
-					if (event === 'delete') {
-						Zotero.Prefs.set('sync.reminder.setup.enabled', true);
-						Zotero.Prefs.set('sync.reminder.setup.lastDisplayed', String(Date.now()));
-						ZoteroPane.setupSyncReminders(false);
+				{
+					notify: (event) => {
+						// When the API Key is deleted we need to add an observer
+						if (event === 'delete') {
+							Zotero.Prefs.set('sync.reminder.setUp.enabled', true);
+							Zotero.Prefs.set('sync.reminder.setUp.lastDisplayed', Date.now());
+							ZoteroPane.initSyncReminders(false);
+						}
+						// When API Key is added we can remove the observer
+						else if (event === 'add') {
+							ZoteroPane.initSyncReminders(false);
+						}
 					}
-					// When API Key is added we can remove the observer
-					else if (event === 'add') {
-						ZoteroPane.setupSyncReminders(false);
-					}
-				} },
+				},
 				'api-key');
 		}
 
 		// If both reminders are disabled, we don't need an observer
-		if (!Zotero.Prefs.get('sync.reminder.setup.enabled')
-			&& !Zotero.Prefs.get('sync.reminder.autoSync.enabled')) {
+		if (!Zotero.Prefs.get('sync.reminder.setUp.enabled')
+				&& !Zotero.Prefs.get('sync.reminder.autoSync.enabled')) {
 			if (this._syncRemindersObserverID) {
 				Zotero.Notifier.unregisterObserver(this._syncRemindersObserverID);
 				this._syncRemindersObserverID = null;
@@ -2248,21 +2250,45 @@ var ZoteroPane = new function()
 
 		const eventTypes = ['add', 'modify', 'delete'];
 		this._syncRemindersObserverID = Zotero.Notifier.registerObserver(
-			{ notify: (event) => {
-				if (!eventTypes.includes(event)) {
-					return;
+			{
+				notify: (event) => {
+					if (!eventTypes.includes(event)) {
+						return;
+					}
+					setTimeout(() => {
+						this.showSetUpSyncReminder();
+						this.showAutoSyncReminder();
+					}, 5000);
 				}
-				setTimeout(() => {
-					this.showSetupSyncReminder();
-					this.showAutoSyncOffReminder();
-				}, 5000);
-			} },
+			},
 			'item',
 			'syncReminder');
 	};
 
 
-	this.showAutoSyncOffReminder = function () {
+	this.showSetUpSyncReminder = function () {
+		const sevenDays = 1000 * 60 * 60 * 24 * 7;
+
+		// Reasons not to show reminder:
+		// - User turned reminder off
+		// - Sync is enabled
+		if (!Zotero.Prefs.get('sync.reminder.setUp.enabled')
+				|| Zotero.Sync.Runner.enabled) {
+			return;
+		}
+
+		// Check lastDisplayed was 7+ days ago
+		let lastDisplayed = parseInt(Zotero.Prefs.get(`sync.reminder.setUp.lastDisplayed`));
+		if (lastDisplayed > (Date.now() - sevenDays)) {
+			return;
+		}
+
+		// When we have not seen the first warning, hide the checkbox
+		this.showSyncReminder('setUp', lastDisplayed === 0);
+	};
+
+
+	this.showAutoSyncReminder = function () {
 		const sevenDays = 1000 * 60 * 60 * 24 * 7;
 
 		// Reasons not to show reminder:
@@ -2271,14 +2297,15 @@ var ZoteroPane = new function()
 		// - Auto-Sync is enabled
 		// - Last sync for all libraries was within 7 days
 		if (!Zotero.Prefs.get('sync.reminder.autoSync.enabled')
-			|| !Zotero.Sync.Runner.enabled
-			|| Zotero.Prefs.get('sync.autoSync')
-			|| !Zotero.Libraries.getAll()
-				.find(library => library.lastSync.getTime() < (Date.now() - sevenDays))) {
+				|| !Zotero.Sync.Runner.enabled
+				|| Zotero.Prefs.get('sync.autoSync')
+				|| Zotero.Libraries.getAll()
+					.every(library => !library.syncable
+						|| library.lastSync.getTime() > (Date.now() - sevenDays))) {
 			return;
 		}
 
-		// Check lastDisplayed was 30+ days ago
+		// Check lastDisplayed was 7+ days ago
 		let lastDisplayed = parseInt(Zotero.Prefs.get(`sync.reminder.autoSync.lastDisplayed`));
 		if (lastDisplayed > (Date.now() - sevenDays)) {
 			return;
@@ -2288,35 +2315,17 @@ var ZoteroPane = new function()
 	};
 
 
-	this.showSetupSyncReminder = function () {
-		const sevenDays = 1000 * 60 * 60 * 24 * 7;
-
-		// Reasons not to show reminder:
-		// - User turned reminder off
-		// - Sync is enabled
-		if (!Zotero.Prefs.get('sync.reminder.setup.enabled')
-			|| Zotero.Sync.Runner.enabled) {
-			return;
-		}
-
-		// Check lastDisplayed was 7+ days ago
-		let lastDisplayed = parseInt(Zotero.Prefs.get(`sync.reminder.setup.lastDisplayed`));
-		if (lastDisplayed > (Date.now() - sevenDays)) {
-			return;
-		}
-
-		// When we have not seen the first warning, hide the checkbox
-		this.showSyncReminder('setup', lastDisplayed === 0);
-	};
-
-
 	/**
 	 * Configure the UI and show the sync reminder panel for a given type of reminder
 	 *
-	 * @param reminderType - Possible values: 'setup' or 'autoSync'
+	 * @param reminderType - Possible values: 'setUp' or 'autoSync'
 	 * @param hideDisable - True if the 'Don't show again' link is hidden
 	 */
 	this.showSyncReminder = function (reminderType, hideDisable) {
+		if (!['setUp', 'autoSync'].includes(reminderType)) {
+			throw new Error(`Invalid reminder type: ${reminderType}`);
+		}
+
 		let panel = document.getElementById('sync-reminder-container');
 		const closePanel = function () {
 			panel.setAttribute('collapsed', true);
@@ -2324,7 +2333,7 @@ var ZoteroPane = new function()
 		};
 
 		let message = document.getElementById('sync-reminder-message');
-		message.textContent = Zotero.getString(`sync.reminder.${reminderType}.message`);
+		message.textContent = Zotero.getString(`sync.reminder.${reminderType}.message`, Zotero.appName);
 		message.onclick = function () {
 			closePanel();
 			Zotero.Utilities.Internal.openPreferences('zotero-prefpane-sync');
@@ -2336,27 +2345,27 @@ var ZoteroPane = new function()
 			closePanel();
 
 			switch (reminderType) {
+				case 'setUp':
+					Zotero.Utilities.Internal.openPreferences('zotero-prefpane-sync');
+					break;
 				case 'autoSync':
 					Zotero.Prefs.set(`sync.autoSync`, true);
-					break;
-				case 'setup':
-					Zotero.Utilities.Internal.openPreferences('zotero-prefpane-sync');
 					break;
 			}
 		};
 
 		let dontShowAgainLink = document.getElementById('sync-reminder-disable');
-		dontShowAgainLink.textContent = Zotero.getString('sync.reminder.dontAskAgain');
+		dontShowAgainLink.textContent = Zotero.getString('general.dontAskAgain');
 		dontShowAgainLink.hidden = hideDisable;
 		dontShowAgainLink.onclick = function () {
 			closePanel();
 			Zotero.Prefs.set(`sync.reminder.${reminderType}.enabled`, false);
 			// Check if we no longer need to observe item modifications
-			ZoteroPane.setupSyncReminders(false);
+			ZoteroPane.initSyncReminders(false);
 		};
 
 		let remindMeLink = document.getElementById('sync-reminder-remind');
-		remindMeLink.textContent = Zotero.getString('sync.reminder.remindMeLater');
+		remindMeLink.textContent = Zotero.getString('general.remindMeLater');
 		remindMeLink.onclick = function () {
 			closePanel();
 		};

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -2263,22 +2263,24 @@ var ZoteroPane = new function()
 
 
 	this.showAutoSyncOffReminder = function () {
+		const sevenDays = 1000 * 60 * 60 * 24 * 7;
+
 		// Reasons not to show reminder:
 		// - User turned reminder off
 		// - Sync is not enabled
 		// - Auto-Sync is enabled
-		// - Last sync for all libraries was within 30 days
+		// - Last sync for all libraries was within 7 days
 		if (!Zotero.Prefs.get('sync.reminder.autoSync.enabled')
 			|| !Zotero.Sync.Runner.enabled
 			|| Zotero.Prefs.get('sync.autoSync')
 			|| !Zotero.Libraries.getAll()
-				.find(library => library.lastSync.getTime() < (Date.now() - 2592000000))) {
+				.find(library => library.lastSync.getTime() < (Date.now() - sevenDays))) {
 			return;
 		}
 
 		// Check lastDisplayed was 30+ days ago
 		let lastDisplayed = parseInt(Zotero.Prefs.get(`sync.reminder.autoSync.lastDisplayed`));
-		if (lastDisplayed > (Date.now() - 2592000000)) {
+		if (lastDisplayed > (Date.now() - sevenDays)) {
 			return;
 		}
 
@@ -2287,6 +2289,8 @@ var ZoteroPane = new function()
 
 
 	this.showSetupSyncReminder = function () {
+		const sevenDays = 1000 * 60 * 60 * 24 * 7;
+
 		// Reasons not to show reminder:
 		// - User turned reminder off
 		// - Sync is enabled
@@ -2297,7 +2301,7 @@ var ZoteroPane = new function()
 
 		// Check lastDisplayed was 7+ days ago
 		let lastDisplayed = parseInt(Zotero.Prefs.get(`sync.reminder.setup.lastDisplayed`));
-		if (lastDisplayed > (Date.now() - 604800000)) {
+		if (lastDisplayed > (Date.now() - sevenDays)) {
 			return;
 		}
 
@@ -2334,7 +2338,7 @@ var ZoteroPane = new function()
 		};
 
 		let dontShowAgainLink = document.getElementById('sync-reminder-disable');
-		dontShowAgainLink.textContent = Zotero.getString('general.dontAskMeAgain');
+		dontShowAgainLink.textContent = Zotero.getString('sync.reminder.dontAskAgain');
 		dontShowAgainLink.hidden = hideDisable;
 		dontShowAgainLink.onclick = function () {
 			closePanel();

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -2212,7 +2212,7 @@ var ZoteroPane = new function()
 						// When the API Key is deleted we need to add an observer
 						if (event === 'delete') {
 							Zotero.Prefs.set('sync.reminder.setUp.enabled', true);
-							Zotero.Prefs.set('sync.reminder.setUp.lastDisplayed', Date.now());
+							Zotero.Prefs.set('sync.reminder.setUp.lastDisplayed', Math.round(Date.now() / 1000));
 							ZoteroPane.initSyncReminders(false);
 						}
 						// When API Key is added we can remove the observer
@@ -2267,7 +2267,7 @@ var ZoteroPane = new function()
 
 
 	this.showSetUpSyncReminder = function () {
-		const sevenDays = 1000 * 60 * 60 * 24 * 7;
+		const sevenDays = 60 * 60 * 24 * 7;
 
 		// Reasons not to show reminder:
 		// - User turned reminder off
@@ -2278,8 +2278,8 @@ var ZoteroPane = new function()
 		}
 
 		// Check lastDisplayed was 7+ days ago
-		let lastDisplayed = parseInt(Zotero.Prefs.get(`sync.reminder.setUp.lastDisplayed`));
-		if (lastDisplayed > (Date.now() - sevenDays)) {
+		let lastDisplayed = Zotero.Prefs.get('sync.reminder.setUp.lastDisplayed');
+		if (lastDisplayed > Math.round(Date.now() / 1000) - sevenDays) {
 			return;
 		}
 
@@ -2289,7 +2289,7 @@ var ZoteroPane = new function()
 
 
 	this.showAutoSyncReminder = function () {
-		const sevenDays = 1000 * 60 * 60 * 24 * 7;
+		const sevenDays = 60 * 60 * 24 * 7;
 
 		// Reasons not to show reminder:
 		// - User turned reminder off
@@ -2301,13 +2301,13 @@ var ZoteroPane = new function()
 				|| Zotero.Prefs.get('sync.autoSync')
 				|| Zotero.Libraries.getAll()
 					.every(library => !library.syncable
-						|| library.lastSync.getTime() > (Date.now() - sevenDays))) {
+						|| library.lastSync.getTime() > Date.now() - 1000 * sevenDays)) {
 			return;
 		}
 
 		// Check lastDisplayed was 7+ days ago
-		let lastDisplayed = parseInt(Zotero.Prefs.get(`sync.reminder.autoSync.lastDisplayed`));
-		if (lastDisplayed > (Date.now() - sevenDays)) {
+		let lastDisplayed = Zotero.Prefs.get('sync.reminder.autoSync.lastDisplayed');
+		if (lastDisplayed > Math.round(Date.now() / 1000) - sevenDays) {
 			return;
 		}
 
@@ -2329,7 +2329,7 @@ var ZoteroPane = new function()
 		let panel = document.getElementById('sync-reminder-container');
 		const closePanel = function () {
 			panel.setAttribute('collapsed', true);
-			Zotero.Prefs.set(`sync.reminder.${reminderType}.lastDisplayed`, String(Date.now()));
+			Zotero.Prefs.set(`sync.reminder.${reminderType}.lastDisplayed`, Math.round(Date.now() / 1000));
 		};
 
 		let message = document.getElementById('sync-reminder-message');

--- a/chrome/content/zotero/zoteroPane.xul
+++ b/chrome/content/zotero/zoteroPane.xul
@@ -240,6 +240,7 @@
 						<div xmlns="http://www.w3.org/1999/xhtml" id="sync-reminder-banner">
 							<div id="sync-reminder-message"/>
 							<a id="sync-reminder-action" class="sync-reminder-link"/>
+							<a id="sync-reminder-learn-more" class="sync-reminder-link"/>
 							<div id="sync-reminder-spacer"/>
 							<a id="sync-reminder-disable" class="sync-reminder-link"/>
 							<a id="sync-reminder-remind" class="sync-reminder-link"/>

--- a/chrome/content/zotero/zoteroPane.xul
+++ b/chrome/content/zotero/zoteroPane.xul
@@ -221,7 +221,7 @@
 							<panel id="zotero-sync-error-panel" type="arrow"/>
 							
 							<toolbarbutton id="zotero-tb-sync" class="zotero-tb-button" tooltip="_child"
-									oncommand="Zotero.Sync.Server.canAutoResetClient = true; Zotero.Sync.Server.manualSyncRequired = false; Zotero.Sync.Runner.sync()">
+									oncommand="ZoteroPane.sync()">
 								<tooltip
 										id="zotero-tb-sync-tooltip"
 										onpopupshowing="Zotero.Sync.Runner.registerSyncStatus(this)"
@@ -233,6 +233,23 @@
 									<div xmlns="http://www.w3.org/1999/xhtml" class="sync-button-tooltip-messages"/>
 								</tooltip>
 							</toolbarbutton>
+
+							<panel id="zotero-sync-reminder-panel" type="arrow" noautohide="true">
+								<vbox>
+									<label id="zotero-sync-reminder-header" class="header"/>
+
+									<description id="zotero-sync-reminder-description"/>
+									<hbox pack="end">
+										<label class="zotero-text-link" value="Learn more" href="http://www.zotero.org/support/sync"/>
+									</hbox>
+
+									<checkbox id="zotero-sync-reminder-show-again"/>
+									<hbox pack="end">
+										<button id="zotero-sync-reminder-remind-me"/>
+										<button default="true" id="zotero-sync-reminder-open"/>
+									</hbox>
+								</vbox>
+							</panel>
 						</hbox>
 					</toolbar>
 					

--- a/chrome/content/zotero/zoteroPane.xul
+++ b/chrome/content/zotero/zoteroPane.xul
@@ -233,25 +233,19 @@
 									<div xmlns="http://www.w3.org/1999/xhtml" class="sync-button-tooltip-messages"/>
 								</tooltip>
 							</toolbarbutton>
-
-							<panel id="zotero-sync-reminder-panel" type="arrow" noautohide="true">
-								<vbox>
-									<label id="zotero-sync-reminder-header" class="header"/>
-
-									<description id="zotero-sync-reminder-description"/>
-									<hbox pack="end">
-										<label class="zotero-text-link" value="Learn more" href="http://www.zotero.org/support/sync"/>
-									</hbox>
-
-									<checkbox id="zotero-sync-reminder-show-again"/>
-									<hbox pack="end">
-										<button id="zotero-sync-reminder-remind-me"/>
-										<button default="true" id="zotero-sync-reminder-open"/>
-									</hbox>
-								</vbox>
-							</panel>
 						</hbox>
 					</toolbar>
+
+					<vbox id="sync-reminder-container" collapsed="true">
+						<div xmlns="http://www.w3.org/1999/xhtml" id="sync-reminder-banner">
+							<div id="sync-reminder-message"/>
+							<a id="sync-reminder-action" class="sync-reminder-link"/>
+							<div id="sync-reminder-spacer"/>
+							<a id="sync-reminder-disable" class="sync-reminder-link"/>
+							<a id="sync-reminder-remind" class="sync-reminder-link"/>
+							<div id="sync-reminder-close">×</div>
+						</div>
+					</vbox>
 					
 					<vbox id="retracted-items-container" collapsed="true">
 						<div xmlns="http://www.w3.org/1999/xhtml" id="retracted-items-banner">

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -3,7 +3,6 @@ extensions.zotero@chnm.gmu.edu.description	= The Next-Generation Research Tool
 general.success						= Success
 general.error						= Error
 general.warning						= Warning
-general.dontAskMeAgain				= Don't ask me again
 general.dontShowWarningAgain			= Don't show this warning again.
 general.dontShowAgainFor             = Don’t show again today;Don’t show again for %1$S days
 general.browserIsOffline			= %S is currently in offline mode.
@@ -998,6 +997,7 @@ sync.reminder.setup.message			= Back up your library with Zotero syncing.
 sync.reminder.setup.action			= Set Up Syncing
 sync.reminder.autoSync.message		= Zotero can automatically sync after you make changes.
 sync.reminder.autoSync.action		= Enable Automatic Sync
+sync.reminder.dontAskAgain			= Don't Ask Again
 sync.reminder.remindMeLater			= Remind Me Later
 
 sync.error.usernameNotSet			= Username not set

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -4,6 +4,7 @@ general.success						= Success
 general.error						= Error
 general.warning						= Warning
 general.dontShowWarningAgain			= Don't show this warning again.
+general.dontShowReminderAgain			= Don't show this reminder again.
 general.dontShowAgainFor             = Don’t show again today;Don’t show again for %1$S days
 general.browserIsOffline			= %S is currently in offline mode.
 general.locate						= Locate…
@@ -992,6 +993,12 @@ sync.resetGroupAndSync				= Reset Group and Sync
 sync.resetGroupFilesAndSync          = Reset Group Files and Sync
 sync.skipGroup                   = Skip Group
 sync.removeGroupsAndSync			= Remove Groups and Sync
+
+sync.reminder.setup.header          = Set Up Syncing
+sync.reminder.setup.description     = Zotero can automatically sync your library data using the Zotero servers allowing you to access your data from multiple computers.
+sync.reminder.autoSync.header       = Auto-Sync Disabled
+sync.reminder.autoSync.description  = Zotero is not configured to automatically sync your library data and it has been more than 30 days since your last sync. You can check "Sync automatically" in your preferences to enable this.
+sync.reminder.remindMeLater         = Remind Me Later
 
 sync.error.usernameNotSet			= Username not set
 sync.error.usernameNotSet.text		= You must enter your zotero.org username and password in the Zotero preferences to sync with the Zotero server.

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -3,8 +3,8 @@ extensions.zotero@chnm.gmu.edu.description	= The Next-Generation Research Tool
 general.success						= Success
 general.error						= Error
 general.warning						= Warning
+general.dontAskMeAgain				= Don't ask me again
 general.dontShowWarningAgain			= Don't show this warning again.
-general.dontShowReminderAgain			= Don't show this reminder again.
 general.dontShowAgainFor             = Don’t show again today;Don’t show again for %1$S days
 general.browserIsOffline			= %S is currently in offline mode.
 general.locate						= Locate…
@@ -994,11 +994,11 @@ sync.resetGroupFilesAndSync          = Reset Group Files and Sync
 sync.skipGroup                   = Skip Group
 sync.removeGroupsAndSync			= Remove Groups and Sync
 
-sync.reminder.setup.header          = Set Up Syncing
-sync.reminder.setup.description     = Zotero can automatically sync your library data using the Zotero servers allowing you to access your data from multiple computers.
-sync.reminder.autoSync.header       = Auto-Sync Disabled
-sync.reminder.autoSync.description  = Zotero is not configured to automatically sync your library data and it has been more than 30 days since your last sync. You can check "Sync automatically" in your preferences to enable this.
-sync.reminder.remindMeLater         = Remind Me Later
+sync.reminder.setup.message			= Back up your library with Zotero syncing.
+sync.reminder.setup.action			= Set Up Syncing
+sync.reminder.autoSync.message		= Zotero can automatically sync after you make changes.
+sync.reminder.autoSync.action		= Enable Automatic Sync
+sync.reminder.remindMeLater			= Remind Me Later
 
 sync.error.usernameNotSet			= Username not set
 sync.error.usernameNotSet.text		= You must enter your zotero.org username and password in the Zotero preferences to sync with the Zotero server.

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -64,7 +64,9 @@ general.numMore                    = %S more…
 general.openPreferences				= Open Preferences
 general.keys.ctrlShift				= Ctrl+Shift+
 general.keys.cmdShift				= Cmd+Shift+
-general.dontShowAgain = Don’t Show Again
+general.dontShowAgain	= Don’t Show Again
+general.dontAskAgain	= Don’t Ask Again
+general.remindMeLater	= Remind Me Later
 general.fix                      = Fix…
 general.tryAgain                 = Try Again
 general.tryLater                 = Try Later
@@ -993,12 +995,10 @@ sync.resetGroupFilesAndSync          = Reset Group Files and Sync
 sync.skipGroup                   = Skip Group
 sync.removeGroupsAndSync			= Remove Groups and Sync
 
-sync.reminder.setup.message			= Back up your library with Zotero syncing.
-sync.reminder.setup.action			= Set Up Syncing
-sync.reminder.autoSync.message		= Zotero can automatically sync after you make changes.
+sync.reminder.setUp.message			= Back up your library with %S syncing.
+sync.reminder.setUp.action			= Set Up Syncing
+sync.reminder.autoSync.message		= %S can automatically sync after you make changes.
 sync.reminder.autoSync.action		= Enable Automatic Sync
-sync.reminder.dontAskAgain			= Don't Ask Again
-sync.reminder.remindMeLater			= Remind Me Later
 
 sync.error.usernameNotSet			= Username not set
 sync.error.usernameNotSet.text		= You must enter your zotero.org username and password in the Zotero preferences to sync with the Zotero server.

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -49,6 +49,7 @@ general.import = Import
 general.export = Export
 general.update = Update
 general.moreInformation            = More Information
+general.learnMore                  = Learn More
 general.seeForMoreInformation		= See %S for more information.
 general.open                       = Open %S
 general.close                       = Close
@@ -997,8 +998,7 @@ sync.removeGroupsAndSync			= Remove Groups and Sync
 
 sync.reminder.setUp.message			= Back up your library with %S syncing.
 sync.reminder.setUp.action			= Set Up Syncing
-sync.reminder.autoSync.message		= %S can automatically sync after you make changes.
-sync.reminder.autoSync.action		= Enable Automatic Sync
+sync.reminder.autoSync.message       = %S hasn’t synced in a while. Do you want to enable automatic syncing?
 
 sync.error.usernameNotSet			= Username not set
 sync.error.usernameNotSet.text		= You must enter your zotero.org username and password in the Zotero preferences to sync with the Zotero server.

--- a/chrome/skin/default/zotero/overlay.css
+++ b/chrome/skin/default/zotero/overlay.css
@@ -533,11 +533,11 @@
 }
 
 /* Sync error panel */
-#zotero-sync-error-panel {
+#zotero-sync-error-panel, #zotero-sync-reminder-panel {
 	margin-right: 0;
 }
 
-#zotero-sync-error-panel .error-header {
+#zotero-sync-error-panel .error-header, #zotero-sync-reminder-panel .header {
 	font-size: 14px;
 	font-weight: bold;
 	margin-bottom: 1em;
@@ -552,7 +552,7 @@
 	margin-bottom: 1.1em;
 }
 
-#zotero-sync-error-panel description {
+#zotero-sync-error-panel description, #zotero-sync-reminder-panel description {
 	width: 370px;
 	white-space: pre-wrap;
 }

--- a/chrome/skin/default/zotero/overlay.css
+++ b/chrome/skin/default/zotero/overlay.css
@@ -635,7 +635,7 @@
 	margin-left: 3px !important;
 }
 
-#retracted-items-banner {
+#retracted-items-banner, #sync-reminder-banner {
 	display: flex;
 	justify-content: center;
 	background: #d93425;
@@ -648,8 +648,16 @@
 	position: relative;
 }
 
-#retracted-items-message {
+#sync-reminder-banner {
+	background: rgb(89, 139, 236);
+}
+
+#retracted-items-message, #sync-reminder-message {
 	margin-right: .8em;
+}
+
+#sync-reminder-spacer {
+	flex: 1;
 }
 
 #retracted-items-link {
@@ -658,11 +666,18 @@
 	cursor: pointer;
 }
 
-#retracted-items-link:active {
+.sync-reminder-link {
+	text-decoration: underline;
+	cursor: pointer;
+	padding-left: 0.5em;
+	padding-right: 0.5em;
+}
+
+#retracted-items-link:active, .sync-reminder-link:active {
 	color: #f9e8e2;
 }
 
-#retracted-items-close {
+#retracted-items-close, #sync-reminder-close {
 	position: absolute;
 	cursor: pointer;
 	top: -2px;

--- a/chrome/skin/default/zotero/overlay.css
+++ b/chrome/skin/default/zotero/overlay.css
@@ -646,10 +646,14 @@
 	text-align: center;
 	padding: 0 2em;
 	position: relative;
+	white-space: nowrap;
+	overflow: hidden;
 }
 
 #sync-reminder-banner {
-	background: rgb(89, 139, 236);
+	background: rgb(255, 234, 80);
+	border-bottom: #a9a9a9 .5px solid;
+	color: black;
 }
 
 #retracted-items-message, #sync-reminder-message {
@@ -673,8 +677,12 @@
 	padding-right: 0.5em;
 }
 
-#retracted-items-link:active, .sync-reminder-link:active {
+#retracted-items-link:active {
 	color: #f9e8e2;
+}
+
+.sync-reminder-link:active {
+	color: #4b4b4b;
 }
 
 #retracted-items-close, #sync-reminder-close {

--- a/defaults/preferences/zotero.js
+++ b/defaults/preferences/zotero.js
@@ -160,8 +160,8 @@ pref("extensions.zotero.sync.storage.groups.enabled", true);
 pref("extensions.zotero.sync.storage.downloadMode.personal", "on-sync");
 pref("extensions.zotero.sync.storage.downloadMode.groups", "on-sync");
 pref("extensions.zotero.sync.fulltext.enabled", true);
-pref("extensions.zotero.sync.reminder.setup.enabled", true);
-pref("extensions.zotero.sync.reminder.setup.lastDisplayed", "0");
+pref("extensions.zotero.sync.reminder.setUp.enabled", true);
+pref("extensions.zotero.sync.reminder.setUp.lastDisplayed", "0");
 pref("extensions.zotero.sync.reminder.autoSync.enabled", true);
 pref("extensions.zotero.sync.reminder.autoSync.lastDisplayed", "0");
 

--- a/defaults/preferences/zotero.js
+++ b/defaults/preferences/zotero.js
@@ -160,6 +160,10 @@ pref("extensions.zotero.sync.storage.groups.enabled", true);
 pref("extensions.zotero.sync.storage.downloadMode.personal", "on-sync");
 pref("extensions.zotero.sync.storage.downloadMode.groups", "on-sync");
 pref("extensions.zotero.sync.fulltext.enabled", true);
+pref("extensions.zotero.sync.reminder.setup.enabled", true);
+pref("extensions.zotero.sync.reminder.setup.lastDisplayed", "0");
+pref("extensions.zotero.sync.reminder.autoSync.enabled", true);
+pref("extensions.zotero.sync.reminder.autoSync.lastDisplayed", "0");
 
 // Proxy
 pref("extensions.zotero.proxies.autoRecognize", true);

--- a/defaults/preferences/zotero.js
+++ b/defaults/preferences/zotero.js
@@ -161,9 +161,9 @@ pref("extensions.zotero.sync.storage.downloadMode.personal", "on-sync");
 pref("extensions.zotero.sync.storage.downloadMode.groups", "on-sync");
 pref("extensions.zotero.sync.fulltext.enabled", true);
 pref("extensions.zotero.sync.reminder.setUp.enabled", true);
-pref("extensions.zotero.sync.reminder.setUp.lastDisplayed", "0");
+pref("extensions.zotero.sync.reminder.setUp.lastDisplayed", 0);
 pref("extensions.zotero.sync.reminder.autoSync.enabled", true);
-pref("extensions.zotero.sync.reminder.autoSync.lastDisplayed", "0");
+pref("extensions.zotero.sync.reminder.autoSync.lastDisplayed", 0);
 
 // Proxy
 pref("extensions.zotero.proxies.autoRecognize", true);

--- a/resource/config.js
+++ b/resource/config.js
@@ -21,6 +21,7 @@ var ZOTERO_CONFIG = {
 	QUICK_START_URL: "https://www.zotero.org/support/quick_start_guide",
 	PDF_TOOLS_URL: "https://www.zotero.org/download/xpdf/",
 	SUPPORT_URL: "https://www.zotero.org/support/",
+	SYNC_INFO_URL: "https://www.zotero.org/support/sync",
 	TROUBLESHOOTING_URL: "https://www.zotero.org/support/getting_help",
 	FEEDBACK_URL: "https://forums.zotero.org/",
 	CONNECTORS_URL: "https://www.zotero.org/download/connectors",


### PR DESCRIPTION
Compared to @fletcherhaz's original branch (discussed in the issue comments), I:

- Changed the 30-day sync threshold to seven days
- Title-cased the "Don't Ask Again" action in line with other banner actions
- Changed the behavior of the auto-sync banner to automatically enable the relevant preference without opening the sync preferences window

Closes #1429.