### PR TITLE
Basic viewer: Open separate windows per URI

### DIFF
--- a/chrome/content/zotero/preferences/preferences.js
+++ b/chrome/content/zotero/preferences/preferences.js
@@ -124,22 +124,6 @@ var Zotero_Preferences = {
 		}
 	},
 
-	/**
-	 * Opens a URI in the basic viewer
-	 */
-	openInViewer: function (uri) {
-		var wm = Components.classes["@mozilla.org/appshell/window-mediator;1"]
-			.getService(Components.interfaces.nsIWindowMediator);
-		var win = wm.getMostRecentWindow("zotero:basicViewer");
-		if (win) {
-			win.loadURI(uri);
-		}
-		else {
-			window.openDialog("chrome://zotero/content/standalone/basicViewer.xhtml",
-				"basicViewer", "chrome,resizable,centerscreen,menubar,scrollbars", uri);
-		}
-	},
-
 	_onNavigationSelect() {
 		for (let child of this.content.children) {
 			if (child !== this.helpContainer) {

--- a/chrome/content/zotero/preferences/preferences_advanced.xhtml
+++ b/chrome/content/zotero/preferences/preferences_advanced.xhtml
@@ -253,10 +253,10 @@
 		<hbox id="zotero-prefpane-advanced-open-buttons" align="center">
 			<button id="config-editor"
 				label="&zotero.preferences.configEditor;"
-				oncommand="Zotero_Preferences.openInViewer('about:config')"/>
+				oncommand="Zotero.openInViewer('about:config')"/>
 			<button id="memory-info"
 				label="Memory Info"
-				oncommand="Zotero_Preferences.openInViewer('about:memory')"
+				oncommand="Zotero.openInViewer('about:memory')"
 				hidden="true"/>
 		</hbox>
 	</vbox>

--- a/chrome/content/zotero/preferences/preferences_cite.xhtml
+++ b/chrome/content/zotero/preferences/preferences_cite.xhtml
@@ -61,10 +61,10 @@
 			<hbox>
 				<button id="openCSLEdit"
 					label="&zotero.preferences.styleEditor;"
-					oncommand="Zotero_Preferences.openInViewer('chrome://zotero/content/tools/csledit.xhtml', true)"/>
+					oncommand="Zotero.openInViewer('chrome://zotero/content/tools/csledit.xhtml', true)"/>
 				<button id="openCSLPreview"
 					label="&zotero.preferences.stylePreview;"
-					oncommand="Zotero_Preferences.openInViewer('chrome://zotero/content/tools/cslpreview.xhtml', true)"/>
+					oncommand="Zotero.openInViewer('chrome://zotero/content/tools/cslpreview.xhtml', true)"/>
 			</hbox>
 		</groupbox>
 	</vbox>

--- a/chrome/content/zotero/standalone/basicViewer.js
+++ b/chrome/content/zotero/standalone/basicViewer.js
@@ -52,6 +52,7 @@ window.addEventListener("load", /*async */function () {
 	//browser.docShellIsActive = false;
 
 	// Load URI passed in as nsISupports .data via openWindow()
+	window.viewerOriginalURI = window.arguments[0];
 	loadURI(window.arguments[0]);
 }, false);
 

--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -1090,21 +1090,22 @@ Services.scriptloader.loadSubScript("resource://zotero/polyfill.js");
 	 * @param {Function} [onLoad] - Function to run once URI is loaded; passed the loaded document
 	 */
 	this.openInViewer = function (uri, onLoad) {
-		var wm = Services.wm;
-		var win = wm.getMostRecentWindow("zotero:basicViewer");
-		if (win) {
-			win.loadURI(uri);
-		} else {
-			let ww = Components.classes['@mozilla.org/embedcomp/window-watcher;1']
-				.getService(Components.interfaces.nsIWindowWatcher);
-			let arg = Components.classes["@mozilla.org/supports-string;1"]
-				.createInstance(Components.interfaces.nsISupportsString);
-			arg.data = uri;
-			win = ww.openWindow(null, "chrome://zotero/content/standalone/basicViewer.xhtml",
-				"basicViewer", "chrome,dialog=yes,resizable,centerscreen,menubar,scrollbars", arg);
+		var viewerWins = Services.wm.getEnumerator("zotero:basicViewer");
+		for (let existingWin of viewerWins) {
+			if (existingWin.viewerOriginalURI === uri) {
+				existingWin.focus();
+				return;
+			}
 		}
+		let ww = Components.classes['@mozilla.org/embedcomp/window-watcher;1']
+			.getService(Components.interfaces.nsIWindowWatcher);
+		let arg = Components.classes["@mozilla.org/supports-string;1"]
+			.createInstance(Components.interfaces.nsISupportsString);
+		arg.data = uri;
+		let win = ww.openWindow(null, "chrome://zotero/content/standalone/basicViewer.xhtml",
+			null, "chrome,dialog=yes,resizable,centerscreen,menubar,scrollbars", arg);
 		if (onLoad) {
-			let browser
+			let browser;
 			let func = function () {
 				win.removeEventListener("load", func);
 				// <browser> is created in basicViewer.js in a window load event, so we have to


### PR DESCRIPTION
This focuses but does not reload the existing viewer if it finds a match; it seems likely, for instance, that you don't want to lose your place in the Config Editor window if you left it open in the background. If you actually want to reset the window, you can close it before performing the action that opens it again.