### PR TITLE
Allow disabling JavaScript in basic viewer

### DIFF
--- a/chrome/content/zotero/preferences/preferences_cite.jsx
+++ b/chrome/content/zotero/preferences/preferences_cite.jsx
@@ -140,18 +140,20 @@ Zotero_Preferences.Cite = {
 	
 	
 	openStylesPage: function () {
-		Zotero.openInViewer("https://www.zotero.org/styles/", function (doc) {
-			// Hide header, intro paragraph, Link, and Source
-			//
-			// (The first two aren't sent to the client normally, but hide anyway in case they are.)
-			var style = doc.createElement('style');
-			style.type = 'text/css';
-			style.innerHTML = 'h1, #intro, .style-individual-link, .style-view-source { display: none !important; }'
-				// TEMP: Default UA styles that aren't being included in Firefox 60 for some reason
-				+ 'html { background: #fff; }'
-				+ 'a { color: rgb(0, 0, 238) !important; text-decoration: underline; }'
-				+ 'a:active { color: rgb(238, 0, 0) !important; }';
-			doc.getElementsByTagName('head')[0].appendChild(style);
+		Zotero.openInViewer("https://www.zotero.org/styles/", {
+			onLoad(doc) {
+				// Hide header, intro paragraph, Link, and Source
+				//
+				// (The first two aren't sent to the client normally, but hide anyway in case they are.)
+				var style = doc.createElement('style');
+				style.type = 'text/css';
+				style.innerHTML = 'h1, #intro, .style-individual-link, .style-view-source { display: none !important; }'
+					// TEMP: Default UA styles that aren't being included in Firefox 60 for some reason
+					+ 'html { background: #fff; }'
+					+ 'a { color: rgb(0, 0, 238) !important; text-decoration: underline; }'
+					+ 'a:active { color: rgb(238, 0, 0) !important; }';
+				doc.getElementsByTagName('head')[0].appendChild(style);
+			}
 		});
 	},
 	

--- a/chrome/content/zotero/preferences/preferences_cite.xhtml
+++ b/chrome/content/zotero/preferences/preferences_cite.xhtml
@@ -61,10 +61,10 @@
 			<hbox>
 				<button id="openCSLEdit"
 					label="&zotero.preferences.styleEditor;"
-					oncommand="Zotero.openInViewer('chrome://zotero/content/tools/csledit.xhtml', true)"/>
+					oncommand="Zotero.openInViewer('chrome://zotero/content/tools/csledit.xhtml')"/>
 				<button id="openCSLPreview"
 					label="&zotero.preferences.stylePreview;"
-					oncommand="Zotero.openInViewer('chrome://zotero/content/tools/cslpreview.xhtml', true)"/>
+					oncommand="Zotero.openInViewer('chrome://zotero/content/tools/cslpreview.xhtml')"/>
 			</hbox>
 		</groupbox>
 	</vbox>

--- a/chrome/content/zotero/reportInterface.js
+++ b/chrome/content/zotero/reportInterface.js
@@ -54,7 +54,7 @@ var Zotero_Report_Interface = new function() {
 		
 		url += '/items' + queryString;
 		
-		Zotero.openInViewer(url);
+		Zotero.openInViewer(url, { allowJavaScript: false });
 	}
 	
 	
@@ -71,6 +71,6 @@ var Zotero_Report_Interface = new function() {
 		
 		var url = 'zotero://report/' + Zotero.API.getLibraryPrefix(libraryID) + '/items'
 			+ '?itemKey=' + items.map(item => item.key).join(',');
-		Zotero.openInViewer(url);
+		Zotero.openInViewer(url, { allowJavaScript: false });
 	}
 }

--- a/chrome/content/zotero/standalone/basicViewer.js
+++ b/chrome/content/zotero/standalone/basicViewer.js
@@ -27,6 +27,8 @@
 	"resource://gre/modules/E10SUtils.jsm"
 );*/
 
+const SANDBOXED_SCRIPTS = 0x80;
+
 var browser;
 
 window.addEventListener("load", /*async */function () {
@@ -51,9 +53,10 @@ window.addEventListener("load", /*async */function () {
 	);*/
 	//browser.docShellIsActive = false;
 
-	// Load URI passed in as nsISupports .data via openWindow()
-	window.viewerOriginalURI = window.arguments[0];
-	loadURI(window.arguments[0]);
+	// Get URI and options passed in via openWindow()
+	let { uri, options } = window.arguments[0].wrappedJSObject;
+	window.viewerOriginalURI = uri;
+	loadURI(uri, options);
 }, false);
 
 window.addEventListener("keypress", function (event) {
@@ -73,7 +76,13 @@ window.addEventListener("click", function (event) {
 	}
 });
 
-function loadURI(uri) {
+function loadURI(uri, options = {}) {
+	if (options.allowJavaScript !== false) {
+		browser.browsingContext.sandboxFlags &= ~SANDBOXED_SCRIPTS;
+	}
+	else {
+		browser.browsingContext.sandboxFlags |= SANDBOXED_SCRIPTS;
+	}
 	browser.loadURI(
 		uri,
 		{

--- a/chrome/content/zotero/standalone/basicViewer.js
+++ b/chrome/content/zotero/standalone/basicViewer.js
@@ -77,6 +77,8 @@ window.addEventListener("click", function (event) {
 });
 
 function loadURI(uri, options = {}) {
+	// browser.browsingContext.allowJavascript (sic) would seem to do what we want here,
+	// but it has no effect. So we use sandboxFlags instead:
 	if (options.allowJavaScript !== false) {
 		browser.browsingContext.sandboxFlags &= ~SANDBOXED_SCRIPTS;
 	}

--- a/chrome/content/zotero/standalone/standalone.js
+++ b/chrome/content/zotero/standalone/standalone.js
@@ -850,21 +850,23 @@ ZoteroStandalone.DebugOutput = {
 	
 	
 	view: function () {
-		Zotero.openInViewer("chrome://zotero/content/debugViewer.html", function (doc) {
-			var submitted = false;
-			doc.querySelector('#submit-button').addEventListener('click', function (event) {
-				submitted = true;
-			});
-			doc.querySelector('#clear-button').addEventListener('click', function (event) {
-				Zotero.Debug.clear();
-			});
-			// If output has been submitted, disable logging when window is closed
-			doc.defaultView.addEventListener('unload', function (event) {
-				if (submitted) {
-					Zotero.Debug.setStore(false);
+		Zotero.openInViewer("chrome://zotero/content/debugViewer.html", {
+			onLoad(doc) {
+				var submitted = false;
+				doc.querySelector('#submit-button').addEventListener('click', function (event) {
+					submitted = true;
+				});
+				doc.querySelector('#clear-button').addEventListener('click', function (event) {
 					Zotero.Debug.clear();
-				}
-			});
+				});
+				// If output has been submitted, disable logging when window is closed
+				doc.defaultView.addEventListener('unload', function (event) {
+					if (submitted) {
+						Zotero.Debug.setStore(false);
+						Zotero.Debug.clear();
+					}
+				});
+			}
 		});
 	},
 	

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -537,7 +537,7 @@
 									label="&installConnector.label;"
 									oncommand="ZoteroStandalone.openHelp('connectors');"/>
 							<menuitem id="menu_addons" label="&addons.label;"
-									oncommand="Zotero.openInViewer('chrome://mozapps/content/extensions/aboutaddons.html', ZoteroStandalone.updateAddonsPane)"/>
+									oncommand="Zotero.openInViewer('chrome://mozapps/content/extensions/aboutaddons.html', { onLoad: ZoteroStandalone.updateAddonsPane })"/>
 							<menu id="developer-menu"
 									label="&developer.label;">
 								<menupopup>


### PR DESCRIPTION
And:
- Prevent JavaScript inside notes from executing in reports
- Update calls to `openInViewer()` to pass an options object