### PR TITLE
Fix last editpane tab being misaligned vertically on macOS

### DIFF
--- a/chrome/content/zotero-platform/mac/overlay.css
+++ b/chrome/content/zotero-platform/mac/overlay.css
@@ -152,7 +152,8 @@
 
 /* This seems to be necessary to center the tabs. Not sure why. */
 .zotero-editpane-tabs > tab:last-of-type > hbox .tab-text {
-	margin: 2px 9px 2px 9px !important;
+	margin-left: 9px !important;
+	margin-right: 9px !important;
 }
 
 .zotero-editpane-tabs > tab[selected=true] > hbox .tab-text {


### PR DESCRIPTION
Before:
<img src="https://user-images.githubusercontent.com/1770299/194929401-555b775b-9de8-4bd2-9ee2-1b1c2371cf01.png" width="300">

After:
<img src="https://user-images.githubusercontent.com/1770299/194929425-7946b602-ac15-4435-af6f-1cc90759758b.png" width="300">

(Both upscaled.) The rightmost tab was pushed too far up before and this change corrects its position. Can be cherry-picked to master too.