### PR TITLE
Prompt to import mendeley

### DIFF
--- a/chrome/content/zotero/import/importWizard.js
+++ b/chrome/content/zotero/import/importWizard.js
@@ -49,6 +49,10 @@ var Zotero_Import_Wizard = {
 				document.getElementById('create-collection-checkbox').removeAttribute('checked');
 			}
 		}
+		
+		if (args && args.pageID) {
+			this._wizard.goTo(args.pageID);
+		}
 
 		if (args && args.mendeleyCode && Zotero.Prefs.get("import.mendeleyUseOAuth")) {
 			this._mendeleyCode = args.mendeleyCode;

--- a/chrome/content/zotero/xpcom/integration.js
+++ b/chrome/content/zotero/xpcom/integration.js
@@ -2653,6 +2653,7 @@ Zotero.Integration.URIMap.prototype.getZoteroItemForURIs = async function (uris)
 					text: Zotero.getString('integration.mendeleyImport.description', [Zotero.appName]),
 					button0: Zotero.getString('integration.mendeleyImport.openImporter'),
 					button1: Zotero.getString('general.skip'),
+					button2: Zotero.getString('general.moreInformation'),
 					checkLabel: Zotero.getString('general.dontAskAgain'),
 					checkbox
 				});
@@ -2660,8 +2661,11 @@ Zotero.Integration.URIMap.prototype.getZoteroItemForURIs = async function (uris)
 					setTimeout(() => Zotero.getMainWindow().Zotero_File_Interface.showImportWizard({ pageID: 'mendeley-online-explanation' }));
 					throw new Zotero.Exception.UserCancelled("Importing mendeley citations");
 				}
-				else {
+				else if (result == 1) {
 					this.session.dontPromptForMendeley = true;
+				}
+				else {
+					Zotero.launchURL("https://www.zotero.org/support/kb/mendeley_import#using_mendeley_citations");
 				}
 				if (checkbox.value) {
 					Zotero.Prefs.set('integration.dontPromptMendeleyImport', true);

--- a/chrome/content/zotero/xpcom/integration.js
+++ b/chrome/content/zotero/xpcom/integration.js
@@ -2632,11 +2632,42 @@ Zotero.Integration.URIMap.prototype.getZoteroItemForURIs = async function (uris)
 			replacer = await Zotero.Relations.getByPredicateAndObject(
 				'item', 'mendeleyDB:documentUUID', m[1]
 			);
-			if (replacer.length && !replacer[0].deleted) {
-				zoteroItem = replacer[0];
-				break;
+			if (replacer.length) {
+				if (!replacer[0].deleted) {
+					zoteroItem = replacer[0];
+					break;
+				}
 			}
-		}
+			// If not blocked by user having pressed skip in this session,
+			// or user having checked the checkbox to not be prompted about this,
+			// or user having imported their library with the new version of importer
+			else if (!(this.session.dontPromptForMendeley
+				|| Zotero.Prefs.get('integration.dontPromptMendeleyImport')
+				|| await Zotero.DB.valueQueryAsync("SELECT value FROM settings WHERE setting='mendeleyImport' AND key='version'")
+			)) {
+				// Prompt user to (re)import their mendeley database which might make us recognize
+				// these items
+				let checkbox = {};
+				let result = Zotero.Prompt.confirm({
+					title: Zotero.getString('integration.mendeleyImport.title'),
+					text: Zotero.getString('integration.mendeleyImport.description', [Zotero.appName]),
+					button0: Zotero.getString('integration.mendeleyImport.openImporter'),
+					button1: Zotero.getString('general.skip'),
+					checkLabel: Zotero.getString('general.dontAskAgain'),
+					checkbox
+				});
+				if (result === 0) {
+					setTimeout(() => Zotero.getMainWindow().Zotero_File_Interface.showImportWizard({ pageID: 'mendeley-online-explanation' }));
+					throw new Zotero.Exception.UserCancelled("Importing mendeley citations");
+				}
+				else {
+					this.session.dontPromptForMendeley = true;
+				}
+				if (checkbox.value) {
+					Zotero.Prefs.set('integration.dontPromptMendeleyImport', true);
+				}
+			}
+		};
 		
 	}
 	

