### PR TITLE
fx-compat: Toolbar fixes

### DIFF
--- a/chrome/content/zotero-platform/mac/overlay.css
+++ b/chrome/content/zotero-platform/mac/overlay.css
@@ -34,11 +34,6 @@
 	padding: 4px 4px 4px 11px;
 }
 
-.zotero-tb-button > .toolbarbutton-icon {
-	background: url("chrome://zotero/skin/mac/menubutton-start.png") left center/auto 24px no-repeat;
-	padding: 4px 4px 4px 11px;
-}
-
 /* For menu buttons, decrease left padding by 1px */
 .zotero-tb-button[type=menu] > .toolbarbutton-icon {
 	padding-left: 9px;

--- a/chrome/content/zotero/elements/menuToolbarbutton.js
+++ b/chrome/content/zotero/elements/menuToolbarbutton.js
@@ -58,9 +58,11 @@
 		}
 
 		static get dropmarkerFragment() {
+			// Zotero.hiDPI[Suffix] may not have been initialized yet, so calculate it ourselves
+			let hiDPISuffix = window.devicePixelRatio > 1 ? '@2x' : '';
 			let frag = document.importNode(
 				MozXULElement.parseXULToFragment(`
-					<image src="chrome://zotero/skin/searchbar-dropmarker${Zotero.hiDPISuffix}.png" width="7" height="4" class="toolbarbutton-menu-dropmarker"/>
+					<image src="chrome://zotero/skin/searchbar-dropmarker${hiDPISuffix}.png" width="7" height="4" class="toolbarbutton-menu-dropmarker"/>
 				`),
 				true
 			);


### PR DESCRIPTION
- Don't rely on `Zotero.hiDPISuffix` being initialized in `menuToolbarbutton.js` -- it probably hasn't been at the time that the code that creates the dropmarker is running. This fixes toolbar buttons never using the hiDPI dropmarker icon on fx102.
- Fix merge mistake that created a duplicate block of CSS.

I think we'd benefit from eventually replacing most of the code that checks `hiDPI`[`Suffix`] with CSS so that images update automatically when moving the window between displays with varying pixel densities, but that's another PR.