### PR TITLE
Fix focus stealing in item box #2885

### DIFF
--- a/chrome/content/zotero/bindings/itembox.xml
+++ b/chrome/content/zotero/bindings/itembox.xml
@@ -111,6 +111,7 @@
 					}
 					
 					this._item = val;
+					this._lastTabIndex = null;
 					this.refresh();
 				]]></setter>
 			</property>
@@ -616,7 +617,7 @@
 						this.disableCreatorAddButtons();
 					}
 					
-					// Move to next or previous field if (shift-)tab was pressed
+					// Refocus on last stored tab index. This is required e.g. when remote change triggers refresh.
 					if (this._lastTabIndex && this._lastTabIndex != -1) {
 						this._focusNextField(this._lastTabIndex);
 					}


### PR DESCRIPTION
I don't think this piece of code does what it says in this [14 years old comment](https://github.com/zotero/zotero/blame/13ab3de1a180424eb1614326c94feefc90ddb645/chrome/content/zotero/bindings/itembox.xml#L619). I believe that instead it is re-focusing on the `lastTabIndex` on every item box refresh. We don't want that because that's what's triggering #2885.

We do however want to re-focus after item box has been refreshed due to field change, I believe that relevant code for that is instead [this](https://github.com/zotero/zotero/blame/13ab3de1a180424eb1614326c94feefc90ddb645/chrome/content/zotero/bindings/itembox.xml#L1511-L1519).

Unless there is some use case I'm not aware of, I think we can just remove these few lines and that should resolve #2855.