### PR TITLE
Map Mendeley annotation colors to equivalent Zotero colors on import

### DIFF
--- a/chrome/content/zotero/import/mendeley/mendeleyImport.js
+++ b/chrome/content/zotero/import/mendeley/mendeleyImport.js
@@ -12,6 +12,18 @@ Services.scriptloader.loadSubScript("chrome://zotero/content/import/mendeley/men
 const { apiTypeToDBType, apiFieldToDBField } = mendeleyOnlineMappings;
 const { apiFetch, get, getAll, getTokens } = mendeleyAPIUtils;
 
+const colorMap = new Map();
+colorMap.set('rgb(255, 245, 173)', '#ffd400');
+colorMap.set('#fff5ad', '#ffd400');
+colorMap.set('rgb(255, 181, 182)', '#ff6666');
+colorMap.set('#ffb5b6', '#ff6666');
+colorMap.set('rgb(186, 226, 255)', '#2ea8e5');
+colorMap.set('#bae2ff', '#2ea8e5');
+colorMap.set('rgb(211, 194, 255)', '#a28ae5');
+colorMap.set('#d3c2ff', '#a28ae5');
+colorMap.set('rgb(220, 255, 176)', '#5fb236');
+colorMap.set('#dcffb0', '#5fb236');
+
 var Zotero_Import_Mendeley = function () {
 	this.createNewCollection = null;
 	this.linkFiles = null;
@@ -1568,6 +1580,10 @@ Zotero_Import_Mendeley.prototype._saveAnnotations = async function (annotations,
 				}
 				// PDFWorker needs 'id'
 				annotations.forEach(annotation => annotation.id = annotation.uuid);
+				annotations.forEach(annotation => (colorMap.has(annotation.color)
+					? annotation.color = colorMap.get(annotation.color)
+					: annotation.color
+				));
 				// Returns 'id', 'position', 'type', 'pageLabel', 'sortIndex', 'text' (for highlight)
 				Zotero.debug("Processing annotations in " + file);
 				annotations = await Zotero.PDFWorker.processMendeleyAnnotations(file, annotations);

--- a/test/tests/data/mendeleyMock/annotations.json
+++ b/test/tests/data/mendeleyMock/annotations.json
@@ -5,8 +5,8 @@
         "color":
         {
             "r": 255,
-            "g": 181,
-            "b": 182
+            "g": 245,
+            "b": 173
         },
         "profile_id": "8dbf0832-8723-4c48-b532-20c0b7f6e01a",
         "positions":
@@ -37,8 +37,8 @@
         "color":
         {
             "r": 255,
-            "g": 196,
-            "b": 251
+            "g": 181,
+            "b": 182
         },
         "profile_id": "8dbf0832-8723-4c48-b532-20c0b7f6e01a",
         "positions":
@@ -123,6 +123,35 @@
             }
         ],
         "text": "orange note1",