--- a/chrome/content/zotero/xpcom/prompt.js
+++ b/chrome/content/zotero/xpcom/prompt.js
@@ -1,0 +1,87 @@
+/*
+	***** BEGIN LICENSE BLOCK *****
+	
+	Copyright © 2022 Corporation for Digital Scholarship
+                     Vienna, Virginia, USA
+					http://zotero.org
+	
+	This file is part of Zotero.
+	
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+	
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
+	
+	***** END LICENSE BLOCK *****
+*/
+
+var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+
+Zotero.Prompt = {
+	BUTTON_TITLE_OK: Services.prompt.BUTTON_TITLE_OK,
+	BUTTON_TITLE_CANCEL: Services.prompt.BUTTON_TITLE_CANCEL,
+	BUTTON_TITLE_YES: Services.prompt.BUTTON_TITLE_YES,
+	BUTTON_TITLE_NO: Services.prompt.BUTTON_TITLE_NO,
+	BUTTON_TITLE_SAVE: Services.prompt.BUTTON_TITLE_SAVE,
+	BUTTON_TITLE_DONT_SAVE: Services.prompt.BUTTON_TITLE_DONT_SAVE,
+	BUTTON_TITLE_REVERT: Services.prompt.BUTTON_TITLE_REVERT,
+	
+	/**
+	 * A wrapper around XPCOM's Services.prompt.confirmEx()
+	 * but with a friendlier interface.
+	 *
+	 * Button text can use special static variables from
+	 * Zotero.Prompt
+	 *
+	 * @param options
+	 * - {mozIDOMWindowProxy} window - The parent window or null.
+	 * - {String} title - Text to appear in the title of the dialog.
+	 * - {String} text - Text to appear in the body of the dialog.
+	 * - {String|Number} button0 - Button 0 text
+	 * - {String|Number} button1 - Button 1 text
+	 * - {String|Number} button2 - Button 2 text
+	 * - {String} checkLabel - Text to appear with the checkbox.
+	 * - {Object} checkbox - Contains the initial checked state of the
+	 *        checkbox when this method is called and the final checked
+	 *        state after this method returns. Either {} or  { value: true/false }.
+	 * - {Number} defaultButton - The index of default button. 0 by default
+	 * - {Boolean} delayButtons - Make the buttons initially disabled and enable them after some period
+	 *        so that the user doesn't click through the dialog without reading it.
+	 * @returns {Number} The index of the button pressed.
+	 */
+	confirm(options = {}) {
+		let { window: win, title, text, button0, button1, button2, checkLabel, checkbox, defaultButton, delayButtons } = options;
+		if (!win) win = null;
+		if (!title) throw new Error('`title` is required');
+		if (!text) throw new Error('`text` is required');
+		if (!button0 && !button1 && !button2) {
+			throw new Error('At least one button is required');
+		}
+		if (checkLabel && (!checkbox || typeof checkbox != 'object')) {
+			throw new Error('`checkLabel` provided without `checkbox` option');
+		}
+		let flags = delayButtons ? Services.prompt.BUTTON_DELAY_ENABLE : 0;
+		if (typeof button0 == 'number') flags += Services.prompt.BUTTON_POS_0 * button0;
+		else if (typeof button0 == 'string') flags += Services.prompt.BUTTON_POS_0 * Services.prompt.BUTTON_TITLE_IS_STRING;
+		if (typeof button1 == 'number') flags += Services.prompt.BUTTON_POS_1 * button1;
+		else if (typeof button1 == 'string') flags += Services.prompt.BUTTON_POS_1 * Services.prompt.BUTTON_TITLE_IS_STRING;
+		if (typeof button2 == 'number') flags += Services.prompt.BUTTON_POS_2 * button2;
+		else if (typeof button2 == 'string') flags += Services.prompt.BUTTON_POS_2 * Services.prompt.BUTTON_TITLE_IS_STRING;
+		if (defaultButton) flags += defaultButton == 1 ? Services.prompt.BUTTON_POS_1_DEFAULT : Services.prompt.BUTTON_POS_2_DEFAULT;
+		return Services.prompt.confirmEx(
+			win, title, text, flags,
+			typeof button0 == 'number' ? null : button0,
+			typeof button1 == 'number' ? null : button1,
+			typeof button2 == 'number' ? null : button2,
+			checkLabel, checkbox
+		);
+	}
+};

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -74,6 +74,7 @@ general.tryLater                 = Try Later
 general.showDirectory = Show Directory
 general.showInLibrary = Show in Library
 general.continue = Continue
