### PR TITLE
Don't add border to the top/sides of the toolbar on Windows

### DIFF
--- a/chrome/content/zotero-platform/win/overlay.css
+++ b/chrome/content/zotero-platform/win/overlay.css
@@ -10,7 +10,7 @@
 #zotero-pane #zotero-toolbar {
 	-moz-appearance: none !important;
 	margin-top: -3px;
-	border: 1px solid var(--theme-border-color);
+	border-bottom: 1px solid var(--theme-border-color);
 }
 
 


### PR DESCRIPTION
Before:
![Screenshot 2023-04-05 at 1 52 33 PM](https://user-images.githubusercontent.com/1770299/230163569-b5ba3bb2-98c9-4aa9-aaaa-4476212663c3.png)

After:
![Screenshot 2023-04-05 at 1 52 16 PM](https://user-images.githubusercontent.com/1770299/230163571-3392858c-726a-41f1-8a5a-bd867a5644f8.png)

See gray border to the left of the New Collection button and to the right of the Sync button in the Before screenshot. It doesn't look right, and the commit message (61684d88992ea95f38f96fb971a53d201a6d3bf9) implies that it wasn't intentional.