### PR TITLE
Mendeley importer: Fix issue with empty creators

### DIFF
--- a/chrome/content/zotero/import/mendeley/mendeleyImport.js
+++ b/chrome/content/zotero/import/mendeley/mendeleyImport.js
@@ -636,7 +636,12 @@ Zotero_Import_Mendeley.prototype._getDocumentCreatorsAPI = async function (docum
 		const authors = (doc.authors || []).map(c => this._makeCreator('author', c.first_name, c.last_name));
 		const editors = (doc.editors || []).map(c => this._makeCreator('editor', c.first_name, c.last_name));
 		const translators = (doc.translators || []).map(c => this._makeCreator('translator', c.first_name, c.last_name));
-		map.set(doc.id, [...authors, ...editors, ...translators]);
+		const creators = [...authors, ...editors, ...translators];
+		const validCreators = creators.filter(c => c.name || c.firstName || c.lastName);
+		if (creators.length !== validCreators.length) {
+			Zotero.debug(`Discarding ${creators.length - validCreators.length} invalid creators for document ${doc.id}`);
+		}
+		map.set(doc.id, validCreators);
 	}
 	return map;
 };

--- a/test/tests/data/mendeleyMock/items-empty-creators.json
+++ b/test/tests/data/mendeleyMock/items-empty-creators.json
@@ -1,0 +1,69 @@
+[
+    {
+        "authored": false,
+        "confirmed": true,
+        "created": "2023-03-07T13:30:46.353Z",
+        "file_attached": false,
+        "hidden": false,
+        "id": "b7b1023f-5072-4608-8fd5-87b045b77887",
+        "client_data": "{\"desktop_id\":\"9c03fca4-ee5b-435e-abdd-fb6d7d11cd02\"}",
+        "last_modified": "2023-03-07T13:30:46.025Z",
+        "private_publication": false,
+        "profile_id": "8dbf0832-8723-4c48-b532-20c0b7f6e01a",
+        "read": false,
+        "source": "something wrong",
+        "identifiers": {
+            "doi": "10.1111",
+            "pmid": "PMID:    11111111",
+            "arxiv": "1111.2222"
+        },
+        "starred": false,
+        "title": "This one has no authors",
+        "type": "journal",
+        "folder_uuids": [
+            "8d2f262d-49b3-4dfc-8968-0bb71bcd92ea"
+        ],
+        "year": 1987
+    },
+    {
+        "authored": false,
+        "confirmed": true,
+        "created": "2023-03-07T13:30:46.353Z",
+        "file_attached": false,
+        "hidden": false,
+        "id": "a15698a9-6214-4fac-81c5-5ac62b2d06b5",
+        "client_data": "{\"desktop_id\":\"fd86e48e-1931-4282-b72d-78c535b0398c\"}",
+        "last_modified": "2023-03-07T13:30:46.025Z",
+        "private_publication": false,
+        "profile_id": "8dbf0832-8723-4c48-b532-20c0b7f6e01a",
+        "read": false,
+        "source": "something wrong",
+        "identifiers":
+        {
+            "doi": "10.1111",
+            "pmid": "PMID:    11111111",
+            "arxiv": "1111.2222"
+        },
+        "starred": false,
+        "title": "This one has empty authors",
+        "authors":
+        [
+            {
+                "first_name": "",
+                "last_name": ""
+            },
+            {
+                "first_name": "",
+                "last_name": ""
+            },
+            {
+
+            }
+        ],
+        "type": "journal",
+        "folder_uuids": [
+            "8d2f262d-49b3-4dfc-8968-0bb71bcd92ea"
+        ],
+        "year": 1987
+    }
+]


### PR DESCRIPTION
It does not appear to be possible to create a creator with no values in Mendeley, however we got reports of these causing the imports to fail. This tweak makes the importer more resilient by discarding empty/invalid creators.

I believe this is a fix for https://forums.zotero.org/discussion/comment/429834/#Comment_429834 (though I was only able to reproduce that using mocked data)