### PR TITLE
fx-compat: Fix twisty color inverting on Mac

### DIFF
--- a/scss/mac/_virtualized-table.scss
+++ b/scss/mac/_virtualized-table.scss
@@ -8,10 +8,6 @@
 		}
 	}
 
-	.selected:not(.highlighted) .twisty svg {
-		fill: #fff;
-	}
-
 	.spacer-twisty {
 		min-width: 19px;
 	}


### PR DESCRIPTION
Since we're now using a much milder background color for table rows, inverting the twisty's color looks wrong. No available highlight color option clashes with the darker twisty color.

Before:
<img width="65" alt="image" src="https://user-images.githubusercontent.com/1770299/174190623-aa6faf92-4ac4-4411-8ee2-0bf97bec2397.png">

After:
<img width="81" alt="image" src="https://user-images.githubusercontent.com/1770299/174190630-58835dd8-5058-4f0d-bc86-2e5416aab42d.png">
