### PR TITLE
Clear sync error and start sync after logging in in prefs

### DIFF
--- a/chrome/content/zotero/preferences/preferences_sync.jsx
+++ b/chrome/content/zotero/preferences/preferences_sync.jsx
@@ -38,7 +38,6 @@ var { renderCell } = VirtualizedTable;
 Zotero_Preferences.Sync = {
 	checkmarkChar: '\u2705',
 	noChar: '\uD83D\uDEAB',
-	syncOnClose: false,
 	
 	init: async function () {
 		this.updateStorageSettingsUI();

--- a/chrome/content/zotero/preferences/preferences_sync.jsx
+++ b/chrome/content/zotero/preferences/preferences_sync.jsx
@@ -190,9 +190,7 @@ Zotero_Preferences.Sync = {
 			Zotero.Sync.Runner.updateIcons([]);
 		}
 		window.addEventListener('beforeunload', () => {
-			if (!Zotero.Sync.Runner.syncInProgress) {
-				Zotero.Sync.Runner.sync();
-			}
+			Zotero.Sync.Runner.setSyncTimeout(1);
 		});
 		
 		this.displayFields(json.username);

--- a/chrome/content/zotero/preferences/preferences_sync.jsx
+++ b/chrome/content/zotero/preferences/preferences_sync.jsx
@@ -38,6 +38,7 @@ var { renderCell } = VirtualizedTable;
 Zotero_Preferences.Sync = {
 	checkmarkChar: '\u2705',
 	noChar: '\uD83D\uDEAB',
+	syncOnClose: false,
 	
 	init: async function () {
 		this.updateStorageSettingsUI();
@@ -182,6 +183,19 @@ Zotero_Preferences.Sync = {
 			Zotero.Sync.Runner.deleteAPIKey();
 			return;
 		}
+		
+		// It shouldn't be possible for a sync to be in progress if the user wasn't logged in,
+		// but check to be sure
+		if (!Zotero.Sync.Runner.syncInProgress) {
+			// Clear any displayed sync errors
+			Zotero.Sync.Runner.updateIcons([]);
+		}
+		window.addEventListener('beforeunload', () => {
+			if (!Zotero.Sync.Runner.syncInProgress) {
+				Zotero.Sync.Runner.sync();
+			}
+		});
+		
 		this.displayFields(json.username);
 	}),
 

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -202,7 +202,7 @@ var ZoteroPane = new function()
 				if (index == 0) {
 					Zotero.Sync.Server.sync({
 						onSuccess: function () {
-							Zotero.Sync.Runner.updateIcons();
+							Zotero.Sync.Runner.updateIcons([]);
 							
 							ps.alert(
 								null,

--- a/test/tests/preferences_syncTest.js
+++ b/test/tests/preferences_syncTest.js
@@ -98,7 +98,23 @@ describe("Sync Preferences", function () {
 				yield assert.eventually.equal(Zotero.Sync.Data.Local.getAPIKey(), apiKey);
 				assert.equal(doc.getElementById('sync-unauthorized').getAttribute('hidden'), 'true');
 			});
+			
+			it("should clear sync errors from the toolbar after logging in", async function () {
+				let win = await loadZoteroPane();
+				after(function () {
+					win.close();
+				});
+				
+				let syncError = win.document.getElementById('zotero-tb-sync-error');
+				
+				Zotero.Sync.Runner.updateIcons(new Error("a sync error"));
+				assert.isFalse(syncError.hidden);
 
+				getAPIKeyFromCredentialsStub.resolves(apiResponse);
+				await setCredentials("Username", "correctPassword");
+				
+				assert.isTrue(syncError.hidden);
+			});
 		})
 	})
 })

--- a/test/tests/preferences_syncTest.js
+++ b/test/tests/preferences_syncTest.js
@@ -112,7 +112,6 @@ describe("Sync Preferences", function () {
 
 				getAPIKeyFromCredentialsStub.resolves(apiResponse);
 				await setCredentials("Username", "correctPassword");
-				
 				assert.isTrue(syncError.hidden);
 			});
 		})


### PR DESCRIPTION
It would be nice if `preferences.js` could just send an `unload` (or `beforeunload`) event to panes like it does with `load`, but it seems that, at least on macOS, the interpreter won't dispatch events from a [`before`]`unload` handler. So for now, at least, panes need to add their own listeners to the window.

Also fixes an existing error due to an argumentless call to `Zotero.Sync.Runner.updateIcons()` in ZoteroPane.

Fixes #2785.