### PR TITLE
`duplicateAndConvertSelectedItem`: Don't copy abstracts

### DIFF
--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -1853,6 +1853,8 @@ var ZoteroPane = new function()
 			duplicate.setCreators(creators);
 		}
 		
+		duplicate.setField('abstractNote', '');
+
 		duplicate.addRelatedItem(original);
 		original.addRelatedItem(duplicate);
 		

--- a/test/tests/zoteroPaneTest.js
+++ b/test/tests/zoteroPaneTest.js
@@ -467,6 +467,16 @@ describe("ZoteroPane", function() {
 				assert.sameMembers(bookSectionItem2.relatedItems, [bookItem.key, otherBookSection.key]);
 			});
 		});
+		
+		it("should not copy abstracts", async function() {
+			await selectLibrary(win);
+			var bookItem = await createDataObject('item', { itemType: 'book', title: "Book Title" });
+			bookItem.setField('abstractNote', 'An abstract');
+			bookItem.saveTx();
+
+			var bookSectionItem = await zp.duplicateAndConvertSelectedItem();
+			assert.isEmpty(bookSectionItem.getField('abstractNote'));
+		});
 	});
 	
 	


### PR DESCRIPTION
Fixes #2796. This clears the abstract in both directions - it doesn't often seem sensible to copy the abstract from a section to the whole book either.