### PR TITLE
Fix read-only items becoming editable after refresh

### DIFF
--- a/chrome/content/zotero/itemPane.js
+++ b/chrome/content/zotero/itemPane.js
@@ -153,7 +153,7 @@ var ZoteroItemPane = new function() {
 	this.notify = Zotero.Promise.coroutine(function* (action, type, ids, extraData) {
 		var viewBox = document.getElementById('zotero-view-item');
 		if (viewBox.selectedIndex == 0 && action == 'refresh' && _lastItem) {
-			yield this.viewItem(_lastItem, null, 0);
+			yield this.viewItem(_lastItem, _lastItem.library?.editable ? null : 'view', 0);
 		}
 	});
 	


### PR DESCRIPTION
The bug that this fixes is observable in Z6 and Z7 by translating a feed item. After a few seconds, the original feed item will refresh and the ItemBox will go into edit mode. The item being edited will still be the original feed item, which should stay read-only.