### PR TITLE
Item Tree: Attempt to fix OS font scaling

### DIFF
--- a/chrome/content/zotero/components/virtualized-table.jsx
+++ b/chrome/content/zotero/components/virtualized-table.jsx
@@ -284,15 +284,8 @@ class VirtualizedTable extends React.Component {
 		this._columns = new Columns(this);
 		
 		this._renderedTextHeight = this._getRenderedTextHeight();
-		this._rowHeight = props.linesPerRow * this._renderedTextHeight;
-		if (!props.disableFontSizeScaling) {
-			this._rowHeight *= Zotero.Prefs.get('fontSize');
-		}
-		this._rowHeight += 2;
-		this._rowHeight = Math.max(MINIMUM_ROW_HEIGHT, this._rowHeight);
-		
+		this._rowHeight = this._getRowHeight();
 		this.selection = new TreeSelection(this);
-		
 
 		// Due to how the Draggable element works dragging (for column dragging and for resizing)
 		// is not handled via React events but via native ones attached on `document`
@@ -1215,12 +1208,7 @@ class VirtualizedTable extends React.Component {
 				+ "disabled. Change the prop instead.");
 			return;
 		}
-		this._rowHeight = this.props.linesPerRow * this._renderedTextHeight;
-		if (!this.props.disableFontSizeScaling) {
-			this._rowHeight *= Zotero.Prefs.get('fontSize');
-		}
-		this._rowHeight += 2;
-		this._rowHeight = Math.max(MINIMUM_ROW_HEIGHT, this._rowHeight);
+		this._rowHeight = this._getRowHeight();
 		
 		if (!this._jsWindow) return;
 		this._jsWindow.update(this._getWindowedListOptions());
@@ -1228,6 +1216,17 @@ class VirtualizedTable extends React.Component {
 		this._jsWindow.invalidate();
 	}
 	
+	_getRowHeight() {
+		let rowHeight = this.props.linesPerRow * this._renderedTextHeight;
+		if (!this.props.disableFontSizeScaling) {
+			rowHeight *= Zotero.Prefs.get('fontSize');
+		}
+		// padding
+		rowHeight *= 1.4;
+		rowHeight = Math.round(Math.max(MINIMUM_ROW_HEIGHT, rowHeight));
+		return rowHeight;
+	}
+
 	_getRenderedTextHeight() {
 		let div = document.createElementNS("http://www.w3.org/1999/xhtml", 'div');
 		div.style.visibility = "hidden";

--- a/scss/components/_virtualized-table.scss
+++ b/scss/components/_virtualized-table.scss
@@ -234,7 +234,7 @@
 	overflow: auto;
 
 	.cell {
-		padding: 2px 5px;
+		padding: 0 5px;
 		text-overflow: ellipsis;
 		overflow: hidden;
 		max-height: 100%;

--- a/scss/mac/_virtualized-table.scss
+++ b/scss/mac/_virtualized-table.scss
@@ -23,13 +23,10 @@
 
 .virtualized-table-body, .drag-image-container{
 	.cell:not(:first-child) {
-		border-inline-start: 1px solid #ddd;
-		
-		// A hack to make empty cells have a content, otherwise the border applied
-		// above has a height of a few pixels in empty cells.
-		&::after {
-			content: " ";
-			border-inline-start: 1px solid transparent;
-		}
+		background-image: linear-gradient(#ddd, #ddd);
+		background-size: 1px 80%;
+		background-position: left;
+		background-repeat: no-repeat;
+		height: 100%;
 	}
 }


### PR DESCRIPTION
Closes #2381, closes #2450

A slight rethinking to the way row heights are specified for the item tree. They will now be specified in multiples of lines of text we expect to render for whatever the CSS and then OS-level font-scaling expected rendered font size for the tree rows is. The default is 1 line of text per one row. This is required to deal with OS-level font-scaling. A side effect of this is that row-heights may be slightly different for different font-sizes (as chosen in the Zotero interface) when compared to before with the XUL tree. I've also set a minimum row height of 20px. Tested on all platforms and looks fine to me.