### PR TITLE
Add a hidden pref for tab title with support for Creator-Year-Title option

### DIFF
--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -173,33 +173,32 @@ class ReaderInstance {
 	
 	async updateTitle() {
 		let item = Zotero.Items.get(this._itemID);
-		let title = item.getDisplayTitle();
+		let readerTitle = item.getDisplayTitle();
 		let parentItem = item.parentItem;
 		if (parentItem) {
 			let attachment = await parentItem.getBestAttachment();
 			if (attachment && attachment.id === this._itemID) {
 				let parts = [];
 				let type = Zotero.Prefs.get('tabs.title');
-				if (type === 'creatorYearTitle') {
-					let firstCreator = parentItem.getField('firstCreator');
-					if (firstCreator) {
-						parts.push(firstCreator);
-					}
-					let year = parentItem.getField('year');
-					if (year) {
-						parts.push(year);
-					}
+				let creator = parentItem.getField('firstCreator');
+				let year = parentItem.getField('year');
+				let title = parentItem.getDisplayTitle();
+				// If creator is missing fall back to titleCreatorYear
+				if (type === 'creatorYearTitle' && creator) {
+					parts = [creator, year, title];
 				}
-				let displayTitle = parentItem.getDisplayTitle();
-				if (displayTitle) {
-					parts.push(displayTitle);
+				else if (type === 'title') {
+					parts = [title];
 				}
-				title = parts.join(' - ');
+				// If type is titleCreatorYear, or is missing, or another type falls back
+				else {
+					parts = [title, creator, year];
+				}
+				readerTitle = parts.filter(x => x).join(' - ');
 			}
 		}
-		
-		this._title = title;
-		this._setTitleValue(title);
+		this._title = readerTitle;
+		this._setTitleValue(readerTitle);
 	}
 
 	async setAnnotations(items) {

--- a/defaults/preferences/zotero.js
+++ b/defaults/preferences/zotero.js
@@ -213,4 +213,4 @@ pref("extensions.zotero.annotations.noteTemplates.note", "<p>{{citation}} {{comm
 pref("extensions.zotero.scaffold.eslint.enabled", true);
 
 // Tabs
-pref("extensions.zotero.tabs.title", "title");
+pref("extensions.zotero.tabs.title", "titleCreatorYear");

--- a/defaults/preferences/zotero.js
+++ b/defaults/preferences/zotero.js
@@ -211,3 +211,6 @@ pref("extensions.zotero.annotations.noteTemplates.note", "<p>{{citation}} {{comm
 
 // Scaffold
 pref("extensions.zotero.scaffold.eslint.enabled", true);
+
+// Tabs
+pref("extensions.zotero.tabs.title", "title");


### PR DESCRIPTION
- Added `zotero.tabs.title` pref (just like Firefox has), but if we don't expect to have more prefs under `zotero.tabs` group, we could have a different name.
- The pref is not only for PDF tabs, but for all future tab types as well. At least for what the reader provides. Maybe except note tab, if we'll ever do it.
- The pref supports two options: `title`, `creatorYearTitle`.
- The pref will only have an effect if the current PDF file is the "best" attachment, otherwise tab title will be an attachment filename.
- The default option now is 'title' (previously we were displaying `Title - Creator - Year`).
- After changing the pref, unloaded tabs won't be updated until selected, because of technical limitations. If we think this is too annoying we can try to work around that.
