### PR TITLE
Fix sorting by attachment

### DIFF
--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -3791,7 +3791,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 
 	_canGetBestAttachmentState(item) {
 		return (item.isRegularItem() && item.numAttachments())
-			|| (item.isAttachment() && item.isTopLevelItem());
+			|| (item.isFileAttachment() && item.isTopLevelItem());
 	}
 	
 	_isOnlyEmoji(str) {

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -1343,7 +1343,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 					const order = ['pdf', 'snapshot', 'other', 'none'];
 					fieldA = order.indexOf(fieldA.type || 'none') + (fieldA.exists ? 0 : 4);
 					fieldB = order.indexOf(fieldB.type || 'none') + (fieldB.exists ? 0 : 4);
-					return fieldB - fieldA;
+					return fieldA - fieldB;
 				}
 
 				if (sortField == 'callNumber') {

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -1270,7 +1270,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 				return Zotero.Items.getSortTitle(item.getDisplayTitle());
 			
 			case 'hasAttachment':
-				if (this._canCalculateAttachmentState(item)) {
+				if (this._canGetBestAttachmentState(item)) {
 					return item.getBestAttachmentStateCached();
 				}
 				else {
@@ -2749,7 +2749,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 
 		// TEMP: For now, we use the blue bullet for all non-PDF attachments, but there's
 		// commented-out code for showing different icons for snapshots, files, and URL/DOI links
-		if (this._canCalculateAttachmentState(item)) {
+		if (this._canGetBestAttachmentState(item)) {
 			const { type, exists } = item.getBestAttachmentStateCached();
 			let icon = "";
 			let ariaLabel;
@@ -3514,7 +3514,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 				let t = new Date();
 				for (let i = 0; i < this._rows.length; i++) {
 					let item = this.getRow(i).ref;
-					if (this._canCalculateAttachmentState(item)) {
+					if (this._canGetBestAttachmentState(item)) {
 						await item.getBestAttachmentState();
 					}
 				}
@@ -3789,7 +3789,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 		return icon;
 	}
 
-	_canCalculateAttachmentState(item) {
+	_canGetBestAttachmentState(item) {
 		return (item.isRegularItem() && item.numAttachments())
 			|| (item.isAttachment() && item.isTopLevelItem());
 	}

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -1262,7 +1262,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 		sortFields.forEach(x => cache[x] = {});
 		
 		// Get the display field for a row (which might be a placeholder title)
-		function getField(field, row) {
+		let getField = (field, row) => {
 			var item = row.ref;
 			
 			switch (field) {
@@ -1270,23 +1270,12 @@ var ItemTree = class ItemTree extends LibraryTree {
 				return Zotero.Items.getSortTitle(item.getDisplayTitle());
 			
 			case 'hasAttachment':
-				if (item.isFileAttachment()) {
-					var state = item.fileExistsCached() ? 1 : -1;
-				}
-				else if (item.isRegularItem()) {
-					var state = item.getBestAttachmentStateCached();
+				if (this._canCalculateAttachmentState(item)) {
+					return item.getBestAttachmentStateCached();
 				}
 				else {
 					return 0;
 				}
-				// Make sort order present, missing, empty when ascending
-				if (state === 1) {
-					state = 2;
-				}
-				else if (state === -1) {
-					state = 1;
-				}
-				return state;
 			
 			case 'numNotes':
 				return row.numNotes(false, true) || 0;
@@ -1350,6 +1339,10 @@ var ItemTree = class ItemTree extends LibraryTree {
 				}
 				
 				if (sortField == 'hasAttachment') {
+					// PDFs at the top
+					const order = ['pdf', 'snapshot', 'other', 'none'];
+					fieldA = order.indexOf(fieldA.type || 'none') + (fieldA.exists ? 0 : 4);
+					fieldB = order.indexOf(fieldB.type || 'none') + (fieldB.exists ? 0 : 4);
 					return fieldB - fieldA;
 				}
 
@@ -2756,93 +2749,60 @@ var ItemTree = class ItemTree extends LibraryTree {
 
 		// TEMP: For now, we use the blue bullet for all non-PDF attachments, but there's
 		// commented-out code for showing different icons for snapshots, files, and URL/DOI links
-		if (this.isContainer(index)) {
-			if (item.isRegularItem()) {
-				const { type, exists } = item.getBestAttachmentStateCached();
-				let icon = "";
-				let ariaLabel;
-				// If the item has a child attachment
-				if (type !== null && type != 'none') {
-					if (type == 'pdf') {
-						icon = getDOMElement('IconTreeitemAttachmentPDF');
-						ariaLabel = Zotero.getString('pane.item.attachments.hasPDF');
-						if (!exists) {
-							icon.classList.add('icon-missing-file');
-						}
-					}
-					else if (type == 'snapshot') {
-						//icon = getDOMElement('IconTreeitemAttachmentSnapshot');
-						icon = exists ? getDOMElement('IconBulletBlue') : getDOMElement('IconBulletBlueEmpty');
-						ariaLabel = Zotero.getString('pane.item.attachments.hasSnapshot');
-					}
-					else {
-						//icon = getDOMElement('IconTreeitem');
-						icon = exists ? getDOMElement('IconBulletBlue') : getDOMElement('IconBulletBlueEmpty');
-						ariaLabel = Zotero.getString('pane.item.attachments.has');
-					}
-					icon.classList.add('cell-icon');
-					//if (!exists) {
-					//	icon.classList.add('icon-missing-file');
-					//}
-				}
-				//else if (type == 'none') {
-				//	if (item.getField('url') || item.getField('DOI')) {
-				//		icon = getDOMElement('IconLink');
-				//		ariaLabel = Zotero.getString('pane.item.attachments.hasLink');
-				//		icon.classList.add('cell-icon');
-				//	}
-				//}
-				if (ariaLabel) {
-					icon.setAttribute('aria-label', ariaLabel + '.');
-					span.setAttribute('title', ariaLabel);
-				}
-				span.append(icon);
-
-				// Don't run this immediately since it might cause a db check and disk access
-				// but delay for some time and see if the item is still visible in the tree
-				// (i.e. if we haven't scrolled right past it)
-				setTimeout(() => {
-					if (!this.tree.rowIsVisible(index)) return;
-					item.getBestAttachmentState()
-						// Refresh cell when promise is fulfilled
-						.then(({ type: newType, exists: newExists }) => {
-							if (newType !== type || newExists !== exists) {
-								this.tree.invalidateRow(index);
-							}
-						});
-				}, ATTACHMENT_STATE_LOAD_DELAY);
-			}
-		}
-
-		if (item.isFileAttachment()) {
-			const exists = item.fileExistsCached();
+		if (this._canCalculateAttachmentState(item)) {
+			const { type, exists } = item.getBestAttachmentStateCached();
 			let icon = "";
-			if (exists !== null) {
-				if (item.isPDFAttachment()) {
+			let ariaLabel;
+			// If the item has a child attachment
+			if (type !== null && type != 'none') {
+				if (type == 'pdf') {
 					icon = getDOMElement('IconTreeitemAttachmentPDF');
+					ariaLabel = Zotero.getString('pane.item.attachments.hasPDF');
 					if (!exists) {
 						icon.classList.add('icon-missing-file');
 					}
 				}
-				else if (item.isSnapshotAttachment()) {
+				else if (type == 'snapshot') {
 					//icon = getDOMElement('IconTreeitemAttachmentSnapshot');
 					icon = exists ? getDOMElement('IconBulletBlue') : getDOMElement('IconBulletBlueEmpty');
+					ariaLabel = Zotero.getString('pane.item.attachments.hasSnapshot');
 				}
 				else {
 					//icon = getDOMElement('IconTreeitem');
 					icon = exists ? getDOMElement('IconBulletBlue') : getDOMElement('IconBulletBlueEmpty');
+					ariaLabel = Zotero.getString('pane.item.attachments.has');
 				}
 				icon.classList.add('cell-icon');
 				//if (!exists) {
 				//	icon.classList.add('icon-missing-file');
 				//}
 			}
+			//else if (type == 'none') {
+			//	if (item.getField('url') || item.getField('DOI')) {
+			//		icon = getDOMElement('IconLink');
+			//		ariaLabel = Zotero.getString('pane.item.attachments.hasLink');
+			//		icon.classList.add('cell-icon');
+			//	}
+			//}
+			if (ariaLabel) {
+				icon.setAttribute('aria-label', ariaLabel + '.');
+				span.setAttribute('title', ariaLabel);
+			}
 			span.append(icon);
 
-			item.fileExists()
-				// TODO: With no cell refreshing this is possibly somewhat inefficient
-				// Refresh cell when promise is fulfilled
-				.then(realExists => realExists != exists && this.tree.invalidateRow(index));
+			// Don't run this immediately since it might cause a db check and disk access
+			// but delay for some time and see if the item is still visible in the tree
+			// (i.e. if we haven't scrolled right past it)
+			setTimeout(() => {
+				if (!this.tree.rowIsVisible(index)) return;
+				item.getBestAttachmentState()
+					// Refresh cell when promise is fulfilled
+					.then(({ type: newType, exists: newExists }) => {
+						if (newType !== type || newExists !== exists) {
+							this.tree.invalidateRow(index);
+						}
+					});
+			}, ATTACHMENT_STATE_LOAD_DELAY);
 		}
 
 		return span;
@@ -3554,7 +3514,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 				let t = new Date();
 				for (let i = 0; i < this._rows.length; i++) {
 					let item = this.getRow(i).ref;
-					if (item.isRegularItem()) {
+					if (this._canCalculateAttachmentState(item)) {
 						await item.getBestAttachmentState();
 					}
 				}
@@ -3827,6 +3787,11 @@ var ItemTree = class ItemTree extends LibraryTree {
 			return document.createElementNS(HTML_NS, 'span');
 		}
 		return icon;
+	}
+
+	_canCalculateAttachmentState(item) {
+		return (item.isRegularItem() && item.numAttachments())
+			|| (item.isAttachment() && item.isTopLevelItem());
 	}
 	
 	_isOnlyEmoji(str) {

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -3740,7 +3740,7 @@ Zotero.Item.prototype.getBestAttachmentState = async function () {
 	else {
 		type = 'other';
 	}
-	var exists = !item.isFileAttachment() || await item.fileExists();
+	var exists = await item.fileExists();
 	return this._bestAttachmentState = { type, exists };
 };
 

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -3740,7 +3740,7 @@ Zotero.Item.prototype.getBestAttachmentState = async function () {
 	else {
 		type = 'other';
 	}
-	var exists = await item.fileExists();
+	var exists = !item.isFileAttachment() || await item.fileExists();
 	return this._bestAttachmentState = { type, exists };
 };
 

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -3713,7 +3713,7 @@ Zotero.Item.prototype.getBestAttachments = Zotero.Promise.coroutine(function* ()
 
 
 /**
- * Return state of best attachment
+ * Return state of best attachment (or this item if it's a standalone attachment)
  *
  * @return {Promise<Object>} - Promise for object with string 'type' ('none'|'pdf'|'snapshot'|'other')
  *     and boolean 'exists'
@@ -3722,7 +3722,9 @@ Zotero.Item.prototype.getBestAttachmentState = async function () {
 	if (this._bestAttachmentState !== null) {
 		return this._bestAttachmentState;
 	}
-	var item = await this.getBestAttachment();
+	var item = this.isAttachment() && this.isTopLevelItem()
+		? this
+		: await this.getBestAttachment();
 	if (!item) {
 		return this._bestAttachmentState = {
 			type: 'none'

--- a/test/tests/itemTest.js
+++ b/test/tests/itemTest.js
@@ -1169,6 +1169,15 @@ describe("Zotero.Item", function () {
 				{ type: 'other', exists: false }
 			);
 		})
+
+		it("should cache state for a standalone attachment", async function () {
+			var standaloneAttachment = await importPDFAttachment();
+			await standaloneAttachment.getBestAttachmentState();
+			assert.deepEqual(
+				standaloneAttachment.getBestAttachmentStateCached(),
+				{ type: 'pdf', exists: true }
+			);
+		});
 	})
 	
 	


### PR DESCRIPTION
In the process, simplified sorting and displaying attachment states a fair amount by making `getBestAttachmentState` treat the item it's called on as the "best attachment" when called on an attachment item. That removed the need for duplicate logic to determine attachment icons for standalone attachments and even more duplicate logic to figure out sort positions.

1. Is that a reasonable change?
2. And if so, should `getBestAttachment` and `getBestAttachments` also support attachment items?

Fixes #2416.