### PR TITLE
Allow creating and editing tables in note-editor

### DIFF
--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -1352,6 +1352,14 @@ noteEditor.applyAnnotationColors = Show Annotation Colors
 noteEditor.removeAnnotationColors = Hide Annotation Colors
 noteEditor.addCitations = Show Annotation Citations
 noteEditor.removeCitations = Hide Annotation Citations
+noteEditor.insertTable = Insert Table
+noteEditor.insertRowBefore = Insert Row Above
+noteEditor.insertRowAfter = Insert Row Below
+noteEditor.insertColumnBefore = Insert Column Left
+noteEditor.insertColumnAfter = Insert Column Right
+noteEditor.deleteRow = Delete Row
+noteEditor.deleteColumn = Delete Column
+noteEditor.deleteTable = Delete Table
 
 pdfReader.annotations = Annotations
 pdfReader.showAnnotations = Show Annotations

--- a/chrome/skin/default/zotero/report/detail.css
+++ b/chrome/skin/default/zotero/report/detail.css
@@ -170,3 +170,21 @@ ul.attachments div.note {
 ul.attachments div.note p:first-child {
 	margin-top: .75em;
 }
+
+div table {
+	border-collapse: collapse;
+}
+
+div table td, div table th {
+	border: 1px #ccc solid;
+	border-collapse: collapse;
+}
+
+
+div table td *:first-child, div table th *:first-child {
+	margin-top: 0;
+}
+
+div table td *:last-child, div table th *:last-child {
+	margin-bottom: 0;
+}


### PR DESCRIPTION
Currently only row/column insertion/deletion is supported. Probably no need to hurry with advanced features like merging/splitting cells, setting table header.

I took some inspiration from Google Docs for the table context menu.

You will probably see displaced table resizing handles, the first time when you open a note with table and focus the table. That's Firefox bug, and resizing handles are completely disabled from Firefox 64. That might be very time consuming to work around, therefore I'm leaving this unfixed. Maybe we could do something with prefs…

Fixes #2480