### PR TITLE
option to set primary attachment for item

### DIFF
--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -1287,6 +1287,18 @@ Zotero.Item.prototype.addRelatedItem = function (item) {
 	return this.addRelation(Zotero.Relations.relatedItemPredicate, Zotero.URI.getItemURI(item));
 }
 
+/**
+ * Removes primary attachment relations of this item if it exists.
+ */
+Zotero.Item.prototype._removePrimaryAttachmentRelation = async function (env) {
+	let primaryAttachmentFor = (await Zotero.Relations.getByPredicateAndObject(
+		'item', Zotero.Relations.primaryAttachmentPredicate, this.key
+	))[0];
+	if (primaryAttachmentFor) {
+		primaryAttachmentFor.removeRelation(Zotero.Relations.primaryAttachmentPredicate, this.key);
+		await primaryAttachmentFor.save({ skipEditCheck: env.options.skipEditCheck, skipDateModifiedUpdate: true });
+	}
+}
 
 /**
  * @param {Zotero.Item}
@@ -1580,6 +1592,11 @@ Zotero.Item.prototype._saveData = Zotero.Promise.coroutine(function* (env) {
 	if (this._changed.parentKey) {
 		if (parentItemKey && parentItemKey == this.key) {
 			throw new Error("Item cannot be set as parent of itself");
+		}
+		// If the file is moved, make sure the primary file relation
+		// of this file is removed.
+		if (this.isFileAttachment()) {
+			yield this._removePrimaryAttachmentRelation(env);
 		}
 		
 		// Make sure parent is a regular item
@@ -3807,7 +3824,11 @@ Zotero.Item.prototype.getAttachments = function(includeTrashed) {
 	
 	var cacheKey = (Zotero.Prefs.get('sortAttachmentsChronologically') ? 'chronological' : 'alphabetical')
 		+ 'With' + (includeTrashed ? '' : 'out') + 'Trashed';
-	
+
+	let primaryAttachmentKey = this.getRelationsByPredicate(Zotero.Relations.primaryAttachmentPredicate)[0];
+	if (primaryAttachmentKey) {
+		cacheKey += `_primary=${primaryAttachmentKey}`;
+	}
 	if (this._attachments[cacheKey]) {
 		return this._attachments[cacheKey];
 	}
@@ -3823,15 +3844,22 @@ Zotero.Item.prototype.getAttachments = function(includeTrashed) {
 		rows.sort((a, b) => collation.compareString(1, a.title, b.title));
 	}
 	var ids = rows.map(row => row.itemID);
+	// If there is a primary attachment for this item, move it to the
+	// top of the array
+	if (primaryAttachmentKey) {
+		let primaryAttachment = Zotero.Items.getByLibraryAndKey(this.libraryID, primaryAttachmentKey);
+		ids = ids.filter(id => id !== primaryAttachment.id);
+		ids.unshift(primaryAttachment.id);
+	}
 	this._attachments[cacheKey] = ids;
 	return ids;
 }
 
 
 /**
- * Looks for attachment in the following order: oldest PDF attachment matching parent URL,
- * oldest non-PDF attachment matching parent URL, oldest PDF attachment not matching URL,
- * old non-PDF attachment not matching URL
+ * Looks for attachment in the following order: oattachment marked as a primary attachment,
+ * oldest PDF attachment matching parent URL, oldest non-PDF attachment matching parent URL,
+ * oldest PDF attachment not matching URL, old non-PDF attachment not matching URL
  *
  * @return {Promise<Zotero.Item|FALSE>} - A promise for attachment item or FALSE if none
  */
