### PR TITLE
added option to configure image annotation in PDFs

### DIFF
--- a/chrome/content/zotero/xpcom/editorInstance.js
+++ b/chrome/content/zotero/xpcom/editorInstance.js
@@ -1486,7 +1486,7 @@ class EditorInstanceUtilities {
 				template = Zotero.Prefs.get('annotations.noteTemplates.note');
 			}
 			else if (annotation.type === 'image') {
-				template = '<p>{{image}}<br/>{{citation}} {{comment}}</p>';
+				template = Zotero.Prefs.get('annotations.noteTemplates.image');
 			}
 
 			Zotero.debug('Using note template:');

--- a/defaults/preferences/zotero.js
+++ b/defaults/preferences/zotero.js
@@ -207,6 +207,8 @@ pref("extensions.zotero.retractions.recentItems", "[]");
 pref("extensions.zotero.annotations.noteTemplates.title", "<h1>{{title}}<br/>({{date}})</h1>");
 pref("extensions.zotero.annotations.noteTemplates.highlight", "<p>{{highlight}} {{citation}} {{comment}}</p>");
 pref("extensions.zotero.annotations.noteTemplates.note", "<p>{{citation}} {{comment}}</p>");
+pref("extensions.zotero.annotations.noteTemplates.image", "<p>{{image}}{{if comment}}<p>{{comment}}</p>{{endif}}<p>{{citation}}</p><p>{{if tags}}[[{{tags join=']], [['}}]]{{endif}}</p>");
+
 
 // Scaffold
 pref("extensions.zotero.scaffold.eslint.enabled", true);


### PR DESCRIPTION
the image note template was "hard coded" in chrome/content/zotero/xpcom/editorInstance.js. This pull request aims to make extensions.zotero.annotations.noteTemplates.image customizable to allow for configurable templates.

An example configuration is provided in defaults/preferences/zotero.js