### PR TITLE
getSortTitle: Only strip initial punctuation clusters

### DIFF
--- a/chrome/content/zotero/xpcom/data/items.js
+++ b/chrome/content/zotero/xpcom/data/items.js
@@ -1993,7 +1993,7 @@ Zotero.Items = function() {
 		'</span>',
 		// Any punctuation at the beginning of the string, repeated any number
 		// of times, and any opening punctuation that follows
-		'^\\s*([^\\P{P}@])\\1*[\\p{Ps}"\']*',
+		'^\\s*([^\\P{P}@#*])\\1*[\\p{Ps}"\']*',
 	].map(re => Zotero.Utilities.XRegExp(re, 'g'));
 	
 	

--- a/chrome/content/zotero/xpcom/data/items.js
+++ b/chrome/content/zotero/xpcom/data/items.js
@@ -1991,11 +1991,9 @@ Zotero.Items = function() {
 		'<span style="font-variant:small-caps;">',
 		'<span class="nocase">',
 		'</span>',
-		// Any punctuation at the beginning of the string
-		'^\\p{P}+',
-		// Initial, opening, closing, final, and "other" punctuation that isn't
-		// followed by a digit. Doesn't match connectors or dashes.
-		'[\\p{Pi}\\p{Ps}\\p{Pe}\\p{Pf}\\p{Po}](?!\\d)'
+		// Any punctuation at the beginning of the string, repeated any number
+		// of times, and any opening punctuation that follows
+		'^\\s*(\\p{P})\\1*[\\p{Ps}"\']*',
 	].map(re => Zotero.Utilities.XRegExp(re, 'g'));
 	
 	

--- a/chrome/content/zotero/xpcom/data/items.js
+++ b/chrome/content/zotero/xpcom/data/items.js
@@ -1993,7 +1993,7 @@ Zotero.Items = function() {
 		'</span>',
 		// Any punctuation at the beginning of the string, repeated any number
 		// of times, and any opening punctuation that follows
-		'^\\s*(\\p{P})\\1*[\\p{Ps}"\']*',
+		'^\\s*([^\\P{P}@])\\1*[\\p{Ps}"\']*',
 	].map(re => Zotero.Utilities.XRegExp(re, 'g'));
 	
 	

--- a/test/tests/itemsTest.js
+++ b/test/tests/itemsTest.js
@@ -1192,14 +1192,17 @@ describe("Zotero.Items", function () {
 			}
 		});
 
-		it("should strip any punctuation at the beginning of the string besides the @ sign", function () {
+		it("should strip any punctuation at the beginning of the string besides @, #, and *", function () {
 			let tests = [
 				['_title', 'title'],
 				['-title', 'title'],
 				['-- longer title', 'longer title'],
 				['-_ longer title with different second character', '_ longer title with different second character'],
 				['"Quoted title', 'Quoted title'],
-				['@zotero on Twitter', '@zotero on Twitter']
+				['@zotero on Twitter', '@zotero on Twitter'],
+				['#hashtag', '#hashtag'],
+				['*special', '*special'],
+				['**repeated', '**repeated']
 			];
 
 			for (let [input, expected] of tests) {

--- a/test/tests/itemsTest.js
+++ b/test/tests/itemsTest.js
@@ -1197,20 +1197,8 @@ describe("Zotero.Items", function () {
 				['_title', 'title'],
 				['-title', 'title'],
 				['-- longer title', 'longer title'],
+				['-_ longer title with different second character', '_ longer title with different second character'],
 				['"Quoted title', 'Quoted title']
-			];
-
-			for (let [input, expected] of tests) {
-				assert.equal(Zotero.Items.getSortTitle(input), expected);
-			}
-		});
-
-		it("should strip quotes", function () {
-			let tests = [
-				['A "title"', 'A title'],
-				['A “title”', 'A title'],
-				[' xyz ”””', 'xyz'],
-				['‘Punctuation’', 'Punctuation']
 			];
 
 			for (let [input, expected] of tests) {
@@ -1231,15 +1219,39 @@ describe("Zotero.Items", function () {
 			}
 		});
 
-		it("should not strip any punctuation before a digit", function () {
+		it("should strip opening punctuation after string-initial punctuation", function () {
 			let tests = [
-				['1.5', '1.5'],
-				['abc .5', 'abc .5'],
-				['abc 5.', 'abc 5']
+				['.[Test]', 'Test]'],
+				['"❮Word❯"', 'Word❯"'],
+				['"@": The Musical', '@": The Musical'],
 			];
 
 			for (let [input, expected] of tests) {
 				assert.equal(Zotero.Items.getSortTitle(input), expected);
+			}
+		});
+
+		it("should sort titles with special characters correctly", function () {
+			let tests = [
+				[
+					['A*B*@!@C*D 1', 'ABCD 2', 'A*B*@!@C*D 3', 'ABCD 4'],
+					['A*B*@!@C*D 1', 'A*B*@!@C*D 3', 'ABCD 2', 'ABCD 4']
+				],
+				[
+					['Why? Volume 1', 'Why! Volume 1', 'Why! Volume 2', 'Why? Volume 2'],
+					['Why! Volume 1', 'Why! Volume 2', 'Why? Volume 1', 'Why? Volume 2']
+				],
+				[
+					['Sign and symbol', '"@" Sign. Its accidental history.', 'Sign language'],
+					['"@" Sign. Its accidental history.', 'Sign and symbol', 'Sign language']
+				],
+			];
+
+			let st = Zotero.Items.getSortTitle;
+			let collation = Zotero.getLocaleCollation();
+			for (let [input, expected] of tests) {
+				input.sort((a, b) => collation.compareString(1, st(a), st(b)));
+				assert.deepEqual(input, expected);
 			}
 		});
 	});

--- a/test/tests/itemsTest.js
+++ b/test/tests/itemsTest.js
@@ -1192,13 +1192,14 @@ describe("Zotero.Items", function () {
 			}
 		});
 
-		it("should strip any punctuation at the beginning of the string", function () {
+		it("should strip any punctuation at the beginning of the string besides the @ sign", function () {
 			let tests = [
 				['_title', 'title'],
 				['-title', 'title'],
 				['-- longer title', 'longer title'],
 				['-_ longer title with different second character', '_ longer title with different second character'],
-				['"Quoted title', 'Quoted title']
+				['"Quoted title', 'Quoted title'],
+				['@zotero on Twitter', '@zotero on Twitter']
 			];
 
 			for (let [input, expected] of tests) {


### PR DESCRIPTION
Removes:

- Any punctuation of any type at the beginning of the string besides @, #, and *, including the *same character* repeated multiple times. So `-- title` would become `title` but `-_ title` would become `_ title`.
- Any [opening punctuation](https://www.fileformat.info/info/unicode/category/Ps/list.htm) or neutral quotes immediately following it.

I think this has a better balance between removing non-meaningful characters in titles, preserving meaningful ones (like the @ example in the forum thread), and letting people use title hacks if they really, really want to.

See test cases for some examples. Includes a test which sorts the examples given in the thread.

Fixes #2535.