### PR TITLE
Remove outdated startup error messages

### DIFF
--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -797,10 +797,7 @@ Services.scriptloader.loadSubScript("resource://zotero/polyfill.js");
 			if (_checkDataDirAccessError(e)) {}
 			// Storage busy
 			else if (e.message.includes('2153971713')) {
-				Zotero.startupError = Zotero.getString('startupError.databaseInUse') + "\n\n"
-					+ Zotero.getString(
-						"startupError.close" + (Zotero.isStandalone ? 'Firefox' : 'Standalone')
-					);
+				Zotero.startupError = Zotero.getString('startupError.databaseInUse');
 			}
 			else {
 				let stack = e.stack ? Zotero.Utilities.Internal.filterStack(e.stack) : null;

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -222,8 +222,6 @@ app.firefox						= Zotero for Firefox
 
 startupError								= There was an error starting %S.
 startupError.databaseInUse					= Your Zotero database is currently in use. Only one instance of Zotero using the same database may be opened simultaneously at this time.
-startupError.closeStandalone				= If Zotero Standalone is open, please close it and restart Firefox.
-startupError.closeFirefox					= If Firefox with the Zotero extension is open, please close it and restart Zotero Standalone.
 startupError.zoteroVersionIsOlder			= This version of Zotero is older than the version last used with your database.
 startupError.incompatibleDBVersion         = This %1$S database requires %1$S %2$S or later.
 startupError.zoteroVersionIsOlder.current	= Current version: %S


### PR DESCRIPTION
Zotero for Firefox is no longer relevant, since even someone still using it couldn't be using it with the same database as Z7, and "Firefox with the Zotero extension" reads like it's talking about the current Zotero browser extension.