### PR TITLE
Improve keyboard navigation in PDF reader tab

### DIFF
--- a/chrome/content/zotero/bindings/noteeditor.xml
+++ b/chrome/content/zotero/bindings/noteeditor.xml
@@ -349,6 +349,25 @@
 				</body>
 			</method>
 
+			<method name="focusFirst">
+				<body>
+					<![CDATA[
+						(async () => {
+							let n = 0;
+							while (!this._editorInstance && n++ < 100) {
+								await Zotero.Promise.delay(10);
+							}
+							await this._editorInstance._initPromise;
+							this._iframe.focus();
+							try {
+								this._editorInstance._iframeWindow.document.querySelector('.toolbar-button-return').focus();
+							} catch(e) {
+							}
+						})();
+					]]>
+				</body>
+			</method>
+
 			<method name="_id">
 				<parameter name="id"/>
 				<body>

--- a/chrome/content/zotero/contextPane.js
+++ b/chrome/content/zotero/contextPane.js
@@ -259,19 +259,23 @@ var ZoteroContextPane = new function () {
 
 		if (splitter.getAttribute('state') != 'collapsed') {
 			if (_panesDeck.selectedIndex == 0) {
-				var node = _itemPaneDeck.selectedPanel;
-				node.querySelector('tab').focus();
+				var node = _panesDeck.selectedPanel;
+				node.querySelector('tab[selected]').focus();
+				return true;
 			}
 			else {
 				var node = _notesPaneDeck.selectedPanel;
 				if (node.selectedIndex == 0) {
 					node.querySelector('textbox').focus();
+					return true;
 				}
 				else {
 					node.querySelector('zoteronoteeditor').focus();
+					return true;
 				}
 			}
 		}
+		return false;
 	}
 
 	function _updateAddToNote() {

--- a/chrome/content/zotero/contextPane.js
+++ b/chrome/content/zotero/contextPane.js
@@ -58,6 +58,7 @@ var ZoteroContextPane = new function () {
 	this.update = _update;
 	this.getActiveEditor = _getActiveEditor;
 	this.focus = _focus;
+	this.isLastFocusableNodeFocused = _isLastFocusableNodeFocused;
 
 	this.init = function () {
 		if (!Zotero) {
@@ -270,8 +271,42 @@ var ZoteroContextPane = new function () {
 					return true;
 				}
 				else {
-					node.querySelector('zoteronoteeditor').focus();
+					node.querySelector('zoteronoteeditor').focusFirst();
 					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	function _isLastFocusableNodeFocused() {
+		var splitter;
+		if (Zotero.Prefs.get('layout') == 'stacked') {
+			splitter = _contextPaneSplitterStacked;
+		}
+		else {
+			splitter = _contextPaneSplitter;
+		}
+
+		if (splitter.getAttribute('state') != 'collapsed') {
+			if (_panesDeck.selectedIndex == 0) {
+				let node = document.activeElement;
+				if (node
+					&& node.parentNode
+					&& node.parentNode.parentNode
+					&& node.parentNode.parentNode.id === 'itembox-field-textbox-extra') {
+					return true;
+				}
+			}
+			else {
+				var node = _notesPaneDeck.selectedPanel;
+				if (node.selectedIndex == 0) {
+					// node.querySelector('textbox').focus();
+					// return true;
+				}
+				else {
+					// node.querySelector('zoteronoteeditor').focus();
+					// return true;
 				}
 			}
 		}

--- a/chrome/content/zotero/contextPane.js
+++ b/chrome/content/zotero/contextPane.js
@@ -58,7 +58,6 @@ var ZoteroContextPane = new function () {
 	this.update = _update;
 	this.getActiveEditor = _getActiveEditor;
 	this.focus = _focus;
-	this.isLastFocusableNodeFocused = _isLastFocusableNodeFocused;
 
 	this.init = function () {
 		if (!Zotero) {
@@ -273,40 +272,6 @@ var ZoteroContextPane = new function () {
 				else {
 					node.querySelector('zoteronoteeditor').focusFirst();
 					return true;
-				}
-			}
-		}
-		return false;
-	}
-
-	function _isLastFocusableNodeFocused() {
-		var splitter;
-		if (Zotero.Prefs.get('layout') == 'stacked') {
-			splitter = _contextPaneSplitterStacked;
-		}
-		else {
-			splitter = _contextPaneSplitter;
-		}
-
-		if (splitter.getAttribute('state') != 'collapsed') {
-			if (_panesDeck.selectedIndex == 0) {
-				let node = document.activeElement;
-				if (node
-					&& node.parentNode
-					&& node.parentNode.parentNode
-					&& node.parentNode.parentNode.id === 'itembox-field-textbox-extra') {
-					return true;
-				}
-			}
-			else {
-				var node = _notesPaneDeck.selectedPanel;
-				if (node.selectedIndex == 0) {
-					// node.querySelector('textbox').focus();
-					// return true;
-				}
-				else {
-					// node.querySelector('zoteronoteeditor').focus();
-					// return true;
 				}
 			}
 		}

--- a/chrome/content/zotero/contextPane.js
+++ b/chrome/content/zotero/contextPane.js
@@ -259,7 +259,7 @@ var ZoteroContextPane = new function () {
 
 		if (splitter.getAttribute('state') != 'collapsed') {
 			if (_panesDeck.selectedIndex == 0) {
-				var node = _panesDeck.selectedPanel;
+				var node = _itemPaneDeck.selectedPanel;
 				node.querySelector('tab[selected]').focus();
 				return true;
 			}

--- a/chrome/content/zotero/contextPane.js
+++ b/chrome/content/zotero/contextPane.js
@@ -57,7 +57,8 @@ var ZoteroContextPane = new function () {
 	
 	this.update = _update;
 	this.getActiveEditor = _getActiveEditor;
-	
+	this.focus = _focus;
+
 	this.init = function () {
 		if (!Zotero) {
 			return;
@@ -247,6 +248,32 @@ var ZoteroContextPane = new function () {
 		}
 	}
 
+	function _focus() {
+		var splitter;
+		if (Zotero.Prefs.get('layout') == 'stacked') {
+			splitter = _contextPaneSplitterStacked;
+		}
+		else {
+			splitter = _contextPaneSplitter;
+		}
+
+		if (splitter.getAttribute('state') != 'collapsed') {
+			if (_panesDeck.selectedIndex == 0) {
+				var node = _itemPaneDeck.selectedPanel;
+				node.querySelector('tab').focus();
+			}
+			else {
+				var node = _notesPaneDeck.selectedPanel;
+				if (node.selectedIndex == 0) {
+					node.querySelector('textbox').focus();
+				}
+				else {
+					node.querySelector('zoteronoteeditor').focus();
+				}
+			}
+		}
+	}
+
 	function _updateAddToNote() {
 		var reader = Zotero.Reader.getByTabID(Zotero_Tabs.selectedID);
 		if (reader) {
@@ -358,6 +385,10 @@ var ZoteroContextPane = new function () {
 		
 		splitter.setAttribute('state', hide ? 'collapsed' : 'open');
 		_update();
+
+		if (!hide) {
+			ZoteroContextPane.focus();
+		}
 	}
 	
 	function _getCurrentAttachment() {
@@ -455,6 +486,8 @@ var ZoteroContextPane = new function () {
 		listBox.setAttribute('flex', '1');
 		var listInner = document.createElementNS(HTML_NS, 'div');
 		listInner.className = 'notes-list-container';
+		// Otherwise it can be focused with tab
+		listInner.tabIndex = -1;
 		listBox.append(listInner);
 
 		list.append(head, listBox);

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -158,6 +158,19 @@ class ReaderInstance {
 	setSidebarOpen(open) {
 		this._postMessage({ action: 'setSidebarOpen', open });
 	}
+
+	focusLastToolbarButton() {
+		this._iframeWindow.focus();
+		this._postMessage({ action: 'focusLastToolbarButton' });
+	}
+
+	tabToolbar(reverse) {
+		this._postMessage({ action: 'tabToolbar', reverse });
+		// Avoid toolbar find button being focused for a short moment
+		setTimeout(() => {
+			this._iframeWindow.focus();
+		});
+	}
 	
 	async setBottomPlaceholderHeight(height) {
 		await this._initPromise;
@@ -735,6 +748,20 @@ class ReaderInstance {
 					let { open } = message;
 					if (this.onChangeSidebarOpen) {
 						this.onChangeSidebarOpen(open);
+					}
+					return;
+				}
+				case 'focusSplitButton': {
+					let win = Zotero.getMainWindow();
+					if (win) {
+						win.document.getElementById('zotero-tb-toggle-item-pane').focus();
+					}
+					return;
+				}
+				case 'focusContextPane': {
+					let win = Zotero.getMainWindow();
+					if (win) {
+						this._window.ZoteroContextPane.focus();
 					}
 					return;
 				}

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -167,9 +167,12 @@ class ReaderInstance {
 	tabToolbar(reverse) {
 		this._postMessage({ action: 'tabToolbar', reverse });
 		// Avoid toolbar find button being focused for a short moment
-		setTimeout(() => {
-			this._iframeWindow.focus();
-		});
+		setTimeout(() => this._iframeWindow.focus());
+	}
+
+	focusFirst() {
+		this._postMessage({ action: 'focusFirst' });
+		setTimeout(() => this._iframeWindow.focus());
 	}
 	
 	async setBottomPlaceholderHeight(height) {
@@ -761,7 +764,9 @@ class ReaderInstance {
 				case 'focusContextPane': {
 					let win = Zotero.getMainWindow();
 					if (win) {
-						this._window.ZoteroContextPane.focus();
+						if (!this._window.ZoteroContextPane.focus()) {
+							this.focusFirst();
+						}
 					}
 					return;
 				}
@@ -849,6 +854,7 @@ class ReaderTab extends ReaderInstance {
 		this._tabContainer = container;
 		
 		this._iframe = this._window.document.createElement('browser');
+		this._iframe.setAttribute('class', 'reader');
 		this._iframe.setAttribute('flex', '1');
 		this._iframe.setAttribute('type', 'content');
 		this._iframe.setAttribute('src', 'resource://zotero/pdf-reader/viewer.html');

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -515,39 +515,57 @@ var ZoteroPane = new function()
 	 * Trigger actions based on keyboard shortcuts
 	 */
 	function handleKeyDown(event, from) {
-		let itemPaneToggle = document.getElementById('zotero-tb-toggle-item-pane');
-		let notesPaneToggle = document.getElementById('zotero-tb-toggle-notes-pane');
-		if (event.key === 'ArrowRight') {
-			if (event.target === itemPaneToggle) {
-				notesPaneToggle.focus();
-			}
-		}
-		else if (event.key === 'ArrowLeft') {
-			if (event.target === notesPaneToggle) {
-				itemPaneToggle.focus();
-			}
-			else if (event.target === itemPaneToggle) {
-				let reader = Zotero.Reader.getByTabID(Zotero_Tabs.selectedID);
-				if (reader) {
-					reader.focusLastToolbarButton();
+		if (Zotero_Tabs.selectedIndex > 0) {
+			let itemPaneToggle = document.getElementById('zotero-tb-toggle-item-pane');
+			let notesPaneToggle = document.getElementById('zotero-tb-toggle-notes-pane');
+			// Using ArrowDown and ArrowUp to be consistent with pdf-reader
+			if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+				if (event.target === itemPaneToggle) {
+					notesPaneToggle.focus();
 				}
 			}
-		}
-		else if (event.key === 'Tab'
-			&& [itemPaneToggle, notesPaneToggle].includes(event.target)) {
-			let reader = Zotero.Reader.getByTabID(Zotero_Tabs.selectedID);
-			if (reader) {
-				reader.tabToolbar(event.shiftKey);
-				event.preventDefault();
-				event.stopPropagation();
+			else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+				if (event.target === notesPaneToggle) {
+					itemPaneToggle.focus();
+				}
+				else if (event.target === itemPaneToggle) {
+					let reader = Zotero.Reader.getByTabID(Zotero_Tabs.selectedID);
+					if (reader) {
+						reader.focusLastToolbarButton();
+					}
+				}
 			}
-		}
-		else if (event.key === 'Escape') {
-			let reader = Zotero.Reader.getByTabID(Zotero_Tabs.selectedID);
-			if (reader) {
-				reader.focus();
-				event.preventDefault();
-				event.stopPropagation();
+			else if (event.key === 'Tab'
+				&& [itemPaneToggle, notesPaneToggle].includes(event.target)) {
+				let reader = Zotero.Reader.getByTabID(Zotero_Tabs.selectedID);
+				if (reader) {
+					reader.tabToolbar(event.shiftKey);
+					event.preventDefault();
+					event.stopPropagation();
+				}
+			}
+			else if (event.key === 'Escape') {
+				if (!document.activeElement.classList.contains('reader')) {
+					let reader = Zotero.Reader.getByTabID(Zotero_Tabs.selectedID);
+					if (reader) {
+						reader.focus();
+						event.preventDefault();
+						event.stopPropagation();
+					}
+				}
+			}
+			// If Shift-Tab was pressed and the focus shifted to PDF reader iframe
+			else if (event.key === 'Tab' && event.shiftKey) {
+				if (!document.activeElement.classList.contains('reader')) {
+					setTimeout(() => {
+						if (document.activeElement.classList.contains('reader')) {
+							let reader = Zotero.Reader.getByTabID(Zotero_Tabs.selectedID);
+							if (reader) {
+								reader.focus();
+							}
+						}
+					});
+				}
 			}
 		}
 

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -515,6 +515,42 @@ var ZoteroPane = new function()
 	 * Trigger actions based on keyboard shortcuts
 	 */
 	function handleKeyDown(event, from) {
+		let itemPaneToggle = document.getElementById('zotero-tb-toggle-item-pane');
+		let notesPaneToggle = document.getElementById('zotero-tb-toggle-notes-pane');
+		if (event.key === 'ArrowRight') {
+			if (event.target === itemPaneToggle) {
+				notesPaneToggle.focus();
+			}
+		}
+		else if (event.key === 'ArrowLeft') {
+			if (event.target === notesPaneToggle) {
+				itemPaneToggle.focus();
+			}
+			else if (event.target === itemPaneToggle) {
+				let reader = Zotero.Reader.getByTabID(Zotero_Tabs.selectedID);
+				if (reader) {
+					reader.focusLastToolbarButton();
+				}
+			}
+		}
+		else if (event.key === 'Tab'
+			&& [itemPaneToggle, notesPaneToggle].includes(event.target)) {
+			let reader = Zotero.Reader.getByTabID(Zotero_Tabs.selectedID);
+			if (reader) {
+				reader.tabToolbar(event.shiftKey);
+				event.preventDefault();
+				event.stopPropagation();
+			}
+		}
+		else if (event.key === 'Escape') {
+			let reader = Zotero.Reader.getByTabID(Zotero_Tabs.selectedID);
+			if (reader) {
+				reader.focus();
+				event.preventDefault();
+				event.stopPropagation();
+			}
+		}
+
 		const cmdOrCtrlOnly = Zotero.isMac
 			? (event.metaKey && !event.shiftKey && !event.ctrlKey && !event.altKey)
 			: (event.ctrlKey && !event.shiftKey && !event.altKey);

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -570,13 +570,15 @@ var ZoteroPane = new function()
 				}
 			}
 			else if (event.key === 'Tab') {
-				if (ZoteroContextPane.isLastFocusableNodeFocused()) {
-					let reader = Zotero.Reader.getByTabID(Zotero_Tabs.selectedID);
-					if (reader) {
-						reader.focus();
-					}
-					event.preventDefault();
-					event.stopPropagation();
+				if (!document.activeElement.classList.contains('reader')) {
+					setTimeout(() => {
+						if (document.activeElement.classList.contains('reader')) {
+							let reader = Zotero.Reader.getByTabID(Zotero_Tabs.selectedID);
+							if (reader) {
+								reader.focusFirst();
+							}
+						}
+					});
 				}
 			}
 		}

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -537,12 +537,17 @@ var ZoteroPane = new function()
 			}
 			else if (event.key === 'Tab'
 				&& [itemPaneToggle, notesPaneToggle].includes(event.target)) {
-				let reader = Zotero.Reader.getByTabID(Zotero_Tabs.selectedID);
-				if (reader) {
-					reader.tabToolbar(event.shiftKey);
-					event.preventDefault();
-					event.stopPropagation();
+				if (event.shiftKey) {
+					ZoteroContextPane.focus();
 				}
+				else {
+					let reader = Zotero.Reader.getByTabID(Zotero_Tabs.selectedID);
+					if (reader) {
+						reader.tabToolbar();
+					}
+				}
+				event.preventDefault();
+				event.stopPropagation();
 			}
 			else if (event.key === 'Escape') {
 				if (!document.activeElement.classList.contains('reader')) {

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -554,17 +554,29 @@ var ZoteroPane = new function()
 					}
 				}
 			}
-			// If Shift-Tab was pressed and the focus shifted to PDF reader iframe
 			else if (event.key === 'Tab' && event.shiftKey) {
-				if (!document.activeElement.classList.contains('reader')) {
-					setTimeout(() => {
-						if (document.activeElement.classList.contains('reader')) {
-							let reader = Zotero.Reader.getByTabID(Zotero_Tabs.selectedID);
-							if (reader) {
-								reader.focus();
-							}
-						}
-					});
+				let node = document.activeElement;
+				if (node && node.nodeType === Node.ELEMENT_NODE && (
+					node.parentNode.classList.contains('zotero-editpane-tabs')
+					|| node.getAttribute('type') === 'search'
+					|| node.getAttribute('anonid') === 'editor-view'
+					&& node.contentWindow.document.activeElement.classList.contains('toolbar-button-return'))) {
+					let reader = Zotero.Reader.getByTabID(Zotero_Tabs.selectedID);
+					if (reader) {
+						reader.focus();
+					}
+					event.preventDefault();
+					event.stopPropagation();
+				}
+			}
+			else if (event.key === 'Tab') {
+				if (ZoteroContextPane.isLastFocusableNodeFocused()) {
+					let reader = Zotero.Reader.getByTabID(Zotero_Tabs.selectedID);
+					if (reader) {
+						reader.focus();
+					}
+					event.preventDefault();
+					event.stopPropagation();
 				}
 			}
 		}

--- a/chrome/content/zotero/zoteroPane.xul
+++ b/chrome/content/zotero/zoteroPane.xul
@@ -84,8 +84,8 @@
 			</box>
 			<box id="zotero-tab-toolbar" class="toolbar" hidden="true">
 				<div id="zotero-tb-split" xmlns="http://www.w3.org/1999/xhtml" class="split-button">
-					<div id="zotero-tb-toggle-item-pane" class="toolbarButton item" title="&zotero.toolbar.context.item;"><span/></div>
-					<div id="zotero-tb-toggle-notes-pane" class="toolbarButton notes" title="&zotero.toolbar.context.notes;"><span/></div>
+					<button id="zotero-tb-toggle-item-pane" class="toolbarButton item" title="&zotero.toolbar.context.item;" tabindex="-1"><span/></button>
+					<button id="zotero-tb-toggle-notes-pane" class="toolbarButton notes" title="&zotero.toolbar.context.notes;" tabindex="-1"><span/></button>
 				</div>
 			</box>
 			<deck id="tabs-deck" flex="1">

--- a/scss/abstracts/_split-button.scss
+++ b/scss/abstracts/_split-button.scss
@@ -189,6 +189,11 @@ $toolbar-btn-icon-active-offset:    0;
     }
   }
 
+  // Remove strange inner dotted outline that appears on focus
+  &::-moz-focus-inner {
+    border: 0;
+  }
+
   &:hover {
     background: $toolbar-btn-hover-bg;
     border-color: $toolbar-btn-border-hover-color;

--- a/scss/components/_notesList.scss
+++ b/scss/components/_notesList.scss
@@ -136,3 +136,16 @@
 		padding-top: 6px !important;
 	}
 }
+
+.note-row, .more-row {
+	outline: 0;
+
+	&:-moz-focusring {
+		box-shadow: $toolbar-btn-focus-box-shadow;
+		z-index: 1;
+
+		@include retina {
+			box-shadow: $toolbar-btn-focus-box-shadow-2x;
+		}
+	}
+}


### PR DESCRIPTION
Let's try this out.

- Toolbar navigation is now continuous.
- Improved notes list navigation.
- Toggling Item/Notes split button focuses context pane, even when doing so with mouse (which is not necessary good).

#2379