### PR TITLE
HTML Tree: Add a dotted border to pivot rows

### DIFF
--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -830,7 +830,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 			return false;
 		}
 		if (this.selection.count == 0) {
-			this.selection.select(0);
+			this.selection.select(this.selection.pivot);
 		}
 	}
 	
@@ -1011,6 +1011,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 		this._getColumns();
 
 		this.selection.clearSelection();
+		this.selection.pivot = 0;
 		await this.refresh();
 		if (Zotero.CollectionTreeCache.error) {
 			return this.setItemsPaneMessage(Zotero.getString('pane.items.loadError'));
@@ -2866,6 +2867,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 		}
 
 		div.classList.toggle('selected', selection.isSelected(index));
+		div.classList.toggle('pivot', selection.pivot == index);
 		div.classList.remove('drop', 'drop-before', 'drop-after');
 		const rowData = this._getRowData(index);
 		div.classList.toggle('context-row', !!rowData.contextRow);

--- a/scss/components/_virtualized-table.scss
+++ b/scss/components/_virtualized-table.scss
@@ -136,7 +136,7 @@
 	}
 }
 
-.virtualized-table.multi-select {
+.virtualized-table.multi-select:focus {
 
 	.row.pivot {
 		border: 1px dotted highlight;

--- a/scss/components/_virtualized-table.scss
+++ b/scss/components/_virtualized-table.scss
@@ -136,6 +136,23 @@
 	}
 }
 
+.virtualized-table.multi-select {
+
+	.row.pivot {
+		border: 1px dotted highlight;
+		box-sizing: initial;
+		margin: -1px 0;
+		width: calc(100% - 2px);
+
+		> *:first-child {
+			margin-inline-start: -1px;
+		}
+		> *:last-child {
+			margin-inline-end: -1px;
+		}
+	}
+}
+
 .virtualized-table-header {
 	display: flex;
 	flex-direction: row;


### PR DESCRIPTION
Closes #2373.

As a result of this after changing the collection the first row always has the pivot border. I don't think it's a big problem and that's how it always was on Window or Linux, but you may think it to be unusual or distracting, so your call on how/whether we address that.