### PR TITLE
fx-compat: More progress on platform menus

### DIFF
--- a/chrome/content/zotero/platformKeys.js
+++ b/chrome/content/zotero/platformKeys.js
@@ -1,14 +1,46 @@
 window.addEventListener('DOMContentLoaded', () => {
+	// Don't need to depend on Zotero object here
+	let isWin = AppConstants.platform == 'win';
+	let isMac = AppConstants.platform == 'macosx';
+
 	let redoKey = document.getElementById('key_redo');
-	if (redoKey) {
-		// Don't need to depend on Zotero object here
-		if (AppConstants.platform == 'win') {
+
+	let fileQuitSeparator = document.getElementById('menu_NonMacFileQuitSeparator');
+	let fileQuitItem = document.getElementById('menu_NonMacFileQuitItem');
+
+	let editPreferencesSeparator = document.getElementById('menu_EditPreferencesSeparator');
+	let editPreferencesItem = document.getElementById('menu_EditPreferencesItem');
+
+	let applicationMenu = document.getElementById('mac_application_menu');
+	let windowMenu = document.getElementById('windowMenu');
+	let macKeyset = document.getElementById('macKeyset');
+
+	if (isWin) {
+		// Set behavior on Windows only
+		if (redoKey) {
 			redoKey.setAttribute('data-l10n-id', 'text-action-redo-shortcut');
 			redoKey.setAttribute('modifiers', 'accel');
 		}
-		else {
+	}
+	else {
+		// Set behavior on all non-Windows platforms
+		if (redoKey) {
 			redoKey.setAttribute('data-l10n-id', 'text-action-undo-shortcut');
 			redoKey.setAttribute('modifiers', 'accel,shift');
 		}
+	}
+
+	if (isMac) {
+		// Set behavior on macOS only
+		if (fileQuitSeparator) fileQuitSeparator.hidden = true;
+		if (fileQuitItem) fileQuitItem.hidden = true;
+		if (editPreferencesSeparator) editPreferencesSeparator.hidden = true;
+		if (editPreferencesItem) editPreferencesItem.hidden = true;
+	}
+	else {
+		// Set behavior on all non-macOS platforms
+		if (applicationMenu) applicationMenu.hidden = true;
+		if (windowMenu) windowMenu.hidden = true;
+		if (macKeyset) macKeyset.disabled = true;
 	}
 });

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -173,7 +173,29 @@
 					the children can be modified. All non-menu nodes are ignored
 				-->
 				<menubar id="main-menubar"
-				style="border:0px;padding:0px;margin:0px;-moz-appearance:none">
+				style="border:0px;padding:0px;margin:0px;-moz-appearance:none">		
+					<!-- nsMenuBarX hides these and uses them to build the Application menu. -->
+					<menupopup id="mac_application_menu">
+						<menuitem id="menu_preferences"
+								label="&preferencesCmdMac.label;"
+								key="key_preferencesCmdMac"
+								oncommand="Zotero.Utilities.Internal.openPreferences()"/>
+						<menuitem id="menu_mac_services"
+								label="&servicesMenuMac.label;"/>
+						<menuitem id="menu_mac_hide_app"
+								label="&hideThisAppCmdMac.label;"
+								key="key_hideThisAppCmdMac"/>
+						<menuitem id="menu_mac_hide_others"
+								label="&hideOtherAppsCmdMac.label;"
+								key="key_hideOtherAppsCmdMac"/>
+						<menuitem id="menu_mac_show_all"
+								label="&showAllAppsCmdMac.label;"/>
+						<menuitem id="menu_FileQuitItem"
+								label="&quitApplicationCmdMac.label;"
+								key="key_quitApplication"
+								command="cmd_quitApplication"/>
+					</menupopup>
+
 					<!-- File menu -->
 					<menu id="fileMenu" label="&fileMenu.label;" accesskey="&fileMenu.accesskey;"
 							onpopupshowing="ZoteroStandalone.onFileMenuOpen()">
@@ -215,15 +237,11 @@
 									command="cmd_zotero_importFromClipboard" key="key_importFromClipboard"/>
 							<menuitem id="menu_exportLibrary" class="menu-type-library" label="&zotero.toolbar.export.label;"
 									command="cmd_zotero_exportLibrary"/>
-							<!--
-							#ifdef XP_WIN
-							<menuseparator/>
-							<menuitem id="menu_FileQuitItem"
+							<menuseparator id="menu_NonMacFileQuitSeparator"/>
+							<menuitem id="menu_NonMacFileQuitItem"
 									label="&quitApplicationCmdWin.label;"
 									key="key_quitApplication"
 									command="cmd_quitApplication"/>
-							#endif
-							-->
 						</menupopup>
 					</menu>
 					
@@ -285,15 +303,9 @@
 									command="cmd_switchTextDirection"
 									key="key_switchTextDirection"
 									hidden="true" data-l10n-id="menu-edit-bidi-switch-text-direction"/>
-							<!--
-							#ifdef XP_UNIX
-							#ifndef XP_MACOSX
-							<menuseparator/>
-							<menuitem id="menu_preferences"
-								oncommand="Zotero.Utilities.Internal.openPreferences()" data-l10n-id="menu-preferences"/>
-							#endif
-							#endif
-							-->
+							<menuseparator id="menu_EditPreferencesSeparator"/>
+							<menuitem id="menu_EditPreferencesItem"
+								oncommand="Zotero.Utilities.Internal.openPreferences()" data-l10n-id="menu-settings"/>
 						</menupopup>
 					</menu>
 					
@@ -546,7 +558,6 @@
 						</menupopup>
 					</menu>
 					
-<!-- ifdef mac -->
 					<commandset id="macCommandSet"> <!-- was mainCommandSet -->
 						<command id="minimizeWindow"
 								label="&minimizeWindow.label;"
@@ -586,28 +597,6 @@
 								internal="true"/>
 					</keyset>
 					
-					<!-- nsMenuBarX hides these and uses them to build the Application menu. -->
-					<menupopup id="menu_FilePopup">
-						<menuitem id="menu_preferences"
-								label="&preferencesCmdMac.label;"
-								key="key_preferencesCmdMac"
-								oncommand="Zotero.Utilities.Internal.openPreferences()"/>
-						<menuitem id="menu_mac_services"
-								label="&servicesMenuMac.label;"/>
-						<menuitem id="menu_mac_hide_app"
-								label="&hideThisAppCmdMac.label;"
-								key="key_hideThisAppCmdMac"/>
-						<menuitem id="menu_mac_hide_others"
-								label="&hideOtherAppsCmdMac.label;"
-								key="key_hideOtherAppsCmdMac"/>
-						<menuitem id="menu_mac_show_all"
-								label="&showAllAppsCmdMac.label;"/>
-						<menuitem id="menu_FileQuitItem"
-								label="&quitApplicationCmdMac.label;"
-								key="key_quitApplication"
-								command="cmd_quitApplication"/>
-					</menupopup>
-					
 					<menu id="windowMenu"
 							label="&windowMenu.label;"
 							datasources="rdf:window-mediator" ref="NC:WindowMediatorRoot"
@@ -634,7 +623,6 @@
 							<menuseparator id="sep-window-list"/>
 						</menupopup>
 					</menu>
-<!-- endif -->
 					
 					<menu id="helpMenu"
 							label="&helpMenu.label;"


### PR DESCRIPTION
Not able to test on non-Mac yet, but this behavior should be right. Removes all the #ifdefs and moves the behavior into platformKeys.js.