@@ -3849,9 +3877,9 @@ Zotero.Item.prototype.getBestAttachment = Zotero.Promise.coroutine(function* () 
 
 
 /**
- * Looks for attachment in the following order: oldest PDF attachment matching parent URL,
- * oldest PDF attachment not matching parent URL, oldest non-PDF attachment matching parent URL,
- * old non-PDF attachment not matching parent URL
+ * Looks for attachment in the following order: attachment marked as a primary attachment,
+ * oldest PDF attachment matching parent URL, oldest PDF attachment not matching parent URL,
+ * oldest non-PDF attachment matching parent URL, old non-PDF attachment not matching parent URL
  *
  * @return {Promise<Zotero.Item[]>} - A promise for an array of Zotero items
  */
@@ -3862,13 +3890,14 @@ Zotero.Item.prototype.getBestAttachments = Zotero.Promise.coroutine(function* ()
 	
 	var url = this.getField('url');
 	var urlFieldID = Zotero.ItemFields.getID('url');
-	
+	var primaryAttachmentPredicateID = Zotero.RelationPredicates.getID('zotero:primaryAttachment');
 	var sql = "SELECT IA.itemID FROM itemAttachments IA NATURAL JOIN items I "
 		+ `LEFT JOIN itemData ID ON (IA.itemID=ID.itemID AND fieldID=${urlFieldID}) `
 		+ "LEFT JOIN itemDataValues IDV ON (ID.valueID=IDV.valueID) "
+		+ `LEFT JOIN itemRelations IR ON (IA.parentItemID = IR.itemID AND IR.predicateID = ${primaryAttachmentPredicateID} AND I.key = IR.object)`
 		+ `WHERE parentItemID=? AND linkMode NOT IN (${Zotero.Attachments.LINK_MODE_LINKED_URL}) `
 		+ "AND IA.itemID NOT IN (SELECT itemID FROM deletedItems) "
-		+ "ORDER BY contentType='application/pdf' DESC, value=? DESC, dateAdded ASC";
+		+ "ORDER BY (IR.predicateID IS NOT NULL) DESC, contentType='application/pdf' DESC, value=? DESC, dateAdded ASC";
 	var itemIDs = yield Zotero.DB.columnQueryAsync(sql, [this.id, url]);
 	return this.ObjectsClass.get(itemIDs);
 });
