### PR TITLE
Add sorting options and column picker to View menu

### DIFF
--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -558,8 +558,7 @@ var ZoteroPane = new function()
 			key.id = 'key_sortCol' + i;
 			key.setAttribute('modifiers', Zotero.isMac ? 'accel alt control' : 'accel alt');
 			key.setAttribute('key', (i + 1) % 10);
-			// addListener('command', ...) doesn't trigger unless attached to a menuitem
-			key.setAttribute('oncommand', `ZoteroPane.itemsView.toggleSort(${i}, true)`);
+			key.addEventListener('command', () => ZoteroPane.itemsView.toggleSort(i, true));
 			sortSubmenuKeys.append(key);
 		}
 		

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -6178,14 +6178,20 @@ var ZoteroPane = new function()
 		this.itemPane.handleResize();
 	}
 
-	this.onColumnPickerSubmenuOpen = function () {
+	this.onColumnPickerPopupShowing = function (event) {
 		let menuPopup = document.getElementById('column-picker-submenu').menupopup;
+		if (event.target !== menuPopup) {
+			return;
+		}
 		menuPopup.replaceChildren();
 		this.itemsView?.buildColumnPickerMenu(menuPopup);
 	};
 
-	this.onSortSubmenuOpen = function () {
+	this.onSortPopupShowing = function (event) {
 		let menuPopup = document.getElementById('sort-submenu').menupopup;
+		if (event.target !== menuPopup) {
+			return;
+		}
 		menuPopup.replaceChildren();
 		this.itemsView?.buildSortMenu(menuPopup);
 

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -552,6 +552,17 @@ var ZoteroPane = new function()
 		
 		Zotero.Keys.windowInit(document);
 		
+		let sortSubmenuKeys = document.getElementById('sortSubmenuKeys');
+		for (let i = 0; i < 10; i++) {
+			let key = document.createElement('key');
+			key.id = 'key_sortCol' + i;
+			key.setAttribute('modifiers', Zotero.isMac ? 'accel alt control' : 'accel alt');
+			key.setAttribute('key', (i + 1) % 10);
+			// addListener('command', ...) doesn't trigger unless attached to a menuitem
+			key.setAttribute('oncommand', `ZoteroPane.itemsView.toggleSort(${i}, true)`);
+			sortSubmenuKeys.append(key);
+		}
+		
 		if (Zotero.restoreFromServer) {
 			Zotero.restoreFromServer = false;
 			
@@ -6166,6 +6177,25 @@ var ZoteroPane = new function()
 
 		this.itemPane.handleResize();
 	}
+
+	this.onColumnPickerSubmenuOpen = function () {
+		let menuPopup = document.getElementById('column-picker-submenu').menupopup;
+		menuPopup.replaceChildren();
+		this.itemsView?.buildColumnPickerMenu(menuPopup);
+	};
+
+	this.onSortSubmenuOpen = function () {
+		let menuPopup = document.getElementById('sort-submenu').menupopup;
+		menuPopup.replaceChildren();
+		this.itemsView?.buildSortMenu(menuPopup);
+
+		for (let i = 0; i < 10; i++) {
+			if (!menuPopup.children[i]) {
+				break;
+			}
+			menuPopup.children[i].setAttribute('key', 'key_sortCol' + i);
+		}
+	};
 	
 	/**
 	 * Opens the about dialog

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -552,16 +552,6 @@ var ZoteroPane = new function()
 		
 		Zotero.Keys.windowInit(document);
 		
-		let sortSubmenuKeys = document.getElementById('sortSubmenuKeys');
-		for (let i = 0; i < 10; i++) {
-			let key = document.createElement('key');
-			key.id = 'key_sortCol' + i;
-			key.setAttribute('modifiers', Zotero.isMac ? 'accel alt control' : 'accel alt');
-			key.setAttribute('key', (i + 1) % 10);
-			key.addEventListener('command', () => ZoteroPane.itemsView.toggleSort(i, true));
-			sortSubmenuKeys.append(key);
-		}
-		
 		if (Zotero.restoreFromServer) {
 			Zotero.restoreFromServer = false;
 			
@@ -1634,6 +1624,16 @@ var ZoteroPane = new function()
 			});
 			ZoteroPane.itemsView.onRefresh.addListener(() => ZoteroPane.setTagScope());
 			ZoteroPane.itemsView.waitForLoad().then(() => Zotero.uiIsReady());
+
+			let sortSubmenuKeys = document.getElementById('sortSubmenuKeys');
+			for (let i = 0; i < 10; i++) {
+				let key = document.createElement('key');
+				key.id = 'key_sortCol' + i;
+				key.setAttribute('modifiers', Zotero.isMac ? 'accel alt control' : 'accel alt');
+				key.setAttribute('key', (i + 1) % 10);
+				key.addEventListener('command', () => ZoteroPane.itemsView.toggleSort(i, true));
+				sortSubmenuKeys.append(key);
+			}
 		}
 		catch (e) {
 			Zotero.logError(e);

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -191,6 +191,8 @@
 		<key id="key_findPrevious2" keycode="&findAgainCmd.key2;" modifiers="shift" command="cmd_findPrevious"/>
 	</keyset>
 	
+	<keyset id="sortSubmenuKeys"/>
+	
 	<vbox id="titlebar">
 		<hbox class="titlebar-icon-container">
 			<html:div class="titlebar-icon"></html:div>
@@ -623,6 +625,19 @@
 										label="&zotero.general.reset;"
 										oncommand="ZoteroStandalone.onViewMenuItemClick(event); event.stopPropagation();"/>
 								</menupopup>
+							</menu>
+							<menuseparator class="menu-type-library" />
+							<menu id="column-picker-submenu"
+								  class="menu-type-library"
+								  label="&columns.label;"
+								  onpopupshowing="ZoteroPane_Local.onColumnPickerSubmenuOpen()">
+								<menupopup/>
+							</menu>
+							<menu id="sort-submenu"
+								  class="menu-type-library"
+								  label="&sortBy.label;"
+								  onpopupshowing="ZoteroPane_Local.onSortSubmenuOpen()">
+								<menupopup/>
 							</menu>
 							<menuseparator/>
 							<menuitem id="view-menuitem-recursive-collections"

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -630,13 +630,13 @@
 							<menu id="column-picker-submenu"
 								  class="menu-type-library"
 								  label="&columns.label;"
-								  onpopupshowing="ZoteroPane_Local.onColumnPickerSubmenuOpen()">
+								  onpopupshowing="ZoteroPane_Local.onColumnPickerPopupShowing(event)">
 								<menupopup/>
 							</menu>
 							<menu id="sort-submenu"
 								  class="menu-type-library"
 								  label="&sortBy.label;"
-								  onpopupshowing="ZoteroPane_Local.onSortSubmenuOpen()">
+								  onpopupshowing="ZoteroPane_Local.onSortPopupShowing(event)">
 								<menupopup/>
 							</menu>
 							<menuseparator/>

--- a/chrome/locale/en-US/zotero/standalone.dtd
+++ b/chrome/locale/en-US/zotero/standalone.dtd
@@ -60,6 +60,8 @@
 <!ENTITY recursiveCollections.label     "Show Items from Subcollections">
 <!ENTITY fontSize.label                 "Font Size">
 <!ENTITY noteFontSize.label             "Note Font Size">
+<!ENTITY columns.label                  "Columns">
+<!ENTITY sortBy.label                   "Sort By">
 
 <!--TOOLS MENU-->
 <!ENTITY toolsMenu.label           "Tools"> 


### PR DESCRIPTION
ItemTree now exposes `toggleSort` (with a convenience `countVisible` parameter so ZP doesn't need to know anything about which columns are visible) and a couple menu builders.

Fixes #2273.