### PR TITLE
Add Component DevHelper (fx102)

### DIFF
--- a/chrome/content/zotero/devHelper.js
+++ b/chrome/content/zotero/devHelper.js
@@ -1,0 +1,69 @@
+Components.utils.import("resource://gre/modules/Services.jsm");
+Components.utils.import('chrome://remote/content/shared/WindowManager.jsm');
+Components.utils.import("resource://gre/modules/osfile.jsm");
+
+// eslint-disable-next-line no-unused-vars
+class DevHelper {
+	constructor(element) {
+		Zotero.Server.Endpoints['/dev-helper/update'] = function () { };
+		Zotero.Server.Endpoints['/dev-helper/update'].prototype = {
+			supportedMethods: ["POST"],
+			supportedDataTypes: ["application/json", "text/plain"],
+			permitBookmarklet: false,
+			
+			init: () => {
+				this.refresh();
+				return 200;
+			},
+		};
+
+		this.componentPathInput = element.querySelector('#component-path');
+		this.loadComponentBtn = element.querySelector('#load-component');
+		this.autoResizeCheckbox = element.querySelector('#auto-resize');
+		this.frame = document.getElementById('component-iframe');
+		this.componentHasBeenSelected = false;
+
+		const handleComponentSelected = () => {
+			this.componentHasBeenSelected = true;
+			this.refresh();
+		};
+
+		this.componentPathInput.addEventListener('select', handleComponentSelected);
+		this.loadComponentBtn.addEventListener('click', handleComponentSelected);
+		this.frame.contentWindow.document.addEventListener('load', this.resizeWindow.bind(this));
+	}
+
+	register() {
+		Zotero.DevHelper = this;
+	}
+
+	async refresh() {
+		if (!this.componentHasBeenSelected) {
+			return;
+		}
+		const wi = this.frame.docShell.QueryInterface(Ci.nsIWebNavigation);
+		wi.loadURI(`chrome://zotero/content/${this.componentPathInput.value}`, {
+			triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal(),
+		});
+
+		if (this.autoResizeCheckbox.checked) {
+			setTimeout(this.resizeWindow.bind(this), 200);
+		}
+	}
+
+	resizeWindow() {
+		const componentWindow = Array.from(this.frame.contentWindow.document.childNodes).find(cn => cn.tagName?.toLowerCase() === 'window');
+		if (componentWindow) {
+			const width = parseInt(componentWindow.getAttribute('width'));
+			const height = parseInt(componentWindow.getAttribute('height'));
+			if (width && height) {
+				window.innerWidth = width;
+				window.innerHeight = height + 40;
+			}
+			else {
+				window.innerWidth = 600;
+				window.innerHeight = 400;
+			}
+		}
+	}
+}

--- a/chrome/content/zotero/devHelper.xhtml
+++ b/chrome/content/zotero/devHelper.xhtml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
+<?xml-stylesheet href="chrome://zotero/skin/zotero.css" type="text/css"?>
+<!DOCTYPE window SYSTEM "chrome://zotero/locale/about.dtd">
+
+<window id="component-dev-helper"
+		xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
+		xmlns:html="http://www.w3.org/1999/xhtml"
+		title="Component DevHelper"
+		onload="const cdh = new DevHelper(document); cdh.register();"
+		persist="screenX screenY"
+		width="600" height="400"
+>
+	<script src="include.js"/>
+	<script src="devHelper.js"/>
+	<html:div style="-moz-box-flex: 1; display: flex; flex-direction: column; height: 100%; border-bottom: 1px solid #bbb;">
+		<html:div style="height: 40px; padding: 1px 10px; display: flex; align-items: center;">
+			<html:div style="display: flex; align-items: center;">
+				<html:label for="component-path">Component to debug:</html:label>
+				<menulist value="zoteroPane.xhtml" style="display: inline-block;" id="component-path">
+					<menupopup>
+						{%OPTIONS%}
+					</menupopup>
+				</menulist>
+				<html:button class="btn" id="load-component">Load</html:button>
+			</html:div>
+			<html:div>
+				<html:input id="auto-resize" type="checkbox" checked="checked" />
+				<html:label for="auto-resize">Auto-resize window?</html:label>
+			</html:div>
+		</html:div>
+		<iframe style="flex: 1 0 auto; width: 100%;" id="component-iframe"></iframe>
+	</html:div>
+</window>

