### PR TITLE
fx-compat: Fix adding/editing feeds

### DIFF
--- a/chrome/content/zotero-platform/mac/zotero.css
+++ b/chrome/content/zotero-platform/mac/zotero.css
@@ -1,7 +1,0 @@
-.zotero-advanced-options > .zotero-advanced-options-label > dropmarker {
-	transform: rotate(270deg) translateX(4px);
-}
-
-.zotero-advanced-options[state="open"] > .zotero-advanced-options-label > dropmarker {
-	transform: translateX(4px);
-}

--- a/chrome/content/zotero/feedSettings.xhtml
+++ b/chrome/content/zotero/feedSettings.xhtml
@@ -17,33 +17,22 @@
 	<script src="chrome://global/content/customElements.js"/>
 	<script src="feedSettings.js"/>
 	
-	<grid>
-		<columns>
-			<column/>
-			<column flex="1"/>
-		</columns>
-		
-		<rows>
-			<row>
-				<hbox align="center">
-					<label value="&zotero.feedSettings.url.label;" control="feed-url"/>
-				</hbox>
-				<textbox id="feed-url" flex="1" size="2"
-					 oninput="Zotero_Feed_Settings.invalidateURL();Zotero_Feed_Settings.validateURL()"
-					 focused="true" newlines="stripsurroundingwhitespace"
-					 style="width: 30em; max-width: 30em"/>
-			</row>
-			<row>
-				<hbox align="center">
-					<label value="&zotero.feedSettings.title.label;" control="feed-url"/>
-				</hbox>
-				<textbox id="feed-title" flex="1" newlines="replacewithspaces"/>
-			</row>
-		</rows>
-	</grid>
+	<html:div class="form-grid">
+		<hbox align="center">
+			<label value="&zotero.feedSettings.url.label;" control="feed-url"/>
+		</hbox>
+		<html:input id="feed-url"
+				oninput="Zotero_Feed_Settings.invalidateURL();Zotero_Feed_Settings.validateURL()"
+				autofocus="true" style="width: 30em; max-width: 30em; -moz-box-flex: 1;"/>
+
+		<hbox align="center">
+			<label value="&zotero.feedSettings.title.label;" control="feed-title"/>
+		</hbox>
+		<html:input id="feed-title" style="-moz-box-flex: 1;"/>
+	</html:div>
 	<vbox id="advanced-options" class="zotero-advanced-options">
 		<hbox onclick="Zotero_Feed_Settings.toggleAdvancedOptions()"  class="zotero-advanced-options-label">
-			<dropmarker/>
+			<toolbarbutton class="toolbarbutton-menu-dropmarker"/>
 			<hbox align="center">
 				<label value="&zotero.general.advancedOptions.label;"/>
 			</hbox>

--- a/chrome/skin/default/zotero/zotero.css
+++ b/chrome/skin/default/zotero/zotero.css
@@ -283,12 +283,11 @@ zoterosearch .menulist-icon {
 	max-width: 29.5em;
 }
 
-.zotero-advanced-options>.zotero-advanced-options-label>dropmarker {
-	list-style-image: url("chrome://browser/skin/toolbarbutton-dropdown-arrow.png");
+.zotero-advanced-options > .zotero-advanced-options-label > .toolbarbutton-menu-dropmarker {
 	transform: rotate(270deg);
 }
 
-.zotero-advanced-options[state=open]>.zotero-advanced-options-label>dropmarker {
+.zotero-advanced-options[state=open] > .zotero-advanced-options-label > .toolbarbutton-menu-dropmarker {
 	transform: none;
 }
 
@@ -321,6 +320,11 @@ zoterosearch .menulist-icon {
 
 #zotero-edit-bibliography-dialog #item-list .listcell-icon {
 	max-width: 16px;
+}
+
+.form-grid {
+	display: grid;
+	grid-template-columns: max-content 1fr;
 }
 
 


### PR DESCRIPTION
The dropmarker had to be replaced - the built-in `<dropmarker>` tag (which is now a custom element) now uses CSS `appearance:` and overflows its bounds, so getting text to align along its middle in a cross-platform way isn't straightforward. We should either copy the dropmarker image used in older Firefox or find something new (which could be the menu dropmarker image this is using now - at least on Mac that appearance is consistent with "disclosure triangles" in Cocoa apps).

Includes a new `.form-grid` utility to replace our most common use of the now-nonfunctional `<grid>` tag: a two-column form layout with a left column for labels (fits content width) and a right column for fields (takes as much width as possible).