### PR TITLE
Hide About window in Window menu (Mac)

### DIFF
--- a/chrome/content/zotero/about.xhtml
+++ b/chrome/content/zotero/about.xhtml
@@ -7,7 +7,8 @@
 
 <window
 	xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
-	onload="moveToAlertPosition(); sizeToContent(); document.getElementById('zotero-about').getButton('accept').focus();">
+	onload="moveToAlertPosition(); sizeToContent(); document.getElementById('zotero-about').getButton('accept').focus();"
+	inwindowmenu="false">
 <dialog
 		id="zotero-about"
 		buttons="accept"


### PR DESCRIPTION
Showing a titleless window and hiding it in the Window menu is in line with the behavior of Mail, TextEdit, and Firefox, but not Finder (which sets a title and shows it in the Window menu).

Fixes #3103.