--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -201,6 +201,7 @@ Services.scriptloader.loadSubScript("resource://zotero/polyfill.js");
 			opts.filter(opt => options[opt]).forEach(opt => this[opt] = true);
 			
 			this.forceDataDir = options.forceDataDir;
+			this.devHelper = options.devHelper;
 		}
 		
 		this.mainThread = Services.tm.mainThread;
@@ -756,6 +757,14 @@ Services.scriptloader.loadSubScript("resource://zotero/polyfill.js");
 			Zotero.addShutdownListener(() => Zotero.Feeds.uninit());
 			
 			Zotero.Schema.schemaUpdatePromise.then(Zotero.purgeDataObjects.bind(Zotero));
+
+			if (Zotero.devHelper) {
+				Components.classes['@mozilla.org/embedcomp/window-watcher;1']
+					.getService(Components.interfaces.nsIWindowWatcher)
+					.openWindow(null, 'chrome://zotero/content/devHelper.xhtml',
+						"devHelper", "chrome,dialog=yes,resizable,centerscreen,menubar,scrollbars", null
+					);
+			}
 			
 			return true;
 		}

--- a/components/zotero-service.js
+++ b/components/zotero-service.js
@@ -502,6 +502,8 @@ ZoteroCommandLineHandler.prototype = {
 		}
 		
 		zInitOptions.forceDataDir = cmdLine.handleFlagWithParam("datadir", false);