+general.skip	        = Skip
 general.copy			= Copy
 general.copyToClipboard = Copy to Clipboard
 general.cancel			= Cancel
@@ -990,6 +991,9 @@ integration.exportDocument.description1 = Zotero will convert citations in the d
 integration.exportDocument.description2 = You should make a backup of the document before proceeding.
 integration.importInstructions = The Zotero citations in this document have been converted to a format that can be safely transferred between word processors. Open this document in a supported word processor and press Refresh in the Zotero plugin to continue working with the citations.
 integration.upgradeTemplate = The %S plugin for %S is outdated. Reinstall the plugin from Preferences → Cite → Word Processors.
+integration.mendeleyImport.title          = Missing Mendeley Data
+integration.mendeleyImport.description    = %1$S detected that the document you are citing with contains Mendeley citations. %1$S will be able to manage these citations if you import your Mendeley database.
+integration.mendeleyImport.openImporter   = Open Mendeley Importer...
 
 styles.install.title				= Install Style
 styles.install.unexpectedError		= An unexpected error occurred while installing "%1$S"

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -991,9 +991,9 @@ integration.exportDocument.description1 = Zotero will convert citations in the d
 integration.exportDocument.description2 = You should make a backup of the document before proceeding.
 integration.importInstructions = The Zotero citations in this document have been converted to a format that can be safely transferred between word processors. Open this document in a supported word processor and press Refresh in the Zotero plugin to continue working with the citations.
 integration.upgradeTemplate = The %S plugin for %S is outdated. Reinstall the plugin from Preferences → Cite → Word Processors.
-integration.mendeleyImport.title          = Missing Mendeley Data
-integration.mendeleyImport.description    = %1$S detected that the document you are citing with contains Mendeley citations. %1$S will be able to manage these citations if you import your Mendeley database.
-integration.mendeleyImport.openImporter   = Open Mendeley Importer...
+integration.mendeleyImport.title          = Unlinked Mendeley Citations
+integration.mendeleyImport.description    = This document contains Mendeley citations that aren’t linked to items in your %1$S library. If you import your Mendeley library, %1$S can automatically relink citations you created with Mendeley.
+integration.mendeleyImport.openImporter   = Open Mendeley Importer…
 
 styles.install.title				= Install Style
 styles.install.unexpectedError		= An unexpected error occurred while installing "%1$S"

--- a/components/zotero-service.js
+++ b/components/zotero-service.js
@@ -53,6 +53,7 @@ const xpcomFilesAll = [
 	'mimeTypeHandler',
 	'pdfWorker/manager',
 	'ipc',
+	'prompt',
 	'profile',
 	'progressWindow',
 	'proxy',

--- a/defaults/preferences/zotero.js
+++ b/defaults/preferences/zotero.js
@@ -137,6 +137,7 @@ pref("extensions.zotero.integration.autoRegenerate", -1);	// -1 = ask; 0 = no; 1
 pref("extensions.zotero.integration.useClassicAddCitationDialog", false);
 pref("extensions.zotero.integration.keepAddCitationDialogRaised", false);
 pref("extensions.zotero.integration.upgradeTemplateDelayedOn", 0);
+pref("extensions.zotero.integration.dontPromptMendeleyImport", false);
 
 // Connector settings
 pref("extensions.zotero.httpServer.enabled", false);	// TODO enabled for testing only


### PR DESCRIPTION
- Adds a `Zotero.Prompt` interface and simplifies `Services.prompt.confirmEx()`. It's a pain having to work with `confirmEx()` since there's no in-code documentation and the old Firefox documentation isn't even available on MDN, and the function signature is complicated by flags and such. This PR fixes that. `Zotero.Prompt` can be further extended as needed and existing calls to `Services.prompt.confirmEx()` can be replaced gradually.
- Adds a prompt when performing an integration operation and an unlinked Mendeley citation is detected, suggesting the user to (re)import their Mendeley db.
  * If user clicks skip, the prompt is skipped until Zotero is restarted for that document (but occurs for other docs)
  * If user checks "Don't ask again" checkbox, the prompt is disabled forever
  * If user imports (or has imported) their Mendeley database with the updated importer, then this prompt won't be displayed