+        "created": "2021-11-09T10:26:16.640Z",
+        "last_modified": "2021-11-09T10:26:16.640Z",
+        "privacy_level": "private",
+        "filehash": "cc22c6611277df346ff8dc7386ba3880b2bafa15",
+        "document_id": "c54b0c6f-c4ce-4706-8742-bc7d032df862"
+    },
+    {
+        "id": "734743eb-2be3-49ef-b1ac-3f1e84fea2f2",
+        "type": "sticky_note",
+        "color": {
+            "r": 220,
+            "g": 255,
+            "b": 176
+        },
+        "profile_id": "8dbf0832-8723-4c48-b532-20c0b7f6e01a",
+        "positions": [
+            {
+                "top_left": {
+                    "x": 287.4041774203229,
+                    "y": 662.2221955464859
+                },
+                "bottom_right": {
+                    "x": 287.4041774203229,
+                    "y": 662.2221955464859
+                },
+                "page": 1
+            }
+        ],
+        "text": "green note",
         "created": "2021-11-09T10:26:16.640Z",
         "last_modified": "2021-11-09T10:26:16.640Z",
         "privacy_level": "private",

--- a/test/tests/mendeleyImportTest.js
+++ b/test/tests/mendeleyImportTest.js
@@ -179,11 +179,53 @@ describe('Zotero_Import_Mendeley', function () {
 			// attachment & annotations
 			assert.lengthOf(withpdf.getAttachments(), 1);
 			assert.equal(pdf.parentID, withpdf.id);
+
+			const yellowHighlight = (await Zotero.Relations
+				.getByPredicateAndObject('item', 'mendeleyDB:annotationUUID', '339d0202-d99f-48a2-aa0d-9b0c5631af26'))
+				.filter(item => item.libraryID == Zotero.Libraries.userLibraryID && !item.deleted)
+				.shift();
+			const redHighlight = (await Zotero.Relations
+				.getByPredicateAndObject('item', 'mendeleyDB:annotationUUID', '885615a7-170e-4613-af80-0227ea76ae55'))
+				.filter(item => item.libraryID == Zotero.Libraries.userLibraryID && !item.deleted)
+				.shift();
+			const blueNote = (await Zotero.Relations
+				.getByPredicateAndObject('item', 'mendeleyDB:annotationUUID', 'bfbdb972-171d-4b21-8ae6-f156ac9a2b41'))
+				.filter(item => item.libraryID == Zotero.Libraries.userLibraryID && !item.deleted)
+				.shift();
+			const greenNote = (await Zotero.Relations
+				.getByPredicateAndObject('item', 'mendeleyDB:annotationUUID', '734743eb-2be3-49ef-b1ac-3f1e84fea2f2'))
+				.filter(item => item.libraryID == Zotero.Libraries.userLibraryID && !item.deleted)
+				.shift();
+			const orangeNote = (await Zotero.Relations
+				.getByPredicateAndObject('item', 'mendeleyDB:annotationUUID', 'c436932f-b14b-4580-a649-4587a5cdc2c3'))
+				.filter(item => item.libraryID == Zotero.Libraries.userLibraryID && !item.deleted)
+				.shift();
+			const purpleGroupNote = (await Zotero.Relations
+				.getByPredicateAndObject('item', 'mendeleyDB:annotationUUID', '656fd591-451a-4bb0-8d5f-30c36c135fc9'))
+				.filter(item => item.libraryID == Zotero.Libraries.userLibraryID && !item.deleted)
+				.shift();
+
+			assert.equal(blueNote.annotationComment, 'blue note 2');
+			assert.equal(greenNote.annotationComment, 'green note');
+			assert.equal(orangeNote.annotationComment, 'orange note1');
+			assert.equal(purpleGroupNote.annotationComment, 'note by me');
+			
+			// map yellow	rgb(255, 245, 173) -> #ffd400'
+			assert.equal(yellowHighlight.annotationColor, '#ffd400');
+			// map red:		rgb(255, 181, 182) -> #ff6666
+			assert.equal(redHighlight.annotationColor, '#ff6666');
+			// map blue:	rgb(186, 226, 255) -> '#2ea8e5'
+			assert.equal(blueNote.annotationColor, '#2ea8e5');
+			// map purple:	rgb(211, 194, 255) -> '#a28ae5'
+			assert.equal(purpleGroupNote.annotationColor, '#a28ae5');
+			// map green:	rgb(220, 255, 176) -> #5fb236
+			assert.equal(greenNote.annotationColor, '#5fb236');
+			// preserve other colors rgb(255, 222, 180) stays as #ffdeb4
+			assert.equal(orangeNote.annotationColor, '#ffdeb4');
+
+			// group annotations by others and mismatched annotations are not included
 			const annotations = await pdf.getAnnotations();
-			assert.equal(annotations.length, 5);
-			assert.isTrue(annotations.some(a => a.annotationComment === 'blue note 2'));
-			assert.isTrue(annotations.some(a => a.annotationComment === 'orange note1'));
-			assert.isTrue(annotations.some(a => a.annotationComment === 'note by me'));
+			assert.equal(annotations.length, 6);
 			assert.isFalse(annotations.some(a => a.annotationComment === 'note by other'));
 			assert.isFalse(annotations.some(a => a.annotationComment === 'mismatched note'));
 


### PR DESCRIPTION
`rgb(255, 245, 173)` -> `#ffd400`
`rgb(255, 181, 182)` -> `#ff6666`
`rgb(186, 226, 255)` -> `#2ea8e5`
`rgb(211, 194, 255)` -> `#a28ae5`
`rgb(220, 255, 176)` -> `#5fb236`

Other colors preserved. Didn't do anything about "empty" color as this will be taken care at data layer (#2818).

Resolves #2819