### PR TITLE
Improve Citavi annotations importing

### DIFF
--- a/chrome/content/zotero/import/citavi.js
+++ b/chrome/content/zotero/import/citavi.js
@@ -9,6 +9,9 @@ const parseCitavi5Quads = (quadsRaw) => {
 const ImportCitaviAnnotatons = async (translation) => {
 	const IDMap = translation._itemSaver._IDMap;
 	const ZU = translation._sandboxZotero.Utilities;
+	
+	// stream might be closed by now, re-init to make sure getXML() works
+	translation._io.init('xml/dom');
 	const doc = translation._sandboxZotero.getXML();
 	const isCitavi5 = ZU.xpathText(doc, '//CitaviExchangeData/@Version').startsWith('5');
 	var annotationNodes = ZU.xpath(doc, '//Annotations/Annotation');
@@ -29,7 +32,7 @@ const ImportCitaviAnnotatons = async (translation) => {
 	const stageProgress = 50;
 	let progress = baseProgress;
 	translation.getProgress = () => progress;
-	
+
 	for (var i = 0, n = annotationNodes.length; i < n; i++) {
 		const id = ZU.xpathText(annotationNodes[i], '@id');
 		const quadsRaw = ZU.xpathText(annotationNodes[i], './Quads');

--- a/chrome/content/zotero/import/citavi.js
+++ b/chrome/content/zotero/import/citavi.js
@@ -38,11 +38,23 @@ const ImportCitaviAnnotatons = async (translation) => {
 		const quadsRaw = ZU.xpathText(annotationNodes[i], './Quads');
 		const locationID = ZU.xpathText(annotationNodes[i], './LocationID');
 
-		const location = ZU.xpath(doc, `//Locations/Location[@${isCitavi5 ? 'ID' : 'id'}='${locationID}']`)[0];
+		const location = ZU.xpath(doc, `//Locations/Location[@id='${locationID}']|//Locations/Location[@ID='${locationID}']`)[0];
+
+		if (!location) {
+			Zotero.debug(`Missing <Location> entry for annotation ${id}, skipping...`);
+			continue;
+		}
+
 		const referenceID = ZU.xpathText(location, './ReferenceID');
 		const entityLink = ZU.xpath(doc, `//EntityLinks/EntityLink[TargetID='${id}']`)[0];
+
+		if (!entityLink) {
+			Zotero.debug(`Missing <EntityLink> entry for annotation ${id}, skipping...`);
+			continue;
+		}
+
 		const entitySourceID = ZU.xpathText(entityLink, './SourceID');
-		const knowledgeItem = ZU.xpath(doc, `//KnowledgeItems/KnowledgeItem[@${isCitavi5 ? 'ID' : 'id'}='${entitySourceID}']`)[0];
+		const knowledgeItem = ZU.xpath(doc, `//KnowledgeItems/KnowledgeItem[@id='${entitySourceID}']|//KnowledgeItems/KnowledgeItem[@ID='${entitySourceID}']`)[0];
 		const keywordsIDsText = ZU.xpathText(doc, `//KnowledgeItemKeywords/OnetoN[starts-with(text(), "${entitySourceID}")]`);
 		const keywords = keywordsIDsText
 			? keywordsIDsText
@@ -137,16 +149,22 @@ const ImportCitaviAnnotatons = async (translation) => {
 
 			annotations.push(annotation);
 		});
-		
-		annotations = await Zotero.PDFWorker.processCitaviAnnotations(
-			itemAttachment.getFilePath(), annotations
-		);
-		
-		annotations.forEach((annotation) => {
-			promises.push(Zotero.Annotations.saveFromJSON(
-				itemAttachment, annotation, { skipSelect: true }
-			));
-		});
+
+
+		try {
+			// eslint-disable-next-line no-await-in-loop
+			annotations = await Zotero.PDFWorker.processCitaviAnnotations(
+				itemAttachment.getFilePath(), annotations
+			);
+			annotations.forEach((annotation) => {
+				promises.push(Zotero.Annotations.saveFromJSON(
+					itemAttachment, annotation, { skipSelect: true }
+				));
+			});
+		}
+		catch (e) {
+			Zotero.debug(`Could not process annotations for attachment item ${itemAttachment.key} (file path: ${itemAttachment.getFilePath()})`);
+		}
 
 		progress = baseProgress + Math.ceil((i / annotationNodes.length) * stageProgress);
 		translation._runHandler('itemDone', []);


### PR DESCRIPTION
This PR contains few improvements to Citavi annotations importer:

* Fixed an issue where sometimes `getXML()` would throw an error because file stream was already closed after translator has finished running
* Added few extra checks so that import continues if a single annotation cannot be imported or processed.