### PR TITLE
Block remote content when indexing HTML file

### DIFF
--- a/chrome/content/zotero/xpcom/fulltext.js
+++ b/chrome/content/zotero/xpcom/fulltext.js
@@ -1541,7 +1541,7 @@ Zotero.Fulltext = Zotero.FullText = new function(){
 		var pageData;
 		try {
 			let url = Zotero.File.pathToFileURI(path);
-			browser = await HiddenBrowser.create(url);
+			browser = await HiddenBrowser.create(url, { blockRemoteResources: true });
 			pageData = await HiddenBrowser.getPageData(browser, ['characterSet', 'bodyText']);
 		}
 		finally {

--- a/test/tests/data/test-hidden.html
+++ b/test/tests/data/test-hidden.html
@@ -3,6 +3,7 @@
 		<meta charset="utf-8"/>
 	</head>
 	<body>
+		<img src="http://127.0.0.1:16213/remote.png">
 		<p>This is a test.</p>
 		<p style="display: none">This is hidden text.</p>
 	</body>


### PR DESCRIPTION
We add an `http-on-modify-request` observer that blocks any request to a non-file: URL in browsers created with the `blockRemoteResources` option set to true. The observer is added on demand and removed when all browsers with remote content blocked have been destroyed. You'd think there'd be an easier way, but this is the best I could find.

Fixes #2721