### PR TITLE
Add option to Mendeley importer to only relink items

### DIFF
--- a/chrome/content/zotero/fileInterface.js
+++ b/chrome/content/zotero/fileInterface.js
@@ -450,6 +450,7 @@ var Zotero_File_Interface = new function() {
 			translation.mendeleyAuth = options.mendeleyAuth;
 			translation.mendeleyCode = options.mendeleyCode;
 			translation.newItemsOnly = options.newItemsOnly;
+			translation.relinkOnly = options.relinkOnly;
 		}
 		else {
 			// Check if the file is an SQLite database

--- a/chrome/content/zotero/import/importWizard.js
+++ b/chrome/content/zotero/import/importWizard.js
@@ -86,6 +86,11 @@ var Zotero_Import_Wizard = {
 		document.getElementById('mendeley-password').addEventListener('keyup', this.onMendeleyAuthKeyUp.bind(this));
 		
 		document.getElementById('relink-only-checkbox').addEventListener('command', this.onRelinkOnlyChange.bind(this));
+		// Set from integration.js prompt
+		if (args && args.relinkOnly) {
+			document.getElementById('relink-only-checkbox').checked = true;
+			this.onRelinkOnlyChange();
+		}
 		
 		Zotero.Translators.init(); // async
 	},
@@ -284,6 +289,10 @@ var Zotero_Import_Wizard = {
 		const hideExtraMendeleyOptions = !this._mendeleyHasPreviouslyImported || !(this._mendeleyAuth || this._mendeleyCode);
 		document.getElementById('mendeley-options').hidden = hideExtraMendeleyOptions;
 		document.getElementById('relink-only-wrapper').hidden = hideExtraMendeleyOptions || this._mendeleyImporterVersion > 0;
+		document.getElementById('relink-only-more-info').addEventListener('click', function () {
+			Zotero.launchURL('https://www.zotero.org/support/kb/mendeley_import#using_mendeley_citations');
+			window.close();
+		});
 		if (hideExtraMendeleyOptions) {
 			document.getElementById('new-items-only-checkbox').removeAttribute('checked');
 		}
@@ -340,9 +349,12 @@ var Zotero_Import_Wizard = {
 			}
 			
 			let numItems = this._translation.newItems.length;
+			let numRelinked = this._translation.numRelinked;
 			this._onDone(
 				Zotero.getString('fileInterface.importComplete'),
-				Zotero.getString(`fileInterface.itemsWereImported`, numItems, numItems)
+				document.getElementById('relink-only-checkbox').checked
+					? Zotero.getString(`fileInterface.itemsWereRelinked`, numRelinked, numRelinked)
+					: Zotero.getString(`fileInterface.itemsWereImported`, numItems, numItems)
 			);
 		}
 		catch (e) {

--- a/chrome/content/zotero/import/importWizard.xul
+++ b/chrome/content/zotero/import/importWizard.xul
@@ -80,7 +80,10 @@
 			onpageadvanced="Zotero_Import_Wizard.onImportStart()">
 
 		<vbox id="relink-only-wrapper">
-			<checkbox id="relink-only-checkbox" label="&zotero.import.online.relinkOnly;" />
+			<hbox align="center">
+				<checkbox id="relink-only-checkbox" label="&zotero.import.online.relinkOnly;" />
+				<label id="relink-only-more-info" class="zotero-text-link" value="&zotero.general.moreInformation;"/>
+			</hbox>
 		</vbox>
 
 		<checkbox id="create-collection-checkbox" label="&zotero.import.createCollection;" checked="true" />

--- a/chrome/content/zotero/import/importWizard.xul
+++ b/chrome/content/zotero/import/importWizard.xul
@@ -78,6 +78,11 @@
 			onpageshow="Zotero_Import_Wizard.onOptionsShown()"
 			onpagerewound="return Zotero_Import_Wizard.goToStart()"
 			onpageadvanced="Zotero_Import_Wizard.onImportStart()">
+
+		<vbox id="relink-only-wrapper">
+			<checkbox id="relink-only-checkbox" label="&zotero.import.online.relinkOnly;" />
+		</vbox>
+
 		<checkbox id="create-collection-checkbox" label="&zotero.import.createCollection;" checked="true" />
 		
 		<vbox id="file-handling-options">

--- a/chrome/content/zotero/import/mendeley/mendeleyImport.js
+++ b/chrome/content/zotero/import/mendeley/mendeleyImport.js
@@ -33,6 +33,7 @@ var Zotero_Import_Mendeley = function () {
 	this.mendeleyAuth = null;
 	this.newItemsOnly = false;
 	this.relinkOnly = false;
+	this.numRelinked = 0;
 	
 	this._tokens = null;
 	this._db = null;
@@ -1319,6 +1320,7 @@ Zotero_Import_Mendeley.prototype._saveItems = async function (libraryID, json) {
 				// Update any child items to point to the existing item's key instead of the
 				// new generated one
 				this._updateParentKeys('item', json, i + 1, itemJSON.key, item.key);
+				this.numRelinked++;
 				
 				// Leave item in any collections it's in
 				itemJSON.collections = item.getCollections()

--- a/chrome/content/zotero/xpcom/integration.js
+++ b/chrome/content/zotero/xpcom/integration.js
@@ -2658,7 +2658,14 @@ Zotero.Integration.URIMap.prototype.getZoteroItemForURIs = async function (uris)
 					checkbox
 				});
 				if (result === 0) {
-					setTimeout(() => Zotero.getMainWindow().Zotero_File_Interface.showImportWizard({ pageID: 'mendeley-online-explanation' }));
+					setTimeout(
+						() => Zotero.getMainWindow().Zotero_File_Interface.showImportWizard(
+							{
+								pageID: 'mendeley-online-explanation',
+								relinkOnly: true
+							}
+						)
+					);
 					throw new Zotero.Exception.UserCancelled("Importing mendeley citations");
 				}
 				else if (result == 1) {

--- a/chrome/locale/en-US/zotero/zotero.dtd
+++ b/chrome/locale/en-US/zotero/zotero.dtd
@@ -15,6 +15,7 @@
 <!ENTITY zotero.general.advancedOptions.label				"Advanced Options">
 <!ENTITY zotero.general.tools                             "Tools">
 <!ENTITY zotero.general.more                              "More">
+<!ENTITY zotero.general.moreInformation                   "More Information">
 <!ENTITY zotero.general.loading "Loading…">
 <!ENTITY zotero.general.close                              "Close">
 <!ENTITY zotero.general.minimize                           "Minimize">

--- a/chrome/locale/en-US/zotero/zotero.dtd
+++ b/chrome/locale/en-US/zotero/zotero.dtd
@@ -187,6 +187,7 @@
 <!ENTITY zotero.import.createCollection                "Place imported collections and items into new collection">
 <!ENTITY zotero.import.fileHandling                    "File Handling">
 <!ENTITY zotero.import.online.newItemsOnly             "Download new items only; don’t update previously imported items">
+<!ENTITY zotero.import.online.relinkOnly               "Relink Mendeley Desktop citations">
 
 <!ENTITY zotero.exportOptions.title						"Export…">
 <!ENTITY zotero.exportOptions.format.label				"Format:">

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -784,6 +784,7 @@ dragAndDrop.filesNotFound = The following files were not found and could not be 
 fileInterface.importing = Importing…
 fileInterface.importComplete = Import Complete
 fileInterface.itemsWereImported = %1$S item was imported;%1$S items were imported
+fileInterface.itemsWereRelinked = %1$S item was relinked;%1$S items were relinked
 fileInterface.itemsExported		= Exporting items…
 fileInterface.import			= Import
 fileInterface.chooseAppDatabaseToImport = Choose the %S database to import

--- a/chrome/skin/default/zotero/importWizard.css
+++ b/chrome/skin/default/zotero/importWizard.css
@@ -122,3 +122,7 @@ button, checkbox {
 	color: red;
 	font-weight: bold;
 }
+
+[disabled="true"] .checkbox-label {
+	opacity: .5;
+}


### PR DESCRIPTION
New option only appears if importer version is < 1 or not present. It will:

- Skip fetching collections and attachments
- Skip adding any new items
- Update relations on existing imported items so that `mendeleyDB:documentUUID` stores Mendeley Desktop ID and thus can be recognized in a word processor document.