### PR TITLE
jumpback only to library tab

### DIFF
--- a/chrome/content/zotero/tabs.js
+++ b/chrome/content/zotero/tabs.js
@@ -181,7 +181,7 @@ var Zotero_Tabs = new function () {
 	 * @param {Function} onClose
 	 * @return {{ id: string, container: XULElement}} id - tab id, container - a new tab container created in the deck
 	 */
-	this.add = function ({ id, type, data, title, index, select, onClose }) {
+	this.add = function ({ id, type, data, title, index, select, onClose, preventJumpback }) {
 		if (typeof type != 'string') {
 		}
 		if (typeof title != 'string') {
@@ -205,7 +205,9 @@ var Zotero_Tabs = new function () {
 		if (select) {
 			let previousID = this._selectedID;
 			this.select(id);
-			this._prevSelectedID = previousID;
+			if (!preventJumpback) {
+				this._prevSelectedID = previousID;
+			}
 		}
 		return { id, container };
 	};
@@ -368,7 +370,8 @@ var Zotero_Tabs = new function () {
 				title: tab.title,
 				tabIndex,
 				allowDuplicate: true,
-				secondViewState: tab.data.secondViewState
+				secondViewState: tab.data.secondViewState,
+				preventJumpback: true
 			});
 			return;
 		}

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -1287,7 +1287,7 @@ class ReaderInstance {
 }
 
 class ReaderTab extends ReaderInstance {
-	constructor({ itemID, title, sidebarWidth, sidebarOpen, bottomPlaceholderHeight, index, tabID, background }) {
+	constructor({ itemID, title, sidebarWidth, sidebarOpen, bottomPlaceholderHeight, index, tabID, background, preventJumpback }) {
 		super();
 		this._itemID = itemID;
 		this._sidebarWidth = sidebarWidth;
@@ -1303,7 +1303,8 @@ class ReaderTab extends ReaderInstance {
 			data: {
 				itemID
 			},
-			select: !background
+			select: !background,
+			preventJumpback: preventJumpback
 		});
 		this.tabID = id;
 		this._tabContainer = container;
@@ -1647,7 +1648,7 @@ class Reader {
 		await this.open(item.id, location, options);
 	}
 
-	async open(itemID, location, { title, tabIndex, tabID, openInBackground, openInWindow, allowDuplicate, secondViewState } = {}) {
+	async open(itemID, location, { title, tabIndex, tabID, openInBackground, openInWindow, allowDuplicate, secondViewState, preventJumpback } = {}) {
 		this._loadSidebarState();
 		this.triggerAnnotationsImportCheck(itemID);
 		let reader;
@@ -1706,7 +1707,8 @@ class Reader {
 				background: openInBackground,
 				sidebarWidth: this._sidebarWidth,
 				sidebarOpen: this._sidebarOpen,
-				bottomPlaceholderHeight: this._bottomPlaceholderHeight
+				bottomPlaceholderHeight: this._bottomPlaceholderHeight,
+				preventJumpback: preventJumpback
 			});
 			this._readers.push(reader);
 			if (!(await reader.open({ itemID, location, secondViewState }))) {


### PR DESCRIPTION
When a new tab is added, record _prevSelectedID only if the previous tab was zotero-pane.

Fixes: #3152