### PR TITLE
Add UI for editing attachment rename format pref

### DIFF
--- a/chrome/content/zotero/preferences/preferences_file_renaming.js
+++ b/chrome/content/zotero/preferences/preferences_file_renaming.js
@@ -1,0 +1,66 @@
+/*
+	***** BEGIN LICENSE BLOCK *****
+    
+	Copyright © 2006–2023 Center for History and New Media
+					 George Mason University, Fairfax, Virginia, USA
+					 http://zotero.org
+    
+	This file is part of Zotero.
+    
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+    
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+    
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
+    
+	***** END LICENSE BLOCK *****
+*/
+/* eslint-disable camelcase */
+/* global Zotero_Preferences: false */
+
+Zotero_Preferences.FileRenaming = {
+	mockItem: null,
+	init: function () {
+		this.inputRef = document.getElementById('file-renaming-template');
+		this.updatePreview();
+		this.inputRef.addEventListener('keyup', this.updatePreview.bind(this));
+		Zotero.getActiveZoteroPane()?.itemsView.onSelect.addListener(this.updatePreview.bind(this));
+	},
+
+	updatePreview() {
+		const item = Zotero.getActiveZoteroPane()?.getSelectedItems()?.[0] ?? this.mockItem ?? this.makeMockItem();
+		const tpl = document.getElementById('file-renaming-template').value;
+		const preview = Zotero.Attachments.getFileBaseNameFromItem(item, tpl);
+		document.getElementById('file-renaming-preview').innerText = `${preview}.pdf`;
+	},
+
+	makeMockItem() {
+		this.mockItem = new Zotero.Item('journalArticle');
+		this.mockItem.setField('title', 'Example Article: Zotero Engineering');
+		this.mockItem.setCreators([
+			{ firstName: 'Jane', lastName: 'Doe', creatorType: 'author' },
+			{ firstName: 'John', lastName: 'Smith', creatorType: 'author' }
+		]);
+		this.mockItem.setField('shortTitle', 'Example Article');
+		this.mockItem.setField('publicationTitle', 'Advances in Zotero Engineering');
+		this.mockItem.setField('volume', '9');
+		this.mockItem.setField('issue', '1');
+		this.mockItem.setField('pages', '34-55');
+		this.mockItem.setField('date', '2016');
+		this.mockItem.setField('DOI', '10.1016/1234-example');
+		this.mockItem.setField('ISSN', '1234-5678');
+		this.mockItem.setField('abstractNote', 'This is an example abstract.');
+		this.mockItem.setField('extra', 'This is an example extra field.');
+		this.mockItem.setField('accessDate', '2020-01-01');
+		this.mockItem.setField('url', 'https://example.com');
+		this.mockItem.setField('libraryCatalog', 'Example Library Catalog');
+		return this.mockItem;
+	},
+};

--- a/chrome/content/zotero/preferences/preferences_file_renaming.js
+++ b/chrome/content/zotero/preferences/preferences_file_renaming.js
@@ -22,42 +22,41 @@
     
 	***** END LICENSE BLOCK *****
 */
