### PR TITLE
fx-compat: Handle files opened via OS

### DIFF
--- a/chrome.manifest
+++ b/chrome.manifest
@@ -65,8 +65,8 @@ skin		zotero	default		chrome/skin/default/zotero/
 component	{e4c61080-ec2d-11da-8ad9-0800200c9a66}			components/zotero-service.js
 component	{531828f8-a16c-46be-b9aa-14845c3b010f}			components/zotero-service.js
 contract	@zotero.org/Zotero;1 							{e4c61080-ec2d-11da-8ad9-0800200c9a66}
-contract	@mozilla.org/commandlinehandler/general-startup;1?type=zotero 	{531828f8-a16c-46be-b9aa-14845c3b010f}
-category	command-line-handler 	m-zotero	@mozilla.org/commandlinehandler/general-startup;1?type=zotero
+contract	@mozilla.org/browser/clh;1						{531828f8-a16c-46be-b9aa-14845c3b010f}
+category	command-line-handler m-zotero					@mozilla.org/browser/clh;1
 
 component	{06a2ed11-d0a4-4ff0-a56f-a44545eee6ea}			components/zotero-autocomplete.js
 contract	@mozilla.org/autocomplete/search;1?name=zotero 	{06a2ed11-d0a4-4ff0-a56f-a44545eee6ea}


### PR DESCRIPTION
By using the `@mozilla.org/browser/clh;1` contract. Our `@mozilla.org/commandlinehandler/general-startup;1?type=zotero` handler was still getting called, but seemingly only after all the arguments had already been eaten by other handlers.

Fixes #2737