### PR TITLE
Fix indentation in bibliography

### DIFF
--- a/chrome/content/zotero/xpcom/integration.js
+++ b/chrome/content/zotero/xpcom/integration.js
@@ -1348,18 +1348,11 @@ Zotero.Integration.Session.prototype._updateDocument = async function(forceCitat
 				} else {
 					bibliographyText = bib[0].bibstart+bib[1].join("")+bib[0].bibend;
 				}
-				
-				// if bibliography style not set, set it
-				if(!this.data.style.bibliographyStyleHasBeenSet) {
-					var bibStyle = Zotero.Cite.getBibliographyFormatParameters(bib);
-					
-					// set bibliography style
-					await this._doc.setBibliographyStyle(bibStyle.firstLineIndent, bibStyle.indent,
-						bibStyle.lineSpacing, bibStyle.entrySpacing, bibStyle.tabStops, bibStyle.tabStops.length);
-					
-					// set bibliographyStyleHasBeenSet parameter to prevent further changes	
-					this.data.style.bibliographyStyleHasBeenSet = true;
-				}
+
+				var bibStyle = Zotero.Cite.getBibliographyFormatParameters(bib);
+				await this._doc.setBibliographyStyle(bibStyle.firstLineIndent, bibStyle.indent,
+					bibStyle.lineSpacing, bibStyle.entrySpacing, bibStyle.tabStops, bibStyle.tabStops.length);
+				this.data.style.bibliographyStyleHasBeenSet = true;
 			}
 			
 			// set bibliography text


### PR DESCRIPTION
Fix indentation in bibliography when a new item is added and therefore the recalculation of indents are needed.

https://forums.zotero.org/discussion/23689/bibliography-indentation

Before:
![before](https://github.com/zotero/zotero/assets/321850/e6d76ab3-0ee8-4102-a0e3-a4c03e9ddf39)

After:
![after](https://github.com/zotero/zotero/assets/321850/3e431a47-d3e8-44d5-bd1d-f6f30dcbf661)
