### PR TITLE
Select an item when passed a zotero://select URI at startup

### DIFF
--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -1195,6 +1195,7 @@ var ZoteroPane = new function()
 			});
 			ZoteroPane.itemsView.onRefresh.addListener(() => ZoteroPane.setTagScope());
 			ZoteroPane.itemsView.waitForLoad().then(() => Zotero.uiIsReady());
+			ZoteroPane.collectionsView.itemTreeView = ZoteroPane.itemsView;
 		}
 		catch (e) {
 			Zotero.logError(e);


### PR DESCRIPTION
`CollectionTree#selectItems()` calls `itemTreeView.waitForLoad()`, but `itemTreeView` is set from `ItemTree#changeCollectionTreeRow()`, which we can't listen for the completion of unless we... already have an ItemTree. Which we don't.

So we set `itemTreeView` immediately upon creating the CollectionTree and ItemTree. As far as I can tell, that doesn't break anything.

https://forums.zotero.org/discussion/comment/435588/#Comment_435588