### PR TITLE
Add scripts to convert ftl to/from Transifex JSON

### DIFF
--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -55,8 +55,7 @@ file-interface-items-were-relinked = { $numRelinked ->
     *[other] { $numRelinked } items were relinked
     }
 
-import-mendeley-encrypted = The selected Mendeley database cannot be read, likely because it is encrypted.
-                            See <a data-l10n-name="mendeley-import-kb">How do I import a Mendeley library into Zotero?</a> for more information.
+import-mendeley-encrypted = The selected Mendeley database cannot be read, likely because it is encrypted. See <a data-l10n-name="mendeley-import-kb">How do I import a Mendeley library into Zotero?</a> for more information.
                             
 file-interface-import-error-translator = An error occurred importing the selected file with “{ $translator }”. Please ensure that the file is valid and try again.
 

--- a/js-build/config.js
+++ b/js-build/config.js
@@ -129,8 +129,22 @@ const scssFiles = [
 	'chrome/skin/default/zotero/**/*.scss'
 ];
 
+const ftlFileBaseNames = [
+	'zotero',
+	'preferences',
+];
+
 const buildsURL = 'https://zotero-download.s3.amazonaws.com/ci/';
 
 module.exports = {
-	dirs, symlinkDirs, copyDirs, symlinkFiles, browserifyConfigs, jsFiles, scssFiles, ignoreMask, buildsURL
+	dirs,
+	symlinkDirs,
+	copyDirs,
+	symlinkFiles,
+	browserifyConfigs,
+	jsFiles,
+	scssFiles,
+	ignoreMask,
+	ftlFileBaseNames,
+	buildsURL,
 };

--- a/js-build/ftl-to-json.mjs
+++ b/js-build/ftl-to-json.mjs
@@ -5,16 +5,15 @@ import { fileURLToPath } from 'url';
 import { onError, onSuccess } from './utils.js';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
