### PR TITLE
Mendeley Import: Switch to direct login/password auth in order to obtain Mendeley Desktop item id

### DIFF
--- a/chrome/content/zotero/fileInterface.js
+++ b/chrome/content/zotero/fileInterface.js
@@ -444,10 +444,12 @@ var Zotero_File_Interface = new function() {
 		
 		var translation;
 		
-		if (options.mendeleyCode) {
+		if (options.mendeleyAuth || options.mendeleyCode) {
 			translation = yield _getMendeleyTranslation();
 			translation.createNewCollection = createNewCollection;
+			translation.mendeleyAuth = options.mendeleyAuth;
 			translation.mendeleyCode = options.mendeleyCode;
+			translation.newItemsOnly = options.newItemsOnly;
 		}
 		else {
 			// Check if the file is an SQLite database
@@ -983,7 +985,7 @@ var Zotero_File_Interface = new function() {
 			if (matchResult) {
 				const mendeleyCode = matchResult[1];
 				Zotero.getMainWindow().setTimeout(() => this.showImportWizard({ mendeleyCode }), 0);
-				
+
 				// Clear all cookies to remove access
 				//
 				// This includes unrelated cookies in the central cookie store, but that's fine for
@@ -998,7 +1000,7 @@ var Zotero_File_Interface = new function() {
 				catch (e) {
 					Zotero.logError(e);
 				}
-				
+
 				win.close();
 				return;
 			}

--- a/chrome/content/zotero/import/importWizard.js
+++ b/chrome/content/zotero/import/importWizard.js
@@ -12,7 +12,7 @@ var Zotero_Import_Wizard = {
 	_mendeleyCode: null,
 	_mendeleyAuth: null,
 	_mendeleyHasPreviouslyImported: false,
-	
+	_isZotfileInstalled: false,
 	
 	init: async function () {
 		this._wizard = document.getElementById('import-wizard');
@@ -21,6 +21,9 @@ var Zotero_Import_Wizard = {
 			// Local import disabled
 			//document.getElementById('radio-import-source-mendeley').hidden = false;
 		}
+
+		const extensions = await Zotero.getInstalledExtensions();
+		this._isZotfileInstalled = !!extensions.find(extName => extName.match(/^ZotFile((?!disabled).)*$/));
 
 		const predicateID = Zotero.RelationPredicates.getID('mendeleyDB:documentUUID');
 
@@ -95,6 +98,14 @@ var Zotero_Import_Wizard = {
 				break;
 
 			case 'radio-import-source-mendeley-online':
+					if (this._isZotfileInstalled) {
+						this._onDone(
+							Zotero.getString('general.error'),
+							Zotero.getString('import.online.blockedByPlugin', 'ZotFile'),
+							false
+						);
+						return;
+					}
 				wizard.goTo('mendeley-online-explanation');
 				wizard.canRewind = true;
 			break;

--- a/chrome/content/zotero/import/importWizard.xul
+++ b/chrome/content/zotero/import/importWizard.xul
@@ -37,6 +37,17 @@
 	>
 		<description id="mendeley-online-description" />
 		<description id="mendeley-online-description2" />
+		<html:fieldset id="mendeley-login">
+			<html:div class="field">
+				<html:label for="mendeley-username"/>
+				<html:input type="text" id="mendeley-username" />
+			</html:div>
+			<html:div class="field">
+				<html:label for="mendeley-password"/>
+				<html:input type="password" id="mendeley-password" />
+			</html:div>
+		</html:fieldset>
+		<description id="mendeley-online-login-feedback" />
 	</wizardpage>
 	
 	<wizardpage pageid="page-file-list"
@@ -76,6 +87,9 @@
 				<radio id="file-handling-link"/>
 			</radiogroup>
 			<description id="file-handling-description"/>
+		</vbox>
+		<vbox id="mendeley-options">
+			<checkbox id="new-items-only-checkbox" label="&zotero.import.online.newItemsOnly;" checked="true" />
 		</vbox>
 	</wizardpage>
 	

--- a/chrome/content/zotero/import/mendeley/mendeleyOnlineMappings.js
+++ b/chrome/content/zotero/import/mendeley/mendeleyOnlineMappings.js
@@ -28,6 +28,7 @@ var mendeleyOnlineMappings = {
 		arxiv: 'arxivId',
 		accessed: 'dateAccessed',
 		authors: false, // all author types handled separately
+		client_data: false, // desktop_id extraction handled separately
 		citation_key: 'citationKey',
 		created: 'added',
 		edition: 'edition',

--- a/chrome/locale/en-US/zotero/zotero.dtd
+++ b/chrome/locale/en-US/zotero/zotero.dtd
@@ -186,6 +186,7 @@
 <!ENTITY zotero.import.size                            "Size">
 <!ENTITY zotero.import.createCollection                "Place imported collections and items into new collection">
 <!ENTITY zotero.import.fileHandling                    "File Handling">
+<!ENTITY zotero.import.online.newItemsOnly             "Download new items only; don’t update previously imported items">
 
 <!ENTITY zotero.exportOptions.title						"Export…">
 <!ENTITY zotero.exportOptions.format.label				"Format:">

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -813,6 +813,7 @@ import.online.formIntro = Please enter your credentials to log in to %2$S. This 
 import.online.intro = In the next step you will be asked to log in to %2$S and grant %1$S access. This is necessary to import your %3$S library into %1$S.
 import.online.intro2 = %1$S will never see or store your %2$S password.
 import.online.wrongCredentials = Login to %1$S failed. Please re-enter credentials and try again.
+import.online.blockedByPlugin = The import cannot continue with "%1$S" installed. Please disable this plugin and try again.
 
 quickCopy.copyAs = Copy as %S
 

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -94,6 +94,8 @@ general.loading                    = Loading…
 general.richText = Rich Text
 general.clearSelection = Clear Selection
 general.insert = Insert
+general.username = Username
+general.password = Password
 
 general.yellow = Yellow
 general.red = Red
@@ -807,8 +809,10 @@ import.localImport = local import
 import.fileHandling.store = Copy files to the %S storage folder
 import.fileHandling.link = Link to files in original location
 import.fileHandling.description = Linked files cannot be synced by %S.
+import.online.formIntro = Please enter your credentials to log in to %2$S. This is necessary to import your %3$S library into %1$S.
 import.online.intro = In the next step you will be asked to log in to %2$S and grant %1$S access. This is necessary to import your %3$S library into %1$S.
 import.online.intro2 = %1$S will never see or store your %2$S password.
+import.online.wrongCredentials = Login to %1$S failed. Please re-enter credentials and try again.
 
 quickCopy.copyAs = Copy as %S
 

--- a/chrome/skin/default/zotero/importWizard.css
+++ b/chrome/skin/default/zotero/importWizard.css
@@ -3,6 +3,40 @@
 	font-weight: bold;
 }
 
+#mendeley-login {
+	padding: 1.5em 1em 0;
+	font-size: 13px;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	border: none;
+}
+
+#mendeley-login .field {
+	display: flex;
+	max-width: 300px;
+	line-height: 1.5em;
+	align-items: center;
+}
+
+#mendeley-login .field + .field {
+	margin-top: .5em;
+}
+
+#mendeley-login label {
+	flex: 0 0 90px;
+	width: 90px;
+	margin-right: 8px;
+	text-align: right;
+}
+
+#mendeley-login input {
+	flex: 1 1 auto;
+	font-size: 13px;
+}
+
+
+
 /* Start */
 wizard[currentpageid="page-start"] .wizard-header-label {
 	padding-top: 24px;
@@ -79,4 +113,12 @@ button, checkbox {
 #result-report-error {
 	margin-top: 13px;
 	margin-left: 0;
+}
+
+#mendeley-online-login-feedback {
+	text-align: center;
+	font-size: 13px;
+	margin-top: 1.3em;
+	color: red;
+	font-weight: bold;
 }

--- a/test/tests/data/mendeleyMock/items-simple-no-desktop-id.json
+++ b/test/tests/data/mendeleyMock/items-simple-no-desktop-id.json
@@ -6,7 +6,6 @@
         "file_attached": false,
         "hidden": false,
         "id": "7fea3cb3-f97d-3f16-8fad-f59caaa71688",
-        "client_data": "{\"desktop_id\":\"b5f57b1a-f083-486c-aec7-5d5edd366dd2\"}",
         "last_modified": "2021-11-02T12:26:30.025Z",
         "private_publication": false,
         "profile_id": "8dbf0832-8723-4c48-b532-20c0b7f6e01a",
@@ -43,7 +42,6 @@
         "file_attached": false,
         "hidden": false,
         "id": "07a74c26-28d1-4d9f-a60d-3f3bc5ef76ef",
-        "client_data": "{\"desktop_id\":\"616ec6d1-8d23-4414-8b6e-7bb129677577\"}",
         "last_modified": "2021-11-04T11:53:10.353Z",
         "private_publication": false,
         "profile_id": "8dbf0832-8723-4c48-b532-20c0b7f6e01a",
@@ -63,7 +61,6 @@
             "https://zotero.org"
         ],
         "id": "c54b0c6f-c4ce-4706-8742-bc7d032df862",
-        "client_data": "{\"desktop_id\":\"3630a4bf-d97e-46c4-8611-61ec50f840c6\"}",
         "created": "2021-11-09T10:26:15.201Z",
         "file_attached": true,
         "profile_id": "8dbf0832-8723-4c48-b532-20c0b7f6e01a",

--- a/test/tests/data/mendeleyMock/items-updated.json
+++ b/test/tests/data/mendeleyMock/items-updated.json
@@ -2,10 +2,11 @@
     {
         "authored": false,
         "confirmed": true,
-        "created": "2021-11-04T11:53:10.353Z",
+        "created": "2021-12-05T12:00:00.000Z",
         "file_attached": false,
         "hidden": false,
         "id": "07a74c26-28d1-4d9f-a60d-3f3bc5ef76ef",
+        "client_data": "{\"desktop_id\":\"616ec6d1-8d23-4414-8b6e-7bb129677577\"}",
         "last_modified": "2021-11-05T11:53:10.353Z",
         "private_publication": false,
         "profile_id": "8dbf0832-8723-4c48-b532-20c0b7f6e01a",
@@ -15,5 +16,23 @@
         "type": "journal",
         "source": "lorem ipsum",
         "year": 2002
+    },
+    {
+        "authored": false,
+        "confirmed": true,
+        "created": "2021-11-05T12:33:18.353Z",
+        "file_attached": false,
+        "hidden": false,
+        "id": "31a8251f-88b0-497b-9d30-1b2516771057",
+        "client_data": "{\"desktop_id\":\"86e56a00-5ae5-4fe8-a977-9298a03b16d6\"}",
+        "last_modified": "2021-11-05T12:33:18.353Z",
+        "private_publication": false,
+        "profile_id": "8dbf0832-8723-4c48-b532-20c0b7f6e01a",
+        "read": false,
+        "starred": true,
+        "title": "Completely new item",
+        "type": "book",
+        "source": "lorem ipsum",
+        "year": 1999
     }
 ]


### PR DESCRIPTION
As discussed, this approach pretends to be Mendeley Desktop and performs login directly using username and password obtained from the user via form. Signing in this way ensures that Mendeley servers include extra key for documents (`client_data`) which contains Mendeley Desktop UUID. Storing this UUID makes #2622 possible.