### PR TITLE
fx-compat: Item box: Use custom text field styles on Windows

### DIFF
--- a/scss/win/elements/_itemBox.scss
+++ b/scss/win/elements/_itemBox.scss
@@ -17,10 +17,22 @@ item-box {
 		margin-bottom: 0;
 	}
 	
-	input {
-		padding: 2px;
-		margin: -1px 0;
-		margin-inline-start: 1px;
+	@media (-moz-platform: windows-win10) {
+		td > input, td > textarea, .creator-name-box > input {
+			// Give text fields a consistent, native-ish look using Windows 11 colors
+			// Ideally, we only want to do this on Windows 11, but Windows 11 reports its version number as 10.0.
+			// The OS build number (the only reliable way to determine whether we're running on >=11) is only
+			// accessible from C++.
+			appearance: none;
+			padding: 2px 3px;
+			border: 1px solid #838383;
+			border-radius: 3px;
+			outline: none;
+
+			&:focus {
+				border: 1px solid #2B65BA;
+			}
+		}
 	}
 	
 	#item-type-menu

--- a/scss/win/elements/_itemBox.scss
+++ b/scss/win/elements/_itemBox.scss
@@ -19,11 +19,10 @@ item-box {
 	
 	@media (-moz-platform: windows-win10) {
 		td > input, td > textarea, .creator-name-box > input {
-			// Give text fields a consistent, native-ish look using Windows 11 colors
-			// Ideally, we only want to do this on Windows 11, but Windows 11 reports its version number as 10.0.
-			// The OS build number (the only reliable way to determine whether we're running on >=11) is only
-			// accessible from C++.
-			appearance: none;
+			// Give text fields a consistent, native-ish look using Windows 11
+			// colors. Ideally, we only want to do this on Windows 11, but
+			// Windows 11 can't currently be specifically targeted.
+			// https://bugzilla.mozilla.org/show_bug.cgi?id=1825447
 			padding: 2px 3px;
 			border: 1px solid #838383;
 			border-radius: 3px;


### PR DESCRIPTION
Active:

![Screenshot 2023-04-05 at 1 45 54 PM](https://user-images.githubusercontent.com/1770299/230161709-f0f5f335-eed3-4d0d-988c-6123697e2015.png)

Inactive:

![Screenshot 2023-04-05 at 1 46 05 PM](https://user-images.githubusercontent.com/1770299/230161731-cd3a0241-4a9d-4a8c-bd5f-d296884abbfa.png)

We can't make this only affect >= 11, unfortunately - see comment in the SCSS.

Fixes #3050