### PR TITLE
only save username to prefs on successful login

### DIFF
--- a/chrome/content/zotero/preferences/preferences_sync.jsx
+++ b/chrome/content/zotero/preferences/preferences_sync.jsx
@@ -125,8 +125,6 @@ Zotero_Preferences.Sync = {
 		var trimmed = username.trim();
 		if (username != trimmed) {
 			tb.value = trimmed;
-			// Setting .value alone doesn't seem to cause the pref to sync, so set it manually
-			Zotero.Prefs.set('sync.server.username', trimmed);
 		}
 	},
 	
@@ -181,7 +179,9 @@ Zotero_Preferences.Sync = {
 			Zotero.Sync.Runner.deleteAPIKey();
 			return;
 		}
-		
+
+		Zotero.Prefs.set('sync.server.username', username);
+
 		// It shouldn't be possible for a sync to be in progress if the user wasn't logged in,
 		// but check to be sure
 		if (!Zotero.Sync.Runner.syncInProgress) {

--- a/chrome/content/zotero/preferences/preferences_sync.xhtml
+++ b/chrome/content/zotero/preferences/preferences_sync.xhtml
@@ -34,7 +34,6 @@
                     <html:div class="form-grid">
                         <label value="&zotero.preferences.sync.username;"/>
                         <html:input id="sync-username-textbox"
-                            preference="extensions.zotero.sync.server.username"
                             onblur="Zotero_Preferences.Sync.trimUsername()"
                             oninput="Zotero_Preferences.Sync.credentialsChange(event)"
                             onchange="Zotero_Preferences.Sync.credentialsChange(event)"


### PR DESCRIPTION
Failing to login does not update the username in prefs.

Fixes #2901