### PR TITLE
Advanced Search: Make sure items are loaded

### DIFF
--- a/chrome/content/zotero/advancedSearch.js
+++ b/chrome/content/zotero/advancedSearch.js
@@ -96,6 +96,8 @@ var ZoteroAdvancedSearch = new function() {
 			ref: _searchBox.search,
 			isSearchMode: () => true,
 			getItems: async function () {
+				await Zotero.Libraries.get(_libraryID).waitForDataLoad('item');
+
 				var search = _searchBox.search.clone();
 				search.libraryID = _libraryID;
 				var ids = await search.search();


### PR DESCRIPTION
Fixes a (longstanding?) issue that causes a search in a feed that hasn't yet been loaded (clicked on in the library tree) to fail.