### PR TITLE
Allow marking as different and batch merging in Duplicate Items

### DIFF
--- a/chrome/content/zotero/xpcom/data/items.js
+++ b/chrome/content/zotero/xpcom/data/items.js
@@ -960,8 +960,7 @@ Zotero.Items = function() {
 	this.merge = function (item, otherItems) {
 		Zotero.debug("Merging items");
 
-		return Zotero.DB.executeTransaction(async function () {
-			var replPred = Zotero.Relations.replacedItemPredicate;
+		return Zotero.DB.executeTransaction(async () => {
 			var toSave = {};
 			toSave[item.id] = item;
 			
@@ -1033,7 +1032,7 @@ Zotero.Items = function() {
 			for (let i in toSave) {
 				await toSave[i].save();
 			}
-		}.bind(this));
+		});
 	};
 
 

--- a/chrome/content/zotero/xpcom/data/items.js
+++ b/chrome/content/zotero/xpcom/data/items.js
@@ -1355,8 +1355,13 @@ Zotero.Items = function() {
 		Zotero.DB.requireTransaction();
 
 		let replPred = Zotero.Relations.replacedItemPredicate;
+		let diffPred = Zotero.Relations.differentItemPredicate;
 		let fromURI = Zotero.URI.getItemURI(fromItem);
 		let toURI = Zotero.URI.getItemURI(toItem);
+
+		// Remove all different-item relations pointing in either direction
+		fromItem.removeRelation(diffPred, toURI);
+		toItem.removeRelation(diffPred, fromURI);
 
 		// Add relations to toItem
 		let oldRelations = fromItem.getRelations();

--- a/chrome/content/zotero/xpcom/data/relations.js
+++ b/chrome/content/zotero/xpcom/data/relations.js
@@ -28,6 +28,7 @@
 Zotero.Relations = new function () {
 	Zotero.defineProperty(this, 'relatedItemPredicate', {value: 'dc:relation'});
 	Zotero.defineProperty(this, 'linkedObjectPredicate', {value: 'owl:sameAs'});
+	Zotero.defineProperty(this, 'differentItemPredicate', {value: 'owl:differentFrom'});
 	Zotero.defineProperty(this, 'replacedItemPredicate', {value: 'dc:replaces'});
 	
 	this._namespaces = {

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -964,6 +964,7 @@
 										</menupopup>
 									</menu>
 									<menuitem class="menuitem-iconic zotero-menuitem-remove-items" oncommand="ZoteroPane_Local.deleteSelectedItems();"/>
+									<menuitem class="menuitem-iconic zotero-menuitem-mark-as-different" label="&zotero.items.menu.markAsDifferent;" oncommand="ZoteroPane_Local.markSelectedItemsAsDifferent();"/>
 									<menuitem class="menuitem-iconic zotero-menuitem-duplicate-and-convert" oncommand="ZoteroPane_Local.duplicateAndConvertSelectedItem();"/>
 									<menuitem class="menuitem-iconic zotero-menuitem-duplicate-item" label="&zotero.items.menu.duplicateItem;" oncommand="ZoteroPane_Local.duplicateSelectedItem().done();"/>
 									<menuitem class="menuitem-iconic zotero-menuitem-restore-to-library" label="&zotero.items.menu.restoreToLibrary;" oncommand="ZoteroPane_Local.restoreSelectedItems();"/>

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -971,6 +971,12 @@
 									<menuitem class="menuitem-iconic zotero-menuitem-move-to-trash" oncommand="ZoteroPane_Local.deleteSelectedItems(true, true);"/>
 									<menuitem class="menuitem-iconic zotero-menuitem-delete-from-lib" oncommand="ZoteroPane_Local.deleteSelectedItems(false, true)"/>
 									<menuitem class="menuitem-iconic zotero-menuitem-merge-items" label="&zotero.items.menu.mergeItems;" oncommand="ZoteroPane_Local.mergeSelectedItems();"/>
+									<menu class="menuitem-iconic zotero-menuitem-merge-all-duplicates" label="&zotero.items.menu.mergeAllDuplicates;">
+										<menupopup id="zotero-merge-all-duplicates-popup">
+											<menuitem label="&zotero.items.menu.mergeAllDuplicates.intoNewest;" oncommand="ZoteroPane_Local.mergeAllDuplicates('dateAdded', true)"/>
+											<menuitem label="&zotero.items.menu.mergeAllDuplicates.intoOldest;" oncommand="ZoteroPane_Local.mergeAllDuplicates('dateAdded', false)"/>
+										</menupopup>
+									</menu>
 									<menuseparator/>
 									<menuitem class="menuitem-iconic zotero-menuitem-export" oncommand="Zotero_File_Interface.exportItems();"/>
 									<menuitem class="menuitem-iconic zotero-menuitem-create-bibliography" oncommand="Zotero_File_Interface.bibliographyFromItems();"/>

--- a/chrome/locale/en-US/zotero/zotero.dtd
+++ b/chrome/locale/en-US/zotero/zotero.dtd
@@ -74,6 +74,9 @@
 <!ENTITY zotero.items.menu.markAsDifferent				"Hide in Duplicate Items">
 <!ENTITY zotero.items.menu.duplicateItem					"Duplicate Item">
 <!ENTITY zotero.items.menu.mergeItems					"Merge Items…">
+<!ENTITY zotero.items.menu.mergeAllDuplicates			"Merge All Duplicates">
+<!ENTITY zotero.items.menu.mergeAllDuplicates.intoNewest "Into Newest Matching Item">
+<!ENTITY zotero.items.menu.mergeAllDuplicates.intoOldest "Into Oldest Matching Item">
 <!ENTITY zotero.items.menu.unrecognize                "Undo Retrieve Metadata">
 
 <!ENTITY zotero.duplicatesMerge.versionSelect			"Choose the version of the item to use as the master item:">

--- a/chrome/locale/en-US/zotero/zotero.dtd
+++ b/chrome/locale/en-US/zotero/zotero.dtd
@@ -71,6 +71,7 @@
 <!ENTITY zotero.items.menu.attach.fileLink				"Attach Link to File…">
 
 <!ENTITY zotero.items.menu.restoreToLibrary				"Restore to Library">
+<!ENTITY zotero.items.menu.markAsDifferent				"Hide in Duplicate Items">
 <!ENTITY zotero.items.menu.duplicateItem					"Duplicate Item">
 <!ENTITY zotero.items.menu.mergeItems					"Merge Items…">
 <!ENTITY zotero.items.menu.unrecognize                "Undo Retrieve Metadata">

--- a/test/tests/duplicatesTest.js
+++ b/test/tests/duplicatesTest.js
@@ -82,4 +82,26 @@ describe("Duplicate Items", function () {
 			assert.isTrue(collection2.hasItem(item1.id));
 		});
 	});
+
+	describe("Different-Item Relations", function () {
+		it("should prevent items from showing in Duplicate Items", async function () {
+			let item1 = await createDataObject('item', { setTitle: true });
+			let item2 = item1.clone();
+			await item2.saveTx();
+
+			item1.addRelation(Zotero.Relations.differentItemPredicate, Zotero.URI.getItemURI(item2));
+			item2.addRelation(Zotero.Relations.differentItemPredicate, Zotero.URI.getItemURI(item1));
+			await item1.saveTx();
+			await item2.saveTx();
+
+			let userLibraryID = Zotero.Libraries.userLibraryID;
+
+			let selected = await cv.selectByID('D' + userLibraryID);
+			assert.ok(selected);
+			await waitForItemsLoad(win);
+
+			let iv = zp.itemsView;
+			assert.equal(iv.rowCount, 0);
+		});
+	});
 });

--- a/test/tests/itemsTest.js
+++ b/test/tests/itemsTest.js
@@ -959,6 +959,37 @@ describe("Zotero.Items", function () {
 			assert.isFalse(attachment2.deleted);
 			assert.equal(attachment2.parentItemID, item1.id);
 		});
+
+		it("should remove different-item relations between items in the merge", async function () {
+			let diffPred = Zotero.Relations.differentItemPredicate;
+
+			let item1 = await createDataObject('item');
+			let item2 = await createDataObject('item');
+			let item3 = await createDataObject('item');
+
+			// Add different-item relations between all three
+			item1.addRelation(diffPred, Zotero.URI.getItemURI(item2));
+			item1.addRelation(diffPred, Zotero.URI.getItemURI(item3));
+			item2.addRelation(diffPred, Zotero.URI.getItemURI(item1));
+			item2.addRelation(diffPred, Zotero.URI.getItemURI(item3));
+			item3.addRelation(diffPred, Zotero.URI.getItemURI(item1));
+			item3.addRelation(diffPred, Zotero.URI.getItemURI(item2));
+
+			// But we only merge the first two
+			await Zotero.Items.merge(item1, [item2]);
+
+			let rels1 = item1.getRelationsByPredicate(diffPred);
+			let rels2 = item2.getRelationsByPredicate(diffPred);
+			let rels3 = item3.getRelationsByPredicate(diffPred);
+			assert.lengthOf(rels1, 1);
+			assert.lengthOf(rels2, 1);
+			assert.lengthOf(rels3, 2);
+
+			assert.equal(rels1[0], Zotero.URI.getItemURI(item3));
+			assert.equal(rels2[0], Zotero.URI.getItemURI(item3));
+			assert.equal(rels3[0], Zotero.URI.getItemURI(item1));
+			assert.equal(rels3[1], Zotero.URI.getItemURI(item2));
+		});
 	})
 	
 	


### PR DESCRIPTION
I'm not dead-set on "Hide in Duplicate Items" for marking items as different, but I like it because it's self-explanatory, even though it isn't really a great description of what's happening behind the scenes. I also thought about just "Mark as Different," but it's not especially self-explanatory. "Ignore Duplicates" doesn't feel quite right either, since I feel like it implies ignoring duplicates in _general_.

If you have two items that are detected as duplicates, mark them as non-duplicates, then add a third that also gets detected as a duplicate in the same set, the first two will reappear along with the third in Duplicate Items. I don't know if that's the best behavior, but it's kind of inherent to the relation-based approach - the first two are correctly detected as duplicates of the third, and there's no relation saying they aren't.

Fixes #1122, fixes #898.