### PR TITLE
refine itemtype changes

### DIFF
--- a/chrome/content/zotero/bindings/itembox.xml
+++ b/chrome/content/zotero/bindings/itembox.xml
@@ -1211,6 +1211,12 @@
 							fieldNames += "\n - " +
 								Zotero.ItemFields.getLocalizedString(fieldsToDelete[i]);
 						}
+						var fieldsPair = new Map();
+						for (let fieldId of fieldsToDelete) {
+							//let fieldName = Zotero.ItemFields.getName(fieldId);
+							let fieldValue = this.item.getField(fieldId);
+							fieldsPair.set(fieldId, fieldValue);
+						}
 						
 						var promptService = Components.classes["@mozilla.org/embedcomp/prompt-service;1"]
 							.getService(Components.interfaces.nsIPromptService);
@@ -1222,6 +1228,16 @@
 								Zotero.getString('pane.item.changeType.text') + "\n" + fieldNames)) {
 						this.item.setType(itemTypeID);
 						
+						let addedExtra = "";
+						for (let [fieldId, value] of fieldsPair) {
+							let fieldLocalizedName = Zotero.ItemFields.getLocalizedString(fieldId);
+							addedExtra += fieldLocalizedName + ": " + value + "\n";
+						}
+						addedExtra += "\n";
+						let oldExtra = this.item.getField("extra");
+						let newExtra = addedExtra + oldExtra;
+						this.item.setField("extra", newExtra);
+
 						if (this.saveOnEdit) {
 							// See note in transformText()
 							await this.blurOpenField();

--- a/chrome/skin/default/zotero/bindings/itembox.css
+++ b/chrome/skin/default/zotero/bindings/itembox.css
@@ -124,11 +124,6 @@ row > vbox > description
 	padding: 0 !important;
 }
 
-#item-type-menu > .menulist-dropmarker
-{
-	display: none;
-}
-
 .zotero-field-toggle
 {
 	width: 27px !important;


### PR DESCRIPTION
ref: https://forums.zotero.org/discussion/102009/ux-about-changeable-item-type

I think this is correct.

This may lack unit testing, and date & bookSection handle.

![zotero](https://user-images.githubusercontent.com/1769875/211144626-a83e1621-063a-48a0-96e6-2499ad8b3773.png)
