### PR TITLE
Made toolbar accessible to keyboard

### DIFF
--- a/chrome/content/zotero-platform/unix/overlay.css
+++ b/chrome/content/zotero-platform/unix/overlay.css
@@ -63,3 +63,7 @@ tab {
 	background-color: #ececec;
 	border-top: 1px solid hsla(0, 0%, 0%, 0.2);
 }
+
+.zotero-tb-button:focus {
+	border: 1px dotted #999;
+}

--- a/chrome/content/zotero/bindings/itembox.xml
+++ b/chrome/content/zotero/bindings/itembox.xml
@@ -2344,14 +2344,14 @@
 			<method name="focusLastField">
 				<body><![CDATA[
 					const tabbableFields = this._dynamicFields.querySelectorAll('*[ztabindex]:not([disabled=true])');
-					const next = tabbableFields[tabbableFields.length - 1];
+					const last = tabbableFields[tabbableFields.length - 1];
 					
-					if (next.id == 'item-type-menu' || next.classList.contains('zotero-focusable')) {
-						next.focus();
+					if (last.classList.contains('zotero-focusable')) {
+						last.focus();
 					}
 					// Fields need to be clicked
 					else {
-						next.click();
+						last.click();
 					}
 				]]></body>
 			</method>			

--- a/chrome/content/zotero/bindings/itembox.xml
+++ b/chrome/content/zotero/bindings/itembox.xml
@@ -2340,7 +2340,21 @@
 				]]>
 				</body>
 			</method>
-			
+
+			<method name="focusLastField">
+				<body><![CDATA[
+					const tabbableFields = this._dynamicFields.querySelectorAll('*[ztabindex]:not([disabled=true])');
+					const next = tabbableFields[tabbableFields.length - 1];
+					
+					if (next.id == 'item-type-menu' || next.classList.contains('zotero-focusable')) {
+						next.focus();
+					}
+					// Fields need to be clicked
+					else {
+						next.click();
+					}
+				]]></body>
+			</method>			
 			
 			<method name="focusField">
 				<parameter name="fieldName"/>

--- a/chrome/content/zotero/bindings/relatedbox.xml
+++ b/chrome/content/zotero/bindings/relatedbox.xml
@@ -330,6 +330,13 @@
 					]]>
 				</body>
 			</method>
+
+			<method name="receiveKeyboardFocus">
+				<body><![CDATA[
+					this.id("addButton").focus();
+					// TODO: the relatedbox is not currently keyboard accessible
+				]]></body>
+			</method>
 		</implementation>
 		<content>
 			<xul:vbox xbl:inherits="flex" class="zotero-box">

--- a/chrome/content/zotero/bindings/relatedbox.xml
+++ b/chrome/content/zotero/bindings/relatedbox.xml
@@ -332,9 +332,11 @@
 			</method>
 
 			<method name="receiveKeyboardFocus">
+				<parameter name="direction" />
 				<body><![CDATA[
 					this.id("addButton").focus();
 					// TODO: the relatedbox is not currently keyboard accessible
+					// so we are ignoring the direction
 				]]></body>
 			</method>
 		</implementation>

--- a/chrome/content/zotero/components/itemPane/tagsBox.jsx
+++ b/chrome/content/zotero/components/itemPane/tagsBox.jsx
@@ -415,7 +415,7 @@ const TagsBox = React.forwardRef((props, ref) => {
 		<div className="tags-box" ref={rootRef} onClick={blurOpenField}>
 			<div className="tags-box-header">
 				<div className="tags-box-count">{renderCount()}</div>
-				{ props.editable && <div><button onClick={handleAddTag}>Add</button></div> }
+				{ props.editable && <div><button onClick={handleAddTag} id="tags-box-add-button">Add</button></div> }
 			</div>
 			<div className="tags-box-list-container">
 				<ul className="tags-box-list">

--- a/chrome/content/zotero/lookup.js
+++ b/chrome/content/zotero/lookup.js
@@ -218,7 +218,9 @@ var Zotero_Lookup = new function () {
 			event.stopPropagation();
 			this._button.focus();
 			this._button = null;
-		} else this._button = null;
+		} else {
+			this._button = null;
+		}
 	}
 	
 	

