### PR TITLE
Add "Open PDF reader in new window" preference

### DIFF
--- a/chrome/content/zotero/preferences/preferences_general.js
+++ b/chrome/content/zotero/preferences/preferences_general.js
@@ -170,11 +170,13 @@ Zotero_Preferences.General = {
 		var handler = Zotero.Prefs.get('fileHandler.pdf');
 		var menulist = document.getElementById('fileHandler-pdf');
 		var customMenuItem = document.getElementById('fileHandler-custom');
+		var inNewWindowCheckbox = document.getElementById('open-reader-in-new-window');
 		
 		// System default
 		if (handler == 'system') {
 			customMenuItem.hidden = true;
 			menulist.selectedIndex = 1;
+			inNewWindowCheckbox.disabled = true;
 		}
 		// Custom handler
 		else if (handler) {
@@ -201,6 +203,7 @@ Zotero_Preferences.General = {
 			}
 			customMenuItem.hidden = false;
 			menulist.selectedIndex = 2;
+			inNewWindowCheckbox.disabled = true;
 
 			// There's almost certainly a better way to do this...
 			// but why doesn't the icon just behave by default?
@@ -211,6 +214,7 @@ Zotero_Preferences.General = {
 			let menuitem = document.getElementById('fileHandler-internal');
 			menulist.selectedIndex = 0;
 			customMenuItem.hidden = true;
+			inNewWindowCheckbox.disabled = false;
 		}
 	},
 	

--- a/chrome/content/zotero/preferences/preferences_general.xhtml
+++ b/chrome/content/zotero/preferences/preferences_general.xhtml
@@ -55,20 +55,26 @@
 					oncommand="Zotero_Preferences.General.updateAutoRenameFilesUI()" native="true"/>
 		</vbox>
 		
-		<hbox align="center">
-			<label value="&zotero.preferences.fileHandler.openPDFsUsing;" control="file-handler-pdf"/>
-			<menulist id="fileHandler-pdf" class="fileHandler-menu" native="true">
-				<menupopup>
-					<menuitem id="fileHandler-internal"
-							oncommand="Zotero_Preferences.General.setFileHandler('pdf', '')"/>
-					<menuitem label="&zotero.preferences.fileHandler.systemDefault;"
-							oncommand="Zotero_Preferences.General.setFileHandler('pdf', 'system')"/>
-					<menuitem id="fileHandler-custom"/>
-					<menuitem label="&zotero.preferences.custom;"
-							oncommand="Zotero_Preferences.General.chooseFileHandler('pdf')"/>
-				</menupopup>
-			</menulist>
-		</hbox>
+		<vbox>
+			<hbox align="center">
+				<label value="&zotero.preferences.fileHandler.openPDFsUsing;" control="file-handler-pdf"/>
+				<menulist id="fileHandler-pdf" class="fileHandler-menu" native="true">
+					<menupopup>
+						<menuitem id="fileHandler-internal"
+								oncommand="Zotero_Preferences.General.setFileHandler('pdf', '')"/>
+						<menuitem label="&zotero.preferences.fileHandler.systemDefault;"
+								oncommand="Zotero_Preferences.General.setFileHandler('pdf', 'system')"/>
+						<menuitem id="fileHandler-custom"/>
+						<menuitem label="&zotero.preferences.custom;"
+								oncommand="Zotero_Preferences.General.chooseFileHandler('pdf')"/>
+					</menupopup>
+				</menulist>
+			</hbox>
+			<checkbox id="open-reader-in-new-window" class="indented-pref"
+					label="&zotero.preferences.fileHandler.openReaderInNewWindow;"
+					preference="extensions.zotero.openReaderInNewWindow"
+					native="true"/>
+		</vbox>
 	</groupbox>
 
 	<groupbox>

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -4403,13 +4403,17 @@ var ZoteroPane = new function()
 				let pdfHandler  = Zotero.Prefs.get("fileHandler.pdf");
 				// Zotero PDF reader
 				if (!pdfHandler) {
+					let openInWindow = Zotero.Prefs.get('openReaderInNewWindow');
+					let useAlternateWindowBehavior = event?.shiftKey || extraData?.forceAlternateWindowBehavior;
+					if (useAlternateWindowBehavior) {
+						openInWindow = !openInWindow;
+					}
 					await Zotero.Reader.open(
 						itemID,
 						extraData && extraData.location,
 						{
-							openInWindow: (event && event.shiftKey)
-								|| (extraData && extraData.forceOpenPDFInWindow),
-							allowDuplicate: event && event.shiftKey
+							openInWindow,
+							allowDuplicate: openInWindow
 						}
 					);
 					return;

--- a/chrome/locale/en-US/zotero/preferences.dtd
+++ b/chrome/locale/en-US/zotero/preferences.dtd
@@ -19,6 +19,7 @@
 <!ENTITY zotero.preferences.autoRenameFiles.renameLinked  "Rename linked files">
 <!ENTITY zotero.preferences.fileHandler.openPDFsUsing "Open PDFs using">
 <!ENTITY zotero.preferences.fileHandler.systemDefault "System Default">
+<!ENTITY zotero.preferences.fileHandler.openReaderInNewWindow "Open PDF reader in new window">
 
 <!ENTITY zotero.preferences.miscellaneous				"Miscellaneous">
 <!ENTITY zotero.preferences.autoUpdate					"Automatically check for updated translators and styles">

--- a/chrome/locale/en-US/zotero/preferences.dtd
+++ b/chrome/locale/en-US/zotero/preferences.dtd
@@ -19,7 +19,7 @@
 <!ENTITY zotero.preferences.autoRenameFiles.renameLinked  "Rename linked files">
 <!ENTITY zotero.preferences.fileHandler.openPDFsUsing "Open PDFs using">
 <!ENTITY zotero.preferences.fileHandler.systemDefault "System Default">
-<!ENTITY zotero.preferences.fileHandler.openReaderInNewWindow "Open PDF reader in new window">
+<!ENTITY zotero.preferences.fileHandler.openReaderInNewWindow "Open PDFs in new windows instead of tabs">
 
 <!ENTITY zotero.preferences.miscellaneous				"Miscellaneous">
 <!ENTITY zotero.preferences.autoUpdate					"Automatically check for updated translators and styles">

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -1212,6 +1212,7 @@ createParent.prompt					= Enter a DOI, ISBN, PMID, arXiv ID, or ADS Bibcode to i
 locate.online.label					= View Online
 locate.pdf.label					= Open PDF
 locate.pdfNewWindow.label			= Open PDF in New Window
+locate.pdfNewTab.label				= Open PDF in New Tab
 locate.snapshot.label				= View Snapshot
 locate.file.label					= View File
 locate.externalViewer.label			= Open in External Viewer

--- a/defaults/preferences/zotero.js
+++ b/defaults/preferences/zotero.js
@@ -184,8 +184,8 @@ pref("extensions.zotero.purge.tags", false);
 // Zotero pane persistent data
 pref("extensions.zotero.pane.persist", "");
 
-// Custom file handlers
 pref("extensions.zotero.fileHandler.pdf", "");
+pref("extensions.zotero.openReaderInNewWindow", false);
 
 // File/URL opening executable if launch() fails
 pref("extensions.zotero.fallbackLauncher.unix", "/usr/bin/xdg-open");


### PR DESCRIPTION
When enabled:
- Double-clicking a PDF or choosing "Open PDF" opens a new window
- Shift-double-clicking opens a new tab
- "Open in New Window" locate option becomes "Open in New Tab" and has the reverse behavior

Fixes #2680