-const JSONDir = join(ROOT, 'tmp', 'tx');
 
 async function getJSON() {
 	const t1 = performance.now();
-	await fs.mkdirp(JSONDir);
-	const sourcefile = join(ROOT, 'chrome', 'locale', 'en-US', 'zotero', 'zotero.ftl');
-	const destFile = join(JSONDir, 'zotero_en_US.json');
-	const ftl = await fs.readFile(sourcefile, 'utf8');
+	const sourceDir = join(ROOT, 'chrome', 'locale', 'en-US', 'zotero');
+	const sourceFile = join(sourceDir, 'zotero.ftl');
+	const destFile = join(sourceDir, 'zotero.json');
+	const ftl = await fs.readFile(sourceFile, 'utf8');
 	const json = ftlToJSON(ftl, { transformTerms: false, storeTermsInJSON: false });
-	await fs.outputJSON(destFile, json);
+	await fs.outputJSON(destFile, json, { spaces: '\t' });
 	const t2 = performance.now();
 	return ({
 		action: 'ftl->json',

--- a/js-build/ftl-to-json.mjs
+++ b/js-build/ftl-to-json.mjs
@@ -2,25 +2,29 @@ import { ftlToJSON } from "ftl-tx";
 import fs from 'fs-extra';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
-import { onError, onSuccess } from './utils.js';
+import { ftlFileBaseNames as sourceFileBaseNames } from './config.js';
+import { onError, onProgress, onSuccess } from './utils.js';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 
 async function getJSON() {
 	const t1 = performance.now();
 	const sourceDir = join(ROOT, 'chrome', 'locale', 'en-US', 'zotero');
-	const sourceFile = join(sourceDir, 'zotero.ftl');
-	const destFile = join(sourceDir, 'zotero.json');
-	const ftl = await fs.readFile(sourceFile, 'utf8');
-	const json = ftlToJSON(ftl, { transformTerms: false, storeTermsInJSON: false });
-	await fs.outputJSON(destFile, json, { spaces: '\t' });
+	for (let sourceFileBaseName of sourceFileBaseNames) {
+		const sourceFile = join(sourceDir, sourceFileBaseName + '.ftl');
+		const destFile = join(sourceDir, sourceFileBaseName + '.json');
+		const ftl = await fs.readFile(sourceFile, 'utf8');
+		const json = ftlToJSON(ftl, { transformTerms: false, storeTermsInJSON: false });
+		await fs.outputJSON(destFile, json, { spaces: '\t' });
+		onProgress(destFile, destFile, 'json');
+	}
 	const t2 = performance.now();
-	return ({
-		action: 'ftl->json',
-		count: 1,
-		totalCount: 1,
-		processingTime: t2 - t1
-	});
+		return ({
+			action: 'ftl->json',
+			count: sourceFileBaseNames.length,
+			totalCount: sourceFileBaseNames.length,
+			processingTime: t2 - t1
+		});
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/js-build/ftl-to-json.mjs
+++ b/js-build/ftl-to-json.mjs
@@ -1,0 +1,38 @@
+import { ftlToJSON } from "ftl-tx";
+import fs from 'fs-extra';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { onError, onSuccess } from './utils.js';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const JSONDir = join(ROOT, 'tmp', 'tx');
+
+async function getJSON() {
+	const t1 = performance.now();
+	await fs.mkdirp(JSONDir);
+	const sourcefile = join(ROOT, 'chrome', 'locale', 'en-US', 'zotero', 'zotero.ftl');
+	const destFile = join(JSONDir, 'zotero_en_US.json');
+	const ftl = await fs.readFile(sourcefile, 'utf8');
+	const json = ftlToJSON(ftl, { transformTerms: false, storeTermsInJSON: false });
+	await fs.outputJSON(destFile, json);
+	const t2 = performance.now();
+	return ({
+		action: 'ftl->json',
+		count: 1,
+		totalCount: 1,
+		processingTime: t2 - t1
+	});
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+	(async () => {
+		try {
+			onSuccess(await getJSON());
+		}
+		catch (err) {
+			process.exitCode = 1;
+			global.isError = true;
+			onError(err);
+		}
+	})();
+}

--- a/js-build/localize-ftl.mjs
+++ b/js-build/localize-ftl.mjs
@@ -2,6 +2,7 @@ import { extractTerms, ftlToJSON, JSONToFtl } from 'ftl-tx';
 import fs from 'fs-extra';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
+import { ftlFileBaseNames as sourceFileBaseNames } from './config.js';
 import { onError, onProgress, onSuccess } from './utils.js';
 import { exit } from 'process';
 
@@ -9,7 +10,6 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const localesDir = join(ROOT, 'chrome', 'locale');
 const sourceDir = join(localesDir, 'en-US', 'zotero');
 const termsSourceFTLPath = join(ROOT, 'app', 'assets', 'branding', 'locale', 'brand.ftl');
-const fallbackJSONPath = join(sourceDir, 'zotero.json');
 
 function getLocaleDir(locale) {
 	return join(localesDir, locale, 'zotero');
@@ -17,62 +17,66 @@ function getLocaleDir(locale) {
 
 async function getFTL() {
 	const t1 = performance.now();
-	if (!(await fs.pathExists(fallbackJSONPath))) {
-		console.error(`File ${fallbackJSONPath} does not exist -- please run 'ftl-to-json' first`);
-		exit(1);
-	}
-
+	
 	if (!(await fs.pathExists(termsSourceFTLPath))) {
 		console.error(`Required file ${termsSourceFTLPath} does not exist`);
 		exit(1);
 	}
-
-	const fallbackJSON = await fs.readJSON(fallbackJSONPath);
+	
 	const terms = extractTerms(await fs.readFile(termsSourceFTLPath, 'utf-8'));
-
+	
 	const foundLocales = (await fs.readdir(localesDir, { withFileTypes: true }))
 		.filter(dirent => dirent.isDirectory())
 		.map(dirent => dirent.name)
 		// Valid locale codes only
 		.filter(name => /^[a-z]{2}(-[A-Z]{2})?$/.test(name));
-
-	let locale;
+	
 	let count = 0;
-	while ((locale = foundLocales.pop())) {
-		// Skip source locale
-		if (locale == 'en-US') {
-			continue;
+	for (let sourceFileBaseName of sourceFileBaseNames) {
+		const fallbackJSONPath = join(sourceDir, sourceFileBaseName + '.json');
+		if (!(await fs.pathExists(fallbackJSONPath))) {
+			console.error(`File ${fallbackJSONPath} does not exist -- please run 'ftl-to-json' first`);
+			exit(1);
 		}
-
-		const ftlFilePath = join(getLocaleDir(locale), 'zotero.ftl');
-		let jsonFromLocalFTL = {};
-		try {
-			const ftl = await fs.readFile(ftlFilePath, 'utf8');
-			jsonFromLocalFTL = ftlToJSON(ftl, { transformTerms: false, storeTermsInJSON: false });
+		
+		const fallbackJSON = await fs.readJSON(fallbackJSONPath);
+		
+		for (let locale of foundLocales) {
+			// Skip source locale
+			if (locale == 'en-US') {
+				continue;
+			}
+			
+			const ftlFilePath = join(getLocaleDir(locale), sourceFileBaseName + '.ftl');
+			let jsonFromLocalFTL = {};
+			try {
+				const ftl = await fs.readFile(ftlFilePath, 'utf8');
+				jsonFromLocalFTL = ftlToJSON(ftl, { transformTerms: false, storeTermsInJSON: false });
+			}
+			catch (e) {
+				// no local .ftl file
+			}
+			
+			const jsonFilePath = join(getLocaleDir(locale), sourceFileBaseName + `.json`);
+			let jsonFromTransifex = {};
+			try {
+				const json = await fs.readJSON(jsonFilePath);
+				jsonFromTransifex = json;
+			}
+			catch (e) {
+				// no .json file from transifex
+			}
+			
+			const mergedJSON = { ...fallbackJSON, ...jsonFromLocalFTL, ...jsonFromTransifex };
+			const ftl = JSONToFtl(mergedJSON, { addTermsToFTL: false, storeTermsInJSON: false, transformTerms: false, terms });
+			
+			const outFtlPath = join(getLocaleDir(locale), sourceFileBaseName + '.ftl');
+			await fs.outputFile(outFtlPath, ftl);
+			onProgress(outFtlPath, outFtlPath, 'ftl');
+			count++;
 		}
-		catch (e) {
-			// no local .ftl file
-		}
-
-		const jsonFilePath = join(getLocaleDir(locale), `zotero.json`);
-		let jsonFromTransifex = {};
-		try {
-			const json = await fs.readJSON(jsonFilePath);
-			jsonFromTransifex = json;
-		}
-		catch (e) {
-			// no .json file from transifex
-		}
-
-		const mergedJSON = { ...fallbackJSON, ...jsonFromLocalFTL, ...jsonFromTransifex };
-		const ftl = JSONToFtl(mergedJSON, { addTermsToFTL: false, storeTermsInJSON: false, transformTerms: false, terms });
-
-		const outFtlPath = join(getLocaleDir(locale), 'zotero.ftl');
-		await fs.outputFile(outFtlPath, ftl);
-		onProgress(outFtlPath, outFtlPath, 'ftl');
-		count++;
 	}
-
+	
 	const t2 = performance.now();
 	return ({
 		action: 'ftl',

--- a/js-build/localize-ftl.mjs
+++ b/js-build/localize-ftl.mjs
@@ -1,0 +1,98 @@
+import { extractTerms, ftlToJSON, JSONToFtl } from 'ftl-tx';
+import fs from 'fs-extra';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { onError, onProgress, onSuccess } from './utils.js';
+import { exit } from 'process';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const JSONDir = join(ROOT, 'tmp', 'tx');
+const localesDir = join(ROOT, 'chrome', 'locale');
+const sourceDir = join(localesDir, 'en-US', 'zotero');
+
+const termsSourceFTLPath = join(ROOT, 'app', 'assets', 'branding', 'locale', 'brand.ftl');
+const fallbackJSONPath = join(sourceDir, 'zotero.json');
+
+// don't override source zotero.ftl
+const localeToSkip = ['en-US'];
+
+async function getFTL() {
+	const t1 = performance.now();
+	if (!(await fs.pathExists(fallbackJSONPath))) {
+		console.error(`File ${fallbackJSONPath} does not exist, please run 'ftl-to-json' first`);
+		exit(1);
+	}
+
+	if (!(await fs.pathExists(termsSourceFTLPath))) {
+		console.error(`Required file ${termsSourceFTLPath} does not exist`);
+		exit(1);
+	}
+
+	const fallbackJSON = await fs.readJSON(fallbackJSONPath);
+	const terms = extractTerms(await fs.readFile(termsSourceFTLPath, 'utf-8'));
+
+	const expectedLocale = (await fs.readdir(localeDir, { withFileTypes: true }))
+		.filter(dirent => dirent.isDirectory())
+		.map(dirent => dirent.name);
+
+	const totalCount = expectedLocale.length;
+	let locale;
+	let count = 0;
+
+	while ((locale = expectedLocale.pop())) {
+		if (localeToSkip.includes(locale)) {
+			count++;
+			continue;
+		}
+
+		const ftlFilePath = join(ROOT, 'chrome', 'locale', locale, 'zotero', 'zotero.ftl');
+		let JSONFromLocalFTL = {};
+		try {
+			const ftl = await fs.readFile(ftlFilePath, 'utf8');
+			JSONFromLocalFTL = ftlToJSON(ftl, { transformTerms: false, storeTermsInJSON: false });
+		}
+		catch (e) {
+			// no local .ftl file
+		}
+
+		const JSONFilePath = join(JSONDir, `zotero_${locale.replace('-', '_')}.json`);
+		let JSONFromTransifex = {};
+		try {
+			const json = await fs.readJSON(JSONFilePath);
+			JSONFromTransifex = json;
+		}
+		catch (e) {
+			// no .json file from transifex
+		}
+
+		const mergedJSON = { ...fallbackJSON, ...JSONFromLocalFTL, ...JSONFromTransifex };
+		const ftl = JSONToFtl(mergedJSON, { addTermsToFTL: false, storeTermsInJSON: false, transformTerms: false, terms });
+
+		const outFtlPath = join(ROOT, 'chrome', 'locale', locale, 'zotero', 'zotero.ftl');
+		await fs.outputFile(outFtlPath, ftl);
+		onProgress(outFtlPath, outFtlPath, 'ftl');
+		count++;
+	}
+
+	const t2 = performance.now();
+	return ({
+		action: 'ftl',
+		count,
+		totalCount,
+		processingTime: t2 - t1
+	});
+}
+
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+	(async () => {
+		try {
+			onSuccess(await getFTL());
+		}
+		catch (err) {
+			process.exitCode = 1;
+			global.isError = true;
+			onError(err);
+		}
+	})();
+}

--- a/js-build/utils.js
+++ b/js-build/utils.js
@@ -21,7 +21,7 @@ function onSuccess(result) {
 		msg += ` | ${result.totalCount} checked`; 
 	}
 
-	msg += ` [${yellow(`${result.processingTime}ms`)}]`;	
+	msg += ` [${yellow(`${result.processingTime.toFixed(2)}ms`)}]`;	
 
 	console.log(msg);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zotero",
-  "version": "5.0.0",
+  "version": "7.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zotero",
-      "version": "5.0.0",
+      "version": "7.0.0",
       "dependencies": {
         "@citeproc-rs/wasm": "^0.2.0",
         "ace-builds": "^1.4.12",
@@ -40,6 +40,7 @@
         "eslint-plugin-react": "^7.28.0",
         "eslint-plugin-react-hooks": "^4.0.4",
         "fs-extra": "^3.0.1",
+        "ftl-tx": "^0.6.0",
         "globby": "^6.1.0",
         "jspath": "^0.4.0",
         "mocha": "^3.5.3",
@@ -918,6 +919,16 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "node_modules/@fluent/syntax": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@fluent/syntax/-/syntax-0.19.0.tgz",
+      "integrity": "sha512-5D2qVpZrgpjtqU4eNOcWGp1gnUCgjfM+vKGE2y03kKN6z5EBhtx0qdRFbg8QuNNj8wXNoX93KJoYb+NqoxswmQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/@formatjs/intl-displaynames": {
       "version": "1.2.10",
@@ -3559,6 +3570,15 @@
       },
       "engines": {
         "node": ">= 4.0"
+      }
+    },
+    "node_modules/ftl-tx": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/ftl-tx/-/ftl-tx-0.6.0.tgz",
+      "integrity": "sha512-w7s0p6RNsaUKpiuQZ5Q0KIyiX2JIDItqI4qRKt49u0aMqdGp0gDc5G5Qnubgu6l2ww5PDt4wsyL7A1iZo1VGMQ==",
+      "dev": true,
+      "dependencies": {
+        "@fluent/syntax": "^0.19.0"
       }
     },
     "node_modules/function-bind": {
@@ -7533,6 +7553,12 @@
         }
       }
     },
+    "@fluent/syntax": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@fluent/syntax/-/syntax-0.19.0.tgz",
+      "integrity": "sha512-5D2qVpZrgpjtqU4eNOcWGp1gnUCgjfM+vKGE2y03kKN6z5EBhtx0qdRFbg8QuNNj8wXNoX93KJoYb+NqoxswmQ==",
+      "dev": true
+    },
     "@formatjs/intl-displaynames": {
       "version": "1.2.10",
       "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-1.2.10.tgz",
@@ -9767,6 +9793,15 @@
       "requires": {
         "bindings": "^1.5.0",
         "nan": "^2.12.1"
+      }
+    },
+    "ftl-tx": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/ftl-tx/-/ftl-tx-0.6.0.tgz",
+      "integrity": "sha512-w7s0p6RNsaUKpiuQZ5Q0KIyiX2JIDItqI4qRKt49u0aMqdGp0gDc5G5Qnubgu6l2ww5PDt4wsyL7A1iZo1VGMQ==",
+      "dev": true,
+      "requires": {
+        "@fluent/syntax": "^0.19.0"
       }
     },
     "function-bind": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "sass": "node ./js-build/sass.js",
     "js": "node ./js-build/js.js",
     "clean": "node ./js-build/clean.js",
+    "ftl-to-json": "node ./js-build/ftl-to-json.mjs",
+    "localize-ftl": "node ./js-build/localize-ftl.mjs",
     "clean-build": "node ./js-build/clean.js && node ./js-build/build.js",
     "clean-start": "node ./js-build/clean.js && node ./js-build/build.js && node ./js-build/watch.js"
   },
@@ -47,6 +49,7 @@
     "eslint-plugin-react": "^7.28.0",
     "eslint-plugin-react-hooks": "^4.0.4",
     "fs-extra": "^3.0.1",
+    "ftl-tx": "^0.6.0",
     "globby": "^6.1.0",
     "jspath": "^0.4.0",
     "mocha": "^3.5.3",


### PR DESCRIPTION
This PR adds a pair of scripts to generate JSON that Transifex can understand from `chrome/locale/en-US/zotero/zotero.ftl`.

* Runing `npm run ftl-to-json` produces `tmp/tx/zotero_en_US.json` which is recognized by Transifex
* `Structured JSON` is the format in Transfiex I've used for testing. I believe `key-value JSON` also works because we're not using nested messages feature of structured JSON
* Running `npm run json-to-ftl` collects files from `tmp/tx` using regex `/(zotero_)([a-z]{2}([_-][A-Z]{2})?).json/` and creates translated `zotero.ftl` in locale-named folders in `chrome/locale/`. `en-US` is ignored because it is a source file.
* Some extra data is embedded in JSON to assist translating back to ftl. I've tested and Transifex does include it in the output file so this shouldn't be an issue
* Actual logic for translation exists in [ftl-tx](https://github.com/tnajdek/ftl-tx) and is included via dev npm depdendency.
* There are some [limitations](https://github.com/tnajdek/ftl-tx#limitations) of what is possible with the translation. Everything that is in current `zotero.ftl` works
* Requires relatively-modern Node (>= 16 should be sufficient)

I hope these scripts can be integrated with any pre-existing Transifex-related automation, if anything needs adjusting let me know.