### PR TITLE
fx-compat: Style Editor: Validate CSL inline

### DIFF
--- a/chrome/content/zotero/tools/csledit.js
+++ b/chrome/content/zotero/tools/csledit.js
@@ -147,6 +147,10 @@ var Zotero_CSL_Editor = new function() {
 	
 	this.onStyleModified = function () {
 		let xml = editor.getValue();
+		Zotero.Styles.validate(xml).then(
+			() => this.updateMarkers(''),
+			rawErrors => this.updateMarkers(rawErrors)
+		);
 		let cslList = document.getElementById('zotero-csl-list');
 		let savedStyle = Zotero.Styles.get(cslList.value);
 		if (!savedStyle || xml !== savedStyle?.getXML()) {
@@ -238,18 +242,26 @@ var Zotero_CSL_Editor = new function() {
 		}
 		styleEngine.free();
 	}
-	
-	
-	// From http://kb.mozillazine.org/Inserting_text_at_cursor
-	function _insertText(text) {
-		var command = "cmd_insertText";
-		var controller = document.commandDispatcher.getControllerForCommand(command);
-		if (controller && controller.isCommandEnabled(command)) {
-			controller = controller.QueryInterface(Components.interfaces.nsICommandController);
-			var params = Components.classes["@mozilla.org/embedcomp/command-params;1"];
-			params = params.createInstance(Components.interfaces.nsICommandParams);
-			params.setStringValue("state_data", "\t");
-			controller.doCommandWithParams(command, params);
-		}
-	}
+
+	this.updateMarkers = function (rawErrors) {
+		let model = editor.getModel();
+		let errors = rawErrors ? rawErrors.split('\n') : [];
+		let markers = errors.map((error) => {
+			let matches = error.match(/^[^:]*:(?<line>[^:]*):(?<column>[^:]*): error: (?<message>.+)/);
+			if (!matches) return null;
+			let { line, message } = matches.groups;
+			line = parseInt(line);
+			return {
+				startLineNumber: line,
+				endLineNumber: line,
+				// The error message doesn't give us an end column, so using its
+				// start column looks weird. Just highlight the whole line.
+				startColumn: model.getLineFirstNonWhitespaceColumn(line),
+				endColumn: model.getLineMaxColumn(line),
+				message,
+				severity: 8
+			};
+		}).filter(Boolean);
+		monaco.editor.setModelMarkers(model, 'csl-validator', markers);
+	};
 }();


### PR DESCRIPTION
Lines that fail validation are highlighted, and hovering shows you the error:

<img width="377" alt="image" src="https://user-images.githubusercontent.com/1770299/182671068-21d208ab-0643-4160-923b-1c2a76e18b48.png">

Errors are also marked in red under the scroll bar so you can quickly scroll to the offending line.