### PR TITLE
trash functionality for collections

### DIFF
--- a/chrome/content/zotero/collectionTree.jsx
+++ b/chrome/content/zotero/collectionTree.jsx
@@ -750,10 +750,18 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 				// If collection isn't currently visible and it isn't in the trash (because it was
 				// undeleted), add it (if possible without opening any containers)
 				else if (!collection.deleted) {
-					await this._addSortedRow('collection', id);
-					// Invalidate parent in case it's become non-empty
 					let parentRow = this.getRowIndexByID("C" + collection.parentID);
-					if (parentRow !== false) {
+					if (!parentRow || this.isContainerOpen(parentRow)) {
+						// When no parentRow or it's already opened, add the sorted row
+						await this._addSortedRow('collection', id, 'T' + collection.libraryID);
+					}
+					else {
+						// Otherwise, open it and invalidate - new collection will be added
+						// by forceUpdate
+						if(!this.isContainerOpen(parentRow)) {
+							await this.toggleOpenState(parentRow);
+						}
+						// Invalidate parent in case it's become non-empty
 						this.tree.invalidateRow(parentRow);
 					}
 				}
@@ -1066,7 +1074,7 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 	async deleteSelection(deleteItems) {
 		var treeRow = this.getRow(this.selection.focused);
 		if (treeRow.isCollection() || treeRow.isFeed()) {
-			await treeRow.ref.eraseTx({ deleteItems });
+			await treeRow.ref.eraseTx({ deleteItems, skipUnload: treeRow.isCollection() });
 		}
 		else if (treeRow.isSearch()) {
 			await Zotero.Searches.erase(treeRow.ref.id);
@@ -2342,9 +2350,10 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 	 *
 	 * @param {String} objectType
 	 * @param {Integer} id - collectionID
+	 * @param {String} moveToID - optional ID of collectionTree entry to select after row is added
 	 * @return {Integer|false} - Index at which the row was added, or false if it wasn't added
 	 */
-	async _addSortedRow(objectType, id) {
+	async _addSortedRow(objectType, id, moveToID) {
 		let beforeRow;
 		if (objectType == 'collection') {
 			let collection = await Zotero.Collections.getAsync(id);
@@ -2463,7 +2472,10 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 				beforeRow
 			);
 		}
-
+		if (moveToID) {
+			this.selectByID(moveToID);
+			return beforeRow;
+		}
 		let moveSelect = beforeRow + 1;
 		if (moveSelect <= this.selection.focused) {
 			while (!this.isSelectable(moveSelect)) {

--- a/chrome/content/zotero/components/icons.jsx
+++ b/chrome/content/zotero/components/icons.jsx
@@ -155,7 +155,7 @@ i('TreeitemTvBroadcast', 'chrome://zotero/skin/treeitem-tvBroadcast.png', false)
 i('TreeitemVideoRecording', 'chrome://zotero/skin/treeitem-videoRecording.png', false);
 i('TreeitemWebpageGray', 'chrome://zotero/skin/treeitem-webpage-gray.png');
 i('TreeitemWebpage', 'chrome://zotero/skin/treeitem-webpage.png');
-
+i('TreeitemCollection', 'chrome://zotero/skin/treesource-collection.png', false);
 // Treesource
 i('TreesourceBucket', 'chrome://zotero/skin/treesource-bucket.png', false);
 i('TreesourceCollection', 'chrome://zotero/skin/treesource-collection.png');

--- a/chrome/content/zotero/xpcom/collectionTreeRow.js
+++ b/chrome/content/zotero/xpcom/collectionTreeRow.js
@@ -269,6 +269,22 @@ Zotero.CollectionTreeRow.prototype.getChildren = function () {
 	}
 }
 
+// Returns the list of deleted collections in the trash.
+// Subcollections of deleted collections are filtered out.
+Zotero.CollectionTreeRow.prototype.getTrashedCollections = Zotero.Promise.coroutine(function* ()
+{
+	if (!this.isTrash()) {
+		return [];
+	}
+	const deleted = Zotero.Collections.getLoaded().filter(d => d.deleted);
+
+	const deletedParents = new Set();
+	for (let d of deleted) {
+		deletedParents.add(d.key);
+	}
+	return deleted.filter(d => !d._parentKey || !deletedParents.has(d._parentKey));
+})
+
 Zotero.CollectionTreeRow.prototype.getItems = Zotero.Promise.coroutine(function* ()
 {
 	switch (this.type) {

--- a/chrome/content/zotero/xpcom/data/collections.js
+++ b/chrome/content/zotero/xpcom/data/collections.js
@@ -41,7 +41,7 @@ Zotero.Collections = function() {
 		synced: "O.synced",
 		
 		deleted: "DC.collectionID IS NOT NULL AS deleted",
-		
+		dateDeleted: "DC.dateDeleted",
 		parentID: "O.parentCollectionID AS parentID",
 		parentKey: "CP.key AS parentKey",
 		

--- a/chrome/content/zotero/xpcom/data/dataObject.js
+++ b/chrome/content/zotero/xpcom/data/dataObject.js
@@ -1254,7 +1254,7 @@ Zotero.DataObject.prototype.erase = Zotero.Promise.coroutine(function* (options 
 		Zotero.debug((new Error).stack, 2);
 		env.options.tx = true;
 	}
-	
+
 	let proceed = yield this._initErase(env);
 	if (!proceed) return false;
 	
@@ -1303,10 +1303,12 @@ Zotero.DataObject.prototype._finalizeErase = Zotero.Promise.coroutine(function* 
 			this.objectType, this._libraryID, this._key
 		);
 	}
-	
-	Zotero.DB.addCurrentCallback("commit", function () {
-		this.ObjectsClass.unload(env.deletedObjectIDs || this.id);
-	}.bind(this));
+
+	if (!env.options.skipUnload) {
+		Zotero.DB.addCurrentCallback("commit", function () {
+			this.ObjectsClass.unload(env.deletedObjectIDs || this.id);
+		}.bind(this));
+	}
 	
 	if (env.options.skipDeleteLog) {
 		env.notifierData[this.id].skipDeleteLog = true;

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -125,7 +125,7 @@ Zotero.defineProperty(Zotero.Item.prototype, 'itemID', {
 	enumerable: false
 });
 
-for (let name of ['libraryID', 'key', 'dateAdded', 'dateModified', 'version', 'synced',
+for (let name of ['libraryID', 'key', 'dateAdded', 'dateModified', 'dateDeleted', 'version', 'synced',
 		'createdByUserID', 'lastModifiedByUserID']) {
 	let prop = '_' + name;
 	Zotero.defineProperty(Zotero.Item.prototype, name, {
@@ -665,6 +665,7 @@ Zotero.Item.prototype.setField = function(field, value, loadIn) {
 				break;
 			
 			case 'dateAdded':
+			case 'dateDeleted':
 			case 'dateModified':
 				// Accept ISO dates
 				if (Zotero.Date.isISODate(value)) {

--- a/chrome/content/zotero/xpcom/data/items.js
+++ b/chrome/content/zotero/xpcom/data/items.js
@@ -57,6 +57,7 @@ Zotero.Items = function() {
 				sortCreator: _getSortCreatorSQL(),
 				
 				deleted: "DI.itemID IS NOT NULL AS deleted",
+				dateDeleted: "DI.dateDeleted",
 				inPublications: "PI.itemID IS NOT NULL AS inPublications",
 				
 				parentID: `(CASE O.itemTypeID `
@@ -1482,6 +1483,13 @@ Zotero.Items = function() {
 			let parentItem = yield Zotero.Items.getAsync(parentItemID);
 			yield parentItem.reload(['primaryData', 'childItems'], true);
 		}
+
+		// After item moved to trash, we need to have its deletedDate to know
+		// which collection if any it was deleted with. To get deledateDate, need this reload
+		for (let item of items) {
+			yield item.reload(['primaryData'], true);
+		};
+
 		Zotero.Notifier.queue('modify', 'item', ids);
 		Zotero.Notifier.queue('trash', 'item', ids);
 		Array.from(libraryIDs).forEach(libraryID => {


### PR DESCRIPTION
When a collection is deleted, it goes to trash where it shows up among deleted items. Subcollections of a deleted collection go to trash as well.
Subcollections of a deleted collection do not show up in trash - only top-most collection does.
When a collection is deleted or restored, its children (items + subcollections) are deleted or restored in case if they were moved to trash at the same time as the collection. On select of a collection in the trash, the context pane displays a message with the number of subcollections and items that were moved to trash at the same time with the specified collection.