### PR TITLE
Prompt to finish login when closing preferences

### DIFF
--- a/chrome/content/zotero/preferences/preferences.js
+++ b/chrome/content/zotero/preferences/preferences.js
@@ -84,6 +84,19 @@ var Zotero_Preferences = {
 		if (Zotero_Preferences.Debug_Output) {
 			Zotero_Preferences.Debug_Output.onUnload();
 		}
+
+		if (Zotero.isMac && Zotero_Preferences.Sync.hasUnsubmittedSyncCredentials()) {
+			Zotero_Preferences.Sync.promptToSubmitSyncCredentials(true);
+		}
+	},
+
+	onDialogAccept: function () {
+		if (!Zotero.isMac && Zotero_Preferences.Sync.hasUnsubmittedSyncCredentials()) {
+			Zotero_Preferences.Sync.promptToSubmitSyncCredentials(false);
+			return false;
+		}
+
+		return true;
 	},
 	
 	openURL: function (url, windowName) {

--- a/chrome/content/zotero/preferences/preferences.xul
+++ b/chrome/content/zotero/preferences/preferences.xul
@@ -42,6 +42,7 @@
 		title="&zotero.preferences.title;"
 		onload="Zotero_Preferences.init()"
 		onunload="Zotero_Preferences.onUnload()"
+		ondialogaccept="return Zotero_Preferences.onDialogAccept(event)"
 		ondialoghelp="Zotero_Preferences.openHelpLink()"
 		windowtype="zotero:pref"
 		xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">

--- a/chrome/content/zotero/preferences/preferences_sync.jsx
+++ b/chrome/content/zotero/preferences/preferences_sync.jsx
@@ -38,6 +38,7 @@ var { renderCell } = VirtualizedTable;
 Zotero_Preferences.Sync = {
 	checkmarkChar: '\u2705',
 	noChar: '\uD83D\uDEAB',
+	syncCredentialsPromptDisplayed: false,
 	
 	init: Zotero.Promise.coroutine(function* () {
 		this.updateStorageSettingsUI();
@@ -77,6 +78,20 @@ Zotero_Preferences.Sync = {
 		}
 		
 		this.initResetPane();
+
+		if (window.arguments) {
+			let io = window.arguments[0];
+			io = io.wrappedJSObject || io;
+			if (io.action?.setUpSyncing) {
+				document.getElementById('sync-username-textbox').value
+					= io.action.setUpSyncing.username;
+				document.getElementById('sync-password').value
+					= io.action.setUpSyncing.password;
+				this.credentialsChange();
+				this.linkAccount();
+				this.syncCredentialsPromptDisplayed = true;
+			}
+		}
 	}),
 	
 	displayFields: function (username) {
@@ -875,6 +890,49 @@ Zotero_Preferences.Sync = {
 			
 			default:
 				throw new Error(`Invalid action '${action}' in handleSyncReset()`);
+		}
+	},
+
+
+	hasUnsubmittedSyncCredentials: function () {
+		if (this.syncCredentialsPromptDisplayed || Zotero.Sync.Data.Local.hasCredentials()) {
+			return false;
+		}
+
+		let username = document.getElementById('sync-username-textbox').value;
+		let password = document.getElementById('sync-password').value;
+		return !!(username && password);
+	},
+
+
+	promptToSubmitSyncCredentials: function (promptInMainWindow) {
+		let username = document.getElementById('sync-username-textbox').value;
+		let password = document.getElementById('sync-password').value;
+
+		function prompt(targetWindow) {
+			let ps = Services.prompt;
+			let ok = ps.confirm(targetWindow,
+				Zotero.getString('account.submitCredentialsPrompt.title'),
+				Zotero.getString('account.submitCredentialsPrompt', Zotero.appName)
+			);
+			if (ok) {
+				Zotero.Utilities.Internal.openPreferences('zotero-prefpane-sync', {
+					action: {
+						setUpSyncing: { username, password }
+					}
+				});
+			}
+			else if (!promptInMainWindow) {
+				window.close();
+			}
+		}
+
+		if (promptInMainWindow) {
+			let mainWindow = Zotero.getMainWindow();
+			mainWindow.setTimeout(() => prompt(mainWindow), 1000); // 1s delay so it isn't abrupt
+		}
+		else {
+			prompt(window);
 		}
 	}
 };

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -1048,6 +1048,9 @@ account.lastSyncWithDifferentAccount.beforeContinuing = Before continuing, make 
 account.confirmDelete					= Remove all data for “%S” from this computer
 account.confirmDelete.button			= Switch Accounts
 
+account.submitCredentialsPrompt.title	= Finish Setup
+account.submitCredentialsPrompt			= You entered %S account credentials but did not finish setting up syncing. Log in with the credentials you entered?
+
 sync.conflict.autoChange.alert			= One or more locally deleted Zotero %S have been modified remotely since the last sync.
 sync.conflict.autoChange.log			= A Zotero %S has changed both locally and remotely since the last sync:
 sync.conflict.remoteVersionsKept 		= The remote versions have been kept.


### PR DESCRIPTION
Different behavior on different platforms:

- On Windows and Linux, the prompt shows when the user clicks OK in the Preferences window. The window will be prevented from closing but preference changes will still have been applied. If the user accepts the prompt, the Preferences window stays open and the credentials they entered are submitted. If they cancel it, the Preferences window closes and the credentials are not submitted. If the login is unsuccessful or they log back out and *again* leave unsubmitted credentials entered when they close the window, they will not be prompted a second time.
- On macOS, the prompt shows *after* the Preferences window closes and cannot prevent it from closing. If the user accepts, the Preferences window reopens and the credentials they entered are submitted. As above, the prompt will not be shown a second time if unsubmitted credentials are present when the new window is closed.

Credentials are not stored; they are, however, passed as arguments when the Preferences window is reopened. I don't think this has any security implications given that anything that has access to the Preferences window object can already read the username and password fields.

Fixes #1847.