### PR TITLE
Always autocomplete creators in `hideEditor`

### DIFF
--- a/chrome/content/zotero/bindings/itembox.xml
+++ b/chrome/content/zotero/bindings/itembox.xml
@@ -1821,6 +1821,12 @@
 				<parameter name="textbox"/>
 				<body><![CDATA[
 				return (async function () {
+					// Handle cases where creator autocomplete doesn't trigger
+					// the textentered and change events handled in showEditor
+					if (textbox.getAttribute('fieldname').startsWith('creator-')) {
+						this.handleCreatorAutoCompleteSelect(textbox);
+					}
+
 					Zotero.debug(`Hiding editor for ${textbox.getAttribute('fieldname')}`);
 					
 					var label = Zotero.getAncestorByTagName(textbox, 'row').querySelector('label');


### PR DESCRIPTION
This handles all the cases that were being missed before: tabbing out of the field (`change` doesn't reliably fire anymore...), clicking on an option in the autocomplete list, and clicking on another field/out of the itembox entirely. The `ontextentered` and `onchange` handlers added in `showEditor` are still necessary; this is a fallback.

Fixes #2515.