### PR TITLE
stop opening while right click on attachment's url

### DIFF
--- a/chrome/content/zotero/bindings/attachmentbox.xml
+++ b/chrome/content/zotero/bindings/attachmentbox.xml
@@ -245,7 +245,9 @@
 							urlField.setAttribute('hidden', false);
 							if (this.clickableLink) {
 								 urlField.onclick = function (event) {
-									ZoteroPane_Local.loadURI(this.value, event)
+									if (event.button != 2) {
+										ZoteroPane_Local.loadURI(this.value, event)
+									}
 								};
 								urlField.className = 'zotero-text-link';
 							}


### PR DESCRIPTION
This is an unexpected behavior. Although the control cannot provide context menu, I don't want it to be opening the url.