### PR TITLE
Tab bar: Make bottom border span the whole window

### DIFF
--- a/scss/components/_tabBar.scss
+++ b/scss/components/_tabBar.scss
@@ -1,5 +1,6 @@
 #tab-bar-container {
 	min-height: 30px;
+	border-bottom: $tab-border;
 }
 
 .tab-bar-inner-container {
@@ -80,7 +81,6 @@
 		content: "";
 		width: 0px;
 		min-width: 0px;
-		border-bottom: $tab-border;
 		border-inline-end: $tab-border;
 	}
 
@@ -89,7 +89,6 @@
 		flex: 1 0 0%;
 		width: 100%;
 		min-width: 0px;
-		border-bottom: $tab-border;
 		border-inline-start: $tab-border;
 	}
 }

--- a/scss/components/_tabBar.scss
+++ b/scss/components/_tabBar.scss
@@ -1,6 +1,32 @@
 #tab-bar-container {
+	// These variables can be overridden in platform styles to set platform-specific safe areas
+	--safe-area-start: 0;
+	--safe-area-end: 0;
+
 	min-height: 30px;
-	border-bottom: $tab-border;
+	
+	&:not([hidden]) {
+		// display: flex overrides the hidden attribute
+		display: flex;
+	}
+
+	&::before {
+		content: '';
+		min-width: var(--safe-area-start);
+		// Add bottom border to safe area space
+		border-bottom: $tab-border;
+	}
+
+	&::after {
+		content: '';
+		min-width: var(--safe-area-end);
+		// Add bottom border to safe area space
+		border-bottom: $tab-border;
+	}
+	
+	& > div {
+		flex-grow: 1;
+	}
 }
 
 .tab-bar-inner-container {
@@ -19,6 +45,11 @@
 		color: #bebebe;
 		display: none;
 		box-shadow: none;
+		// Add bottom border to scroll arrows,
+		// and negate the extra vertical pixel added by the border with a negative margin
+		border-bottom: $tab-border;
+		margin-bottom: -1px;
+		box-sizing: border-box;
 
 		.icon {
 			display: flex;
@@ -79,16 +110,18 @@
 
 	&:before {
 		content: "";
-		width: 0px;
-		min-width: 0px;
+		width: 0;
+		min-width: 0;
 		border-inline-end: $tab-border;
 	}
 
 	&:after {
 		content: "";
-		flex: 1 0 0%;
+		flex: 1 0 0;
 		width: 100%;
-		min-width: 0px;
+		min-width: 0;
+		// Add bottom border to the space between the last tab and the spacer in #tab-bar-container::after
+		border-bottom: $tab-border;
 		border-inline-start: $tab-border;
 	}
 }

--- a/scss/mac/_tabBar.scss
+++ b/scss/mac/_tabBar.scss
@@ -1,12 +1,12 @@
+#tab-bar-container {
+	--safe-area-start: 78px;
+	--safe-area-end: 20px;
+}
+
 .tabs {
 	-moz-window-dragging: drag;
 }
 
 .tab {
 	-moz-window-dragging: no-drag;
-}
-
-.tab-bar-inner-container {
-	margin-inline-start: 78px;
-	margin-inline-end: 20px;
 }


### PR DESCRIPTION
This isn't an fx102 regression, but it keeps bothering me and now seems like an alright time to try an idea for a fix.

Before:

![before-left](https://user-images.githubusercontent.com/1770299/230422849-6313f2c0-4f09-4761-80db-0e785682293b.png)
No dark border on the left.
![before-right](https://user-images.githubusercontent.com/1770299/230422876-d40ce3b3-8585-4e92-a859-19f14562a9b9.png)
Dark border until halfway through the Sync button.

After:
![after-left](https://user-images.githubusercontent.com/1770299/230423482-b98f32db-e784-4f92-ad79-222976d6307d.png)
![after-right](https://user-images.githubusercontent.com/1770299/230423496-ba24d3c3-945c-4b76-9053-ea57a620bbcd.png)
Dark border throughout.