@@ -5068,6 +5097,7 @@ Zotero.Item.prototype._eraseData = Zotero.Promise.coroutine(function* (env) {
 			if (id) {
 				yield Zotero.SyncedSettings.clear(Zotero.Libraries.userLibraryID, id);
 			}
+			yield this._removePrimaryAttachmentRelation(env);
 		}
 		
 		// Zotero.Sync.EventListeners.ChangeListener needs to know if this was a storage file

--- a/chrome/content/zotero/xpcom/data/relations.js
+++ b/chrome/content/zotero/xpcom/data/relations.js
@@ -29,6 +29,7 @@ Zotero.Relations = new function () {
 	Zotero.defineProperty(this, 'relatedItemPredicate', {value: 'dc:relation'});
 	Zotero.defineProperty(this, 'linkedObjectPredicate', {value: 'owl:sameAs'});
 	Zotero.defineProperty(this, 'replacedItemPredicate', {value: 'dc:replaces'});
+	Zotero.defineProperty(this, 'primaryAttachmentPredicate', { value: 'zotero:primaryAttachment' });
 	
 	this._namespaces = {
 		dc: 'http://purl.org/dc/elements/1.1/',

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -3560,6 +3560,7 @@ var ZoteroPane = new function()
 			'sep3',
 			'toggleRead',
 			'changeParentItem',
+			'markAsPrimaryAttachment',
 			'addToCollection',
 			'removeItems',
 			'duplicateAndConvert',
@@ -3836,6 +3837,17 @@ var ZoteroPane = new function()
 						if (!item.isTopLevelItem() && item.attachmentLinkMode != Zotero.Attachments.LINK_MODE_LINKED_URL) {
 							show.add(m.renameAttachments);
 							showSep5 = true;
+						}
+
+						// Set/Unset as a Primary Attachment
+						if (!item.isTopLevelItem()) {
+							show.add(m.markAsPrimaryAttachment);
+
+							let parent = Zotero.Items.get(item.parentID);
+							let existingPrimaryAttachmentRelation = parent.getRelationsByPredicate(Zotero.Relations.primaryAttachmentPredicate)[0];
+							let isSelectedPrimaryAttachment = existingPrimaryAttachmentRelation === item.key;
+							let primaryAttachmentMenu = menu.childNodes[m.markAsPrimaryAttachment];
+							primaryAttachmentMenu.dataset.l10nArgs = `{ "type": "${isSelectedPrimaryAttachment ? "unset" : "set"}" }`;
 						}
 						
 						// If not linked URL, show reindex line
@@ -6094,6 +6106,33 @@ var ZoteroPane = new function()
 		}
 	};
 
+	this.toggleSelectedItemAsPrimaryAttachment = async function () {
+		if (!this.canEdit() || !this.canEditFiles()) {
+			this.displayCannotEditLibraryMessage();
+			return;
+		}
+		var items = this.getSelectedItems();
+
+		if (items.length !== 1 || items[0].isTopLevelItem() || !items[0].isFileAttachment()) {
+			return;
+		}
+		let item = items[0];
+
+		// Check if attachment's parent already has a relation to this item.
+		// If yes - we need to remove it. Otherwise, create a new relation.
+		let parent = await Zotero.Items.getAsync(item.parentItemID);
+		let existingPrimaryAttachment = parent.getRelationsByPredicate(Zotero.Relations.primaryAttachmentPredicate)[0];
+
+		if (existingPrimaryAttachment !== item.key) {
+			let updatedRelations = parent.getRelations();
+			updatedRelations[Zotero.Relations.primaryAttachmentPredicate] = item.key;
+			parent.setRelations(updatedRelations);
+		}
+		else {
+			parent.removeRelation(Zotero.Relations.primaryAttachmentPredicate, item.key);
+		}
+		await parent.saveTx({ skipDateModifiedUpdate: true });
+	};
 
 	/**
 	 * Attempt to find a file in the LABD matching the passed attachment

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -974,6 +974,7 @@
 			<menuseparator/>
 			<menuitem class="menuitem-iconic zotero-menuitem-toggle-read-item" oncommand="ZoteroPane_Local.toggleSelectedItemsRead();"/>
 			<menuitem class="menuitem-iconic zotero-menuitem-change-top-level-item" data-l10n-id="item-menu-change-parent-item" oncommand="ZoteroPane_Local.changeParentItem();"/>
+			<menuitem class="menuitem-iconic zotero-menuitem-mark-as-primary-attachment" data-l10n-id="item-menu-mark-as-primary-attachment" oncommand="ZoteroPane.toggleSelectedItemAsPrimaryAttachment()"/>
 			<menu class="menu-iconic zotero-menuitem-add-to-collection">
 				<menupopup id="zotero-add-to-collection-popup" onpopupshowing="ZoteroPane_Local.buildAddItemToCollectionMenu(event)"/>
 			</menu>

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -146,6 +146,12 @@ item-menu-add-url =
      .label = Web Link
 item-menu-change-parent-item =
      .label = Change Parent Item…
+item-menu-mark-as-primary-attachment =
+     .label = {
+        $type ->
+            [unset] Unset as Primary Attachment
+            *[set] Set as Primary Attachment
+    }
 
 view-online = View Online
 item-menu-option-view-online =

--- a/test/tests/relationsTest.js
+++ b/test/tests/relationsTest.js
@@ -64,4 +64,162 @@ describe("Zotero.Relations", function () {
 			assert.include(rels[0], "/users/2");
 		})
 	})
+
+	describe("Mark as primary attachment", function() {
+		var win, zp, item, attachmentOne, attachmentTwo;
+
+		before(async function () {
+			win = await loadZoteroPane();
+			zp = win.ZoteroPane;
+			item = await createDataObject('item');
+			
+			attachmentOne = await Zotero.Attachments.linkFromFileWithRelativePath({
+				path: 'a/b/test.pdf',
+				title: 'one.pdf',
+				parentItemID: item.id,
+				contentType: 'application/pdf'
+			});
+	
+			attachmentTwo = await Zotero.Attachments.linkFromFileWithRelativePath({
+				path: 'a/b/test.pdf',
+				title: 'two.pdf',
+				parentItemID: item.id,
+				contentType: 'application/pdf'
+			});
+		});
+
+		beforeEach(async function () {
+			item.removeRelation(Zotero.Relations.primaryAttachmentPredicate, attachmentOne.key);
+			item.removeRelation(Zotero.Relations.primaryAttachmentPredicate, attachmentTwo.key);
+			await item.saveTx();
+		});
+
+		after(function () {
+			win.close();
+		});
+
+		it("should mark attachment as primary", async function () {
+			let defaultBestAttachment = await item.getBestAttachment();
+			assert.equal(defaultBestAttachment.id, attachmentOne.id);
+
+			// Make second attachment primary one
+			await zp.selectItem(attachmentTwo.id);
+			await zp.toggleSelectedItemAsPrimaryAttachment();
+
+			// Make sure now the second attachment is now the primary one
+			defaultBestAttachment = await item.getBestAttachment();
+			assert.equal(defaultBestAttachment.id, attachmentTwo.id);
+		});
+
+		it("should remove relation from previous primary attachment", async function () {
+			// Mark first attachment as the primary one
+			await zp.selectItem(attachmentOne.id);
+			await zp.toggleSelectedItemAsPrimaryAttachment();
+			let defaultBestAttachment = await item.getBestAttachment();
+			assert.equal(defaultBestAttachment.id, attachmentOne.id);
+
+			// Then mark the second attachment as primary
+			await zp.selectItem(attachmentTwo.id);
+			await zp.toggleSelectedItemAsPrimaryAttachment();
+
+			// Make sure now the best attachment is now the primary one
+			defaultBestAttachment = await item.getBestAttachment();
+			assert.equal(defaultBestAttachment.id, attachmentTwo.id);
+
+			// Make sure the relation was removed from the first attachment
+			let relations = attachmentOne.getRelations();
+			assert.notProperty(relations, Zotero.Relations.primaryAttachmentPredicate);
+		});
+
+		it("should toggle only primaryAttachment relation", async function () {
+			const dcRelation = "http://zotero.org/users/1/items/SHREREMS";
+			const sameAs = "http://zotero.org/groups/1/items/SRRMGSRM";
+			// Parent has some relations
+			item.setRelations({
+				"dc:relation": [
+					dcRelation
+				],
+				"owl:sameAs": [
+					sameAs,
+				]
+			});
+			await item.saveTx();
+
+			// Make attachment one the primary one
+			await zp.selectItem(attachmentOne.id);
+			await zp.toggleSelectedItemAsPrimaryAttachment();
+
+			// Make sure old relations are there with the new one
+			let relations = item.getRelations();
+			assert.equal(relations["dc:relation"][0], dcRelation);
+			assert.equal(relations["owl:sameAs"][0], sameAs);
+			assert.equal(relations[Zotero.Relations.primaryAttachmentPredicate], attachmentOne.key);
+
+
+			// Toggle again
+			await zp.selectItem(attachmentOne.id);
+			await zp.toggleSelectedItemAsPrimaryAttachment();
+
+			// Make sure old relations are there
+			relations = item.getRelations();
+			assert.equal(relations["dc:relation"][0], dcRelation);
+			assert.equal(relations["owl:sameAs"][0], sameAs);
+			// Primary attachment relation removed
+			assert.notProperty(relations, Zotero.Relations.primaryAttachmentPredicate);
+		});
+
+		it("should ignore primary attachment relations to trashed items", async function () {
+			let defaultBestAttachment = await item.getBestAttachment();
+			assert.equal(defaultBestAttachment.id, attachmentOne.id);
+	
+			// Make second attachment the primary one
+			await zp.selectItem(attachmentTwo.id);
+			await zp.toggleSelectedItemAsPrimaryAttachment();
+
+			// And delete it
+			attachmentTwo.deleted = true;
+			await attachmentTwo.saveTx();
+
+			// Make sure the best attachment is still the first one
+			var newBestAttachment = await item.getBestAttachment();
+			assert.equal(newBestAttachment.id, attachmentOne.id);
+
+			// Un-delete it
+			attachmentTwo.deleted = false;
+			await attachmentTwo.saveTx();
+
+			// Make sure the best attachment is now the second one
+			newBestAttachment = await item.getBestAttachment();
+			assert.equal(newBestAttachment.id, attachmentTwo.id);
+		});
+
+		it("should delete primary attachment relations when attachment is moved to another parent or deleted", async function () {
+			// Make second attachment the primary one
+			await zp.selectItem(attachmentTwo.id);
+			await zp.toggleSelectedItemAsPrimaryAttachment();
+			
+			let itemTwo = await createDataObject('item');
+			// Move attachment two to itemTwo
+			attachmentTwo.parentKey = itemTwo.key;
+			await attachmentTwo.saveTx();
+
+			// Assert the relations was removed from itemOne
+			let relations = item.getRelations();
+			assert.notProperty(relations, Zotero.Relations.primaryAttachmentPredicate);
+
+			// Make second attachment the primary one for itemTwo
+			await zp.selectItem(attachmentTwo.id);
+			await zp.toggleSelectedItemAsPrimaryAttachment();
+
+			// Make sure itemTwo has primary attachment relation
+			let itemTwoRelations = itemTwo.getRelations();
+			assert.equal(itemTwoRelations[Zotero.Relations.primaryAttachmentPredicate], attachmentTwo.key);
+
+			await attachmentTwo.eraseTx();
+
+			// Make sure the relation is now gone
+			itemTwoRelations = itemTwo.getRelations();
+			assert.notProperty(itemTwoRelations, Zotero.Relations.primaryAttachmentPredicate);
+		});
+	});
 })


### PR DESCRIPTION
Tool -> Manage Attachments has a menu item to set an attachment as a primary file by adding a relation to the parent item with attachment's itemID as the object.
Primary attachment will be opened next time on click on the item. If the primary attachment is moved to trash, it is ignored. When a primary attachment is deleted or moved to another parent, the relation is deleted.
getAttachments() function sorts attachments, and if there is a primary attachment, it is moved to the top of the list.

Fixes: #355
Fixes: #1715