### PR TITLE
Fix clicky sizing and appearance

### DIFF
--- a/chrome/content/zotero/searchDialog.xhtml
+++ b/chrome/content/zotero/searchDialog.xhtml
@@ -2,6 +2,7 @@
 <?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
 <?xml-stylesheet href="chrome://zotero/skin/zotero.css" type="text/css"?>
 <?xml-stylesheet href="chrome://zotero/skin/overlay.css" type="text/css"?>
+<?xml-stylesheet href="chrome://zotero-platform/content/zotero.css" type="text/css"?>
 
 <!DOCTYPE bindings SYSTEM "chrome://zotero/locale/searchbox.dtd">
 

--- a/chrome/skin/default/zotero/zotero.css
+++ b/chrome/skin/default/zotero/zotero.css
@@ -248,10 +248,6 @@ zoterosearch .menulist-icon {
 
 /* BEGIN 2X BLOCK -- DO NOT EDIT MANUALLY -- USE 2XIZE */
 @media (min-resolution: 1.25dppx) {
-	.zotero-clicky-minus  { background: url(chrome://zotero/skin/minus@2x.png) center/auto 18px no-repeat !important; }
-	.zotero-clicky-plus  { background: url(chrome://zotero/skin/plus@2x.png) center/auto 18px no-repeat !important; }
-	.zotero-clicky-minus:not([disabled=true]):active  { background-image: url('chrome://zotero/skin/minus-active@2x.png') !important; }
-	.zotero-clicky-plus:not([disabled=true]):active  { background-image: url('chrome://zotero/skin/plus-active@2x.png') !important; }
 	.zotero-scrape-popup-library { list-style-image: url('chrome://zotero/skin/treesource-library@2x.png'); }
 	.zotero-scrape-popup-collection { list-style-image: url('chrome://zotero/skin/treesource-collection@2x.png'); }
 	.zotero-spinner-14  { list-style-image: url(chrome://zotero/skin/spinner-14px@2x.png); }

--- a/scss/components/_clicky.scss
+++ b/scss/components/_clicky.scss
@@ -11,6 +11,8 @@
 	margin-inline-end: 5px !important;
 	width: 18px;
 	height: 18px;
+	min-width: 18px;
+	min-height: 18px;
 }
 
 .zotero-clicky-minus {

--- a/scss/components/_clicky.scss
+++ b/scss/components/_clicky.scss
@@ -11,8 +11,6 @@
 	margin-inline-end: 5px !important;
 	width: 18px;
 	height: 18px;
-	min-width: 18px;
-	min-height: 18px;
 }
 
 .zotero-clicky-minus {


### PR DESCRIPTION
- Remove defunct `.zotero-clicky-*` styles from 2x block in zotero.css
- Include zotero-platform/content/zotero.css in searchDialog.xhtml
   - It seems only the defunct 2x styles from zotero.css were being applied, so the buttons would have been unstyled on a non-hiDPI display

Fixes #3172