### PR TITLE
Sort call numbers alphabetically, handle Dewey specially

### DIFF
--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -1352,6 +1352,28 @@ var ItemTree = class ItemTree extends LibraryTree {
 				if (sortField == 'hasAttachment') {
 					return fieldB - fieldA;
 				}
+
+				if (sortField == 'callNumber') {
+					let deweyRe = /^(\d{3})(?:\.(\d{1,4}))?(?:\/([a-zA-Z]{3}))?$/;
+					let splitA = fieldA.toLowerCase().replace(/\s/g, '').match(deweyRe);
+					let splitB = fieldB.toLowerCase().replace(/\s/g, '').match(deweyRe);
+					if (splitA && splitB) {
+						// Looks like Dewey Decimal, so we'll compare by parts
+						let i;
+						for (i = 1; i < splitA.length && i < splitB.length; i++) {
+							if (splitA[i] < splitB[i]) {
+								return -1;
+							}
+							else if (splitA[i] > splitB[i]) {
+								return 1;
+							}
+						}
+						return (i < splitA.length) ? 1 : (i < splitB.length) ? -1 : 0;
+					}
+					else {
+						return (fieldA > fieldB) ? 1 : (fieldA < fieldB) ? -1 : 0;
+					}
+				}
 				
 				return collation.compareString(1, fieldA, fieldB);
 			}


### PR DESCRIPTION
If a call number looks like Dewey (begins with three digits, then optionally a dot and one to four digits, then optionally a slash and three letters), we split it into parts and sort each using string comparison in order to get [this ordering](https://www.mdek12.org/sites/default/files/Offices/MDE/OA/OEER/Library%20Services/Section%206/Dewey%20Decimal%20Classification%20(1).pdf).

If it doesn't, we still sort using string comparison - locale collation will treat them like cardinal numbers, which I think isn't appropriate in many cases.

Fixes #2194.