### PR TITLE
Add support for mac word transaction initialization via http for Zotero 6.0

### DIFF
--- a/chrome/content/zotero/xpcom/integration.js
+++ b/chrome/content/zotero/xpcom/integration.js
@@ -63,7 +63,11 @@ const EXPORTED_DOCUMENT_MARKER = "ZOTERO_TRANSFER_DOCUMENT";
 
 const NOTE_CITATION_PLACEHOLDER_LINK = 'https://www.zotero.org/?';
 
-const TEMPLATE_VERSION = 1;
+const TEMPLATE_VERSIONS = {
+	MacWord16: 2,
+	WinWord: 1,
+	OpenOffice: 1
+};
 
 const MENDELEY_URI_RE = /^http:\/\/www\.mendeley\.com\/documents\/\?uuid=(.*)/;
 
@@ -141,8 +145,8 @@ Zotero.Integration = new function() {
 	 * @returns {Boolean} true if integration operation should be cancelled
 	 */
 	this.warnOutdatedTemplate = function (agent, templateVersion) {
-		const validAgents = new Set(['OpenOffice', 'MacWord2016', 'MacWord16', 'WinWord']);
-		if (!validAgents.has(agent) || templateVersion >= TEMPLATE_VERSION) return false;
+		const expectedTemplateVersion = TEMPLATE_VERSIONS[agent];
+		if (typeof expectedTemplateVersion != 'undefined' && templateVersion >= expectedTemplateVersion) return false;
 		const daysToIgnore = 30;
 		const now = Math.floor(Date.now() / 1000);
 		const updateTemplateDelayedOn = Zotero.Prefs.get('integration.updateTemplateDelayedOn');

--- a/chrome/content/zotero/xpcom/server_integration.js
+++ b/chrome/content/zotero/xpcom/server_integration.js
@@ -1,0 +1,35 @@
+/*
+	***** BEGIN LICENSE BLOCK *****
+	
+	Copyright © 2023 Corporation for Digital Scholarship
+					 Vienna, Virginia, USA
+					 https://digitalscholar.org
+	
+	This file is part of Zotero.
+	
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+	
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+	
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
+	
+	***** END LICENSE BLOCK *****
+*/
+
+Zotero.Server.Endpoints['/integration/macWordCommand'] = function () {};
+Zotero.Server.Endpoints['/integration/macWordCommand'].prototype = {
+	supportedMethods: ["GET"],
+	supportedDataTypes: ["application/json"],
+	permitBookmarklet: true,
+	init: function (data) {
+		Zotero.Integration.execCommand(data.query.agent, data.query.command, data.query.document, data.query.templateVersion);
+		return 200;
+	},
+};

--- a/components/zotero-service.js
+++ b/components/zotero-service.js
@@ -121,6 +121,7 @@ const xpcomFilesLocal = [
 	'router',
 	'schema',
 	'server',
+	'server_integration',
 	'session',
 	'streamer',
 	'style',


### PR DESCRIPTION
A complimentary PR to https://github.com/zotero/zotero/pull/3168 for Zotero 6.0. To be merged after this feature is tested in the 7.0 Beta. Also the submodule in zotero-standalone for mac word needs to be updated to tag 6.0.7.