### PR TITLE
Item.setType: Extract fields, creators, archive IDs

### DIFF
--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -531,8 +531,22 @@ Zotero.Item.prototype.setType = function(itemTypeID, loadIn) {
 				}
 			}
 		}
+
+		if (this.getField('extra')) {
+			let { fields, creators: extractedCreators, extra } = Zotero.Utilities.Internal.extractExtraFields(
+				this.getField('extra'),
+				this,
+				// Ignore itemType because that's what we're changing
+				['itemType']
+			);
+			for (let [field, value] of fields.entries()) {
+				copiedFields.push([field, value]);
+			}
+			this.setCreators([...this.getCreators(), ...extractedCreators]);
+			copiedFields.push(['extra', extra]);
+		}
 	}
-	
+
 	// Initialize this._itemData with type-specific fields
 	this._itemData = {};
 	var fields = Zotero.ItemFields.getItemTypeFields(itemTypeID);

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -4889,6 +4889,7 @@ Zotero.Item.prototype.fromJSON = function (json, options = {}) {
 			Object.keys(json)
 				// TEMP until we move creator lines to real creators
 				.concat('creators')
+				.filter(x => x !== 'itemType')
 		);
 	// If a different item type was parsed out of Extra, use that instead
 	if (itemType && json.itemType != itemType) {

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -4887,9 +4887,9 @@ Zotero.Item.prototype.fromJSON = function (json, options = {}) {
 			json.extra || '',
 			this,
 			Object.keys(json)
+				.filter(x => x !== 'itemType')
 				// TEMP until we move creator lines to real creators
 				.concat('creators')
-				.filter(x => x !== 'itemType')
 		);
 	// If a different item type was parsed out of Extra, use that instead
 	if (itemType && json.itemType != itemType) {

--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -1214,7 +1214,7 @@ Zotero.Utilities.Internal = {
 					|| additionalFields.has('itemType')
 					|| skipKeys.has(key)
 					// 1) Ignore 'type: note' and 'type: attachment'
-					// 2) Ignore 'article' until we have a Preprint item type
+					// TODO: Don't ignore 'article' now that we have a Preprint item type
 					//    (https://github.com/zotero/translators/pull/2248#discussion_r546428184)
 					|| ['note', 'attachment', 'article'].includes(value)) {
 				return true;

--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -1183,15 +1183,14 @@ Zotero.Utilities.Internal = {
 		}
 		
 		// Process Extra lines
-		var keepLines = [];
 		var skipKeys = new Set();
 		var lines = extra.split(/\n/g);
 		
 		var getKeyAndValue = (line) => {
-			let parts = line.match(/^([a-z][a-z -_]+):(.+)/i);
+			let parts = line.match(/^([a-z][a-z \-_]+):(.+)/i);
 			// Old citeproc.js cheater syntax;
 			if (!parts) {
-				parts = line.match(/^{:([a-z -_]+):(.+)}/i);
+				parts = line.match(/^{:([a-z \-_]+):(.+)}/i);
 			}
 			if (!parts) {
 				return [null, null];
@@ -1212,6 +1211,7 @@ Zotero.Utilities.Internal = {
 			
 			if (!key
 					|| key != 'type'
+					|| additionalFields.has('itemType')
 					|| skipKeys.has(key)
 					// 1) Ignore 'type: note' and 'type: attachment'
 					// 2) Ignore 'article' until we have a Preprint item type
@@ -1245,6 +1245,32 @@ Zotero.Utilities.Internal = {
 			
 			return true;
 		});
+
+		/* eslint-disable quote-props */
+		var archiveMappings = new Map(Object.entries({
+			// Weird _normalizeExtraKey behavior because of arXiv's weird capitalization
+			'ar-xiv': {
+				'repository': 'arXiv',
+				'archiveID': { from: 'extra', prefix: 'arXiv:' }
+			},
+			'arxiv': 'ar-xiv',
+			'ar-xiv-id': 'ar-xiv',
+			'arxiv-id': 'ar-xiv',
+			'pmid': {
+				'repository': 'PubMed',
+				'archiveID': { from: 'extra' }
+			},
+			'pmcid': {
+				'repository': 'PubMed Central',
+				'archiveID': { from: 'extra', prefix: 'PMC' }
+			},
+			'ads-bibcode': {
+				'repository': 'NASA ADS',
+				'archiveID': { from: 'extra' }
+			}
+		}));
+		/* eslint-enable quote-props */
+		var archiveWasExtracted = false;
 		
 		lines = lines.filter((line) => {
 			let [key, value] = getKeyAndValue(line);
@@ -1307,7 +1333,7 @@ Zotero.Utilities.Internal = {
 					if (Zotero.CreatorTypes.isValidForItemType(creatorTypeID, itemTypeID)
 							// Ignore if there are any creators of this type on the item already,
 							// to follow citeproc-js behavior
-							&& !item.getCreators().some(x => x.creatorType == possibleCreatorType)) {
+							&& !item.getCreators().some(x => x.creatorTypeID == creatorTypeID)) {
 						creators.push(c);
 						return false;
 					}
@@ -1316,6 +1342,47 @@ Zotero.Utilities.Internal = {
 					creators.push(c);
 					return false;
 				}
+			}
+
+			let possibleArchiveMapping = !archiveWasExtracted && archiveMappings.get(key);
+			if (typeof possibleArchiveMapping === 'string') {
+				// Allow aliases
+				possibleArchiveMapping = archiveMappings.get(possibleArchiveMapping);
+			}
+			if (possibleArchiveMapping) {
+				let keepRow = false;
+				for (let [itemField, fieldMapping] of Object.entries(possibleArchiveMapping)) {
+					let fieldID = Zotero.ItemFields.getID(itemField);
+					if (additionalFields.has(itemField)
+						|| item && (
+							!Zotero.ItemFields.isValidForType(fieldID, itemTypeID)
+							|| item.getField(fieldID))) {
+						keepRow = true;
+						continue;
+					}
+
+					if (typeof fieldMapping === 'string') {
+						fields.set(itemField, fieldMapping);
+					}
+					else {
+						let { from, prefix } = fieldMapping;
+						switch (from) {
+							case 'extra': {
+								let prefixedValue = prefix && !value.startsWith(prefix)
+									? prefix + value
+									: value;
+								fields.set(itemField, prefixedValue);
+								break;
+							}
+							default:
+								// Might want to have more options in the future,
+								// but for now just accept 'extra'
+								throw new Error(`Unknown value for 'from': ${from}`);
+						}
+					}
+				}
+				archiveWasExtracted = true;
+				return keepRow;
 			}
 			
 			// We didn't find anything, so keep the line in Extra
@@ -1347,10 +1414,10 @@ Zotero.Utilities.Internal = {
 		var keepLines = [];
 		var lines = extra !== '' ? extra.split(/\n/g) : [];
 		for (let line of lines) {
-			let parts = line.match(/^([a-z -_]+):(.+)/i);
+			let parts = line.match(/^([a-z \-_]+):(.+)/i);
 			// Old citeproc.js cheater syntax;
 			if (!parts) {
-				parts = line.match(/^{:([a-z -_]+):(.+)}/i);
+				parts = line.match(/^{:([a-z \-_]+):(.+)}/i);
 			}
 			if (!parts) {
 				keepLines.push(line);

--- a/test/tests/itemTest.js
+++ b/test/tests/itemTest.js
@@ -2780,4 +2780,93 @@ describe("Zotero.Item", function () {
 			}
 		});
 	});
+
+	describe("#setType()", function () {
+		it("should extract an arXiv ID when changing from journalArticle to preprint", function () {
+			let item = new Zotero.Item('journalArticle');
+			item.setField('extra', 'arXiv ID: gr-qc/0201097');
+			item.setType(Zotero.ItemTypes.getID('preprint'));
+			assert.equal(item.getField('archiveID'), 'arXiv:gr-qc/0201097');
+			assert.equal(item.getField('repository'), 'arXiv');
+			assert.equal(item.getField('extra'), '');
+		});
+
+		it("should extract a DOI when changing a report to a journalArticle", function () {
+			let item = new Zotero.Item('report');
+			item.setField('extra', 'DOI: 10.1101/2020.08.12.20173476');
+			item.setType(Zotero.ItemTypes.getID('journalArticle'));
+			assert.equal(item.getField('DOI'), '10.1101/2020.08.12.20173476');
+			assert.equal(item.getField('extra'), '');
+		});
+
+		it("should extract a Zotero date when changing a podcast to audioRecording", function () {
+			let item = new Zotero.Item('podcast');
+			item.setField('extra', 'Date: 2021');
+			item.setType(Zotero.ItemTypes.getID('audioRecording'));
+			assert.equal(item.getField('date'), '2021');
+			assert.equal(item.getField('extra'), '');
+		});
+
+		it("should extract a CSL date when changing a podcast to audioRecording", function () {
+			let item = new Zotero.Item('podcast');
+			item.setField('extra', 'issued: 2021');
+			item.setType(Zotero.ItemTypes.getID('audioRecording'));
+			assert.equal(item.getField('date'), '2021');
+			assert.equal(item.getField('extra'), '');
+		});
+
+		it("should not overwrite fields with values extracted from Extra", function () {
+			let item = new Zotero.Item('book');
+			item.setField('date', '1965');
+			item.setField('extra', 'Date: 1985');
+			item.setType(Zotero.ItemTypes.getID('journalArticle'));
+			assert.equal(item.getField('date'), '1965');
+			assert.equal(item.getField('extra'), 'Date: 1985');
+		});
+
+		it("should extract creators", function () {
+			let item = new Zotero.Item('book');
+			item.setField('extra', 'author: Jones||Mary\nauthor: Smith||John\neditor: John Q. Public');
+			item.setType(Zotero.ItemTypes.getID('journalArticle'));
+			assert.equal(item.numCreators(), 3);
+			assert.deepEqual(item.getCreator(0), {
+				firstName: 'Mary',
+				lastName: 'Jones',
+				fieldMode: 0,
+				creatorTypeID: Zotero.CreatorTypes.getID('author')
+			});
+			assert.deepEqual(item.getCreator(1), {
+				firstName: 'John',
+				lastName: 'Smith',
+				fieldMode: 0,
+				creatorTypeID: Zotero.CreatorTypes.getID('author')
+			});
+			assert.deepEqual(item.getCreator(2), {
+				firstName: '',
+				lastName: 'John Q. Public',
+				fieldMode: 1,
+				creatorTypeID: Zotero.CreatorTypes.getID('editor')
+			});
+			assert.equal(item.getField('extra'), '');
+		});
+
+		it("should not extract a creator of a type that already exists on the item", function () {
+			let item = new Zotero.Item('book');
+			item.setCreator(0, {
+				name: 'Fake Creator 1',
+				fieldMode: 1,
+				creatorType: 'author',
+			});
+			item.setField('extra', 'author: Fake Creator 2');
+			item.setType(Zotero.ItemTypes.getID('journalArticle'));
+			assert.equal(item.numCreators(), 1);
+			assert.deepEqual(item.getCreator(0), {
+				firstName: '',
+				lastName: 'Fake Creator 1',
+				fieldMode: 1,
+				creatorTypeID: Zotero.CreatorTypes.getID('author')
+			});
+			assert.equal(item.getField('extra'), 'author: Fake Creator 2');
+		});
+	});
 });

--- a/test/tests/utilities_internalTest.js
+++ b/test/tests/utilities_internalTest.js
@@ -220,13 +220,22 @@ describe("Zotero.Utilities.Internal", function () {
 		
 		it("should extract an author and add it to existing creators", function () {
 			var item = createUnsavedDataObject('item', { itemType: 'book' });
-			item.setCreator(0, { creatorType: 'author', name: 'Foo' });
+			item.setCreator(0, { creatorType: 'translator', name: 'Foo' });
 			var str = 'author: Bar';
 			var { fields, creators, extra } = Zotero.Utilities.Internal.extractExtraFields(str, item);
 			assert.equal(fields.size, 0);
 			assert.lengthOf(creators, 1);
 			assert.equal(creators[0].creatorType, 'author');
 			assert.equal(creators[0].name, 'Bar');
+		});
+
+		it("should not extract an author when item already has a creator of that type", function () {
+			var item = createUnsavedDataObject('item', { itemType: 'book' });
+			item.setCreator(0, { creatorType: 'author', name: 'Foo' });
+			var str = 'author: Bar';
+			var { fields, creators, extra } = Zotero.Utilities.Internal.extractExtraFields(str, item);
+			assert.equal(fields.size, 0);
+			assert.lengthOf(creators, 0);
 		});
 		
 		it("should extract a CSL date field", function () {
@@ -285,9 +294,87 @@ describe("Zotero.Utilities.Internal", function () {
 		it("should ignore both Event Place and Publisher Place (temporary)", function () {
 			var str = "Event Place: Foo\nPublisher Place: Bar";
 			var { fields, extra } = Zotero.Utilities.Internal.extractExtraFields(str);
-			Zotero.debug([...fields.entries()]);
 			assert.equal(fields.size, 0);
 			assert.equal(extra, "Event Place: Foo\nPublisher Place: Bar");
+		});
+
+		it("should extract an arXiv ID (labeled 'arXiv')", function () {
+			var str = "arXiv: 1604.01979";
+			var { fields, extra } = Zotero.Utilities.Internal.extractExtraFields(str);
+			assert.equal(fields.size, 2);
+			assert.equal(fields.get('repository'), 'arXiv');
+			assert.equal(fields.get('archiveID'), 'arXiv:1604.01979');
+			assert.strictEqual(extra, '');
+		});
+
+		it("shouldn't re-prefix a prefixed arXiv ID", function () {
+			var str = "arXiv: arXiv:1604.01979";
+			var { fields, extra } = Zotero.Utilities.Internal.extractExtraFields(str);
+			assert.equal(fields.size, 2);
+			assert.equal(fields.get('repository'), 'arXiv');
+			assert.equal(fields.get('archiveID'), 'arXiv:1604.01979');
+			assert.strictEqual(extra, '');
+		});
+
+		it("should extract an arXiv ID (labeled 'arXiv ID')", function () {
+			var str = "arXiv ID: 1604.01979";
+			var { fields, extra } = Zotero.Utilities.Internal.extractExtraFields(str);
+			assert.equal(fields.size, 2);
+			assert.equal(fields.get('repository'), 'arXiv');
+			assert.equal(fields.get('archiveID'), 'arXiv:1604.01979');
+			assert.strictEqual(extra, '');
+		});
+
+		it("should extract a PMID", function () {
+			var str = "PMID: 16201210";
+			var { fields, extra } = Zotero.Utilities.Internal.extractExtraFields(str);
+			assert.equal(fields.size, 2);
+			assert.equal(fields.get('repository'), 'PubMed');
+			assert.equal(fields.get('archiveID'), '16201210');
+			assert.strictEqual(extra, '');
+		});
+
+		it("should extract a PMCID", function () {
+			var str = "PMCID: PMC5611655";
+			var { fields, extra } = Zotero.Utilities.Internal.extractExtraFields(str);
+			assert.equal(fields.size, 2);
+			assert.equal(fields.get('repository'), 'PubMed Central');
+			assert.equal(fields.get('archiveID'), 'PMC5611655');
+			assert.strictEqual(extra, '');
+		});
+
+		it("should prefix an unprefixed PMCID", function () {
+			var str = "PMCID: 5611655";
+			var { fields, extra } = Zotero.Utilities.Internal.extractExtraFields(str);
+			assert.equal(fields.size, 2);
+			assert.equal(fields.get('repository'), 'PubMed Central');
+			assert.equal(fields.get('archiveID'), 'PMC5611655');
+			assert.strictEqual(extra, '');
+		});
+
+		it("should leave unextracted ID in Extra", function () {
+			var str = "arXiv: 1604.01979";
+			var item = new Zotero.Item('book'); // Does not support archiveID
+			var { fields, extra } = Zotero.Utilities.Internal.extractExtraFields(str, item);
+			assert.equal(fields.size, 0);
+			assert.equal(extra, str);
+		});
+
+		it("should leave partially extracted ID in Extra", function () {
+			var str = "arXiv: 1604.01979";
+			var { fields, extra } = Zotero.Utilities.Internal.extractExtraFields(str, null, ['repository']);
+			assert.equal(fields.size, 1);
+			assert.equal(fields.get('archiveID'), 'arXiv:1604.01979');
+			assert.equal(extra, str);
+		});
+
+		it("should extract the first identifier and leave others in Extra", function () {
+			var str = "PMID: 16201210\nPMCID: PMC5611655";
+			var { fields, extra } = Zotero.Utilities.Internal.extractExtraFields(str);
+			assert.equal(fields.size, 2);
+			assert.equal(fields.get('repository'), 'PubMed');
+			assert.equal(fields.get('archiveID'), '16201210');
+			assert.equal(extra, str.split('\n')[1]);
 		});
 	});
 	


### PR DESCRIPTION
Archive ID extraction supports arXiv, PubMed, PMC, and ADS identifiers, but arXiv is probably the most useful as long as `archiveID` is limited to preprint items.

Includes two fixes to `extractExtraFields`. The creator type comparison bug [was actually being tested for](https://github.com/zotero/zotero/pull/2401/files#diff-22fa40cdad38325b1ab1013a8cc1c13a6f632c7351338d2dd4d18386bb94f9eaR223) in `utilities_internalTest`, but the intention [as stated in a comment above the comparison](https://github.com/zotero/zotero/pull/2401/files#diff-342a4df16afcea41459591dc0d91563fe5029c603c70803c75a4474c69a23c28R1334-R1335) was clear enough that I'm pretty sure it's right to go with that over the behavior expected by the test.

Fixes #2396.