### PR TITLE
Mendeley importer: Fix issue with empty tags

### DIFF
--- a/chrome/content/zotero/import/mendeley/mendeleyImport.js
+++ b/chrome/content/zotero/import/mendeley/mendeleyImport.js
@@ -680,7 +680,10 @@ Zotero_Import_Mendeley.prototype._getDocumentTagsDB = async function (groupID) {
 Zotero_Import_Mendeley.prototype._getDocumentTagsAPI = async function (documents) {
 	var map = new Map();
 	for (let doc of documents) {
-		const tags = [...(doc.tags || []).map(tag => ({ tag, type: 0 })), ...(doc.keywords || []).map(tag => ({ tag, type: 1 }))];
+		const tags = [
+			...(doc.tags || []).map(tag => ({ tag, type: 0 })),
+			...(doc.keywords || []).map(tag => ({ tag, type: 1 }))
+		].filter(t => t.tag && t.tag.trim());
 		map.set(doc.id, tags);
 	}
 	return map;

--- a/test/tests/data/mendeleyMock/items-bad-data.json
+++ b/test/tests/data/mendeleyMock/items-bad-data.json
@@ -65,5 +65,33 @@
             "8d2f262d-49b3-4dfc-8968-0bb71bcd92ea"
         ],
         "year": 1987
+    },
+    {
+        "authored": false,
+        "confirmed": true,
+        "created": "2023-03-07T13:30:46.353Z",
+        "file_attached": false,
+        "hidden": false,
+        "id": "49426b47-d9ff-4ab6-ba2c-54e3608f56b8",
+        "client_data": "{\"desktop_id\":\"c7ec2737-044a-493b-9d94-d7f67be68765\"}",
+        "last_modified": "2023-03-07T13:30:46.025Z",
+        "private_publication": false,
+        "profile_id": "8dbf0832-8723-4c48-b532-20c0b7f6e01a",
+        "read": false,
+        "source": "something wrong",
+        "identifiers": {
+            "doi": "10.1111",
+            "pmid": "PMID:    11111111",
+            "arxiv": "1111.2222"
+        },
+        "starred": false,
+        "tags": ["", ""],
+        "keywords": [],
+        "title": "This one has empty tags and keywords",
+        "type": "journal",
+        "folder_uuids": [
+            "8d2f262d-49b3-4dfc-8968-0bb71bcd92ea"
+        ],
+        "year": 1987
     }
 ]

--- a/test/tests/data/mendeleyMock/items-simple.json
+++ b/test/tests/data/mendeleyMock/items-simple.json
@@ -87,5 +87,30 @@
                 "filehash": "cc22c6611277df346ff8dc7386ba3880b2bafa15"
             }
         ]
+    },
+    {
+        "authored": false,
+        "confirmed": true,
+        "created": "2021-11-04T11:53:10.353Z",
+        "file_attached": false,
+        "hidden": false,
+        "id": "cda0c150-bc85-4312-af2c-61a29b179595",
+        "client_data": "{\"desktop_id\":\"4308d8ec-e8ea-43fb-9d38-4e6628f7c10a\"}",
+        "last_modified": "2021-11-04T11:53:10.353Z",
+        "private_publication": false,
+        "profile_id": "8dbf0832-8723-4c48-b532-20c0b7f6e01a",
+        "read": false,
+        "starred": false,
+        "tags": [
+            "tag1",
+            "tag2"
+        ],
+        "keywords": [
+            "keyword1",
+            "keyword2"
+        ],
+        "title": "Has tags",
+        "type": "report",
+        "year": 2002
     }
 ]


### PR DESCRIPTION
This is a fix for a problem with Mendeley API returning empty string tags (https://forums.zotero.org/discussion/comment/430106/#Comment_430106)