--- a/chrome/content/zotero/lookup.js
+++ b/chrome/content/zotero/lookup.js
@@ -205,12 +205,20 @@ var Zotero_Lookup = new function () {
 	}
 
 	this.onFocusOut = function(event) {
+		/*
+			if the lookup popup was triggered by the lookup button,
+			we want to return there on focus out. So we check 
+			(1) that we came from a button and (2) that
+			event.relatedTarget === null, i.e. that the user hasn't used
+			the mouse or keyboard to select something, and focus is leaving
+			the popup because the popup was hidden/dismissed.
+		*/
 		if (this._button && event.relatedTarget === null) {
 			event.preventDefault();
 			event.stopPropagation();
 			this._button.focus();
 			this._button = null;
-		}
+		} else this._button = null;
 	}
 	
 	

--- a/chrome/content/zotero/lookup.js
+++ b/chrome/content/zotero/lookup.js
@@ -28,6 +28,7 @@
  * @namespace
  */
 var Zotero_Lookup = new function () {
+	this._button = null;
 	/**
 	 * Performs a lookup by DOI, PMID, or ISBN on the given textBox value
 	 * and adds any items it can.
@@ -135,6 +136,7 @@ var Zotero_Lookup = new function () {
 	this.showPanel = function (button) {
 		var panel = document.getElementById('zotero-lookup-panel');
 		panel.openPopup(button, "after_start", 16, -2, false, false);
+		this._button = button;
 	}
 	
 	
@@ -200,6 +202,15 @@ var Zotero_Lookup = new function () {
 			document.getElementById("zotero-lookup-panel").hidePopup();
 		}
 		return true;
+	}
+
+	this.onFocusOut = function(event) {
+		if (this._button && event.relatedTarget === null) {
+			event.preventDefault();
+			event.stopPropagation();
+			this._button.focus();
+			this._button = null;
+		}
 	}
 	
 	

--- a/chrome/content/zotero/lookup.js
+++ b/chrome/content/zotero/lookup.js
@@ -135,8 +135,11 @@ var Zotero_Lookup = new function () {
 
 	this.showPanel = function (button) {
 		var panel = document.getElementById('zotero-lookup-panel');
-		panel.openPopup(button, "after_start", 16, -2, false, false);
 		this._button = button;
+		if (!button) {
+			button = document.getElementById("zotero-tb-lookup");
+		}
+		panel.openPopup(button, "after_start", 16, -2, false, false);
 	}
 	
 	

--- a/chrome/content/zotero/standalone/standalone.js
+++ b/chrome/content/zotero/standalone/standalone.js
@@ -160,8 +160,7 @@ const ZoteroStandalone = new function() {
 			let item = Zotero.Items.get(reader.itemID);
 			let library = Zotero.Libraries.get(item.libraryID);
 			if (item
-					// Don't allow annotation transfer in group libraries
-					&& library.libraryType == 'user'
+					&& library.filesEditable
 					&& library.editable
 					&& !(item.deleted || item.parentItem && item.parentItem.deleted)) {
 				let annotations = item.getAnnotations();

--- a/chrome/content/zotero/xpcom/sync/syncRunner.js
+++ b/chrome/content/zotero/xpcom/sync/syncRunner.js
@@ -1501,7 +1501,7 @@ Zotero.Sync.Runner_Module = function (options = {}) {
 			panel.removeChild(panel.firstChild);
 		}
 		
-		for (let e of errors) {
+		for (let [index, e] of errors.entries()) {
 			var box = doc.createElement('vbox');
 			var label = doc.createElement('label');
 			if (e.libraryID !== undefined) {
@@ -1526,6 +1526,7 @@ Zotero.Sync.Runner_Module = function (options = {}) {
 				let header = doc.createElement('description');
 				header.className = 'error-header';
 				header.textContent = e.dialogHeader;
+				header.setAttribute("control", `zotero-sync-error-panel-button-${index}`);
 				content.appendChild(header);
 			}
 			
@@ -1544,6 +1545,7 @@ Zotero.Sync.Runner_Module = function (options = {}) {
 			
 			var desc = doc.createElement('description');
 			desc.textContent = msg;
+			desc.setAttribute("control", `zotero-sync-error-panel-button-${index}`);
 			// Make the text selectable
 			desc.setAttribute('style', '-moz-user-select: text; cursor: text');
 			content.appendChild(desc);
@@ -1565,13 +1567,26 @@ Zotero.Sync.Runner_Module = function (options = {}) {
 					var buttonText = e.dialogButtonText;
 					var buttonCallback = e.dialogButtonCallback;
 				}
+
+				function addEventHandlers(button, cb) {
+					button.addEventListener("click", () => {
+						cb();
+						panel.hidePopup();
+					});
+
+					button.addEventListener("keydown", (event) => {
+						if (event.key !== ' ' && event.key !== 'Enter') return;
+						cb();
+						panel.hidePopup();
+					});
+				}
+
+
 				
 				let button = doc.createElement('button');
+				button.setAttribute("id", `zotero-sync-error-panel-button-${index}`);
 				button.setAttribute('label', buttonText);
-				button.onclick = function () {
-					buttonCallback();
-					panel.hidePopup();
-				};
+				addEventHandlers(button, buttonCallback);
 				buttons.appendChild(button);
 				
 				// Second button
@@ -1581,10 +1596,9 @@ Zotero.Sync.Runner_Module = function (options = {}) {
 					
 					let button2 = doc.createElement('button');
 					button2.setAttribute('label', buttonText);
-					button2.onclick = () => {
-						buttonCallback();
-						panel.hidePopup();
-					};
+					button2.setAttribute("id", `zotero-sync-error-panel-button-${index}`);
+					button.removeAttribute("id");
+					addEventHandlers(button2, buttonCallback);
 					buttons.insertBefore(button2, button);
 				}
 			}

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -143,116 +143,152 @@ var ZoteroPane = new function()
 	};
 
 	function setUpToolbar() {
-		/* constants, state, and helper functions */
-		const toolbar = this.document.getElementById("zotero-toolbar");
-		const lookupButton = document.getElementById("zotero-tb-lookup"); // needs special treatment
-		let zone = null;
-		let current = null;
-
 		class TbFocusZone {
-			constructor(node, before, after) {
-				this.node = node;
+			constructor(start, before, after) {
+				this.start = start;
 				this.before = before;
 				this.after = after;
 			}
-			enter(targetButton) {
-				zone = this;
-				current = targetButton;
-			}
-			exit() {
-				zone = null;
-				current = null;
-			}
-			getButtons() {
-				return Array.from(this.node.getElementsByClassName("zotero-tb-button"));
-			}
-			get firstButton() {
-				return this.getButtons()[0];
-			}
-			contains(target) {
-				return this.node.contains(target);
-			}
 		}
 		
-		function moveFocus(n = 0) {
-			const children = zone.getButtons();
-			let currentIndex = children.indexOf(current);
-			if (currentIndex === -1) {
-				throw new Error("Cannot move focus from an element not part of the current toolbar zone.");
-			}
-			if (currentIndex + n < 0 || currentIndex + n >= children.length) return;
-			children[currentIndex + n].focus();
-		}
-		
-		const isTbButton = (node) => node && node.classList && node.classList.contains("zotero-tb-button");
-		
-		/* set up toolbar */
+		// if the hidden property is ever set on a grandparent or more distant
+		// ancestor this will need to be updated
+		const isVisible = (b) => !b.hidden && !b.parentElement.hidden;
+		const isTbButton = (node) => node && node.tagName === "toolbarbutton";
 
+		function nextVisible(id, field = "after") {
+			let b = document.getElementById(id);
+			while (!isVisible(b)) {
+				const mapData = focusMap.get(b.id);
+				b = document.getElementById(mapData[field]);
+			}
+			return b;
+		}
+
+		/* constants */
+		const toolbar = this.document.getElementById("zotero-toolbar");
+
+		// assumes no toolbarbuttons are dynamically added, just hidden
+		// or revealed. If this changes, the observer will have to monitor
+		// changes to the childList for each hbox in the toolbar which might
+		// have dynamic children
+		const buttons = toolbar.getElementsByTagName("toolbarbutton");
+		const focusMap = new Map();
 		const zones = [
-			new TbFocusZone(document.getElementById("zotero-collections-toolbar") ),
-			new TbFocusZone(document.getElementById("zotero-items-toolbar"),
-								() => zones[0].firstButton,
-								() => document.getElementById("zotero-tb-search-menu-button")),
-			new TbFocusZone(document.getElementById("zotero-item-toolbar"),
-								() => document.getElementById("collection-tree"),
-								() => document.getElementById("zotero-tb-search"))
+			new TbFocusZone(
+				"zotero-tb-collection-add", 
+				null, 
+				"zotero-tb-search-menu-button"),
+			new TbFocusZone(
+				"zotero-tb-locate", 
+				"zotero-tb-search",
+				null)
 		];
 
-		for (const zone of zones) {
-			zone.firstButton.setAttribute("tabindex", "0");
+		/* 
+			observe buttons and containers for changes in the "hidden"
+			attribute
+		*/
+		const observer = new MutationObserver((mutations, _) => {
+			for (const mutation of mutations) {
+				if (mutation.target.hidden
+						&& (document.activeElement === mutation.target 
+							|| mutation.target.contains(document.activeElement))
+					) {
+					const next = nextVisible(document.activeElement.id, "before");
+					next.focus();
+				}
+			}
+		});
+
+		/* 
+			build a chain which connects all the <toolbarbutton>s,
+			except for zotero-tb-locate and zotero-tb-advanced-search
+			which is where the chain breaks
+		*/
+		let prev = null;
+		let _zone = zones[0];
+		for (const button of buttons) {
+			focusMap.set(button.id, {
+				before: prev, 
+				after: null,
+				zone: _zone
+			});
+
+			/* observe each button for changes to "hidden" */
+			observer.observe(button, {
+				attributes: true,
+				attributeFilter: ["hidden"]
+			});
+
+			if (focusMap.has(prev)) {
+				focusMap.get(prev).after = button.id; 
+			}
+			
+			prev = button.id;
+			
+			// break the chain at zotero-tb-advanced-search
+			if (button.id === "zotero-tb-advanced-search") {
+				_zone = zones[1];
+				prev = null;
+			}
 		}
 
-		toolbar.addEventListener("focusin", (event) => {
-			if (!isTbButton(event.target)) {
-				return;
-			}
-			else if (zone) {
-				if (current === event.target) return;
-				if (zone.contains(event.target)) {
-					current = event.target;
-					return;
-				}
-			}
-			else {
-				for (const zone of zones) {
-					if (zone.contains(event.target)) {
-						zone.enter(event.target);
-					}
-				}
-			}
+		/* this container sets "hidden" to hide its children, so we have to observe it too */
+		observer.observe(document.getElementById("zotero-tb-sync-progress-box"), {
+			attributes: true,
+			attributeFilter: ["hidden"]		
 		});
 
-		toolbar.addEventListener("focusout", (event) => {
-			if (zone) {
-				if (!(zone.contains(event.relatedTarget))) {
-					zone.exit();
-				}
-				else if (!(isTbButton(event.relatedTarget))) {
-					zone.exit();
-				}
-			}
-		});
+		// lookupButton and syncErrorButton show popup panels, and so need special treatment
+		const lookupButton = document.getElementById("zotero-tb-lookup"); 
+		const syncErrorButton = document.getElementById("zotero-tb-sync-error");
+
+
+		for (const zone of zones) {
+			document.getElementById(zone.start).setAttribute("tabindex", "0");
+		}
 
 		toolbar.addEventListener("keydown", (event) => {
-			// only handle events on a zotero-tb-button inside a zone
-			if (!zone || !isTbButton(event.target)) return;
+			if (event.key === 'Tab' && event.shiftKey 
+					&& !modifierIsNotShift(event) 
+					&& event.originalTarget
+					&& event.originalTarget.id == "zotero-tb-search-menu-button") {
+				event.preventDefault();
+				event.stopPropagation();
+				document.getElementById(zones[0].start).focus();
+				return;
+			}
+			// only handle events on a toolbarbutton inside a zone
+			if (!isTbButton(event.target)) return;
+
+			const mapData = focusMap.get(event.target.id);
 
 			if (!Zotero.rtl && event.key === 'ArrowRight'
 					|| Zotero.rtl && event.key === 'ArrowLeft') {
 				event.preventDefault();
 				event.stopPropagation();
-				moveFocus(1);
+				// moveFocus(forwards);
+				if (mapData.after) {
+					nextVisible(mapData.after, "after").focus();
+				}
 				return;
-			} 
-			else if (!Zotero.rtl && event.key === 'ArrowLeft'
+			}
+			if (!Zotero.rtl && event.key === 'ArrowLeft'
 					|| Zotero.rtl && event.key === 'ArrowRight') {
 				event.preventDefault();
 				event.stopPropagation();
-				moveFocus(-1);
+
+				if (mapData.before) {
+					nextVisible(mapData.before, "before").focus();
+				}
+
+				// moveFocus(backwards);
 				return;
 			} 
+
 			/* manually trigger on space and enter */
-			else if (event.key === ' ' || event.key === 'Enter') {
+			if (event.key === ' ' || event.key === 'Enter') {
 				if (event.target.disabled) return;
 
 				if (event.target === lookupButton) {
@@ -260,6 +296,13 @@ var ZoteroPane = new function()
 					event.stopPropagation();
 					Zotero_Lookup.showPanel(event.target);
 				} 
+				else if (event.target === syncErrorButton) {
+					event.preventDefault();
+					event.stopPropagation();
+					syncErrorButton.dispatchEvent(new MouseEvent("click", {
+						target: event.target
+					}));
+				}
 				else if (event.target.getAttribute('type') === 'menu') {
 					event.preventDefault();
 					event.stopPropagation();
@@ -285,17 +328,15 @@ var ZoteroPane = new function()
 					}
 				}
 				/* prepare for a focus change */
-				else if (event.key === 'ArrowDown' && zone.after) {
-						zone.after().focus();
-						zone.exit();
-						event.preventDefault();
-						event.stopPropagation();
+				else if (event.key === 'ArrowDown' && mapData.zone.before) {
+					document.getElementById(mapData.zone.before).focus();
+					event.preventDefault();
+					event.stopPropagation();
 				}
-				else if (event.key === 'ArrowUp' && zone.before) {
-						zone.before().focus();
-						zone.exit();
-						event.preventDefault();
-						event.stopPropagation();
+				else if (event.key === 'ArrowUp' && mapData.zone.after) {
+					document.getElementById(mapData.zone.after).focus();
+					event.preventDefault();
+					event.stopPropagation();
 				}
 				/* 
 				if neither before nor after have been manually set, 
@@ -303,13 +344,11 @@ var ZoteroPane = new function()
 				behavior proceed
 				*/
 				else {
-					current = zone.firstButton;
-					current.focus();
+					document.getElementById(mapData.zone.start).focus();
 				}
 			}
 			else if (event.key === 'Tab' && !modifierIsNotShift(event)) {
-				current = zone.firstButton;
-				current.focus();
+				document.getElementById(mapData.zone.start).focus();
 				// let the default tab/shift+tab behavior proceed
 			}
 		});

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -170,7 +170,7 @@ var ZoteroPane = new function()
 			{
 				get start() { return document.getElementById("zotero-tb-collection-add"); },
 				focusBefore() {
-					// need to check if the itembox is open
+					// If no item is selected, focus items list.
 					const pane = document.getElementById("zotero-item-pane-content");
 					if (pane.selectedIndex === "0") {
 						document.getElementById("item-tree-main-default").focus();
@@ -191,20 +191,20 @@ var ZoteroPane = new function()
 						else if (tabBox.selectedIndex === 2) {
 							const tagContainer = document.getElementById("tags-box-container");
 							const tags = tagContainer.querySelectorAll("#tags-box-add-button,.zotero-clicky");
-							const next = tags[tags.length - 1];
-							if (next.id === "tags-box-add-button") {
-								next.focus();
+							const last = tags[tags.length - 1];
+							if (last.id === "tags-box-add-button") {
+								last.focus();
 							}
 							else {
-								next.click();
+								last.click();
 							}
 						}
 						else if (tabBox.selectedIndex === 3) {
 							const related = tabBox.querySelector("relatedbox");
-							related.receiveKeyboardFocus();
+							related.receiveKeyboardFocus("end");
 						}
 						else {
-							throw new Error("This error should be unreachable — the selectedIndex should always be between 1 and 4");
+							throw new Error("The selectedIndex should always be between 1 and 4");
 						}
 					}
 				},

--- a/chrome/content/zotero/zoteroPane.xul
+++ b/chrome/content/zotero/zoteroPane.xul
@@ -188,12 +188,14 @@
 							</hbox>
 							<hbox align="center" pack="end">
 								<toolbarbutton tabindex="-1" id="zotero-tb-sync-stop"
+									style="-moz-user-focus: normal;"
 									tooltiptext="&zotero.sync.stop;"
 									oncommand="this.hidden = true; Zotero.Sync.Runner.stop()"
 									hidden="true"/>
 								<hbox id="zotero-tb-sync-progress-box" hidden="true" align="center">
 									<!-- TODO: localize -->
 									<toolbarbutton tabindex="-1" id="zotero-tb-sync-storage-cancel"
+										style="-moz-user-focus: normal;"
 										tooltiptext="Stop sync"
 										oncommand="Zotero.Sync.Runner.stop()"/>
 									<progressmeter id="zotero-tb-sync-progress" mode="determined"
@@ -211,14 +213,19 @@
 		
 							<hbox id="zotero-pq-buttons">
 							</hbox>
-		
-							<toolbarbutton tabindex="-1" id="zotero-tb-sync-error" hidden="true"/>
+
+							<!-- TODO needs label for screenreaders -->
+							<toolbarbutton tabindex="-1" id="zotero-tb-sync-error" hidden="true" style="-moz-user-focus: normal;" />
 							
 							<!--
 								We put this here, but it can be used wherever
 								Zotero.Sync.Runner.updateErrorPanel() puts it
 							-->
-							<panel id="zotero-sync-error-panel" type="arrow"/>
+							<panel id="zotero-sync-error-panel" type="arrow" onpopupshown="
+								const buttons = this.getElementsByTagName('button');
+								if (buttons[0]) {
+									buttons[0].focus();
+								}" />
 							
 							<toolbarbutton tabindex="-1" id="zotero-tb-sync" class="zotero-tb-button" tooltip="_child"
 									oncommand="ZoteroPane.sync()">

--- a/chrome/content/zotero/zoteroPane.xul
+++ b/chrome/content/zotero/zoteroPane.xul
@@ -95,10 +95,10 @@
 					onkeypress="ZoteroPane_Local.handleKeyPress(event)"
 					chromedir="&locale.dir;">
 					
-					<toolbar id="zotero-toolbar" class="toolbar toolbar-primary">
+					<toolbar id="zotero-toolbar" class="toolbar toolbar-primary" tabindex="-1">
 						<hbox id="zotero-collections-toolbar" align="center">
-							<toolbarbutton id="zotero-tb-collection-add" class="zotero-tb-button" tooltiptext="&zotero.toolbar.newCollection.label;" command="cmd_zotero_newCollection"/>
-							<toolbarbutton id="zotero-tb-library-add-menu" class="zotero-tb-button" tooltiptext="&zotero.toolbar.newLibrary.label;" type="menu">
+							<toolbarbutton tabindex="-1" id="zotero-tb-collection-add" class="zotero-tb-button" tooltiptext="&zotero.toolbar.newCollection.label;" command="cmd_zotero_newCollection"/>
+							<toolbarbutton tabindex="-1" id="zotero-tb-library-add-menu" class="zotero-tb-button" tooltiptext="&zotero.toolbar.newLibrary.label;" type="menu">
 								<menupopup id="zotero-tb-library-add-popup">
 									<menuitem id="zotero-tb-group-add" label="&zotero.toolbar.newGroup;" oncommand="ZoteroPane_Local.newGroup()"/>
 									<menu id="zotero-tb-feed-add-menu" label="&zotero.toolbar.feeds.new;">
@@ -114,7 +114,7 @@
 						</hbox>
 						
 						<hbox id="zotero-items-toolbar" align="center">
-							<toolbarbutton id="zotero-tb-add" class="zotero-tb-button" tooltiptext="&zotero.toolbar.newItem.label;" type="menu"
+							<toolbarbutton tabindex="-1" id="zotero-tb-add" class="zotero-tb-button" tooltiptext="&zotero.toolbar.newItem.label;" type="menu"
 									onmousedown="if (this.disabled) { event.preventDefault(); return; }">
 								<menupopup onpopupshowing="ZoteroPane_Local.updateNewItemTypes()">
 									<menuseparator/>
@@ -127,13 +127,13 @@
 								</menupopup>
 							</toolbarbutton>
 							
-							<toolbarbutton id="zotero-tb-lookup" class="zotero-tb-button" tooltiptext="&zotero.toolbar.lookup.label;" type="panel"
-									onmousedown="if (this.disabled) { event.preventDefault(); return; } Zotero_Lookup.showPanel(this)"/>
+							<toolbarbutton tabindex="-1" id="zotero-tb-lookup" class="zotero-tb-button" tooltiptext="&zotero.toolbar.lookup.label;" type="panel"
+									onmousedown="if (this.disabled) { event.preventDefault(); return; } Zotero_Lookup.showPanel(this)" />
 							
 							<panel id="zotero-lookup-panel" type="arrow" onpopupshown="Zotero_Lookup.onShowing(event)"
-									onpopuphidden="Zotero_Lookup.onHidden(event)">
+									onpopuphidden="Zotero_Lookup.onHidden(event)" onfocusout="Zotero_Lookup.onFocusOut(event)">
 								<vbox>
-									<description>&zotero.lookup.description;</description>
+									<label control="zotero-lookup-textbox">&zotero.lookup.description;</label>
 									<vbox id="zotero-lookup-singleLine">
 										<stack>
 											<progressmeter id="zotero-lookup-progress" mode="determined"/>
@@ -155,14 +155,14 @@
 							</panel>
 							
 							<!--<toolbarbutton id="zotero-tb-note-add" class="zotero-tb-button" tooltiptext="&zotero.toolbar.note.standalone;" oncommand="ZoteroPane_Local.newNote(event.shiftKey);"/>-->
-							<toolbarbutton id="zotero-tb-note-add" class="zotero-tb-button" tooltiptext="&zotero.toolbar.newNote;" type="menu"
+							<toolbarbutton tabindex="-1" id="zotero-tb-note-add" class="zotero-tb-button" tooltiptext="&zotero.toolbar.newNote;" type="menu"
 									onmousedown="if (this.disabled) { event.preventDefault(); return; }">
 								<menupopup onpopupshowing="ZoteroPane_Local.updateNoteButtonMenu()">
 									<menuitem label="&zotero.toolbar.note.standalone;" command="cmd_zotero_newStandaloneNote"/>
 									<menuitem label="&zotero.toolbar.note.child;" command="cmd_zotero_newChildNote"/>
 								</menupopup>
 							</toolbarbutton>
-							<toolbarbutton id="zotero-tb-attachment-add" class="zotero-tb-button" tooltiptext="&zotero.items.menu.attach;" type="menu"
+							<toolbarbutton tabindex="-1" id="zotero-tb-attachment-add" class="zotero-tb-button" tooltiptext="&zotero.items.menu.attach;" type="menu"
 									onmousedown="if (this.disabled) { event.preventDefault(); return; }">
 								<menupopup onpopupshowing="ZoteroPane_Local.updateAttachmentButtonMenu(this)">
 									<menuitem class="menuitem-iconic zotero-menuitem-attachments-web-link" label="&zotero.items.menu.attach.link.uri;" oncommand="var itemID = ZoteroPane_Local.getSelectedItems()[0].id; ZoteroPane_Local.addAttachmentFromURI(true, itemID);"/>
@@ -171,29 +171,29 @@
 								</menupopup>
 							</toolbarbutton>
 							<toolbarseparator/>
-							<toolbarbutton id="zotero-tb-advanced-search" class="zotero-tb-button" tooltiptext="&zotero.toolbar.advancedSearch;" command="cmd_zotero_advancedSearch"/>
+							<toolbarbutton tabindex="-1" id="zotero-tb-advanced-search" class="zotero-tb-button" tooltiptext="&zotero.toolbar.advancedSearch;" command="cmd_zotero_advancedSearch"/>
 							<spacer flex="1"/>
 							<image id="zotero-tb-search-spinner" class="zotero-spinner-14" style="display: none"/>
 							<textbox id="zotero-tb-search" type="search" timeout="250"
 									onkeypress="ZoteroPane_Local.handleSearchKeypress(this, event)"
 									oninput="ZoteroPane_Local.handleSearchInput(this, event)"
-									oncommand="ZoteroPane_Local.search()"/>
+									oncommand="ZoteroPane_Local.search()" />
 						</hbox>
 						
 						<hbox id="zotero-item-toolbar" flex="1" align="center" tooltip="html-tooltip">
 							<hbox align="center" pack="start" flex="1">
-								<toolbarbutton id="zotero-tb-locate" class="zotero-tb-button" tooltiptext="&zotero.toolbar.openURL.label;" type="menu">
+								<toolbarbutton tabindex="-1" id="zotero-tb-locate" class="zotero-tb-button" tooltiptext="&zotero.toolbar.openURL.label;" type="menu">
 									<menupopup id="zotero-tb-locate-menu" onpopupshowing="Zotero_LocateMenu.buildLocateMenu()"/>
 								</toolbarbutton>
 							</hbox>
 							<hbox align="center" pack="end">
-								<toolbarbutton id="zotero-tb-sync-stop"
+								<toolbarbutton tabindex="-1" id="zotero-tb-sync-stop"
 									tooltiptext="&zotero.sync.stop;"
 									oncommand="this.hidden = true; Zotero.Sync.Runner.stop()"
 									hidden="true"/>
 								<hbox id="zotero-tb-sync-progress-box" hidden="true" align="center">
 									<!-- TODO: localize -->
-									<toolbarbutton id="zotero-tb-sync-storage-cancel"
+									<toolbarbutton tabindex="-1" id="zotero-tb-sync-storage-cancel"
 										tooltiptext="Stop sync"
 										oncommand="Zotero.Sync.Runner.stop()"/>
 									<progressmeter id="zotero-tb-sync-progress" mode="determined"
@@ -212,7 +212,7 @@
 							<hbox id="zotero-pq-buttons">
 							</hbox>
 		
-							<toolbarbutton id="zotero-tb-sync-error" hidden="true"/>
+							<toolbarbutton tabindex="-1" id="zotero-tb-sync-error" hidden="true"/>
 							
 							<!--
 								We put this here, but it can be used wherever
@@ -220,7 +220,7 @@
 							-->
 							<panel id="zotero-sync-error-panel" type="arrow"/>
 							
-							<toolbarbutton id="zotero-tb-sync" class="zotero-tb-button" tooltip="_child"
+							<toolbarbutton tabindex="-1" id="zotero-tb-sync" class="zotero-tb-button" tooltip="_child"
 									oncommand="ZoteroPane.sync()">
 								<tooltip
 										id="zotero-tb-sync-tooltip"

--- a/chrome/skin/default/zotero/overlay.css
+++ b/chrome/skin/default/zotero/overlay.css
@@ -216,6 +216,7 @@
 }
 
 .zotero-tb-button {
+	-moz-user-focus: normal;
 	padding-left: 5px;
 	padding-right: 5px;
 	margin-right: 2px;


### PR DESCRIPTION
I made the toolbar accessible to the keyboard. There are two sections, one before and one after the search bar. When you tab into a section you can move around with the arrow keys to select an appropriate button. The code listenes on two toolbarbuttons per section, one at the start and end, to determine from which direction the user's focus originates.

The sync button does not have a meaningful label for screen readers, but the other toolbarbuttons do.