-/* eslint-disable camelcase */
 /* global Zotero_Preferences: false */
 
 Zotero_Preferences.FileRenaming = {
 	mockItem: null,
 	init: function () {
-		this.inputRef = document.getElementById('file-renaming-template');
+		this.inputRef = document.getElementById('file-renaming-format-template');
 		this.updatePreview();
-		this.inputRef.addEventListener('keyup', this.updatePreview.bind(this));
+		this.inputRef.addEventListener('input', this.updatePreview.bind(this));
 		Zotero.getActiveZoteroPane()?.itemsView.onSelect.addListener(this.updatePreview.bind(this));
 	},
 
 	updatePreview() {
 		const item = Zotero.getActiveZoteroPane()?.getSelectedItems()?.[0] ?? this.mockItem ?? this.makeMockItem();
-		const tpl = document.getElementById('file-renaming-template').value;
+		const tpl = document.getElementById('file-renaming-format-template').value;
 		const preview = Zotero.Attachments.getFileBaseNameFromItem(item, tpl);
-		document.getElementById('file-renaming-preview').innerText = `${preview}.pdf`;
+		document.getElementById('file-renaming-format-preview').innerText = `${preview}.pdf`;
 	},
 
 	makeMockItem() {
 		this.mockItem = new Zotero.Item('journalArticle');
-		this.mockItem.setField('title', 'Example Article: Zotero Engineering');
+		this.mockItem.setField('title', 'Example Title: Example Subtitle');
 		this.mockItem.setCreators([
 			{ firstName: 'Jane', lastName: 'Doe', creatorType: 'author' },
 			{ firstName: 'John', lastName: 'Smith', creatorType: 'author' }
 		]);
-		this.mockItem.setField('shortTitle', 'Example Article');
-		this.mockItem.setField('publicationTitle', 'Advances in Zotero Engineering');
+		this.mockItem.setField('shortTitle', 'Example Title');
+		this.mockItem.setField('publicationTitle', 'Advances in Example Engineering');
 		this.mockItem.setField('volume', '9');
 		this.mockItem.setField('issue', '1');
 		this.mockItem.setField('pages', '34-55');
-		this.mockItem.setField('date', '2016');
+		this.mockItem.setField('date', '2018');
 		this.mockItem.setField('DOI', '10.1016/1234-example');
 		this.mockItem.setField('ISSN', '1234-5678');
 		this.mockItem.setField('abstractNote', 'This is an example abstract.');
-		this.mockItem.setField('extra', 'This is an example extra field.');
+		this.mockItem.setField('extra', 'This is an example Extra field.');
 		this.mockItem.setField('accessDate', '2020-01-01');
 		this.mockItem.setField('url', 'https://example.com');
 		this.mockItem.setField('libraryCatalog', 'Example Library Catalog');

--- a/chrome/content/zotero/preferences/preferences_file_renaming.js
+++ b/chrome/content/zotero/preferences/preferences_file_renaming.js
@@ -1,9 +1,9 @@
 /*
 	***** BEGIN LICENSE BLOCK *****
     
-	Copyright © 2006–2023 Center for History and New Media
-					 George Mason University, Fairfax, Virginia, USA
-					 http://zotero.org
+    Copyright © Corporation for Digital Scholarship
+                Vienna, Virginia, USA
+                https://www.zotero.org
     
 	This file is part of Zotero.
     

--- a/chrome/content/zotero/preferences/preferences_file_renaming.xhtml
+++ b/chrome/content/zotero/preferences/preferences_file_renaming.xhtml
@@ -1,9 +1,9 @@
 <!--
     ***** BEGIN LICENSE BLOCK *****
     
-    Copyright © 2006–2023 Center for History and New Media
-                     George Mason University, Fairfax, Virginia, USA
-                     http://zotero.org
+    Copyright © Corporation for Digital Scholarship
+                Vienna, Virginia, USA
+                https://www.zotero.org
     
     This file is part of Zotero.
     

--- a/chrome/content/zotero/preferences/preferences_file_renaming.xhtml
+++ b/chrome/content/zotero/preferences/preferences_file_renaming.xhtml
@@ -22,40 +22,47 @@
     
     ***** END LICENSE BLOCK *****
 -->
-<vbox class="main-section" id="zotero-prefpane-file-renaming" onload="Zotero_Preferences.FileRenaming.init()">
-	<html:h1 data-l10n-id="preferences-file-renaming-title" />
-	<label data-l10n-id="preferences-file-renaming-instructions" />
+<vbox class="main-section" id="zotero-prefpane-file-renaming-format" onload="Zotero_Preferences.FileRenaming.init()">
+	<hbox class="header">
+		<html:h1 data-l10n-id="preferences-file-renaming-format-title" />
+	</hbox>
+	
+	<label data-l10n-id="preferences-file-renaming-format-instructions" />
 	<separator class="thin" />
-	<label data-l10n-id="preferences-file-renaming-instructions-example" data-l10n-args='{"example": "{{ title truncate=\"50\" }}"}' />
+	<label data-l10n-id="preferences-file-renaming-format-instructions-example"
+		data-l10n-args='{"example": "{{ title truncate=\"50\" }}"}' />
 	<separator class="thin" />
-	<label data-l10n-id="preferences-file-renaming-instructions-more">
+	<label data-l10n-id="preferences-file-renaming-format-instructions-more">
 		<label
 			is="zotero-text-link"
-			href="https://www.zotero.org/support/preferences/general#file_renaming"
-			data-l10n-name="file-renaming-help-link"
+			href="https://www.zotero.org/support/file_renaming"
+			data-l10n-name="file-renaming-format-help-link"
 		/>
 	</label>
+	
+	<separator class="thin" />
+	
 	<groupbox>
 		<html:label
-			for="file-renaming-template"
-			id="file-renaming-template-label"
+			for="file-renaming-format-template"
+			id="file-renaming-format-template-label"
 		>
-			<html:h2 data-l10n-id="preferences-file-renaming-template" />
+			<html:h2 data-l10n-id="preferences-file-renaming-format-template" />
 		</html:label>
 		<html:textarea
-			aria-labelledby="file-renaming-template-label"
-			id="file-renaming-template"
+			aria-labelledby="file-renaming-format-template-label"
+			id="file-renaming-format-template"
 			preference="extensions.zotero.attachmentRenameTemplate"
 			rows="3"
 		/>
-		<html:label id="file-renaming-preview-label">
+		<html:label id="file-renaming-format-preview-label">
 			<html:h2
-				data-l10n-id="preferences-file-renaming-preview"
+				data-l10n-id="preferences-file-renaming-format-preview"
 			/>
 		</html:label>
-		<html:span
-			aria-labelledby="file-renaming-preview-label"
-			id="file-renaming-preview"
+		<html:label
+			aria-labelledby="file-renaming-format-preview-label"
+			id="file-renaming-format-preview"
 		/>
 	</groupbox>
 </vbox>

--- a/chrome/content/zotero/preferences/preferences_file_renaming.xhtml
+++ b/chrome/content/zotero/preferences/preferences_file_renaming.xhtml
@@ -1,0 +1,61 @@
+<!--
+    ***** BEGIN LICENSE BLOCK *****
+    
+    Copyright © 2006–2023 Center for History and New Media
+                     George Mason University, Fairfax, Virginia, USA
+                     http://zotero.org
+    
+    This file is part of Zotero.
+    
+    Zotero is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    
+    Zotero is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+    
+    You should have received a copy of the GNU Affero General Public License
+    along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
+    
+    ***** END LICENSE BLOCK *****
+-->
+<vbox class="main-section" id="zotero-prefpane-file-renaming" onload="Zotero_Preferences.FileRenaming.init()">
+	<html:h1 data-l10n-id="preferences-file-renaming-title" />
+	<label data-l10n-id="preferences-file-renaming-instructions" />
+	<separator class="thin" />
+	<label data-l10n-id="preferences-file-renaming-instructions-example" data-l10n-args='{"example": "{{ title truncate=\"50\" }}"}' />
+	<separator class="thin" />
+	<label data-l10n-id="preferences-file-renaming-instructions-more">
+		<label
+			is="zotero-text-link"
+			href="https://www.zotero.org/support/preferences/general#file_renaming"
+			data-l10n-name="file-renaming-help-link"
+		/>
+	</label>
+	<groupbox>
+		<html:label
+			for="file-renaming-template"
+			id="file-renaming-template-label"
+		>
+			<html:h2 data-l10n-id="preferences-file-renaming-template" />
+		</html:label>
+		<html:textarea
+			aria-labelledby="file-renaming-template-label"
+			id="file-renaming-template"
+			preference="extensions.zotero.attachmentRenameTemplate"
+			rows="3"
+		/>
+		<html:label id="file-renaming-preview-label">
+			<html:h2
+				data-l10n-id="preferences-file-renaming-preview"
+			/>
+		</html:label>
+		<html:span
+			aria-labelledby="file-renaming-preview-label"
+			id="file-renaming-preview"
+		/>
+	</groupbox>
+</vbox>

--- a/chrome/content/zotero/preferences/preferences_general.xhtml
+++ b/chrome/content/zotero/preferences/preferences_general.xhtml
@@ -23,132 +23,139 @@
     ***** END LICENSE BLOCK *****
 -->
 <vbox id="zotero-prefpane-general" onload="Zotero_Preferences.General.init()">
-	<groupbox>
-		<label><html:h2>&zotero.preferences.interface;</html:h2></label>
+	<vbox class="main-section">
+		<groupbox>
+			<label><html:h2>&zotero.preferences.interface;</html:h2></label>
 
-		<hbox align="center">
-			<label value="&zotero.bibliography.locale.label;"/>
-			<menulist id="locale-menu"
-					onblur="if (!Zotero.isMac) Zotero_Preferences.General.onLocaleChange()"
-					native="true">
-				<menupopup onpopuphidden="Zotero_Preferences.General.onLocaleChange()"/>
-			</menulist>
-		</hbox>
-	</groupbox>
-
-	<groupbox id="zotero-prefpane-file-handling-groupbox">
-		<label><html:h2>&zotero.preferences.fileHandling;</html:h2></label>
-		
-		<vbox>
-			<checkbox id="automaticSnapshots-checkbox"
-				label="&zotero.preferences.automaticSnapshots;"
-				preference="extensions.zotero.automaticSnapshots"
-				native="true"/>
-			<checkbox label="&zotero.preferences.downloadAssociatedFiles;" preference="extensions.zotero.downloadAssociatedFiles" native="true"/>
-			<checkbox label="&zotero.preferences.autoRecognizeFiles;" preference="extensions.zotero.autoRecognizeFiles" native="true"/>
-			<checkbox label="&zotero.preferences.autoRenameFiles;"
-					preference="extensions.zotero.autoRenameFiles"
-					oncommand="Zotero_Preferences.General.updateAutoRenameFilesUI()" native="true"/>
-			<checkbox id="rename-linked-files" class="indented-pref"
-					label="&zotero.preferences.autoRenameFiles.renameLinked;"
-					preference="extensions.zotero.autoRenameFiles.linked"
-					oncommand="Zotero_Preferences.General.updateAutoRenameFilesUI()" native="true"/>
-		</vbox>
-		
-		<vbox>
 			<hbox align="center">
-				<label value="&zotero.preferences.fileHandler.openPDFsUsing;" control="file-handler-pdf"/>
-				<menulist id="fileHandler-pdf" class="fileHandler-menu" native="true">
-					<menupopup>
-						<menuitem id="fileHandler-internal"
-								oncommand="Zotero_Preferences.General.setFileHandler('pdf', '')"/>
-						<menuitem label="&zotero.preferences.fileHandler.systemDefault;"
-								oncommand="Zotero_Preferences.General.setFileHandler('pdf', 'system')"/>
-						<menuitem id="fileHandler-custom"/>
-						<menuitem label="&zotero.preferences.custom;"
-								oncommand="Zotero_Preferences.General.chooseFileHandler('pdf')"/>
+				<label value="&zotero.bibliography.locale.label;"/>
+				<menulist id="locale-menu"
+						onblur="if (!Zotero.isMac) Zotero_Preferences.General.onLocaleChange()"
+						native="true">
+					<menupopup onpopuphidden="Zotero_Preferences.General.onLocaleChange()"/>
+				</menulist>
+			</hbox>
+		</groupbox>
+
+		<groupbox id="zotero-prefpane-file-handling-groupbox">
+			<label><html:h2>&zotero.preferences.fileHandling;</html:h2></label>
+			
+			<vbox>
+				<checkbox id="automaticSnapshots-checkbox"
+					label="&zotero.preferences.automaticSnapshots;"
+					preference="extensions.zotero.automaticSnapshots"
+					native="true"/>
+				<checkbox label="&zotero.preferences.downloadAssociatedFiles;" preference="extensions.zotero.downloadAssociatedFiles" native="true"/>
+				<checkbox label="&zotero.preferences.autoRecognizeFiles;" preference="extensions.zotero.autoRecognizeFiles" native="true"/>
+				<checkbox label="&zotero.preferences.autoRenameFiles;"
+						preference="extensions.zotero.autoRenameFiles"
+						oncommand="Zotero_Preferences.General.updateAutoRenameFilesUI()" native="true"/>
+				<checkbox id="rename-linked-files" class="indented-pref"
+						label="&zotero.preferences.autoRenameFiles.renameLinked;"
+						preference="extensions.zotero.autoRenameFiles.linked"
+						oncommand="Zotero_Preferences.General.updateAutoRenameFilesUI()" native="true"/>
+			</vbox>
+			
+			<vbox>
+				<hbox align="center">
+					<label value="&zotero.preferences.fileHandler.openPDFsUsing;" control="file-handler-pdf"/>
+					<menulist id="fileHandler-pdf" class="fileHandler-menu" native="true">
+						<menupopup>
+							<menuitem id="fileHandler-internal"
+									oncommand="Zotero_Preferences.General.setFileHandler('pdf', '')"/>
+							<menuitem label="&zotero.preferences.fileHandler.systemDefault;"
+									oncommand="Zotero_Preferences.General.setFileHandler('pdf', 'system')"/>
+							<menuitem id="fileHandler-custom"/>
+							<menuitem label="&zotero.preferences.custom;"
+									oncommand="Zotero_Preferences.General.chooseFileHandler('pdf')"/>
+						</menupopup>
+					</menulist>
+				</hbox>
+				<checkbox id="open-reader-in-new-window" class="indented-pref"
+						label="&zotero.preferences.fileHandler.openReaderInNewWindow;"
+						preference="extensions.zotero.openReaderInNewWindow"
+						native="true"/>
+			</vbox>
+		</groupbox>
+
+		<groupbox>
+			<label><html:h2>&zotero.preferences.prefpane.locate;</html:h2></label>
+			
+			<hbox>
+				<menulist id="openurl-menu" native="true">
+					<menupopup
+							id="openurl-primary-popup"
+							onpopupshowing="Zotero_Preferences.General.handleOpenURLPopupShowing(event)"
+							oncommand="Zotero_Preferences.General.handleOpenURLSelected(event)">
+						<menuitem label="&zotero.preferences.openurl.choose;"/>
 					</menupopup>
 				</menulist>
 			</hbox>
-			<checkbox id="open-reader-in-new-window" class="indented-pref"
-					label="&zotero.preferences.fileHandler.openReaderInNewWindow;"
-					preference="extensions.zotero.openReaderInNewWindow"
-					native="true"/>
-		</vbox>
-	</groupbox>
-
-	<groupbox>
-		<label><html:h2>&zotero.preferences.prefpane.locate;</html:h2></label>
+			
+			<hbox style="display: flex; align-items: center;">
+				<label value="&zotero.preferences.openurl.server;"/>
+				<html:input type="text" id="openURLServerField" style="flex: 1;"
+					oninput="Zotero_Preferences.General.onOpenURLCustomized();"
+					preference="extensions.zotero.openURL.resolver"
+				/>
+			</hbox>
 		
-		<hbox>
-			<menulist id="openurl-menu" native="true">
-				<menupopup
-						id="openurl-primary-popup"
-						onpopupshowing="Zotero_Preferences.General.handleOpenURLPopupShowing(event)"
-						oncommand="Zotero_Preferences.General.handleOpenURLSelected(event)">
-					<menuitem label="&zotero.preferences.openurl.choose;"/>
-				</menupopup>
-			</menulist>
-		</hbox>
+			<hbox align="center">
+				<label value="&zotero.preferences.openurl.version;" control="openURLVersionMenu"/>
+				<menulist id="openURLVersionMenu"
+						oncommand="Zotero_Preferences.General.onOpenURLCustomized();"
+						preference="extensions.zotero.openURL.version"
+						native="true">
+					<menupopup>
+						<menuitem label="0.1" value="0.1"/>
+						<menuitem label="1.0" value="1.0"/>
+					</menupopup>
+				</menulist>
+			</hbox>
+		</groupbox>
 		
-		<hbox style="display: flex; align-items: center;">
-			<label value="&zotero.preferences.openurl.server;"/>
-			<html:input type="text" id="openURLServerField" style="flex: 1;"
-				oninput="Zotero_Preferences.General.onOpenURLCustomized();"
-				preference="extensions.zotero.openURL.resolver"
-			/>
-		</hbox>
-	
-		<hbox align="center">
-			<label value="&zotero.preferences.openurl.version;" control="openURLVersionMenu"/>
-			<menulist id="openURLVersionMenu"
-					oncommand="Zotero_Preferences.General.onOpenURLCustomized();"
-					preference="extensions.zotero.openURL.version"
-					native="true">
-				<menupopup>
-					<menuitem label="0.1" value="0.1"/>
-					<menuitem label="1.0" value="1.0"/>
-				</menupopup>
-			</menulist>
-		</hbox>
-	</groupbox>
-	
-	<groupbox id="zotero-prefpane-miscellaneous-groupbox">
-		<label><html:h2>&zotero.preferences.miscellaneous;</html:h2></label>
+		<groupbox id="zotero-prefpane-miscellaneous-groupbox">
+			<label><html:h2>&zotero.preferences.miscellaneous;</html:h2></label>
+			
+			<checkbox label="&zotero.preferences.automaticTags;" preference="extensions.zotero.automaticTags" native="true"/>
+			<hbox align="center">
+				<label value="&zotero.preferences.trashAutoEmptyDaysPre;"/>
+				<html:input type="text" size="2" preference="extensions.zotero.trashAutoEmptyDays"/>
+				<label value="&zotero.preferences.trashAutoEmptyDaysPost;"/>
+			</hbox>
+		</groupbox>
 		
-		<checkbox label="&zotero.preferences.automaticTags;" preference="extensions.zotero.automaticTags" native="true"/>
-		<hbox align="center">
-			<label value="&zotero.preferences.trashAutoEmptyDaysPre;"/>
-			<html:input type="text" size="2" preference="extensions.zotero.trashAutoEmptyDays"/>
-			<label value="&zotero.preferences.trashAutoEmptyDaysPost;"/>
-		</hbox>
-	</groupbox>
-	
-	<groupbox id="zotero-prefpane-reader-groupbox">
-		<label><html:h2>&zotero.preferences.pdfReader;</html:h2></label>
+		<groupbox id="zotero-prefpane-reader-groupbox">
+			<label><html:h2>&zotero.preferences.pdfReader;</html:h2></label>
+			
+			<hbox align="center">
+				<label value="&zotero.preferences.reader.tabsTitle.label;" control="reader-tabs-title"/>
+				<menulist id="reader-tabs-title" preference="extensions.zotero.tabs.title.reader" native="true">
+					<menupopup>
+						<menuitem label="&zotero.preferences.reader.tabsTitle.titleCreatorYear;" value="titleCreatorYear"/>
+						<menuitem label="&zotero.preferences.reader.tabsTitle.creatorYearTitle;" value="creatorYearTitle"/>
+						<menuitem label="&zotero.preferences.reader.tabsTitle.filename;" value="filename"/>
+					</menupopup>
+				</menulist>
+			</hbox>
+		</groupbox>
 		
-		<hbox align="center">
-			<label value="&zotero.preferences.reader.tabsTitle.label;" control="reader-tabs-title"/>
-			<menulist id="reader-tabs-title" preference="extensions.zotero.tabs.title.reader" native="true">
-				<menupopup>
-					<menuitem label="&zotero.preferences.reader.tabsTitle.titleCreatorYear;" value="titleCreatorYear"/>
-					<menuitem label="&zotero.preferences.reader.tabsTitle.creatorYearTitle;" value="creatorYearTitle"/>
-					<menuitem label="&zotero.preferences.reader.tabsTitle.filename;" value="filename"/>
-				</menupopup>
-			</menulist>
-		</hbox>
-	</groupbox>
-	
-	<groupbox>
-		<label><html:h2>&zotero.preferences.groups;</html:h2></label>
-		
-		<label value="&zotero.preferences.groups.whenCopyingInclude;"/>
-		<vbox style="margin-left: 2em">
-			<checkbox label="&zotero.preferences.groups.childNotes;" preference="extensions.zotero.groups.copyChildNotes" native="true"/>
-			<checkbox label="&zotero.preferences.groups.childFiles;" preference="extensions.zotero.groups.copyChildFileAttachments" native="true"/>
-			<checkbox label="&zotero.preferences.groups.annotations;" preference="extensions.zotero.groups.copyAnnotations" native="true"/>
-			<checkbox label="&zotero.preferences.groups.childLinks;" preference="extensions.zotero.groups.copyChildLinks" native="true"/>
-			<checkbox label="&zotero.preferences.groups.tags;" preference="extensions.zotero.groups.copyTags" native="true"/>
-		</vbox>
-	</groupbox>
+		<groupbox>
+			<label><html:h2>&zotero.preferences.groups;</html:h2></label>
+			
+			<label value="&zotero.preferences.groups.whenCopyingInclude;"/>
+			<vbox style="margin-left: 2em">
+				<checkbox label="&zotero.preferences.groups.childNotes;" preference="extensions.zotero.groups.copyChildNotes" native="true"/>
+				<checkbox label="&zotero.preferences.groups.childFiles;" preference="extensions.zotero.groups.copyChildFileAttachments" native="true"/>
+				<checkbox label="&zotero.preferences.groups.annotations;" preference="extensions.zotero.groups.copyAnnotations" native="true"/>
+				<checkbox label="&zotero.preferences.groups.childLinks;" preference="extensions.zotero.groups.copyChildLinks" native="true"/>
+				<checkbox label="&zotero.preferences.groups.tags;" preference="extensions.zotero.groups.copyTags" native="true"/>
+			</vbox>
+		</groupbox>
+	</vbox>
+	<vbox class="main-section" id="file-renaming" align="start">
+		<html:h1 data-l10n-id="preferences-file-renaming-title" />
+		<button data-l10n-id="preferences-show-file-renaming-button"
+			oncommand="Zotero_Preferences.navigateToPane('zotero-subpane-file-renaming')" />
+	</vbox>	
 </vbox>

--- a/chrome/content/zotero/preferences/preferences_general.xhtml
+++ b/chrome/content/zotero/preferences/preferences_general.xhtml
@@ -47,13 +47,6 @@
 					native="true"/>
 				<checkbox label="&zotero.preferences.downloadAssociatedFiles;" preference="extensions.zotero.downloadAssociatedFiles" native="true"/>
 				<checkbox label="&zotero.preferences.autoRecognizeFiles;" preference="extensions.zotero.autoRecognizeFiles" native="true"/>
-				<checkbox label="&zotero.preferences.autoRenameFiles;"
-						preference="extensions.zotero.autoRenameFiles"
-						oncommand="Zotero_Preferences.General.updateAutoRenameFilesUI()" native="true"/>
-				<checkbox id="rename-linked-files" class="indented-pref"
-						label="&zotero.preferences.autoRenameFiles.renameLinked;"
-						preference="extensions.zotero.autoRenameFiles.linked"
-						oncommand="Zotero_Preferences.General.updateAutoRenameFilesUI()" native="true"/>
 			</vbox>
 			
 			<vbox>
@@ -75,6 +68,28 @@
 						label="&zotero.preferences.fileHandler.openReaderInNewWindow;"
 						preference="extensions.zotero.openReaderInNewWindow"
 						native="true"/>
+			</vbox>
+		</groupbox>
+
+		<groupbox id="zotero-prefpane-file-renaming-groupbox">
+			<label><html:h2 data-l10n-id="preferences-file-renaming-title"/></label>
+			
+			<vbox align="start">
+				<label data-l10n-id="preferences-file-renaming-intro"/>
+				<separator class="thin"/>
+				<checkbox data-l10n-id="preferences-file-renaming-auto-rename-files"
+						preference="extensions.zotero.autoRenameFiles"
+						oncommand="Zotero_Preferences.General.updateAutoRenameFilesUI()" native="true"/>
+				<checkbox id="rename-linked-files" class="indented-pref"
+						label="&zotero.preferences.autoRenameFiles.renameLinked;"
+						preference="extensions.zotero.autoRenameFiles.linked"
+						oncommand="Zotero_Preferences.General.updateAutoRenameFilesUI()" native="true"/>
+				<button id="file-renaming-button"
+					data-l10n-id="preferences-file-renaming-customize-button"
+					oncommand="Zotero_Preferences.navigateToPane('zotero-subpane-file-renaming')"/>
+				<!-- data-search-strings="
+						preferences-file-renaming-format-title,
+						preferences-file-renaming-format-template" -->
 			</vbox>
 		</groupbox>
 
@@ -153,9 +168,4 @@
 			</vbox>
 		</groupbox>
 	</vbox>
-	<vbox class="main-section" id="file-renaming" align="start">
-		<html:h1 data-l10n-id="preferences-file-renaming-title" />
-		<button data-l10n-id="preferences-show-file-renaming-button"
-			oncommand="Zotero_Preferences.navigateToPane('zotero-subpane-file-renaming')" />
-	</vbox>	
 </vbox>

--- a/chrome/content/zotero/preferences/preferences_sync_reset.xhtml
+++ b/chrome/content/zotero/preferences/preferences_sync_reset.xhtml
@@ -1,4 +1,4 @@
-<vbox class="main-section" id="sync-reset" onload="Zotero_Preferences.Sync.initResetPane()">
+<vbox class="main-section subpane" id="sync-reset" onload="Zotero_Preferences.Sync.initResetPane()">
 	<html:h1>&zotero.preferences.sync.reset;</html:h1>
 
 	<!-- This doesn't wrap without an explicit width, for some reason -->

--- a/chrome/content/zotero/xpcom/preferencePanes.js
+++ b/chrome/content/zotero/xpcom/preferencePanes.js
@@ -81,6 +81,15 @@ Zotero.PreferencePanes = {
 			scripts: ['chrome://zotero/content/preferences/preferences_sync.js'],
 			defaultXUL: true,
 			helpURL: 'https://www.zotero.org/support/preferences/sync#reset',
+		},
+		{
+			id: 'zotero-subpane-file-renaming',
+			parent: 'zotero-prefpane-general',
+			label: '',
+			src: 'chrome://zotero/content/preferences/preferences_file_renaming.xhtml',
+			scripts: ['chrome://zotero/content/preferences/preferences_file_renaming.js'],
+			defaultXUL: true,
+			helpURL: null,
 		}
 	]),
 

--- a/chrome/locale/en-US/zotero/preferences.dtd
+++ b/chrome/locale/en-US/zotero/preferences.dtd
@@ -15,7 +15,6 @@
 <!ENTITY zotero.preferences.automaticSnapshots			"Automatically take snapshots when creating items from web pages">
 <!ENTITY zotero.preferences.downloadAssociatedFiles		"Automatically attach associated PDFs and other files when saving items">
 <!ENTITY zotero.preferences.autoRecognizeFiles        "Automatically retrieve metadata for PDFs">
-<!ENTITY zotero.preferences.autoRenameFiles     "Automatically rename attachment files using parent metadata">
 <!ENTITY zotero.preferences.autoRenameFiles.renameLinked  "Rename linked files">
 <!ENTITY zotero.preferences.fileHandler.openPDFsUsing "Open PDFs using">
 <!ENTITY zotero.preferences.fileHandler.systemDefault "System Default">

--- a/chrome/locale/en-US/zotero/preferences.ftl
+++ b/chrome/locale/en-US/zotero/preferences.ftl
@@ -1,10 +1,17 @@
 preferences-window =
     .title = { -app-name } Settings
 
-preferences-show-file-renaming-button = Show File Renaming Options
+
 preferences-file-renaming-title = File Renaming
-preferences-file-renaming-template = Rename Template:
-preferences-file-renaming-preview = Preview:
-preferences-file-renaming-instructions = Zotero automatically renames attached files saved from translators. This setting controls how those names are formatted.
-preferences-file-renaming-instructions-example = For example “{ $example }” in this template will be replaced with the title of an item, truncated at 50 characters.
-preferences-file-renaming-instructions-more = See the <label data-l10n-name="file-renaming-help-link">documentation</label> for more information.
+preferences-file-renaming-intro = { -app-name } automatically renames downloaded files based on the details of the parent item (title, author, etc.). You can choose to rename files added from your computer as well.
+preferences-file-renaming-auto-rename-files =
+    .label = Automatically rename locally added files
+preferences-file-renaming-customize-button =
+    .label = Customize Filename Format…
+
+preferences-file-renaming-format-title = Filename Format
+preferences-file-renaming-format-instructions = You can customize the filename pattern { -app-name } uses to rename attachment files from parent metadata.
+preferences-file-renaming-format-instructions-example = For example, “{ $example }” in this template will be replaced with the title of the parent item, truncated at 50 characters.
+preferences-file-renaming-format-instructions-more = See the <label data-l10n-name="file-renaming-format-help-link">documentation</label> for more information.
+preferences-file-renaming-format-template = Filename Template:
+preferences-file-renaming-format-preview = Preview:

--- a/chrome/locale/en-US/zotero/preferences.ftl
+++ b/chrome/locale/en-US/zotero/preferences.ftl
@@ -1,2 +1,10 @@
 preferences-window =
     .title = { -app-name } Settings
+
+preferences-show-file-renaming-button = Show File Renaming Options
+preferences-file-renaming-title = File Renaming
+preferences-file-renaming-template = Rename Template:
+preferences-file-renaming-preview = Preview:
+preferences-file-renaming-instructions = Zotero automatically renames attached files saved from translators. This setting controls how those names are formatted.
+preferences-file-renaming-instructions-example = For example “{ $example }” in this template will be replaced with the title of an item, truncated at 50 characters.
+preferences-file-renaming-instructions-more = See the <label data-l10n-name="file-renaming-help-link">documentation</label> for more information.

--- a/chrome/skin/default/zotero/preferences.css
+++ b/chrome/skin/default/zotero/preferences.css
@@ -568,6 +568,27 @@ button {
 	margin-bottom: .5em;
 }
 
+#zotero-prefpane-file-renaming label:not([is=zotero-text-link]),
+#zotero-prefpane-file-renaming div {
+	display: block;
+}
+
+#file-renaming-template {
+	width: 100%;
+	min-height: 1.25em;
+	padding: 0.25em;
+}
+
+#file-renaming-preview {
+	width: 100%;
+	padding: 0.25em;
+	font-family: monospace;
+}
+
+#file-renaming button {
+	font-size: 14px;
+}
+
 
 /* BEGIN 2X BLOCK -- DO NOT EDIT MANUALLY -- USE 2XIZE */
 @media (min-resolution: 1.25dppx) {

--- a/chrome/skin/default/zotero/preferences.css
+++ b/chrome/skin/default/zotero/preferences.css
@@ -115,11 +115,16 @@
 }
 
 h1 {
-	margin: 0 0 4px 0;
+	margin: 0 0 12px 0;
 	font-size: 1.3em;
 	font-weight: normal;
 }
 
+.header {
+	margin-bottom: 8px;
+}
+
+/* Headers in subsections */
 .main-section {
 	margin-bottom: 16px;
 }
@@ -133,6 +138,10 @@ h1 {
 groupbox > label > h2, groupbox > * > label > h2 {
 	border-bottom: none;
 	font-weight: bold;
+}
+
+groupbox:first-of-type label > h2 {
+	margin-top: .5em !important;
 }
 
 /* Space out sections */
@@ -271,6 +280,29 @@ button {
 
 .fileHandler-menu .menulist-icon {
 	height: 16px;
+}
+
+/* File Renaming tab */
+#file-renaming-customize-button {
+	margin-top: .6em;
+}
+
+#zotero-prefpane-file-renaming-format label:not([is=zotero-text-link]) {
+	display: block;
+}
+
+#file-renaming-format-template {
+	width: 100%;
+	min-height: 1.25em;
+	padding: 0.4em;
+	/* Match label margins */
+	margin-block: 1px 2px;
+	margin-inline: 6px 5px;
+}
+
+#file-renaming-format-preview {
+	width: 100%;
+	padding: 0.4em;
 }
 
 /*
@@ -566,27 +598,6 @@ button {
 	text-align: right;
 	margin-top: 1em;
 	margin-bottom: .5em;
-}
-
-#zotero-prefpane-file-renaming label:not([is=zotero-text-link]),
-#zotero-prefpane-file-renaming div {
-	display: block;
-}
-
-#file-renaming-template {
-	width: 100%;
-	min-height: 1.25em;
-	padding: 0.25em;
-}
-
-#file-renaming-preview {
-	width: 100%;
-	padding: 0.25em;
-	font-family: monospace;
-}
-
-#file-renaming button {
-	font-size: 14px;
 }
 
 


### PR DESCRIPTION
This PR adds input box to edit `extensions.zotero.attachmentRenameFormatString` preference, including a preview for how a currently selected item would be used to derive a file name. If no item is selected, preview will use a mocked item.

`helpURL` is set to a [section](https://www.zotero.org/support/preferences/general#file_renaming) on a support page that does not yet exist. I'm happy to write a couple of paragraphs explaining how this works.

![Screenshot 2023-07-25 at 18 49 02](https://github.com/zotero/zotero/assets/214628/b6f41c0f-820c-4d36-b69d-7962df9514f7)
