### PR TITLE
Fix log spam when library hasn't been synced

### DIFF
--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -2362,7 +2362,7 @@ var ZoteroPane = new function()
 				|| Zotero.Prefs.get('sync.autoSync')
 				|| Zotero.Libraries.getAll()
 					.every(library => !library.syncable
-						|| library.lastSync.getTime() > Date.now() - 1000 * sevenDays)) {
+						|| library.lastSync?.getTime() > Date.now() - 1000 * sevenDays)) {
 			return;
 		}
 


### PR DESCRIPTION
This happens a lot during tests - `library.lastSync` is null, so `showAutoSyncReminder()` throws. It doesn't fail tests but it does spam the log.