### PR TITLE
Citavi import: Tweak how page label is determined

### DIFF
--- a/chrome/content/zotero/import/citavi.js
+++ b/chrome/content/zotero/import/citavi.js
@@ -52,7 +52,6 @@ const ImportCitaviAnnotatons = async (translation) => {
 		const createdOn = xpathTextOrNull(knowledgeItem, './CreatedOn');
 		const modifiedOn = xpathTextOrNull(knowledgeItem, './ModifiedOn');
 		const coreStatement = xpathTextOrNull(knowledgeItem, './CoreStatement');
-		const pageRange = xpathTextOrNull(knowledgeItem, './PageRange');
 		const quotationType = xpathTextOrNull(knowledgeItem, './QuotationType');
 		const text = xpathTextOrNull(knowledgeItem, './Text');
 		const itemID = IDMap[referenceID];
@@ -95,7 +94,6 @@ const ImportCitaviAnnotatons = async (translation) => {
 				comment: isFirstPage ? coreStatement : '',
 				text: isFirstPage ? text : '',
 				position: { pageIndex, rects: pageRects },
-				pageLabel: pageRange || '',
 				dateAdded: createdOn,
 				dateModified: modifiedOn,
 				tags: keywords.map(keyword => ({ name: keyword }))

--- a/test/tests/data/citavi-test-project.ctv6
+++ b/test/tests/data/citavi-test-project.ctv6
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<CitaviExchangeData Version="6.11.0.0" ConnectionIdentifier="citavi-test-project.ctv6" Changeset="10">
+<CitaviExchangeData Version="6.11.0.0" ConnectionIdentifier="test-project-v2.ctv6" Changeset="2">
   <ProjectSettings>
     <AttachmentsFolderPath></AttachmentsFolderPath>
     <ColorScheme><![CDATA[Blue]]></ColorScheme>
@@ -61,10 +61,10 @@
     </CustomFields>
     <Description><![CDATA[]]></Description>
     <IsUtc>true</IsUtc>
-    <LastChangeTime>18/02/2022 18:26:19</LastChangeTime>
+    <LastChangeTime>30/03/2022 12:23:58</LastChangeTime>
   </ProjectSettings>
   <ProjectUserSettings>
-    <LastReferenceId>26ab57d9-2082-4978-bdd2-323e1889381e</LastReferenceId>
+    <LastReferenceId>e54210c0-4909-4113-b0fe-2a3eddb41cb9</LastReferenceId>
     <ShowCategoryClassification>true</ShowCategoryClassification>
     <SortOrder>
       <SortProperty>
@@ -112,7 +112,7 @@
     </SortOrderImport>
   </ProjectUserSettings>
   <Keywords>
-    <Keyword id="b07dfd83-135c-4cb6-977b-864c0f59856d">
+    <Keyword id="7a9841cc-5800-4444-8e0a-b4bda7282fa5">
       <CreatedBy>_Vexli</CreatedBy>
       <CreatedOn>2022-02-18T17:25:29</CreatedOn>
       <ModifiedBy>_Vexli</ModifiedBy>
@@ -122,7 +122,7 @@
       <SortFullName>blue</SortFullName>
       <UniqueFullName>9b736a9739934a4acd0d222f5edab3ab0209f008</UniqueFullName>
     </Keyword>
-    <Keyword id="669dc1b6-694b-4eb8-95b2-2c4e8e2f9055">
+    <Keyword id="8e2887cd-7124-4278-b285-58bd0637a2ee">
       <CreatedBy>_Vexli</CreatedBy>
       <CreatedOn>2022-02-18T17:26:03</CreatedOn>
       <ModifiedBy>_Vexli</ModifiedBy>
@@ -132,7 +132,7 @@
       <SortFullName>comment</SortFullName>
       <UniqueFullName>60fcdfd0c330a0636db449998f8c8f58c7522826</UniqueFullName>
     </Keyword>
-    <Keyword id="c36f7ee8-02d1-49f2-9cd7-6c96e441542f">
+    <Keyword id="2db290bf-52e6-4475-95ea-077161c8e2d0">
       <CreatedBy>_Vexli</CreatedBy>
       <CreatedOn>2022-02-18T17:24:22</CreatedOn>
       <ModifiedBy>_Vexli</ModifiedBy>
@@ -144,7 +144,7 @@
     </Keyword>
   </Keywords>
   <Persons>
-    <Person id="840dd435-d9e6-4d49-84a8-be953b018194">
+    <Person id="3a7b2137-cfb8-4613-adf0-1762eba33929">
       <CreatedBy>_Vexli</CreatedBy>
       <CreatedOn>2022-02-18T17:24:05</CreatedOn>
       <ModifiedBy>_Vexli</ModifiedBy>
@@ -157,11 +157,11 @@
     </Person>
   </Persons>
   <References>
-    <Reference id="26ab57d9-2082-4978-bdd2-323e1889381e">
+    <Reference id="e54210c0-4909-4113-b0fe-2a3eddb41cb9">
       <CreatedBy>_Vexli</CreatedBy>
       <CreatedOn>2022-02-18T17:15:05</CreatedOn>
       <ModifiedBy>_Vexli</ModifiedBy>
-      <ModifiedOn>2022-02-18T17:24:05</ModifiedOn>
+      <ModifiedOn>2022-03-30T10:16:42</ModifiedOn>
       <AbstractComplexity>0</AbstractComplexity>
       <AbstractSourceTextFormat>0</AbstractSourceTextFormat>
       <CitationKeyUpdateType>0</CitationKeyUpdateType>
@@ -186,60 +186,69 @@
     </Reference>
   </References>
   <ReferenceAuthors>
-    <OnetoN>26ab57d9-2082-4978-bdd2-323e1889381e;840dd435-d9e6-4d49-84a8-be953b018194</OnetoN>
+    <OnetoN>e54210c0-4909-4113-b0fe-2a3eddb41cb9;3a7b2137-cfb8-4613-adf0-1762eba33929</OnetoN>
   </ReferenceAuthors>
   <Locations>
-    <Location id="06737ac8-3637-4534-9cb2-a1e551901ce7">
+    <Location id="724c9b68-c466-4c5f-a349-4d52d6b61419">
       <CreatedBy>_Vexli</CreatedBy>
       <CreatedOn>2022-02-18T17:17:22</CreatedOn>
       <ModifiedBy>_Vexli</ModifiedBy>
-      <ModifiedOn>2022-02-18T17:17:22</ModifiedOn>
+      <ModifiedOn>2022-03-30T10:16:42</ModifiedOn>
       <Address>{"$id":"1","$type":"SwissAcademic.Citavi.LinkedResource, SwissAcademic.Citavi","LinkedResourceType":1,"UriString":"recognizePDF_test_title.pdf","LinkedResourceStatus":8}</Address>
       <LocationType>0</LocationType>
       <PreviewBehaviour>0</PreviewBehaviour>
-      <ReferenceID>26ab57d9-2082-4978-bdd2-323e1889381e</ReferenceID>
+      <ReferenceID>e54210c0-4909-4113-b0fe-2a3eddb41cb9</ReferenceID>
     </Location>
   </Locations>
   <Annotations>
-    <Annotation id="f08dbaec-6e7e-41f6-b46b-5f9855cd93ac">
-      <CreatedBy>_Vexli</CreatedBy>
-      <CreatedOn>2022-02-18T17:24:15</CreatedOn>
-      <ModifiedBy>_Vexli</ModifiedBy>
-      <ModifiedOn>2022-02-18T17:24:15</ModifiedOn>
-      <LocationID>06737ac8-3637-4534-9cb2-a1e551901ce7</LocationID>
-      <Quads>[{"IsContainer":false,"PageIndex":1,"X1":230.20219999999998,"X2":275.47790585937497,"Y1":578.879472,"Y2":585.816528},{"IsContainer":true,"PageIndex":1,"X1":230.20219999999998,"X2":275.47790585937497,"Y1":578.879472,"Y2":585.816528}]</Quads>
-      <Visible>false</Visible>
-    </Annotation>
-    <Annotation id="7a8c8a33-5902-48f7-8f6d-03e91d852434">
-      <CreatedBy>_Vexli</CreatedBy>
-      <CreatedOn>2022-02-18T17:25:17</CreatedOn>
-      <ModifiedBy>_Vexli</ModifiedBy>
-      <ModifiedOn>2022-02-18T17:25:17</ModifiedOn>
-      <LocationID>06737ac8-3637-4534-9cb2-a1e551901ce7</LocationID>
-      <Quads>[{"IsContainer":false,"PageIndex":1,"X1":228.3353,"X2":461.75599999999912,"Y1":475.340598,"Y2":482.178702},{"IsContainer":false,"PageIndex":1,"X1":146.3,"X2":437.5108999999992,"Y1":463.840598,"Y2":470.678702},{"IsContainer":true,"PageIndex":1,"X1":146.3,"X2":461.75599999999912,"Y1":463.840598,"Y2":482.178702}]</Quads>
-      <Visible>false</Visible>
-    </Annotation>
-    <Annotation id="9d09af5e-a2bc-4188-a5be-8051cafa348c">
+    <Annotation id="b1b35e86-1ba7-410a-a7ed-474526d6a5bb">
       <CreatedBy>_Vexli</CreatedBy>
       <CreatedOn>2022-02-18T17:25:35</CreatedOn>
       <ModifiedBy>_Vexli</ModifiedBy>
       <ModifiedOn>2022-02-18T17:25:35</ModifiedOn>
-      <LocationID>06737ac8-3637-4534-9cb2-a1e551901ce7</LocationID>
+      <LocationID>724c9b68-c466-4c5f-a349-4d52d6b61419</LocationID>
       <Quads>[{"IsContainer":false,"PageIndex":1,"X1":254.51480000000004,"X2":316.46209999999974,"Y1":532.840598,"Y2":539.67870199999993},{"IsContainer":true,"PageIndex":1,"X1":254.51480000000004,"X2":316.46209999999974,"Y1":532.840598,"Y2":539.67870199999993}]</Quads>
       <Visible>false</Visible>
     </Annotation>
-    <Annotation id="73b76ed5-b1ec-433c-afdd-2f1a08168dd5">
+    <Annotation id="3dc77d5e-ad7f-4f28-a666-39e610027e36">
+      <CreatedBy>_Vexli</CreatedBy>
+      <CreatedOn>2022-02-18T17:24:15</CreatedOn>
+      <ModifiedBy>_Vexli</ModifiedBy>
+      <ModifiedOn>2022-02-18T17:24:15</ModifiedOn>
+      <LocationID>724c9b68-c466-4c5f-a349-4d52d6b61419</LocationID>
+      <Quads>[{"IsContainer":false,"PageIndex":1,"X1":230.20219999999998,"X2":275.47790585937497,"Y1":578.879472,"Y2":585.816528},{"IsContainer":true,"PageIndex":1,"X1":230.20219999999998,"X2":275.47790585937497,"Y1":578.879472,"Y2":585.816528}]</Quads>
+      <Visible>false</Visible>
+    </Annotation>
+    <Annotation id="7125732b-bf3f-4195-85ee-945cd2a0457c">
       <CreatedBy>_Vexli</CreatedBy>
       <CreatedOn>2022-02-18T17:25:56</CreatedOn>
       <ModifiedBy>_Vexli</ModifiedBy>
       <ModifiedOn>2022-02-18T17:25:56</ModifiedOn>
-      <LocationID>06737ac8-3637-4534-9cb2-a1e551901ce7</LocationID>
+      <LocationID>724c9b68-c466-4c5f-a349-4d52d6b61419</LocationID>
       <Quads>[{"IsContainer":false,"PageIndex":1,"X1":146.3,"X2":199.49469218750005,"Y1":429.340598,"Y2":436.178702},{"IsContainer":true,"PageIndex":1,"X1":146.3,"X2":199.49469218750005,"Y1":429.340598,"Y2":436.178702}]</Quads>
+      <Visible>false</Visible>
+    </Annotation>
+    <Annotation id="e23cf096-d249-4607-a16e-13885d42e44a">
+      <CreatedBy>_Vexli</CreatedBy>
+      <CreatedOn>2022-02-18T17:25:17</CreatedOn>
+      <ModifiedBy>_Vexli</ModifiedBy>
+      <ModifiedOn>2022-02-18T17:25:17</ModifiedOn>
+      <LocationID>724c9b68-c466-4c5f-a349-4d52d6b61419</LocationID>
+      <Quads>[{"IsContainer":false,"PageIndex":1,"X1":228.3353,"X2":461.75599999999912,"Y1":475.340598,"Y2":482.178702},{"IsContainer":false,"PageIndex":1,"X1":146.3,"X2":437.5108999999992,"Y1":463.840598,"Y2":470.678702},{"IsContainer":true,"PageIndex":1,"X1":146.3,"X2":461.75599999999912,"Y1":463.840598,"Y2":482.178702}]</Quads>
+      <Visible>false</Visible>
+    </Annotation>
+    <Annotation id="53af7081-5ae2-4a91-bee7-fd6f7e094413">
+      <CreatedBy>_Vexli</CreatedBy>
+      <CreatedOn>2022-03-30T10:15:37</CreatedOn>
+      <ModifiedBy>_Vexli</ModifiedBy>
+      <ModifiedOn>2022-03-30T10:15:37</ModifiedOn>
+      <LocationID>724c9b68-c466-4c5f-a349-4d52d6b61419</LocationID>
+      <Quads>[{"IsContainer":false,"PageIndex":3,"X1":133.3,"X2":185.2685,"Y1":330.92415,"Y2":340.29434999999995},{"IsContainer":true,"PageIndex":3,"X1":133.3,"X2":185.2685,"Y1":330.92415,"Y2":340.29434999999995}]</Quads>
       <Visible>false</Visible>
     </Annotation>
   </Annotations>
   <KnowledgeItems>
-    <KnowledgeItem id="6c72f24c-43dc-43d5-9e14-3a192fc9325c">
+    <KnowledgeItem id="b96887ad-e3cd-4861-b502-6bb002a91a0e">
       <CreatedBy>_Vexli</CreatedBy>
       <CreatedOn>2022-02-18T17:24:15</CreatedOn>
       <ModifiedBy>_Vexli</ModifiedBy>
@@ -250,14 +259,14 @@
       <PageRangeNumber>-1</PageRangeNumber>
       <QuotationIndex>0</QuotationIndex>
       <QuotationType>6</QuotationType>
-      <ReferenceID>26ab57d9-2082-4978-bdd2-323e1889381e</ReferenceID>
+      <ReferenceID>e54210c0-4909-4113-b0fe-2a3eddb41cb9</ReferenceID>
       <Relevance>0</Relevance>
       <SortFullName>peer-to-peer</SortFullName>
       <StaticIDs>["52cbbd8c-80d2-4848-9374-6b435d4719bf"]</StaticIDs>
       <TextSourceTextFormat>0</TextSourceTextFormat>
       <TextComplexity>0</TextComplexity>
     </KnowledgeItem>
-    <KnowledgeItem id="e5b80a60-344c-4b29-b888-e97205753567">
+    <KnowledgeItem id="de2dc289-fa66-4614-9ede-2c8abcb850d8">
       <CreatedBy>_Vexli</CreatedBy>
       <CreatedOn>2022-02-18T17:25:17</CreatedOn>
       <ModifiedBy>_Vexli</ModifiedBy>
@@ -268,7 +277,7 @@
       <PageRangeNumber>-1</PageRangeNumber>
       <QuotationIndex>1</QuotationIndex>
       <QuotationType>1</QuotationType>
-      <ReferenceID>26ab57d9-2082-4978-bdd2-323e1889381e</ReferenceID>
+      <ReferenceID>e54210c0-4909-4113-b0fe-2a3eddb41cb9</ReferenceID>
       <Relevance>0</Relevance>
       <SortFullName>cpu power is controlled by nodes that are …</SortFullName>
       <StaticIDs>["427b6a09-a648-4453-8317-d7735ec2e83e"]</StaticIDs>
@@ -276,7 +285,7 @@
       <Text>CPU power is controlled by nodes that are not cooperating to attack the network, they'll generate the longest chain and outpace attackers.</Text>
       <TextComplexity>0</TextComplexity>
     </KnowledgeItem>
-    <KnowledgeItem id="32954e21-0303-4365-9f17-ca967e9bb0c7">
+    <KnowledgeItem id="e319aee8-104b-4480-89ac-e4adf0407fb1">
       <CreatedBy>_Vexli</CreatedBy>
       <CreatedOn>2022-02-18T17:25:35</CreatedOn>
       <ModifiedBy>_Vexli</ModifiedBy>
@@ -286,14 +295,14 @@
       <PageRangeNumber>-1</PageRangeNumber>
       <QuotationIndex>2</QuotationIndex>
       <QuotationType>5</QuotationType>
-      <ReferenceID>26ab57d9-2082-4978-bdd2-323e1889381e</ReferenceID>
+      <ReferenceID>e54210c0-4909-4113-b0fe-2a3eddb41cb9</ReferenceID>
       <Relevance>0</Relevance>
       <SortFullName>_</SortFullName>
       <StaticIDs>["77efd7da-f246-44dd-80a2-82e9c372b267"]</StaticIDs>
       <TextSourceTextFormat>0</TextSourceTextFormat>
       <TextComplexity>0</TextComplexity>
     </KnowledgeItem>
-    <KnowledgeItem id="a113a66b-2c16-43e2-968c-e530ed9ac5eb">
+    <KnowledgeItem id="d14b7f83-8cda-4d70-a89f-95a9eca94903">
       <CreatedBy>_Vexli</CreatedBy>
       <CreatedOn>2022-02-18T17:25:56</CreatedOn>
       <ModifiedBy>_Vexli</ModifiedBy>
@@ -304,7 +313,7 @@
       <PageRangeNumber>-1</PageRangeNumber>
       <QuotationIndex>3</QuotationIndex>
       <QuotationType>4</QuotationType>
-      <ReferenceID>26ab57d9-2082-4978-bdd2-323e1889381e</ReferenceID>
+      <ReferenceID>e54210c0-4909-4113-b0fe-2a3eddb41cb9</ReferenceID>
       <Relevance>0</Relevance>
       <SortFullName>proof-of-work</SortFullName>
       <StaticIDs>["fab8e0a8-f7a6-4785-ad47-5da0d03d64b6"]</StaticIDs>
@@ -312,59 +321,97 @@
       <Text>This is a comment</Text>
       <TextComplexity>0</TextComplexity>
     </KnowledgeItem>
+    <KnowledgeItem id="87b7745e-4156-410a-83b5-678f1d22f7a4">
+      <CreatedBy>_Vexli</CreatedBy>
+      <CreatedOn>2022-03-30T10:15:37</CreatedOn>
+      <ModifiedBy>_Vexli</ModifiedBy>
+      <ModifiedOn>2022-03-30T10:23:56</ModifiedOn>
+      <CoreStatement>Network</CoreStatement>
+      <CoreStatementUpdateType>1</CoreStatementUpdateType>
+      <KnowledgeItemType>0</KnowledgeItemType>
+      <PageRange><![CDATA[<sp>
+  <ns>Omit</ns>
+  <os>gibberish</os>
+  <ps>gibberish</ps>
+</sp>
+<os>gibberish</os>]]></PageRange>
+      <PageRangeNumber>2147483647</PageRangeNumber>
+      <PageRangeNumeralSystem>100</PageRangeNumeralSystem>
+      <QuotationIndex>4</QuotationIndex>
+      <QuotationType>3</QuotationType>
+      <ReferenceID>e54210c0-4909-4113-b0fe-2a3eddb41cb9</ReferenceID>
+      <Relevance>0</Relevance>
+      <SortFullName>network</SortFullName>
+      <StaticIDs>["154047bb-c681-4ba3-898d-d39335ea8b8e"]</StaticIDs>
+      <TextSourceTextFormat>0</TextSourceTextFormat>
+      <Text>This is a green highlight on page 3</Text>
+      <TextComplexity>0</TextComplexity>
+    </KnowledgeItem>
   </KnowledgeItems>
   <KnowledgeItemKeywords>
-    <OnetoN>6c72f24c-43dc-43d5-9e14-3a192fc9325c;c36f7ee8-02d1-49f2-9cd7-6c96e441542f:0</OnetoN>
-    <OnetoN>e5b80a60-344c-4b29-b888-e97205753567;b07dfd83-135c-4cb6-977b-864c0f59856d:0</OnetoN>
-    <OnetoN>a113a66b-2c16-43e2-968c-e530ed9ac5eb;669dc1b6-694b-4eb8-95b2-2c4e8e2f9055:0</OnetoN>
+    <OnetoN>b96887ad-e3cd-4861-b502-6bb002a91a0e;2db290bf-52e6-4475-95ea-077161c8e2d0:0</OnetoN>
+    <OnetoN>de2dc289-fa66-4614-9ede-2c8abcb850d8;7a9841cc-5800-4444-8e0a-b4bda7282fa5:0</OnetoN>
+    <OnetoN>d14b7f83-8cda-4d70-a89f-95a9eca94903;8e2887cd-7124-4278-b285-58bd0637a2ee:0</OnetoN>
   </KnowledgeItemKeywords>
   <EntityLinks>
-    <EntityLink id="2e795435-2861-44e7-95b7-7ba1e2cf9703">
-      <CreatedBy>_Vexli</CreatedBy>
-      <CreatedOn>2022-02-18T17:24:15</CreatedOn>
-      <ModifiedBy>_Vexli</ModifiedBy>
-      <ModifiedOn>2022-02-18T17:24:15</ModifiedOn>
-      <Indication>PdfKnowledgeItem</Indication>
-      <RelationType>0</RelationType>
-      <SourceID>6c72f24c-43dc-43d5-9e14-3a192fc9325c</SourceID>
-      <SourceType>KnowledgeItem</SourceType>
-      <TargetID>f08dbaec-6e7e-41f6-b46b-5f9855cd93ac</TargetID>
-      <TargetType>Annotation</TargetType>
-    </EntityLink>
-    <EntityLink id="3d962eb6-2381-4e96-b9f5-36f0746ff3c5">
-      <CreatedBy>_Vexli</CreatedBy>
-      <CreatedOn>2022-02-18T17:25:17</CreatedOn>
-      <ModifiedBy>_Vexli</ModifiedBy>
-      <ModifiedOn>2022-02-18T17:25:17</ModifiedOn>
-      <Indication>PdfKnowledgeItem</Indication>
-      <RelationType>0</RelationType>
-      <SourceID>e5b80a60-344c-4b29-b888-e97205753567</SourceID>
-      <SourceType>KnowledgeItem</SourceType>
-      <TargetID>7a8c8a33-5902-48f7-8f6d-03e91d852434</TargetID>
-      <TargetType>Annotation</TargetType>
-    </EntityLink>
-    <EntityLink id="b9fd1a44-8c96-4e22-ae46-96a3ac06d554">
+    <EntityLink id="8b26de48-316e-4ebc-8005-8ac52a045bdf">
       <CreatedBy>_Vexli</CreatedBy>
       <CreatedOn>2022-02-18T17:25:35</CreatedOn>
       <ModifiedBy>_Vexli</ModifiedBy>
       <ModifiedOn>2022-02-18T17:25:35</ModifiedOn>
       <Indication>PdfKnowledgeItem</Indication>
       <RelationType>0</RelationType>
-      <SourceID>32954e21-0303-4365-9f17-ca967e9bb0c7</SourceID>
+      <SourceID>e319aee8-104b-4480-89ac-e4adf0407fb1</SourceID>
       <SourceType>KnowledgeItem</SourceType>
-      <TargetID>9d09af5e-a2bc-4188-a5be-8051cafa348c</TargetID>
+      <TargetID>b1b35e86-1ba7-410a-a7ed-474526d6a5bb</TargetID>
       <TargetType>Annotation</TargetType>
     </EntityLink>
-    <EntityLink id="7e6d73f3-1386-4f0e-a282-a6cf9b676feb">
+    <EntityLink id="e367d9fb-4088-4eb3-8da7-10484c4e49d7">
+      <CreatedBy>_Vexli</CreatedBy>
+      <CreatedOn>2022-02-18T17:24:15</CreatedOn>
+      <ModifiedBy>_Vexli</ModifiedBy>
+      <ModifiedOn>2022-02-18T17:24:15</ModifiedOn>
+      <Indication>PdfKnowledgeItem</Indication>
+      <RelationType>0</RelationType>
+      <SourceID>b96887ad-e3cd-4861-b502-6bb002a91a0e</SourceID>
+      <SourceType>KnowledgeItem</SourceType>
+      <TargetID>3dc77d5e-ad7f-4f28-a666-39e610027e36</TargetID>
+      <TargetType>Annotation</TargetType>
+    </EntityLink>
+    <EntityLink id="6d3444a8-fad8-4df0-887c-934b9272da0a">
       <CreatedBy>_Vexli</CreatedBy>
       <CreatedOn>2022-02-18T17:25:56</CreatedOn>
       <ModifiedBy>_Vexli</ModifiedBy>
       <ModifiedOn>2022-02-18T17:25:56</ModifiedOn>
       <Indication>PdfKnowledgeItem</Indication>
       <RelationType>0</RelationType>
-      <SourceID>a113a66b-2c16-43e2-968c-e530ed9ac5eb</SourceID>
+      <SourceID>d14b7f83-8cda-4d70-a89f-95a9eca94903</SourceID>
       <SourceType>KnowledgeItem</SourceType>
-      <TargetID>73b76ed5-b1ec-433c-afdd-2f1a08168dd5</TargetID>
+      <TargetID>7125732b-bf3f-4195-85ee-945cd2a0457c</TargetID>
+      <TargetType>Annotation</TargetType>
+    </EntityLink>
+    <EntityLink id="ba09076d-d622-4132-ad60-4cba7caa4148">
+      <CreatedBy>_Vexli</CreatedBy>
+      <CreatedOn>2022-02-18T17:25:17</CreatedOn>
+      <ModifiedBy>_Vexli</ModifiedBy>
+      <ModifiedOn>2022-02-18T17:25:17</ModifiedOn>
+      <Indication>PdfKnowledgeItem</Indication>
+      <RelationType>0</RelationType>
+      <SourceID>de2dc289-fa66-4614-9ede-2c8abcb850d8</SourceID>
+      <SourceType>KnowledgeItem</SourceType>
+      <TargetID>e23cf096-d249-4607-a16e-13885d42e44a</TargetID>
+      <TargetType>Annotation</TargetType>
+    </EntityLink>
+    <EntityLink id="8eb91a94-3747-4493-a235-111d50544c5d">
+      <CreatedBy>_Vexli</CreatedBy>
+      <CreatedOn>2022-03-30T10:15:37</CreatedOn>
+      <ModifiedBy>_Vexli</ModifiedBy>
+      <ModifiedOn>2022-03-30T10:15:37</ModifiedOn>
+      <Indication>PdfKnowledgeItem</Indication>
+      <RelationType>0</RelationType>
+      <SourceID>87b7745e-4156-410a-83b5-678f1d22f7a4</SourceID>
+      <SourceType>KnowledgeItem</SourceType>
+      <TargetID>53af7081-5ae2-4a91-bee7-fd6f7e094413</TargetID>
       <TargetType>Annotation</TargetType>
     </EntityLink>
   </EntityLinks>

--- a/test/tests/fileInterfaceTest.js
+++ b/test/tests/fileInterfaceTest.js
@@ -233,35 +233,56 @@ describe("Zotero_File_Interface", function() {
 			assert.equal(importedItem.getField('title'), 'Bitcoin: A Peer-to-Peer Electronic Cash System');
 			const importedPDF = await Zotero.Items.getAsync(importedItem.getAttachments()[0]);
 			const annotations = importedPDF.getAnnotations();
-			assert.lengthOf(annotations, 4);
-			const annotationTexts = importedPDF.getAnnotations().map(a => a.annotationText);
-			const annotationPositions = importedPDF.getAnnotations().map(a => JSON.parse(a.annotationPosition));
-			const annotationSortIndexes = importedPDF.getAnnotations().map(a => a.annotationSortIndex);
-			const annotationTags = importedPDF.getAnnotations().map(a => a.getTags());
-			
-			assert.sameMembers(annotationTexts, [
-				'peer-to-peer',
-				'CPU power is controlled by nodes that are not cooperating to attack the network, they\'ll generate the longest chain and outpace attackers.',
-				'double-spending',
-				'This is a comment'
-			]);
-			assert.sameMembers(annotationSortIndexes, [
-				'00000|000103|00206',
-				'00000|000723|00309',
-				'00000|000390|00252',
-				'00000|000981|00355'
-			]);
+			assert.lengthOf(annotations, 5);
 
-			assert.sameDeepMembers(annotationPositions, [
-				{ pageIndex: 0, rects: [[230.202, 578.879, 275.478, 585.817], [230.202, 578.879, 275.478, 585.817]] },
-				{ pageIndex: 0, rects: [[254.515, 532.841, 316.462, 539.679], [254.515, 532.841, 316.462, 539.679]] },
+			const annotation1 = annotations.find(a => a.annotationText === 'peer-to-peer');
+			const annotation2 = annotations.find(a => a.annotationText === 'CPU power is controlled by nodes that are not cooperating to attack the network, they\'ll generate the longest chain and outpace attackers.');
+			const annotation3 = annotations.find(a => a.annotationText === 'double-spending');
+			const annotation4 = annotations.find(a => a.annotationText === 'This is a comment');
+			const annotation5 = annotations.find(a => a.annotationText === 'This is a green highlight on page 3');
+
+			assert.deepEqual(
+				JSON.parse(annotation1.annotationPosition),
+				{ pageIndex: 0, rects: [[230.202, 578.879, 275.478, 585.817], [230.202, 578.879, 275.478, 585.817]] }
+			);
+
+			assert.deepEqual(
+				JSON.parse(annotation2.annotationPosition),
 				{ pageIndex: 0, rects: [[228.335, 475.341, 461.756, 482.179], [146.3, 463.841, 437.511, 470.679], [146.3, 463.841, 461.756, 482.179]] },
-				{ pageIndex: 0, rects: [[146.3, 429.341, 199.495, 436.179], [146.3, 429.341, 199.495, 436.179]] }
-			]);
+			);
 
-			assert.sameDeepMembers(annotationTags, [
-				[{ tag: 'red' }], [], [{ tag: 'blue' }], [{ tag: 'comment' }]
-			]);
+			assert.deepEqual(
+				JSON.parse(annotation3.annotationPosition),
+				{ pageIndex: 0, rects: [[254.515, 532.841, 316.462, 539.679], [254.515, 532.841, 316.462, 539.679]] },
+			);
+
+			assert.deepEqual(
+				JSON.parse(annotation4.annotationPosition),
+				{ pageIndex: 0, rects: [[146.3, 429.341, 199.495, 436.179], [146.3, 429.341, 199.495, 436.179]] }
+			);
+
+			assert.deepEqual(
+				JSON.parse(annotation5.annotationPosition),
+				{ pageIndex: 2, rects: [[133.3, 330.924, 185.269, 340.294], [133.3, 330.924, 185.269, 340.294]] }
+			);
+
+			assert.equal(annotation1.annotationSortIndex, '00000|000103|00206');
+			assert.equal(annotation2.annotationSortIndex, '00000|000723|00309');
+			assert.equal(annotation3.annotationSortIndex, '00000|000390|00252');
+			assert.equal(annotation4.annotationSortIndex, '00000|000981|00355');
+			assert.equal(annotation5.annotationSortIndex, '00002|001638|00451');
+
+			assert.deepEqual(annotation1.getTags(), [{ tag: 'red' }]);
+			assert.deepEqual(annotation2.getTags(), [{ tag: 'blue' }]);
+			assert.deepEqual(annotation3.getTags(), []);
+			assert.deepEqual(annotation4.getTags(), [{ tag: 'comment' }]);
+			assert.deepEqual(annotation5.getTags(), []);
+
+			assert.equal(annotation1.annotationPageLabel, '1');
+			assert.equal(annotation2.annotationPageLabel, '1');
+			assert.equal(annotation3.annotationPageLabel, '1');
+			assert.equal(annotation4.annotationPageLabel, '1');
+			assert.equal(annotation5.annotationPageLabel, '3');
 		});
 	});
 });


### PR DESCRIPTION
Instead of attempting to extract `PageRange` value we now let pdf-worker always determine page label.

Also improved citavi tests and fixtures.