### PR TITLE
Improve column resizing robustness

### DIFF
--- a/chrome/content/zotero/components/virtualized-table.jsx
+++ b/chrome/content/zotero/components/virtualized-table.jsx
@@ -799,8 +799,9 @@ class VirtualizedTable extends React.Component {
 			offset += resizingRect.width;
 		}
 		const widthSum = aRect.width + bRect.width;
-		const spacingOffset = COLUMN_MIN_WIDTH + COLUMN_PADDING;
-		const aColumnWidth = Math.min(widthSum - spacingOffset, Math.max(spacingOffset, event.clientX - (RESIZER_WIDTH / 2) - offset));
+		const aSpacingOffset = (aColumn.minWidth ? aColumn.minWidth : COLUMN_MIN_WIDTH) + COLUMN_PADDING;
+		const bSpacingOffset = (bColumn.minWidth ? bColumn.minWidth : COLUMN_MIN_WIDTH) + COLUMN_PADDING;
+		const aColumnWidth = Math.min(widthSum - bSpacingOffset, Math.max(aSpacingOffset, event.clientX - (RESIZER_WIDTH / 2) - offset));
 		const bColumnWidth = widthSum - aColumnWidth;
 		let onResizeData = {};
 		onResizeData[aColumn.dataKey] = aColumnWidth;
@@ -1477,10 +1478,13 @@ var Columns = class {
 				column.width = width;
 				prefs[dataKey] = this._getColumnPrefsToPersist(column);
 			}
-			if (column.fixedWidth && column.width) {
+			if (column.fixedWidth) {
+				width = column.width;
+			}
+			if (column.fixedWidth && column.width || column.staticWidth) {
 				this._stylesheet.sheet.cssRules[styleIndex].style.setProperty('flex', `0 0`, `important`);
-				this._stylesheet.sheet.cssRules[styleIndex].style.setProperty('max-width', `${column.width}px`, 'important');
-				this._stylesheet.sheet.cssRules[styleIndex].style.setProperty('min-width', `${column.width}px`, 'important');
+				this._stylesheet.sheet.cssRules[styleIndex].style.setProperty('max-width', `${width}px`, 'important');
+				this._stylesheet.sheet.cssRules[styleIndex].style.setProperty('min-width', `${width}px`, 'important');
 			} else {
 				width = (width - COLUMN_PADDING) * COLUMN_NORMALIZATION_WIDTH / headerWidth;
 				this._stylesheet.sheet.cssRules[styleIndex].style.setProperty('flex-basis', `${width}px`);

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -2734,7 +2734,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 		const depth = this.getLevel(index);
 		let firstChildIndent = 0;
 		if (column.ordinal == 0) {
-			firstChildIndent = 6;
+			firstChildIndent = 5;
 		}
 		span.style.paddingInlineStart = ((CHILD_INDENT * depth) + firstChildIndent) + 'px';
 

--- a/chrome/content/zotero/itemTreeColumns.jsx
+++ b/chrome/content/zotero/itemTreeColumns.jsx
@@ -38,6 +38,9 @@ const Icons = require('components/icons');
  * 	flex: number,					// Default: 1. When the column is added to the tree how much space it should occupy as a flex ratio
  * 	width: string,					// A column width instead of flex ratio. See above.
  * 	fixedWidth: boolean				// Default: false. Set to true to disable column resizing
+ * 	staticWidth: boolean			// Default: false. Set to true to prevent columns from changing width when
+ * 									// the width of the tree increases or decreases
+ * 	minWidth: number,				// Override the default [20px] column min-width for resizing
  *
  * 	label: string,					// The column label. Either a string or the id to an i18n string.
  * 	iconLabel: React.Component,		// Set an Icon label instead of a text-based one
@@ -86,6 +89,7 @@ const COLUMNS = [
 		defaultSort: -1,
 		label: "zotero.items.year_column",
 		flex: 1,
+		staticWidth: true,
 		zoteroPersist: new Set(["width", "hidden", "sortDirection"])
 	},
 	{
@@ -298,6 +302,8 @@ const COLUMNS = [
 		label: "zotero.tabs.notes.label",
 		iconLabel: <Icons.IconTreeitemNoteSmall />,
 		width: "14",
+		minWidth: 14,
+		staticWidth: true,
 		zoteroPersist: new Set(["width", "hidden", "sortDirection"])
 	}
 ];

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -108,7 +108,6 @@ var ZoteroPane = new function()
 			if (!tabsDeck || tabsDeck.getAttribute('selectedIndex') == 0) {
 				this.updateToolbarPosition();
 				this.updateTagsBoxSize();
-				this.updateItemTreeColumnWidths();
 			}
 		});
 		window.setTimeout(this.updateToolbarPosition.bind(this), 0);
@@ -5483,11 +5482,6 @@ var ZoteroPane = new function()
 				- 35; // a little padding
 			list.style.height = height + 'px';
 		}
-	};
-
-	this.updateItemTreeColumnWidths = function() {
-		if (!ZoteroPane.itemsView || !ZoteroPane.itemsView.tree) return;
-		ZoteroPane.itemsView.tree.updateColumnWidths();
 	};
 
 	/**

--- a/scss/components/_virtualized-table.scss
+++ b/scss/components/_virtualized-table.scss
@@ -39,10 +39,6 @@
 		}
 	}
 	
-	.cell:first-child {
-		padding-inline-start: 6px;
-	}
-
 	.cell {
 		min-width: 30px;
 		cursor: default;
@@ -63,7 +59,7 @@
 				flex-shrink: 1;
 				text-overflow: ellipsis;
 				overflow: hidden;
-				margin-inline-start: 6px;
+				margin-inline-start: 5px;
 			}
 
 			.twisty + .cell-text, .spacer-twisty + .cell-text {
@@ -178,6 +174,7 @@
 		position: relative;
 		height: 100%;
 		align-items: center;
+		padding: 0 5px;
 
 		&:hover {
 			background: #fff;
@@ -199,7 +196,7 @@
 		}
 
 		.label {
-			margin-inline-start: 10px;
+			margin-inline-start: 5px;
 			overflow: hidden;
 			text-overflow: ellipsis;
 			flex: 1;


### PR DESCRIPTION
A slight redesign of the column resizing code which restores previous XPCOM tree behavior:

- Previous code calculated and stored column widths based on item tree width. This meant that if you resized the item tree (or Zotero window) the column widths would get recalculated. Making the tree wider and narrower repeatedly would cause rounding errors to accumulate and all column widths to drift towards equal width. This code instead stores all column widths normalized to item tree width of 8192 and no recalculation is ever done when resizing the tree.
- Fixed column width calculation code to be more robust on macOS and not have the column separators get out of sync between the header and cells.

Would be good to see some testing before merging in case I missed something.

Closes #2587. Addresses #2574 to a certain degree and since it restores previous behavior I think we can close.