### PR TITLE
Fix white toolbar when dark theme

### DIFF
--- a/chrome/content/zotero-platform/unix/overlay.css
+++ b/chrome/content/zotero-platform/unix/overlay.css
@@ -8,6 +8,17 @@
 	}
 }
 
+@media (prefers-color-scheme: dark) {
+#zotero-tb, #zotero-toolbar, #navigator-toolbox, #tab-bar-container, .tabs, .tab {
+	background: #353535 !important;
+	color: #FFFFFF !important;
+	border-bottom: 0;
+}
+.tab { background: #242424 !important; }
+.tab:hover { background: #434343 !important; }
+.tab.selected { background: #353535 !important; }
+.tab.selected:hover { background: #353535 !important; } }
+
 .zotero-tb-button[type="menu"] > .toolbarbutton-menu-dropmarker {
 	-moz-default-appearance: toolbarbutton-dropdown;	
 	margin-left: 4px;


### PR DESCRIPTION
Hello to Zotero dev-team! I am using Gnome on Linux (Wayland) with a dark theme (Adwaita-dark) for whole system, but in Zotero the toolbar and tabs were white (when opening a document in pdf viewer).
 
This is a proposition for a fix, adapting the color to system settings. It works on my machine, but I am unsure I modified the correct CSS stylesheet (in particular this fix does not apply to win and mac, because I don't know if there is the same problem on non-Unix platforms).

In particular, this fixes https://github.com/zotero/zotero/pull/2013.