+
+		// Placeholder for ZoterDevHelper, please do not remove, this line may be replaced with code during build
 		
 		// handler to open Zotero pane at startup in Zotero for Firefox
 		if (!isStandalone() && cmdLine.handleFlag("ZoteroPaneOpen", false)) {

--- a/resource/loader.jsm
+++ b/resource/loader.jsm
@@ -798,10 +798,18 @@ const Require = iced(function Require(loader, requirer) {
     // We also freeze module to prevent it from further changes
     // at runtime.
     if (!(uri in modules)) {
+      
+      // Special, non-existent protocol dev:// is used to load file:// and prevent all caching. This
+      // is only used by ZoteroDevHelper.
+      if (uri.startsWith('dev://')) {
+        module = Module(requirement, uri.replace('dev://', 'file://') + `?t=${Date.now()}`);
+        delete loader.sandboxes[uri];
+      } else {
       // Many of the loader's functionalities are dependent
       // on modules[uri] being set before loading, so we set it and
       // remove it if we have any errors.
-      module = modules[uri] = Module(requirement, uri);
+        module = modules[uri] = Module(requirement, uri);
+      }
       try {
         freeze(load(loader, module));
       }

--- a/resource/require.js
+++ b/resource/require.js
@@ -97,19 +97,19 @@ var require = (function() {
 		TextDecoder: TextDecoder,
 	};
 	Object.defineProperty(globals, 'Zotero', { get: getZotero });
-	var loader = Loader({
-		id: 'zotero/require',
-		paths: {
-			'': 'resource://zotero/',
-			'containers/': 'chrome://zotero/content/containers/',
-			'components/': 'chrome://zotero/content/components/',
-			'zotero/': 'chrome://zotero/content/',
-			// TEMP until plugins updated
-			// TODO: Possible to show a deprecation warning?
-			'zotero/filePicker': 'chrome://zotero/content/modules/filePicker',
-		},
-		globals
-	});
+	const makePath = chrPath => (win.Zotero?.devHelper
+			? `dev://${win.Zotero.devHelper}/chrome/${chrPath.replace('zotero/content/', 'content/zotero/')}`
+			: `chrome://${chrPath}`);
+	const paths = {
+		'': 'resource://zotero/',
+		'containers/': makePath('zotero/content/containers/'),
+		'components/': makePath('zotero/content/components/'),
+		'zotero/': makePath('zotero/content/'),
+		// TEMP until plugins updated
+		// TODO: Possible to show a deprecation warning?
+		'zotero/filePicker': 'chrome://zotero/content/modules/filePicker',
+	};
+	var loader = Loader({ id: 'zotero/require', paths, globals });
 	let require = Require(loader, requirer);
 	return require;
 })();

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -8,8 +8,16 @@ const getSymlinks = require('./symlinks');
 const getPDFReader = require('./pdf-reader');
 const getPDFWorker = require('./pdf-worker');
 const getZoteroNoteEditor = require('./note-editor');
-const { formatDirsForMatcher, getSignatures, writeSignatures, cleanUp, onSuccess, onError} = require('./utils');
-const { dirs, symlinkDirs, copyDirs, symlinkFiles, jsFiles, scssFiles, ignoreMask } = require('./config');
+const getRewriteSrc = require('./rewrite-src');
+const { envCheckTrue, formatDirsForMatcher, getSignatures, writeSignatures, cleanUp, onSuccess, onError } = require('./utils');
+const { dirs, envDependentFiles, symlinkDirs, copyDirs, symlinkFiles, jsFiles, scssFiles, rewriteSrcFiles } = require('./config');
+let { ignoreMask } = require('./config');
+
+const REWRITE_SRC = envCheckTrue(process.env.REWRITE_SRC);
+
+if (REWRITE_SRC) {
+	ignoreMask = ignoreMask.filter(f => !f.startsWith('chrome/content/zotero/devHelper'));
+}
 
 if (require.main === module) {
 	(async () => {
@@ -21,15 +29,20 @@ if (require.main === module) {
 				.concat([`!${formatDirsForMatcher(dirs)}/**/*.js`])
 				.concat([`!${formatDirsForMatcher(dirs)}/**/*.jsx`])
 				.concat([`!${formatDirsForMatcher(dirs)}/**/*.scss`])
-				.concat([`!${formatDirsForMatcher(copyDirs)}/**`]);
+				.concat([`!${formatDirsForMatcher(copyDirs)}/**`])
+				.concat(REWRITE_SRC ? rewriteSrcFiles.map(rsf => `!${rsf}`) : []);
 
 			const signatures = await getSignatures();
 
 			// Check if all files in signatures are still present in src; Needed to avoid a problem
 			// where what was a symlink before, now is compiled, resulting in polluting source files
-			onSuccess(await cleanUp(signatures));
+			onSuccess(await cleanUp(
+				signatures,
+				symlinks.concat(symlinkDirs).concat([`!${formatDirsForMatcher(copyDirs)}`]),
+				envDependentFiles
+			));
 			
-			const results = await Promise.all([
+			const jobs = [
 				getBrowserify(signatures),
 				getCopy(copyDirs.map(d => `${d}/**`), { ignore: ignoreMask }, signatures),
 				getJS(jsFiles, { ignore: ignoreMask }, signatures),
@@ -39,7 +52,13 @@ if (require.main === module) {
 				getPDFReader(signatures),
 				getPDFWorker(signatures),
 				getZoteroNoteEditor(signatures)
-			]);
+			];
+
+			if (REWRITE_SRC) {
+				jobs.push(getRewriteSrc(rewriteSrcFiles, { ignore: ignoreMask }, signatures));
+			}
+
+			const results = await Promise.all(jobs);
 
 			await writeSignatures(signatures);
 			for (const result of results) {

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -101,6 +101,8 @@ const ignoreMask = [
 	'chrome/content/zotero/xpcom/translate/README.md',
 	'chrome/content/zotero/xpcom/utilities/node_modules/**/*',
 	'chrome/content/zotero/xpcom/utilities/test/**/*',
+	'chrome/content/zotero/devHelper.xhtml',
+	'chrome/content/zotero/devHelper.js',
 ];
 
 const jsFiles = [
@@ -121,8 +123,19 @@ const scssFiles = [
 	'chrome/skin/default/zotero/**/*.scss'
 ];
 
+const rewriteSrcFiles = [
+	'chrome/**/*.xhtml'
+];
+
+const envDependentFiles = {
+	REWRITE_SRC: [
+		'components/zotero-service.js',
+		'chrome/content/zotero/devHelper.xhtml',
+		'chrome/content/zotero/devHelper.js',
+	]
+};
+
 const buildsURL = 'https://zotero-download.s3.amazonaws.com/ci/';
 
-module.exports = {
-	dirs, symlinkDirs, copyDirs, symlinkFiles, browserifyConfigs, jsFiles, scssFiles, ignoreMask, buildsURL
-};
+module.exports = { dirs, envDependentFiles, symlinkDirs, copyDirs, symlinkFiles, browserifyConfigs,
+	jsFiles, scssFiles, ignoreMask, buildsURL, rewriteSrcFiles };

--- a/scripts/rewrite-src.js
+++ b/scripts/rewrite-src.js
@@ -1,0 +1,151 @@
+const globby = require('globby');
+const path = require('path');
+const fs = require('fs-extra');
+const { getSignatures, writeSignatures, cleanUp, compareSignatures, getFileSignature, onSuccess, onError, onProgress } = require('./utils');
+const { rewriteSrcFiles } = require('./config');
+
+// eslint-disable-next-line multiline-ternary
+const platform = process.platform === 'darwin' ? 'mac' : process.platform === 'win32' ? 'win' : 'unix';
+const ROOT = path.resolve(__dirname, '..');
+
+function getAbsolutePath(relPath, fromPath) {
+	if (relPath.endsWith('overlay.css')) { //TODO
+		return false;
+	}
+	if (relPath.startsWith('chrome://zotero/content/')) {
+		return path.join(ROOT, 'build', 'chrome', 'content', 'zotero', relPath.slice(24));
+	}
+	else if (relPath.startsWith('chrome://zotero/locale/')) {
+		return path.join(ROOT, 'build', 'chrome', 'locale', relPath.slice(23));
+	}
+	else if (relPath.startsWith('chrome://zotero-platform/content/')) {
+		return path.join(ROOT, 'build', 'chrome', 'content', 'zotero-platform', platform, relPath.slice(33));
+	}
+	else if (relPath.startsWith('chrome://zotero-platform-version/content')) {
+		return path.join(ROOT, 'build', 'chrome', 'content', 'zotero-platform', 'default-version', relPath.slice(40));
+	}
+	else if (relPath.startsWith('chrome://zotero/skin/')) {
+		return path.join(ROOT, 'build', 'chrome', 'skin', 'default', 'zotero', relPath.slice(21));
+	}
+	else if (relPath.startsWith('chrome://global/')) {
+		// ignore
+		return false;
+	}
+	else if (relPath.startsWith('chrome://')) {
+		console.log('WARNING: unmaped chrome path', relPath);
+		return false;
+	}
+	else if (relPath.startsWith('resource://')) {
+		return path.join(ROOT, 'build', 'resource', relPath.slice(11));
+	}
+	else {
+		const newPath = path.join(fromPath, relPath);
+
+		if (newPath.startsWith('chrome/content/zotero/')) {
+			return path.join(ROOT, 'build', 'chrome', 'content', 'zotero', newPath.slice(22));
+		}
+		else {
+			console.log('WARNING: unmaped relative path', newPath);
+			return false;
+		}
+	}
+}
+
+function getRewrittenContent(content, fromPath) {
+	content = content.replace(/<script(?:.*?)src="(.*?)"(?:.*?)>(?:<\/script>)?/ig, (match, relPath) => {
+		const newPath = getAbsolutePath(relPath, fromPath);
+		return newPath
+			? `<script>Components.classes["@mozilla.org/moz/jssubscript-loader;1"].getService(Components.interfaces.mozIJSSubScriptLoader).loadSubScriptWithOptions("file://${newPath}", { ignoreCache: true });</script>`
+			: match;
+	});
+
+	content = content.replace(/<\?xml-stylesheet(.*?)href="(.*?)"/ig, (match, p1, relPath) => {
+		const newPath = getAbsolutePath(relPath, fromPath);
+		return newPath
+			? `<?xml-stylesheet${p1}href="file://${newPath}"`
+			: match;
+	});
+
+	content = content.replace(/url\(["']?chrome:\/\/(.*?)["']?\)/ig, (match, relPath) => {
+		const newPath = getAbsolutePath(`chrome://${relPath}`, fromPath);
+		return newPath
+			? `url("file://${newPath}")`
+			: match;
+	});
+
+	return content;
+}
+
+async function getRewriteSrc(source, options, signatures) {
+	const t1 = Date.now();
+	const files = await globby(source, Object.assign({ cwd: ROOT }, options));
+	const selectOptions = files
+		.filter(f => f.startsWith('chrome/content/zotero/'))
+		.map((f) => {
+			const relF = f.slice(22); // remove chrome/content/zotero prefix
+			return `<menuitem value="${relF}" label="${relF}"/>`;
+			// return `<html:option value="${relF}"${relF === 'zoteroPane.xhtml' ? ' selected="selected"' : ''}>${relF}</html:option>`;
+		});
+	const totalCount = files.length;
+	const outFiles = [];
+	var f;
+
+	while ((f = files.pop())) {
+		let newFileSignature = await getFileSignature(f); // eslint-disable-line no-await-in-loop
+		const dest = path.join('build', f);
+
+		if (f in signatures) {
+			if (compareSignatures(newFileSignature, signatures[f])) {
+				try {
+					await fs.access(dest, fs.constants.F_OK); // eslint-disable-line no-await-in-loop
+					continue;
+				}
+				catch (_) {
+					// file does not exists in build, rebuild
+				}
+			}
+		}
+		try {
+			await fs.mkdirp(path.dirname(dest)); // eslint-disable-line no-await-in-loop
+			const content = await fs.readFile(f, 'utf8'); // eslint-disable-line no-await-in-loop
+			let newContent = getRewrittenContent(content, path.dirname(f));
+			if (f === 'chrome/content/zotero/devHelper.xhtml') {
+				newContent = newContent.replace('{%OPTIONS%}', selectOptions.join(''));
+			}
+			await fs.writeFile(dest, newContent); // eslint-disable-line no-await-in-loop
+			onProgress(f, dest, 'rewrite-src');
+			signatures[f] = newFileSignature;
+			outFiles.push(dest);
+		}
+		catch (err) {
+			throw new Error(`Failed on ${f}: ${err}`);
+		}
+	}
+	
+	const t2 = Date.now();
+	return {
+		action: 'rewrite-src',
+		count: outFiles.length,
+		outFiles,
+		totalCount,
+		processingTime: t2 - t1
+	};
+}
+
+module.exports = getRewriteSrc;
+
+if (require.main === module) {
+	(async () => {
+		try {
+			const signatures = await getSignatures();
+			onSuccess(await getRewriteSrc(rewriteSrcFiles, {}, signatures));
+			onSuccess(await cleanUp(signatures));
+			await writeSignatures(signatures);
+		}
+		catch (err) {
+			process.exitCode = 1;
+			global.isError = true;
+			onError(err);
+		}
+	})();
+}

--- a/scripts/watch.js
+++ b/scripts/watch.js
@@ -1,19 +1,28 @@
+/* eslint-disable no-process-env */
 const path = require('path');
 const fs = require('fs-extra');
 const chokidar = require('chokidar');
 const multimatch = require('multimatch');
 const { exec } = require('child_process');
-const { dirs, jsFiles, scssFiles, ignoreMask, copyDirs, symlinkFiles } = require('./config');
+const { dirs, jsFiles, scssFiles, ignoreMask, copyDirs, symlinkFiles, rewriteSrcFiles } = require('./config');
 const { envCheckTrue, onSuccess, onError, getSignatures, writeSignatures, cleanUp, formatDirsForMatcher } = require('./utils');
 const getJS = require('./js');
 const getSass = require('./sass');
 const getCopy = require('./copy');
 const getSymlinks = require('./symlinks');
-
+const getRewriteSrc = require('./rewrite-src');
+const colors = require('colors/safe');
 
 const ROOT = path.resolve(__dirname, '..');
 const addOmniExecPath = path.join(ROOT, '..', 'zotero-standalone-build', 'scripts', 'add_omni_file');
 let shouldAddOmni = false;
+const REWRITE_SRC = envCheckTrue(process.env.REWRITE_SRC);
+const DEBUG = envCheckTrue(process.env.DEBUG);
+const ZOTERO_HTTP_SERVER_PORT = process.env.ZOTERO_HTTP_SERVER_PORT || 23119;
+
+const filteredIgnoreMask = REWRITE_SRC
+	? ignoreMask.filter(f => !f.startsWith('chrome/content/zotero/devHelper'))
+	: ignoreMask;
 
 const source = [
 	'chrome',
@@ -41,13 +50,14 @@ const symlinks = symlinkFiles
 				.concat([`!${formatDirsForMatcher(dirs)}/**/*.js`])
 				.concat([`!${formatDirsForMatcher(dirs)}/**/*.jsx`])
 				.concat([`!${formatDirsForMatcher(dirs)}/**/*.scss`])
-				.concat([`!${formatDirsForMatcher(copyDirs)}/**`]);
+				.concat([`!${formatDirsForMatcher(copyDirs)}/**`])
+				.concat(REWRITE_SRC ? rewriteSrcFiles.map(rsf => `!${rsf}`) : []);
 
 var signatures;
 
 process.on('SIGINT', () => {
 	writeSignatures(signatures);
-	process.exit();
+	process.exit(); // eslint-disable-line no-process-exit
 });
 
 async function addOmniFiles(relPaths) {
@@ -62,7 +72,7 @@ async function addOmniFiles(relPaths) {
 				reject(error);
 			}
 			else {
-				process.env.NODE_ENV === 'debug' && console.log(`Executed:\n${cmd};\nOutput:\n${output}\n`);
+				DEBUG && console.log(`Executed:\n${cmd};\nOutput:\n${output}\n`);
 				resolve(output);
 			}
 		});
@@ -78,6 +88,19 @@ async function addOmniFiles(relPaths) {
 	};
 }
 
+async function notifyHTTP() {
+	const host = '127.0.0.1';
+	try {
+		await fetch(
+			`http://${host}:${ZOTERO_HTTP_SERVER_PORT}/dev-helper/update`,
+			{ method: 'POST', headers: { contentType: 'text/plain' } }
+		);
+		console.log(`${colors.magenta('Notify:')} client on ${host}:${ZOTERO_HTTP_SERVER_PORT} notifed`);
+	} catch (e) {
+		console.log(`${colors.gray('Notify:')} no client on ${host}:${ZOTERO_HTTP_SERVER_PORT}`);
+	}
+}
+
 async function getWatch() {
 	try {
 		await fs.access(addOmniExecPath, fs.constants.F_OK);
@@ -89,14 +112,14 @@ async function getWatch() {
 	.on('change', async (path) => {
 		try {
 			var result = false;
-			if (multimatch(path, jsFiles).length && !multimatch(path, ignoreMask).length) {
-				result = await getJS(path, { ignore: ignoreMask }, signatures);
+			if (multimatch(path, jsFiles).length && !multimatch(path, filteredIgnoreMask).length) {
+				result = await getJS(path, { ignore: filteredIgnoreMask }, signatures);
 				onSuccess(await cleanUp(signatures));
 			}
 			if (!result) {
 				for (var i = 0; i < scssFiles.length; i++) {
 					if (multimatch(path, scssFiles[i]).length) {
-						result = await getSass(scssFiles[i], { ignore: ignoreMask }); // eslint-disable-line no-await-in-loop
+						result = await getSass(scssFiles[i], { ignore: filteredIgnoreMask }); // eslint-disable-line no-await-in-loop
 						break;
 					}
 				}
@@ -104,15 +127,24 @@ async function getWatch() {
 			if (!result && multimatch(path, copyDirs.map(d => `${d}/**`)).length) {
 				result = await getCopy(path, {}, signatures);
 			}
+			if (REWRITE_SRC && !result && multimatch(path, rewriteSrcFiles).length) {
+				result = await getRewriteSrc(rewriteSrcFiles, {}, signatures);
+			}
 			if (!result && multimatch(path, symlinks).length) {
 				result = await getSymlinks(path, { nodir: true }, signatures);
 			}
 
-			onSuccess(result);
-			onSuccess(await cleanUp(signatures));
+			if (result) {
+				onSuccess(result);
+				onSuccess(await cleanUp(signatures));
 
-			if (shouldAddOmni && result.outFiles?.length) {
-				onSuccess(await addOmniFiles(result.outFiles));
+				if (shouldAddOmni && result.outFiles?.length) {
+					onSuccess(await addOmniFiles(result.outFiles));
+				}
+
+				if (REWRITE_SRC && result.outFiles?.length) {
+					await notifyHTTP();
+				}
 			}
 		}
 		catch (err) {
@@ -125,7 +157,7 @@ async function getWatch() {
 	});
 
 	watcher.add(source);
-	console.log(`Watching files for changes (omni updates ${shouldAddOmni ? 'enabled' : 'disabled'})...`);
+	console.log(`[${colors.magenta(shouldAddOmni ? '✓' : '⨯')}] omni updates | [${colors.magenta(REWRITE_SRC ? '✓' : '⨯')}] notify ipc | Watching files for changes...`);
 }
 
 module.exports = getWatch;


### PR DESCRIPTION
This PR adds a new development tool that enables live, in-process updates:

https://user-images.githubusercontent.com/214628/171386152-1f9f8ab5-5f95-4517-ba60-0079f075ae1e.mp4

Changes to `.js`/`.jsx` (and possible other) files in `chrome/content/zotero/**` and changes to `.scss` files should be reflected almost-immediately in a component loaded using devHelper. For platform-specific css, current platform is always used.

**Changes to `.xhtml` require Zotero restart (or rebuild without omni updates) as previously.**

Running DevHelper
---

Firstly build system must be run with environmental variable `REWRITE_SRC` set, e.g.:
````bash
> REWRITE_SRC=1 npm start
````
Switching to and from `REWRITE_SRC=1` works without any additional clean steps.

Then Zotero binary must be started with a switch `ZoteroDevHelper` set to the path of the `build` folder in `zotero-client`, e.g.

````bash
> staging/Zotero.app/Contents/MacOS/zotero -debugger -ZoteroDevHelper "/path/to/zotero-client/build"
````

This switch only works if `zotero-client` was built with `REWRITE_SRC` enabled, otherwise it is ignored.

If the following steps were followed, Zotero starts with additional Component DevHelper window open. Any component loaded from the list will be refreshed whenever build system detects a change. Some components might misbehave if there is a dependency on window arguments.

Implementation details
---

With `REWRITE_SRC` flag enabled all `.xhtml` files are rewritten during the build so that source of `.css` files sourced via `<xml-stylesheet>`  tag and `.js` sourced via `<script>` tag are loaded using `file://` protocol from the actual path on disk (in the build folder) instead of `chrome://`. Additionally `Loader` is tweaked so that if `ZoteroDevHelper` value is provided any `js` dependency also uses `file://` protocol, value of `ZoteroDevHelper` is used to determine actual path of the file on disk.

The build process will use existing IPC channel no notify the client of changes. Upon receiving a notification, devHelper reloads selected component into an iframe.

To ensure that production build is unaffected, piece of code that recognizes `ZoteroDevHelper` command line switch is injected during the build only if `REWRITE_SRC` is set. Similarly `devHelper.xhtml` and `devHelper.js` will not be present in a build unless it was built with `REWRITE_SRC` flag set.





