### PR TITLE
Hide "Find Available PDF" for feed items

### DIFF
--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -1279,6 +1279,7 @@ Zotero.Attachments = new function(){
 	
 	this.canFindPDFForItem = function (item) {
 		return item.isRegularItem()
+			&& !item.isFeedItem
 			&& (!!item.getField('DOI') || !!item.getField('url') || !!item.getExtraField('DOI'))
 			&& item.numPDFAttachments() == 0;
 	};


### PR DESCRIPTION
Fixes "Find Available PDF" showing in the context menu inside feeds. Actually selecting it just shows a "cannot make changes to the selected collection" alert. The issue also occurs on master and I can cherry-pick to there if this is merged.