### PR TITLE
Add items to other libraries via context menu

### DIFF
--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -1699,7 +1699,7 @@ Zotero.Utilities.Internal = {
 	 * @param {Function} clickAction function to execute on clicking the menuitem.
 	 * 		Receives the event and libraryOrCollection for given item.
 	 * @param {Function} disabledPred If provided, called on each library/collection
-	 * 		to determine whether disabled
+	 * 		to determine whether disabled. Can return a boolean or a promise.
 	 * 
 	 * @return {Node<menuitem>|Node<menu>} appended node
 	 */
@@ -1714,7 +1714,7 @@ Zotero.Utilities.Internal = {
 			}
 			menuitem.setAttribute("value", value);
 			menuitem.setAttribute("image", icon);
-			menuitem.setAttribute("disabled", disabled);
+			Promise.resolve(disabled).then(d => menuitem.setAttribute("disabled", d));
 			menuitem.addEventListener('command', command);
 			menuitem.classList.add('menuitem-iconic');
 			return menuitem
@@ -1755,7 +1755,7 @@ Zotero.Utilities.Internal = {
 		if (libraryOrCollection.objectType == 'collection') {
 			collections = Zotero.Collections.getByParent(libraryOrCollection.id);
 		} else {
-			collections = Zotero.Collections.getByLibrary(libraryOrCollection.id);
+			collections = Zotero.Collections.getByLibrary(libraryOrCollection.libraryID);
 		}
 		
 		// If no subcollections, place menuitem for target directly in containing men

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -3471,13 +3471,20 @@ var ZoteroPane = new function()
 		if (event.target.id !== 'zotero-add-to-collection-popup') return;
 
 		let popup = document.getElementById('zotero-add-to-collection-popup');
-		let separator = document.getElementById('zotero-add-to-collection-separator');
-		while (popup.childElementCount > 2) {
+		while (popup.childElementCount > 1) {
 			popup.removeChild(popup.lastElementChild);
 		}
 
 		let items = Zotero.Items.keepParents(this.getSelectedItems());
+		if (!items.length) {
+			// Just in case
+			return;
+		}
+
 		let collections = Zotero.Collections.getByLibrary(this.getSelectedLibraryID());
+		if (collections.length) {
+			popup.append(document.createElement('menuseparator'));
+		}
 		for (let col of collections) {
 			let menuItem = Zotero.Utilities.Internal.createMenuForTarget(
 				col,
@@ -3494,7 +3501,62 @@ var ZoteroPane = new function()
 			popup.append(menuItem);
 		}
 
-		separator.setAttribute('hidden', !collections.length);
+		let libraries = Zotero.Libraries.getAll()
+			.filter(lib => lib.libraryID != items[0].libraryID
+				// copyItemToLibrary will skip attachments if not filesEditable
+				&& lib.editable);
+		if (libraries.length) {
+			popup.append(document.createElement('menuseparator'));
+		}
+		for (let lib of libraries) {
+			let menuItem = Zotero.Utilities.Internal.createMenuForTarget(
+				lib,
+				popup,
+				null,
+				async (event, libOrCollection) => {
+					event.stopPropagation();
+
+					if (event.target.tagName != 'menuitem') {
+						return;
+					}
+
+					let copyOptions = {
+						tags: Zotero.Prefs.get('groups.copyTags'),
+						childNotes: Zotero.Prefs.get('groups.copyChildNotes'),
+						childLinks: Zotero.Prefs.get('groups.copyChildLinks'),
+						childFileAttachments: Zotero.Prefs.get('groups.copyChildFileAttachments'),
+						annotations: Zotero.Prefs.get('groups.copyAnnotations'),
+					};
+
+					await Zotero.DB.executeTransaction(async () => {
+						for (let item of items) {
+							let newID = await Zotero.Items.copyItemToLibrary(
+								item, libOrCollection.libraryID, copyOptions);
+							if (newID && libOrCollection.objectType == 'collection') {
+								let item = await Zotero.Items.get(newID);
+								item.addToCollection(libOrCollection.id);
+								await item.save();
+							}
+						}
+					});
+				},
+				async (libOrCollection) => {
+					for (let item of items) {
+						let linked = await item.getLinkedItem(libOrCollection.libraryID, true);
+						if (linked
+							&& (libOrCollection.objectType == 'library'
+								// Fine if the library contains a copy of this item
+								// but the collection doesn't - it won't be duplicated
+								|| libOrCollection.hasItem(linked))) {
+							return true;
+						}
+					}
+					return false;
+				}
+			);
+
+			popup.append(menuItem);
+		}
 	};
 
 

--- a/chrome/content/zotero/zoteroPane.xul
+++ b/chrome/content/zotero/zoteroPane.xul
@@ -313,7 +313,6 @@
 							<menu class="menuitem-iconic zotero-menuitem-add-to-collection">
 								<menupopup id="zotero-add-to-collection-popup" onpopupshowing="ZoteroPane_Local.buildAddToCollectionMenu(event)">
 									<menuitem id="zotero-add-to-new-collection" label="&zotero.toolbar.newCollection.label;" oncommand="ZoteroPane_Local.addSelectedItemsToCollection(null, true)"/>
-									<menuseparator id="zotero-add-to-collection-separator"/>
 								</menupopup>
 							</menu>
 							<menuitem class="menuitem-iconic zotero-menuitem-remove-items" oncommand="ZoteroPane_Local.deleteSelectedItems();"/>


### PR DESCRIPTION
Extracted copy logic from `CollectionTree` into `Zotero.Items` and slightly tweaked `createMenuForTarget`, again. (There are some extra fixes for that in #2367 that I should probably pull out and push separately, but that's another issue.)

Fixes #2599.