### PR TITLE
Sort LC call numbers better, sort integers as integers

### DIFF
--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -1354,47 +1354,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 				}
 
 				if (sortField == 'callNumber') {
-					let deweyRe = /^(\d{3})(?:\.(\d+))?(?:\/([a-zA-Z]{3}))?$/;
-					let lcWithClassificationRe = /^([a-zA-Z]{1,3}\d+\s*\.)(?=[a-zA-Z])/;
-					let splitA = fieldA.toLowerCase().replace(/\s/g, '').match(deweyRe);
-					let splitB = fieldB.toLowerCase().replace(/\s/g, '').match(deweyRe);
-
-					if (splitA && splitB) {
-						// Looks like Dewey Decimal, so we'll compare by parts
-						let i;
-						for (i = 1; i < splitA.length && i < splitB.length; i++) {
-							if (splitA[i] < splitB[i]) {
-								return -1;
-							}
-							else if (splitA[i] > splitB[i]) {
-								return 1;
-							}
-						}
-						return (i < splitA.length) ? 1 : (i < splitB.length) ? -1 : 0;
-					}
-					else {
-						let classificationA = fieldA.match(lcWithClassificationRe);
-						let classificationB = fieldB.match(lcWithClassificationRe);
-						if (classificationA && classificationB) {
-							// Looks like a LC call number, so we'll first compare
-							// by classification field using locale collation
-							let classificationComp = collation.compareString(
-								1, classificationA[1], classificationB[1]
-							);
-
-							if (classificationComp == 0) {
-								// If they match, we'll compare the rest using
-								// basic string comparison
-								fieldA = fieldA.substring(classificationA[1].length);
-								fieldB = fieldB.substring(classificationB[1].length);
-							}
-							else {
-								return classificationComp;
-							}
-						}
-					}
-
-					return (fieldA > fieldB) ? 1 : (fieldA < fieldB) ? -1 : 0;
+					return Zotero.Utilities.Item.compareCallNumbers(fieldA, fieldB);
 				}
 				
 				return collation.compareString(1, fieldA, fieldB);

--- a/test/tests/utilities_itemTest.js
+++ b/test/tests/utilities_itemTest.js
@@ -279,4 +279,50 @@ describe("Zotero.Utilities.Item", function() {
 			assert.equal(title, 'Annotations');
 		});
 	});
+
+
+	describe("#compareCallNumbers()", function () {
+		function checkSort(numbersInOrder) {
+			let numbersResorted = [...numbersInOrder]
+				.sort(() => Math.random() - 0.5) // First shuffle
+				.sort(Zotero.Utilities.Item.compareCallNumbers); // Then re-sort
+			assert.deepEqual(numbersResorted, numbersInOrder);
+		}
+
+		it("should correctly order integer call numbers", function () {
+			let numbersInOrder = [
+				'1',
+				'2',
+				'12',
+				'20',
+				'21',
+				'100',
+				'101',
+			];
+			checkSort(numbersInOrder);
+		});
+
+		it("should correctly order Dewey Decimal call numbers", function () {
+			let numbersInOrder = [
+				'641.5/Cor',
+				'641.5/wol',
+				'641.55541/Ray',
+				'641.594/Mun',
+				'641.5945/Foo',
+				'641.596/Mon',
+				'642.000/ABC',
+			];
+			checkSort(numbersInOrder);
+		});
+
+		it("should correctly order LC call numbers", function () {
+			let numbersInOrder = [
+				'PJ403.B64 C666',
+				'PJ3930.S49 A53 2015',
+				'PJ4519 .B9798 A58 1999',
+				'PJ4519 .B99 A65 1976',
+			];
+			checkSort(numbersInOrder);
+		});
+	});
 });


### PR DESCRIPTION
Not strictly "correctly," due to the issues mentioned [here](https://github.com/zotero/zotero/issues/2567#issuecomment-1108819863), but in a way that handles the classification field correctly.

Fixes #2567, fixes #2570.