### PR TITLE
Target menu: Show group library collections, support clickable submenus everywhere

### DIFF
--- a/chrome/content/zotero/itemPane.js
+++ b/chrome/content/zotero/itemPane.js
@@ -345,29 +345,10 @@ var ZoteroItemPane = new function() {
 			Zotero.Utilities.Internal.createMenuForTarget(
 				library,
 				menu,
-				target,
-				function(event, libraryOrCollection) {
-					if (event.target.tagName == 'menu') {
-						Zotero.Promise.coroutine(function* () {
-							// Simulate menuitem flash on OS X
-							if (Zotero.isMac) {
-								event.target.setAttribute('_moz-menuactive', false);
-								yield Zotero.Promise.delay(50);
-								event.target.setAttribute('_moz-menuactive', true);
-								yield Zotero.Promise.delay(50);
-								event.target.setAttribute('_moz-menuactive', false);
-								yield Zotero.Promise.delay(50);
-								event.target.setAttribute('_moz-menuactive', true);
-							}
-							menu.hidePopup();
-							
-							ZoteroItemPane.setTranslationTarget(libraryOrCollection);
-							event.stopPropagation();
-						})();
-					}
-					else {
+				{
+					initialValue: target,
+					onChange(event, libraryOrCollection) {
 						ZoteroItemPane.setTranslationTarget(libraryOrCollection);
-						event.stopPropagation();
 					}
 				}
 			);

--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -1692,24 +1692,30 @@ Zotero.Utilities.Internal = {
 	/**
 	 * Create a libraryOrCollection DOM tree to place in <menupopup> element.
 	 * If has no children, returns a <menuitem> element, otherwise <menu>.
-	 * 
-	 * @param {Library|Collection} libraryOrCollection
+	 *
+	 * @param {Zotero.Library|Zotero.Collection} libraryOrCollection
 	 * @param {Node<menupopup>} elem Parent element
-	 * @param {Zotero.Library|Zotero.Collection} currentTarget Currently selected item (displays as checked)
-	 * @param {Function} clickAction function to execute on clicking the menuitem.
-	 * 		Receives the event and libraryOrCollection for given item.
-	 * @param {Function} disabledPred If provided, called on each library/collection
-	 * 		to determine whether disabled
-	 * 
-	 * @return {Node<menuitem>|Node<menu>} appended node
+	 * @param {String} options.initialValue The treeViewID of the initially
+	 * 		selected library or collection
+	 * @param {Function} options.onChange Function to execute when an item is
+	 * 		selected. Receives the event and libraryOrCollection for given item.
+	 * @param {Boolean} options.menusOnTopLevel If true, override default behavior
+	 * 		and create submenus for all top-level nodes, even if they don't have
+	 * 		children.
+	 * @param {Function} options.disabledPred If provided, called on each
+	 * 		library/collection to determine whether disabled.
+	 *
+	 * @return {Node<menuitem>/Node<menu>} appended node
 	 */
-	createMenuForTarget: function(libraryOrCollection, elem, currentTarget, clickAction, disabledPred) {
+	createMenuForTarget: function (libraryOrCollection, elem, options = {}) {
+		let { initialValue, onChange, menusOnTopLevel, disabledPred } = options;
 		var doc = elem.ownerDocument;
+
 		function _createMenuitem(label, value, icon, command, disabled) {
 			let menuitem = doc.createElement('menuitem');
 			menuitem.setAttribute("label", label);
 			menuitem.setAttribute("type", "checkbox");
-			if (value == currentTarget) {
+			if (value == initialValue) {
 				menuitem.setAttribute("checked", "true");
 			}
 			menuitem.setAttribute("value", value);
@@ -1717,17 +1723,17 @@ Zotero.Utilities.Internal = {
 			menuitem.setAttribute("disabled", disabled);
 			menuitem.addEventListener('command', command);
 			menuitem.classList.add('menuitem-iconic');
-			return menuitem
-		}	
+			return menuitem;
+		}
 		
-		function _createMenu(label, value, icon, command) {
+		function _createMenu(label, value, icon, command, disabled) {
 			let menu = doc.createElement('menu');
 			menu.setAttribute("label", label);
 			menu.setAttribute("value", value);
 			menu.setAttribute("image", icon);
 			// Allow click on menu itself to select a target
 			menu.addEventListener('click', (event) => {
-				if (event.target == menu) {
+				if (!disabled && event.target == menu) {
 					command(event);
 				}
 			});
@@ -1742,11 +1748,12 @@ Zotero.Utilities.Internal = {
 		// Create menuitem for library or collection itself, to be placed either directly in the
 		// containing menu or as the top item in a submenu
 		var menuitem = _createMenuitem(
-			libraryOrCollection.name, 
+			libraryOrCollection.name,
 			libraryOrCollection.treeViewID,
 			imageSrc,
-			function (event) {
-				clickAction(event, libraryOrCollection);
+			(event) => {
+				event.stopPropagation();
+				onChange(event, libraryOrCollection);
 			},
 			disabledPred && disabledPred(libraryOrCollection)
 		);
@@ -1754,14 +1761,16 @@ Zotero.Utilities.Internal = {
 		var collections;
 		if (libraryOrCollection.objectType == 'collection') {
 			collections = Zotero.Collections.getByParent(libraryOrCollection.id);
-		} else {
-			collections = Zotero.Collections.getByLibrary(libraryOrCollection.id);
+		}
+		else {
+			collections = Zotero.Collections.getByLibrary(libraryOrCollection.libraryID);
 		}
 		
-		// If no subcollections, place menuitem for target directly in containing men
-		if (collections.length == 0) {
+		// If no subcollections and caller has not specified menusOnTopLevel,
+		// place menuitem for target directly in containing menu
+		if (collections.length == 0 && !menusOnTopLevel) {
 			elem.appendChild(menuitem);
-			return menuitem
+			return menuitem;
 		}
 		
 		// Otherwise create a submenu for the target's subcollections
@@ -1769,16 +1778,36 @@ Zotero.Utilities.Internal = {
 			libraryOrCollection.name,
 			libraryOrCollection.treeViewID,
 			imageSrc,
-			function (event) {
-				clickAction(event, libraryOrCollection);
-			}
+			async (event) => {
+				if (event.target.tagName !== 'menu') return;
+				event.stopPropagation();
+
+				// Simulate menuitem flash on macOS
+				if (Zotero.isMac) {
+					event.target.setAttribute('_moz-menuactive', false);
+					await Zotero.Promise.delay(50);
+					event.target.setAttribute('_moz-menuactive', true);
+					await Zotero.Promise.delay(50);
+					event.target.setAttribute('_moz-menuactive', false);
+					await Zotero.Promise.delay(50);
+					event.target.setAttribute('_moz-menuactive', true);
+				}
+
+				let outerMenupopup = menu;
+				while ((outerMenupopup = outerMenupopup.parentElement.closest('menupopup')) !== null) {
+					outerMenupopup.hidePopup();
+				}
+
+				onChange(event, libraryOrCollection);
+			},
+			disabledPred && disabledPred(libraryOrCollection)
 		);
 		var menupopup = menu.firstChild;
 		menupopup.appendChild(menuitem);
 		menupopup.appendChild(doc.createElement('menuseparator'));
 		for (let collection of collections) {
 			let collectionMenu = this.createMenuForTarget(
-				collection, elem, currentTarget, clickAction, disabledPred
+				collection, elem, { ...options, menusOnTopLevel: false }
 			);
 			menupopup.appendChild(collectionMenu);
 		}

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -3482,14 +3482,15 @@ var ZoteroPane = new function()
 			let menuItem = Zotero.Utilities.Internal.createMenuForTarget(
 				col,
 				popup,
-				null,
-				(event, collection) => {
-					if (event.target.tagName == 'menuitem') {
-						this.addSelectedItemsToCollection(collection);
-						event.stopPropagation();
-					}
-				},
-				collection => items.every(item => collection.hasItem(item))
+				{
+					onChange: (event, collection) => {
+						if (event.target.tagName == 'menuitem') {
+							this.addSelectedItemsToCollection(collection);
+							event.stopPropagation();
+						}
+					},
+					disabledPred: collection => items.every(item => collection.hasItem(item))
+				}
 			);
 			popup.append(menuItem);
 		}


### PR DESCRIPTION
Some improvements that have been necessary for two PRs now and should just be merged separately. This extends clickable submenu behavior to all target menus and, maybe most importantly, fixes an issue that prevented the target menu from showing collections of group libraries (since it was using `Library.id`, not `Library.libraryID`).

- Made the clickable submenu behavior that itemPane.js implemented for feed items automatic.
- Event propagation is always stopped.
- Added a 'menusOnTopLevel' option in case the caller wants to ensure that every top-level node gets a menu, even if it has no children. This is useful for appending "New Collection..." menu items, for instance.
- Replaced all but first two positional arguments with an options object.