### PR TITLE
modified standalone keyset to include the quitApplication keybinding

### DIFF
--- a/chrome/content/zotero-platform/unix/standalone/menuOverlay.xul
+++ b/chrome/content/zotero-platform/unix/standalone/menuOverlay.xul
@@ -40,6 +40,14 @@
 <overlay id="menuOverlay"
          xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
          xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
+
+	<keyset id="mainKeyset">
+		<key id="key_quitApplication"
+				key="&quitApplicationCmd.accesskey;"
+				command="cmd_quitApplication"
+				modifiers="accel"/>
+	</keyset>
+
     <menupopup id="menu_FilePopup">
 		<menuseparator/>		
 		<menuitem id="menu_FileQuitItem" 

--- a/chrome/content/zotero-platform/win/standalone/menuOverlay.xul
+++ b/chrome/content/zotero-platform/win/standalone/menuOverlay.xul
@@ -44,7 +44,7 @@
 		<menuseparator/>
 		<menuitem id="menu_FileQuitItem" 
 				label="&quitApplicationCmdWin.label;"
-				key="&quitApplicationCmdWin.accesskey;"
+				accesskey="&quitApplicationCmdWin.accesskey;"
 				command="cmd_quitApplication"/>
     </menupopup>
     <menupopup id="menu_EditPopup">

--- a/chrome/content/zotero-platform/win/standalone/menuOverlay.xul
+++ b/chrome/content/zotero-platform/win/standalone/menuOverlay.xul
@@ -44,7 +44,7 @@
 		<menuseparator/>
 		<menuitem id="menu_FileQuitItem" 
 				label="&quitApplicationCmdWin.label;"
-				key="key_quitApplication"
+				key="&quitApplicationCmdWin.accesskey;"
 				command="cmd_quitApplication"/>
     </menupopup>
     <menupopup id="menu_EditPopup">


### PR DESCRIPTION
The default keyset on unix and windows does not include the keybinding for exiting the application. On macos this works as expected because the keybinding is included in the macos keyset. This pull request adds the appropriate keybinding for the other platforms as well.