### PR TITLE
fx-compat: Fix `zotero://` protocol for reports

### DIFF
--- a/chrome.manifest
+++ b/chrome.manifest
@@ -71,7 +71,7 @@ category	command-line-handler 	m-zotero	@mozilla.org/commandlinehandler/general-
 component	{06a2ed11-d0a4-4ff0-a56f-a44545eee6ea}			components/zotero-autocomplete.js
 contract	@mozilla.org/autocomplete/search;1?name=zotero 	{06a2ed11-d0a4-4ff0-a56f-a44545eee6ea}
 
-component	{9BC3D762-9038-486A-9D70-C997AF848A7C}			components/zotero-protocol-handler.js
+component	{9BC3D762-9038-486A-9D70-C997AF848A7C}			components/zotero-protocol-handler.js	process=main
 contract	@mozilla.org/network/protocol;1?name=zotero 	{9BC3D762-9038-486A-9D70-C997AF848A7C}
 
 # Scaffold

--- a/chrome/content/zotero/standalone/basicViewer.js
+++ b/chrome/content/zotero/standalone/basicViewer.js
@@ -30,7 +30,7 @@
 var browser;
 
 window.addEventListener("load", /*async */function() {
-	browser = document.querySelector('browser');
+	ensureBrowserType('content');
 	
 	/*
 	browser.setAttribute("remote", "true");
@@ -46,11 +46,6 @@ window.addEventListener("load", /*async */function() {
 		false
 	);*/
 	//browser.docShellIsActive = false;
-	
-	// align page title with title of shown document
-	browser.addEventListener('pagetitlechanged', () => {
-		document.title = browser.contentTitle || browser.currentURI.spec;
-	});
 
 	// Load URI passed in as nsISupports .data via openWindow()
 	loadURI(window.arguments[0]);
@@ -74,9 +69,9 @@ window.addEventListener("click", function (event) {
 });
 
 function ensureBrowserType(type) {
-	let oldBrowser = document.querySelector('browser');
-	if (oldBrowser.getAttribute('type') != type) {
-		let newBrowser = document.createXULElement('browser');
+	let oldBrowser = browser;
+	if (!oldBrowser || oldBrowser.getAttribute('type') != type) {
+		browser = document.createXULElement('browser');
 		let attrs = {
 			type,
 			flex: 1,
@@ -85,10 +80,18 @@ function ensureBrowserType(type) {
 			disableglobalhistory: true,
 		};
 		for (let [attr, value] of Object.entries(attrs)) {
-			newBrowser.setAttribute(attr, value);
+			browser.setAttribute(attr, value);
 		}
-		oldBrowser.replaceWith(newBrowser);
-		return newBrowser;
+		if (oldBrowser) {
+			oldBrowser.replaceWith(browser);
+		}
+		else {
+			document.querySelector('#appcontent').append(browser);
+		}
+		browser.addEventListener('pagetitlechanged', () => {
+			document.title = browser.contentTitle || browser.currentURI.spec;
+		});
+		return browser;
 	}
 	else {
 		return oldBrowser;

--- a/chrome/content/zotero/standalone/basicViewer.js
+++ b/chrome/content/zotero/standalone/basicViewer.js
@@ -73,12 +73,36 @@ window.addEventListener("click", function (event) {
 	}
 });
 
+function ensureBrowserType(type) {
+	let oldBrowser = document.querySelector('browser');
+	if (oldBrowser.getAttribute('type') != type) {
+		let newBrowser = document.createXULElement('browser');
+		let attrs = {
+			type,
+			flex: 1,
+			remote: false,
+			maychangeremoteness: true,
+			disableglobalhistory: true,
+		};
+		for (let [attr, value] of Object.entries(attrs)) {
+			newBrowser.setAttribute(attr, value);
+		}
+		oldBrowser.replaceWith(newBrowser);
+		return newBrowser;
+	}
+	else {
+		return oldBrowser;
+	}
+}
+
 function loadURI(uri) {
-	browser.loadURI(
+	// The zotero protocol handler will not load in a type="content" browser
+	// As a temporary fix, replace the browser with one of the correct type if necessary
+	// (The type attribute can't be changed after the browser is created)
+	ensureBrowserType(uri.startsWith('zotero:') ? 'chrome' : 'content').loadURI(
 		uri,
 		{
 			triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal(),
-			//loadFlags: Ci.nsIWebNavigation.LOAD_FLAGS_STOP_CONTENT,
 		}
 	);
 }

--- a/chrome/content/zotero/standalone/basicViewer.xhtml
+++ b/chrome/content/zotero/standalone/basicViewer.xhtml
@@ -165,13 +165,6 @@
 	</toolbox>
 	
 	<hbox flex="1" id="browser">
-		<vbox id="appcontent" flex="1">
-			<browser
-					type="content"
-					flex="1"
-					remote="false"
-					disableglobalhistory="true"
-					maychangeremoteness="true"/>
-		</vbox>
+		<vbox id="appcontent" flex="1"/>
 	</hbox>
 </window>

--- a/components/zotero-protocol-handler.js
+++ b/components/zotero-protocol-handler.js
@@ -1240,7 +1240,9 @@ ZoteroProtocolHandler.prototype = {
 		
 		return Ci.nsIProtocolHandler.URI_NORELATIVE
 			| Ci.nsIProtocolHandler.URI_IS_LOCAL_RESOURCE
-			| Ci.nsIProtocolHandler.URI_DANGEROUS_TO_LOAD;
+			// URI_IS_UI_RESOURCE: more secure than URI_LOADABLE_BY_ANYONE, less secure than URI_DANGEROUS_TO_LOAD
+			// This is the security level used by the chrome:// protocol
+			| Ci.nsIProtocolHandler.URI_IS_UI_RESOURCE;
 	},
 	get defaultPort() {
 		return -1;


### PR DESCRIPTION
- The protocol can no longer be marked "dangerous to load," only "UI resource" (accessible inside browsers but not by web pages).
- The protocol needs to run in the main process.
- We need to replace the XUL browser to reset its type attribute depending on whether we're loading a `zotero` protocol URI - `zotero` protocol URIs, maybe due to the protocol handler's tight coupling with the main process, cannot load in type="content" browsers. (Not sure what the exact issue is. We don't get any helpful log messages - `zotero://` URLs just get handed off to the OS.)