### PR TITLE
Render markup in item tree, strip when sorting

### DIFF
--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -2597,6 +2597,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 	_renderItemTitle(title, targetNode) {
 		let markupStack = [];
 		let nodeStack = [targetNode];
+		let textContent = '';
 
 		for (let token of title.split(/(<[^>]+>)/)) {
 			if (this._titleMarkup.hasOwnProperty(token)) {
@@ -2606,7 +2607,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 					if (markup.style) {
 						Object.assign(node.style, markup.style);
 					}
-					if (markup.inverseStyle && markupStack.find(otherMarkup => otherMarkup.beginsTag === markup.beginsTag)) {
+					if (markup.inverseStyle && markupStack.some(otherMarkup => otherMarkup.beginsTag === markup.beginsTag)) {
 						Object.assign(node.style, markup.inverseStyle);
 					}
 					markupStack.push({ ...markup, token });
@@ -2631,6 +2632,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 			}
 
 			nodeStack[nodeStack.length - 1].append(token);
+			textContent += token;
 		}
 
 		while (markupStack.length) {
@@ -2638,6 +2640,8 @@ var ItemTree = class ItemTree extends LibraryTree {
 			let discardedNode = nodeStack.pop();
 			nodeStack[0].append(discardedMarkup.token, ...discardedNode.childNodes);
 		}
+
+		return textContent;
 	}
 
 	_renderPrimaryCell(index, data, column) {
@@ -2694,15 +2698,13 @@ var ItemTree = class ItemTree extends LibraryTree {
 			Zotero.debug(e, 1);
 		}
 		
-		let textWithFullStop = data;
+		let textSpan = document.createElementNS(HTML_NS, 'span');
+		let textWithFullStop = this._renderItemTitle(data, textSpan);
 		if (!textWithFullStop.match(/\.$/)) {
 			textWithFullStop += '.';
 		}
 		let textSpanAriaLabel = [textWithFullStop, itemTypeAriaLabel, tagAriaLabel, retractedAriaLabel].join(' ');
-
-		let textSpan = document.createElementNS(HTML_NS, 'span');
 		textSpan.className = "cell-text";
-		this._renderItemTitle(data, textSpan);
 		textSpan.setAttribute('aria-label', textSpanAriaLabel);
 
 		span.append(twisty, icon, retracted, ...tagSpans, textSpan);

--- a/chrome/content/zotero/xpcom/data/items.js
+++ b/chrome/content/zotero/xpcom/data/items.js
@@ -1686,15 +1686,30 @@ Zotero.Items = function() {
 	}
 	
 	
-	this.getSortTitle = function(title) {
-		if (title === false || title === undefined || title == null) {
+	this.getSortTitle = function (title) {
+		if (!title) {
 			return '';
 		}
+
 		if (typeof title == 'number') {
-			return title + '';
+			return title.toString();
 		}
-		return title.replace(/^[\[\'\"](.*)[\'\"\]]?$/, '$1')
-	}
+
+		let toRemove = [
+			'</?i>',
+			'</?b>',
+			'</?sub>',
+			'</?sup>',
+			'<span style="font-variant:small-caps;">',
+			'<span class="nocase">',
+			'</span>',
+			'\\p{P}'
+		].map(re => new RegExp(re, 'g'));
+		for (let re of toRemove) {
+			title = title.replace(re, '');
+		}
+		return title;
+	};
 	
 	
 	Zotero.DataObjects.call(this);


### PR DESCRIPTION
`_renderItemTitle` attempts to follow the behavior of citeproc-js as closely as possible, including two major quirks:

1. Unmatched tags are included as text content in the rendered title. For example, `<i>x<sup>2</i>` is rendered as <i>x\<sup>2</i> and `<i>x</i></i>` is rendered as <i>x</i>\</i>.
2. When `<i>` or `<b>` is nested inside another tag of the same type, the inner tag inverts the outer. For example, `<i>Reading the <i>Odyssey</i> Today</i>` is rendered as <i>Reading the</i> Odyssey <i>Today</i>.

Closes #1396.