### PR TITLE
Fix double separator in Edit menu on Win/Linux

### DIFF
--- a/chrome/content/zotero/standalone/standalone.xul
+++ b/chrome/content/zotero/standalone/standalone.xul
@@ -225,7 +225,7 @@
 									label="&zotero.toolbar.advancedSearch;"
 									command="cmd_zotero_advancedSearch"
 									key="key_advancedSearch"/>
-							<menuseparator class="menu-type-library" hidden="true" id="textfieldDirection-separator"/>
+							<menuseparator hidden="true" id="textfieldDirection-separator"/>
 							<menuitem id="textfieldDirection-swap"
 									command="cmd_switchTextDirection"
 									key="key_switchTextDirection"


### PR DESCRIPTION
Hides one of the two separators above Preferences:

<img width="256" alt="image" src="https://user-images.githubusercontent.com/1770299/161640199-fbe51283-f111-4ed8-bbab-cc3addfef8fa.png">

`menu-type-library` would automatically show the `menuseparator` in the library tab, but the `textfieldDirection-swap` menuitem below it is never shown (and currently seems to be unused).