### PR TITLE
Remove "Store Annotations in File" option

### DIFF
--- a/chrome/content/zotero/standalone/standalone.js
+++ b/chrome/content/zotero/standalone/standalone.js
@@ -166,13 +166,10 @@ const ZoteroStandalone = new function() {
 					&& !(item.deleted || item.parentItem && item.parentItem.deleted)) {
 				let annotations = item.getAnnotations();
 				let canTransferFromPDF = annotations.find(x => x.annotationIsExternal);
-				let canTransferToPDF = annotations.find(x => !x.annotationIsExternal);
 				this.updateMenuItemEnabled('menu_transferFromPDF', canTransferFromPDF);
-				this.updateMenuItemEnabled('menu_transferToPDF', canTransferToPDF);
 			}
 			else {
 				this.updateMenuItemEnabled('menu_transferFromPDF', false);
-				this.updateMenuItemEnabled('menu_transferToPDF', false);
 			}
 		}
 		

--- a/chrome/content/zotero/standalone/standalone.xul
+++ b/chrome/content/zotero/standalone/standalone.xul
@@ -160,12 +160,6 @@
 								label="&zotero.pdfReader.transferFromPDF;"
 								oncommand="ZoteroStandalone.onReaderCmd('transferFromPDF')"
 							/>
-							<menuitem
-								id="menu_transferToPDF"
-								class="menu-type-reader"
-								label="&zotero.pdfReader.transferToPDF;"
-								oncommand="ZoteroStandalone.onReaderCmd('transferToPDF')"
-							/>
 							<menuseparator class="menu-type-reader"/>
 							<menuitem id="menu_export_file" class="menu-type-reader"
 									label="&zotero.general.saveAs;"

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -231,23 +231,14 @@ class ReaderInstance {
 		return true;
 	}
 
-	promptToTransferAnnotations(fromPDF) {
+	promptToTransferAnnotations() {
 		let ps = Services.prompt;
 		let buttonFlags = ps.BUTTON_POS_0 * ps.BUTTON_TITLE_IS_STRING
 			+ ps.BUTTON_POS_1 * ps.BUTTON_TITLE_CANCEL;
 		let index = ps.confirmEx(
 			null,
-			Zotero.getString(
-				fromPDF
-					? 'pdfReader.promptTransferFromPDF.title'
-					: 'pdfReader.promptTransferToPDF.title'
-			),
-			Zotero.getString(
-				fromPDF
-					? 'pdfReader.promptTransferFromPDF.text'
-					: 'pdfReader.promptTransferToPDF.text',
-				Zotero.appName
-			),
+			Zotero.getString('pdfReader.promptTransferFromPDF.title'),
+			Zotero.getString('pdfReader.promptTransferFromPDF.text', Zotero.appName),
 			buttonFlags,
 			Zotero.getString('general.continue'),
 			null, null, null, {}
@@ -268,21 +259,6 @@ class ReaderInstance {
 					}
 					throw e;
 				}
-			}
-		}
-		else if (cmd === 'transferToPDF') {
-			if (this.promptToTransferAnnotations(false)) {
-				try {
-					await Zotero.PDFWorker.export(this._itemID, null, true, '', true);
-				}
-				catch (e) {
-					if (e.name === 'PasswordException') {
-						Zotero.alert(null, Zotero.getString('general.error'),
-							Zotero.getString('pdfReader.promptPasswordProtected'));
-					}
-					throw e;
-				}
-				await Zotero.PDFWorker.import(this._itemID, true);
 			}
 		}
 		else if (cmd === 'export') {

--- a/chrome/locale/en-US/zotero/zotero.dtd
+++ b/chrome/locale/en-US/zotero/zotero.dtd
@@ -325,4 +325,3 @@
 <!ENTITY zotero.pdfReader.zoomAuto							"Automatically Resize">
 <!ENTITY zotero.pdfReader.zoomPageWidth						"Zoom to Page Width">
 <!ENTITY zotero.pdfReader.transferFromPDF					"Import Annotations…">
-<!ENTITY zotero.pdfReader.transferToPDF						"Store Annotations in File…">


### PR DESCRIPTION
This is a confusing, bad option, which was already disabled in groups,
and this removes it from personal libraries as well. People seem to be
using it mainly because they think annotations are locked into Zotero if
they don't, which is causing them to ask for this to be done
automatically on every edit, which we don't do because it would result
in constant file syncing and file conflicts [1].

We provide multiple export options for exporting PDFs with annotations,
and people can use those when sharing a file with people who don't use
Zotero. Otherwise, if storing annotations in the file is a priority,
they can use an external reader that's not designed to be tightly
integrated into Zotero.

(As a rare hack, it's of course also possible to export the PDF with
annotations, replace the original file, and import the annotations.)

[1] https://www.zotero.org/support/kb/annotations_in_database