### PR TITLE
Open context menus with `isContextMenu`

### DIFF
--- a/chrome/content/zotero/bindings/itembox.xml
+++ b/chrome/content/zotero/bindings/itembox.xml
@@ -440,6 +440,9 @@
 								label.setAttribute("onclick", "ZoteroPane_Local.loadURI('" + doi + "', event)");
 								label.setAttribute("tooltiptext", Zotero.getString('pane.item.viewOnline.tooltip'));
 								valueElement.oncontextmenu = () => {
+									// Don't call with isContextMenu set to true;
+									// we're opening with no offset, so the item under
+									// the mouse would immediately be activated
 									this._id('zotero-doi-menu').openPopup(valueElement);
 								};
 								
@@ -808,6 +811,7 @@
 					if (this.editable && fieldMode == 0) {
 						firstlast.oncontextmenu = () => {
 							document.popupNode = firstlast;
+							// As with zotero-doi-menu, can't set isContextMenu
 							this._id('zotero-creator-transform-menu').openPopup(firstlast);
 						};
 					}
@@ -1381,6 +1385,7 @@
 								Zotero.ItemFields.isFieldOfBase(fieldID, 'publicationTitle'))) {
 							valueElement.oncontextmenu = () => {
 								document.popupNode = valueElement;
+								// As with zotero-doi-menu, can't set isContextMenu
 								this._id('zotero-field-transform-menu').openPopup(valueElement);
 							};
 						}

--- a/chrome/content/zotero/containers/tagSelectorContainer.jsx
+++ b/chrome/content/zotero/containers/tagSelectorContainer.jsx
@@ -508,7 +508,8 @@ Zotero.TagSelector = class TagSelectorContainer extends React.PureComponent {
 			tagContextMenu.childNodes[i].disabled = this.state.viewOnly;
 		}
 		ev.preventDefault();
-		tagContextMenu.openPopup(null, null, ev.clientX+2, ev.clientY+2);
+		tagContextMenu.openPopup(null, null, ev.clientX+2, ev.clientY+2,
+			/* isContextMenu */ true);
 		this.contextTag = tag;
 	}
 

--- a/chrome/content/zotero/contextPane.js
+++ b/chrome/content/zotero/contextPane.js
@@ -611,7 +611,7 @@ var ZoteroContextPane = new function () {
 			updateFromCache: () => _updateNotesList(true)
 		};
 		
-		function _handleListPopupClick(id, event) {
+		function _handleListPopupCommand(id, event) {
 			switch (event.originalTarget.id) {
 				case 'context-pane-list-show-in-library':
 					ZoteroPane_Local.selectItem(id);
@@ -634,7 +634,7 @@ var ZoteroContextPane = new function () {
 			}
 		}
 		
-		function _handleAddChildNotePopupClick(event) {
+		function _handleAddChildNotePopupCommand(event) {
 			if (readOnly) {
 				return;
 			}
@@ -651,7 +651,7 @@ var ZoteroContextPane = new function () {
 			}
 		}
 
-		function _handleAddStandaloneNotePopupClick(event) {
+		function _handleAddStandaloneNotePopupCommand(event) {
 			if (readOnly) {
 				return;
 			}
@@ -677,21 +677,21 @@ var ZoteroContextPane = new function () {
 				onContextMenu={(id, event) => {
 					document.getElementById('context-pane-list-move-to-trash').setAttribute('disabled', readOnly);
 					var popup = document.getElementById('context-pane-list-popup');
-					popup.onclick = (event) => _handleListPopupClick(id, event);
-					popup.openPopupAtScreen(event.screenX, event.screenY);
+					popup.addEventListener('command', (event) => _handleListPopupCommand(id, event));
+					popup.openPopupAtScreen(event.screenX, event.screenY, true);
 				}}
 				onAddChildButtonDown={(event) => {
 					document.getElementById('context-pane-add-child-note').setAttribute('disabled', readOnly);
 					document.getElementById('context-pane-add-child-note-from-annotations').setAttribute('disabled', readOnly);
 					var popup = document.getElementById('context-pane-add-child-note-button-popup');
-					popup.onclick = _handleAddChildNotePopupClick;
+					popup.addEventListener('command', _handleAddChildNotePopupCommand);
 					popup.openPopup(event.target, 'after_end');
 				}}
 				onAddStandaloneButtonDown={(event) => {
 					document.getElementById('context-pane-add-standalone-note').setAttribute('disabled', readOnly);
 					document.getElementById('context-pane-add-standalone-note-from-annotations').setAttribute('disabled', readOnly);
 					var popup = document.getElementById('context-pane-add-standalone-note-button-popup');
-					popup.onclick = _handleAddStandaloneNotePopupClick;
+					popup.addEventListener('command', _handleAddStandaloneNotePopupCommand);
 					popup.openPopup(event.target, 'after_end');
 				}}
 			/>,

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -3748,7 +3748,8 @@ var ItemTree = class ItemTree extends LibraryTree {
 		menupopup.appendChild(menuitem);
 		
 		document.children[0].appendChild(menupopup);
-		menupopup.openPopup(null, null, event.clientX + 2, event.clientY + 2);
+		menupopup.openPopup(null, null, event.clientX + 2, event.clientY + 2,
+			/* isContextMenu */ true);
 	}
 
 	_getSecondarySortField() {

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -2665,7 +2665,8 @@ var ZoteroPane = new function()
 		x = x || event.clientX;
 		y = y || event.clientY;
 		document.getElementById('zotero-collectionmenu').openPopup(
-			null, null, x + 1, y + 1);
+			null, null, x + 1, y + 1,
+			/* isContextMenu */ true);
 	};
 	
 	
@@ -2677,7 +2678,8 @@ var ZoteroPane = new function()
 		x = x || event.clientX;
 		y = y || event.clientY;
 		document.getElementById('zotero-itemmenu').openPopup(
-			null, null, x + 1, y + 1);
+			null, null, x + 1, y + 1,
+			/* isContextMenu */ true);
 	};
 	
 	
@@ -3259,9 +3261,9 @@ var ZoteroPane = new function()
 								for (let attachment of attachmentsWithAnnotations) {
 									let menuitem = document.createElement('menuitem');
 									menuitem.setAttribute('label', attachment.getDisplayTitle());
-									menuitem.onclick = () => {
+									menuitem.addEventListener('command', () => {
 										ZoteroPane.createNoteFromAnnotationsForAttachment(attachment);
-									};
+									});
 									popup.appendChild(menuitem);
 								}
 							}


### PR DESCRIPTION
So that releasing the right click that opened the menu will have the correct action (activating the hovered item on macOS and maybe other platforms).

Also:
- Replace some menuitem click listeners with command listeners.
  (click isn't fired when the right click that opened the menu is released.)

Fixes #2593.