### PR TITLE
Fx102 improve build

### DIFF
--- a/scripts/browserify.js
+++ b/scripts/browserify.js
@@ -11,7 +11,7 @@ const ROOT = path.resolve(__dirname, '..');
 
 async function getBrowserify(signatures) {
 	const t1 = Date.now();
-	var count = 0;
+	const outFiles = [];
 	var config, f, totalCount;
 	
 	while ((config = browserifyConfigs.pop()) != null) {
@@ -48,7 +48,7 @@ async function getBrowserify(signatures) {
 
 				onProgress(f, dest, 'browserify');
 				signatures[f] = newFileSignature;
-				count++;
+				outFiles.push(dest);
 			} catch (err) {
 				throw new Error(`Failed on ${f}: ${err}`);
 			}
@@ -58,7 +58,8 @@ async function getBrowserify(signatures) {
 	const t2 = Date.now();
 	return {
 		action: 'browserify',
-		count,
+		count: outFiles.length,
+		outFiles,
 		totalCount,
 		processingTime: t2 - t1
 	};

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -24,6 +24,11 @@ if (require.main === module) {
 				.concat([`!${formatDirsForMatcher(copyDirs)}/**`]);
 
 			const signatures = await getSignatures();
+
+			// Check if all files in signatures are still present in src; Needed to avoid a problem
+			// where what was a symlink before, now is compiled, resulting in polluting source files
+			onSuccess(await cleanUp(signatures));
+			
 			const results = await Promise.all([
 				getBrowserify(signatures),
 				getCopy(copyDirs.map(d => `${d}/**`), { ignore: ignoreMask }, signatures),
@@ -31,7 +36,6 @@ if (require.main === module) {
 				...scssFiles.map(scf => getSass(scf, { ignore: ignoreMask }, signatures)),
 				getSymlinks(symlinks, { nodir: true, ignore: ignoreMask }, signatures),
 				getSymlinks(symlinkDirs, { ignore: ignoreMask }, signatures),
-				cleanUp(signatures),
 				getPDFReader(signatures),
 				getPDFWorker(signatures),
 				getZoteroNoteEditor(signatures)

--- a/scripts/copy.js
+++ b/scripts/copy.js
@@ -12,7 +12,7 @@ async function getCopy(source, options, signatures) {
 	const t1 = Date.now();
 	const files = await globby(source, Object.assign({ cwd: ROOT }, options ));
 	const totalCount = files.length;
-	var count = 0;
+	const outFiles = [];
 	var f;
 
 	while ((f = files.pop()) != null) {
@@ -34,7 +34,7 @@ async function getCopy(source, options, signatures) {
 			await fs.copy(f, dest);
 			onProgress(f, dest, 'cp');
 			signatures[f] = newFileSignature;
-			count++;
+			outFiles.push(dest);
 		} catch (err) {
 			throw new Error(`Failed on ${f}: ${err}`);
 		}
@@ -43,7 +43,8 @@ async function getCopy(source, options, signatures) {
 	const t2 = Date.now();
 	return {
 		action: 'copy',
-		count,
+		count: outFiles.length,
+		outFiles,
 		totalCount,
 		processingTime: t2 - t1
 	};

--- a/scripts/sass.js
+++ b/scripts/sass.js
@@ -11,11 +11,12 @@ const sassRender = universalify.fromCallback(sass.render);
 
 const ROOT = path.resolve(__dirname, '..');
 
-async function getSass(source, options, signatures={}) {
+async function getSass(source, options, signatures = {}) {
 	const t1 = Date.now();
 	const files = await globby(source, Object.assign({ cwd: ROOT }, options));
 	const totalCount = files.length;
-	var count = 0, shouldRebuild = false;
+	const outFiles = [];
+	var shouldRebuild = false;
 
 	for (const f of files) {
 		// if any file changed, rebuild all onSuccess
@@ -54,7 +55,7 @@ async function getSass(source, options, signatures={}) {
 				await fs.outputFile(`${dest}.map`, sass.map);
 				onProgress(f, dest, 'sass');
 				signatures[f] = newFileSignature;
-				count++;
+				outFiles.push(dest);
 			}
 			catch (err) {
 				throw new Error(`Failed on ${f}: ${err}`);
@@ -65,7 +66,8 @@ async function getSass(source, options, signatures={}) {
 	const t2 = Date.now();
 	return {
 		action: 'sass',
-		count,
+		count: outFiles.length,
+		outFiles,
 		totalCount,
 		processingTime: t2 - t1
 	};

--- a/scripts/sass.js
+++ b/scripts/sass.js
@@ -33,13 +33,13 @@ async function getSass(source, options, signatures={}) {
 			let newFileSignature = await getFileSignature(f);
 			let destFile = getPathRelativeTo(f, 'scss');
 			destFile = path.join(path.dirname(destFile), path.basename(destFile, '.scss') + '.css');
-			let dest = path.join.apply(this, ['build', 'chrome', 'skin', 'default', 'zotero', destFile]);
+			let dest = path.join('build', 'chrome', 'skin', 'default', 'zotero', destFile);
 
 			if (['win', 'mac', 'unix'].some(platform => f.endsWith(`-${platform}.scss`))) {
 				let platform = f.slice(f.lastIndexOf('-') + 1, f.lastIndexOf('.'));
 				destFile = destFile.slice(0, destFile.lastIndexOf('-'))
 				+ destFile.slice(destFile.lastIndexOf('-') + 1 + platform.length);
-				dest = path.join.apply(this, ['build', 'chrome', 'content', 'zotero-platform', platform, destFile]);
+				dest = path.join('build', 'chrome', 'content', 'zotero-platform', platform, destFile);
 			}
 
 			try {

--- a/scripts/symlinks.js
+++ b/scripts/symlinks.js
@@ -56,6 +56,7 @@ async function getSymlinks(source, options, signatures) {
 	return {
 		action: 'symlink',
 		count: filesProcessedCount,
+		outFiles: filesToProcess,
 		totalCount: files.length,
 		processingTime: t2 - t1
 	};

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -11,6 +11,7 @@ const NODE_ENV = process.env.NODE_ENV;
 
 
 function onError(err) {
+	console.log('\u0007'); //🔔
 	console.log(colors.red('Error:'), err);
 }
 

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -117,10 +117,13 @@ function comparePaths(actualPath, testedPath) {
 	return path.normalize(actualPath) === path.normalize(testedPath);
 }
 
+const envCheckTrue = env => !!(env && (parseInt(env) || env === true || env === "true"));
+
 module.exports = {
 	cleanUp,
 	comparePaths,
 	compareSignatures,
+	envCheckTrue,
 	formatDirsForMatcher,
 	getFileSignature,
 	getPathRelativeTo,

--- a/scripts/watch.js
+++ b/scripts/watch.js
@@ -56,7 +56,7 @@ function getWatch() {
 				return;
 			}
 			for (var i = 0; i < scssFiles.length; i++) {
-				if (multimatch(path, scssFiles[i])) {
+				if (multimatch(path, scssFiles[i]).length) {
 					onSuccess(await getSass(scssFiles[i], { ignore: ignoreMask }));
 					onSuccess(await cleanUp(signatures));
 					return;


### PR DESCRIPTION
* Fix a bug that would trigger `scss` files build on other changes
* Fix a problem with `.css` files appearing outside of `build/` folder when switching from `master` to `fx102` branch. See commit for convoluted reasons this was happening
* Run `add_omni_file` script when source change is detected (**DEPENDS ON** zotero/zotero-standalone-build/pull/98)
* Ring the bell on error.