### PR TITLE
Add "Any Field" advanced search condition

### DIFF
--- a/chrome/content/zotero/elements/zoteroSearch.js
+++ b/chrome/content/zotero/elements/zoteroSearch.js
@@ -354,6 +354,7 @@
 
 		isPrimaryCondition(condition) {
 			switch (condition) {
+				case 'anyField':
 				case 'collection':
 				case 'creator':
 				case 'title':

--- a/chrome/content/zotero/xpcom/data/search.js
+++ b/chrome/content/zotero/xpcom/data/search.js
@@ -961,7 +961,8 @@ Zotero.Search.prototype._buildQuery = Zotero.Promise.coroutine(function* () {
 	var conditions = [];
 	
 	let lastCondition;
-	for (let condition of Object.values(this._conditions)) {
+	let conditionsToProcess = Object.values(this._conditions);
+	for (let condition of conditionsToProcess) {
 		let name = condition.condition;
 		let conditionData = Zotero.SearchConditions.get(name);
 		
@@ -1054,6 +1055,39 @@ Zotero.Search.prototype._buildQuery = Zotero.Promise.coroutine(function* () {
 					continue;
 				case 'blockEnd':
 					conditions.push({name:'blockEnd'});
+					continue;
+				
+				case 'anyField':
+					// We expand this condition to the same underlying set of conditions as 'quicksearch-fields'
+					// (although we don't detect keys or split into quoted and unquoted segments). 'quicksearch-fields'
+					// is expanded in addCondition(), but we can't do that with this condition because we don't want
+					// to save the conditions it expands to in the search object
+					conditionsToProcess.push({ condition: 'blockStart' });
+					conditionsToProcess.push({
+						condition: 'field',
+						operator: condition.operator,
+						value: condition.value,
+						required: false
+					});
+					conditionsToProcess.push({
+						condition: 'tag',
+						operator: condition.operator,
+						value: condition.value,
+						required: false
+					});
+					conditionsToProcess.push({
+						condition: 'note',
+						operator: condition.operator,
+						value: condition.value,
+						required: false
+					});
+					conditionsToProcess.push({
+						condition: 'creator',
+						operator: condition.operator,
+						value: condition.value,
+						required: false
+					});
+					conditionsToProcess.push({ condition: 'blockEnd' });
 					continue;
 			}
 			

--- a/chrome/content/zotero/xpcom/data/searchConditions.js
+++ b/chrome/content/zotero/xpcom/data/searchConditions.js
@@ -664,6 +664,10 @@ Zotero.SearchConditions = new function(){
 		
 		var collation = Zotero.getLocaleCollation();
 		_standardConditions.sort(function(a, b) {
+			// Sort Any Field to the top
+			if (a.name == 'anyField') {
+				return -1;
+			}
 			return collation.compareString(1, a.localized, b.localized);
 		});
 	});

--- a/chrome/content/zotero/xpcom/data/searchConditions.js
+++ b/chrome/content/zotero/xpcom/data/searchConditions.js
@@ -451,6 +451,18 @@ Zotero.SearchConditions = new function(){
 					+ "'section','seriesNumber','issue')"),
 				template: true // mark for special handling
 			},
+
+			{
+				name: 'anyField',
+				operators: {
+					is: true,
+					isNot: true,
+					contains: true,
+					doesNotContain: true,
+					beginsWith: true
+				},
+				special: false
+			},
 			
 			{
 				name: 'datefield',

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -853,6 +853,7 @@ searchConditions.programmingLanguage	= Programming Language
 searchConditions.fileTypeID		= Attachment File Type
 searchConditions.annotationText = Annotation Text
 searchConditions.annotationComment = Annotation Comment
+searchConditions.anyField = Any Field
 
 fulltext.indexState.indexed								= Indexed
 fulltext.indexState.unavailable							= Unknown


### PR DESCRIPTION
I'm not hugely enthused by how I ended up having to implement this - we didn't seem to have a good way to add compound conditions like "Any Field" that expand at query time instead of when initially being added, so I had to tack something onto the main loop in `_buildQuery()`. If there's a better way that I missed, I'll change it!

Fixes #1699