### PR TITLE
Add `/connector/request` endpoint

### DIFF
--- a/chrome/content/zotero/xpcom/connector/server_connector.js
+++ b/chrome/content/zotero/xpcom/connector/server_connector.js
@@ -1901,11 +1901,11 @@ Zotero.Server.Connector.Request.prototype = {
 				return [
 					400,
 					'text/plain',
-					`Unsupported URL: host was ${uri.host}, expected one of [${Zotero.Server.Connector.Request.allowedHosts.join(', ')}]`
+					'Unsupported URL'
 				];
 			}
 
-			if (req.headers['User-Agent'] && !req.headers['User-Agent'].startsWith('Mozilla/')) {
+			if (!req.headers['User-Agent'] || !req.headers['User-Agent'].startsWith('Mozilla/')) {
 				return [400, 'text/plain', 'Unsupported User-Agent'];
 			}
 		}

--- a/chrome/content/zotero/xpcom/connector/server_connector.js
+++ b/chrome/content/zotero/xpcom/connector/server_connector.js
@@ -1870,7 +1870,7 @@ Zotero.Server.Connector.Request.allowedHosts = ['www.worldcat.org'];
 /**
  * For testing: allow disabling validation so we can make requests to the server.
  */
-Zotero.Server.Connector.Request.validateHosts = true;
+Zotero.Server.Connector.Request.enableValidation = false;
 
 Zotero.Server.Endpoints["/connector/request"] = Zotero.Server.Connector.Request;
 Zotero.Server.Connector.Request.prototype = {
@@ -1896,13 +1896,18 @@ Zotero.Server.Connector.Request.prototype = {
 			return [400, 'text/plain', 'Unsupported scheme'];
 		}
 
-		if (Zotero.Server.Connector.Request.validateHosts
-				&& !Zotero.Server.Connector.Request.allowedHosts.includes(uri.host)) {
-			return [
-				400,
-				'text/plain',
-				`Unsupported URL: host was ${uri.host}, expected one of [${Zotero.Server.Connector.Request.allowedHosts.join(', ')}]`
-			];
+		if (Zotero.Server.Connector.Request.enableValidation) {
+			if (!Zotero.Server.Connector.Request.allowedHosts.includes(uri.host)) {
+				return [
+					400,
+					'text/plain',
+					`Unsupported URL: host was ${uri.host}, expected one of [${Zotero.Server.Connector.Request.allowedHosts.join(', ')}]`
+				];
+			}
+
+			if (req.headers['User-Agent'] && !req.headers['User-Agent'].startsWith('Mozilla/')) {
+				return [400, 'text/plain', 'Unsupported User-Agent'];
+			}
 		}
 		
 		options = options || {};

--- a/test/tests/httpTest.js
+++ b/test/tests/httpTest.js
@@ -45,6 +45,20 @@ describe("Zotero.HTTP", function () {
 				}
 			}
 		);
+		httpd.registerPathHandler(
+			'/requireJSON',
+			{
+				handle(request, response) {
+					if (request.getHeader('Content-Type') == 'application/json') {
+						response.setStatusLine(null, 200, "OK");
+					}
+					else {
+						response.setStatusLine(null, 400, "Bad Request");
+					}
+					response.write('JSON required');
+				}
+			}
+		);
 	});
 	
 	beforeEach(function () {
@@ -122,6 +136,20 @@ describe("Zotero.HTTP", function () {
 			
 			assert.instanceOf(e, Zotero.HTTP.CancelledException);
 			server.respond();
+		});
+		
+		it("should process headers case insensitively", async function () {
+			Zotero.HTTP.mock = null;
+			var req = await Zotero.HTTP.request(
+				'GET',
+				baseURL + 'requireJSON',
+				{
+					headers: {
+						'content-type': 'application/json'
+					}
+				}
+			);
+			assert.equal(req.status, 200);
 		});
 		
 		describe("Retries", function () {


### PR DESCRIPTION
This allows HTTP requests from the Connector to be routed through the client, once that functionality is implemented in `zotero/translate` and `zotero/zotero-connectors` (that's next).

Also updates `Zotero.HTTP.request()` to use the Fetch API's `Headers` class so that operations on the headers are case insensitive.