### PR TITLE
Accessibility and tab-navigation updates

### DIFF
--- a/chrome/content/zotero/contextPane.js
+++ b/chrome/content/zotero/contextPane.js
@@ -916,6 +916,7 @@ var ZoteroContextPane = new function () {
 		// tabbox
 		var tabbox = document.createXULElement('tabbox');
 		tabbox.setAttribute('flex', '1');
+		tabbox.setAttribute('role', 'tablist');
 		tabbox.className = 'zotero-view-tabbox';
 
 		container.append(tabbox);
@@ -948,6 +949,7 @@ var ZoteroContextPane = new function () {
 		var panelInfo = document.createXULElement('tabpanel');
 		panelInfo.setAttribute('flex', '1');
 		panelInfo.className = 'zotero-editpane-item-box';
+		panelInfo.setAttribute("role", "tabpanel");
 		var itemBox = new (customElements.get('item-box'));
 		itemBox.setAttribute('flex', '1');
 		panelInfo.append(itemBox);

--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -94,7 +94,7 @@
 					</div>
 					<table id="info-table">
 						<tr>
-							<th><label class="key">&zotero.items.itemType;</label></th>
+							<th><label class="key" id="itembox-field-itemType-label" >&zotero.items.itemType;</label></th>
 						</tr>
 					</table>
 				</div>
@@ -589,6 +589,7 @@
 					let label = document.createElement('label');
 					label.className = 'key';
 					label.textContent = prefix + Zotero.ItemFields.getLocalizedString(fieldName);
+					label.setAttribute("id", `itembox-field-${fieldName}-label`);
 					th.appendChild(label);
 				}
 				
@@ -822,6 +823,7 @@
 					this.itemTypeMenuTab(event);
 				}
 			});
+			menulist.setAttribute("aria-labelledby", "itembox-field-itemType-label");
 			td.appendChild(menulist);
 			this._infoTable.firstChild.appendChild(td);
 		}
@@ -1057,6 +1059,7 @@
 			var label = document.createElement('label');
 			label.className = 'key';
 			label.textContent = Zotero.ItemFields.getLocalizedString(field);
+			label.setAttribute("id", `itembox-field-${field}-label`);
 			th.appendChild(label);
 			
 			var td = document.createElement('td');
@@ -1716,6 +1719,7 @@
 			t.style.mozBoxFlex = 1;
 			t.setAttribute('fieldname', fieldName);
 			t.setAttribute('ztabindex', tabindex);
+			t.setAttribute('aria-labelledby', `itembox-field-${fieldName}-label`);
 			// We set dir in createValueElement(), so figure out what it was computed as
 			// and then propagate to the new text field
 			t.dir = getComputedStyle(elem).direction;
@@ -1938,7 +1942,7 @@
 						if (this._lastTabIndex == this._tabIndexMaxFields) {
 							return;
 						}
-						this._focusNextField(++this._lastTabIndex);
+						this._focusNextField(this._lastTabIndex + 1);
 					}
 			}
 		}
@@ -2371,6 +2375,7 @@
 					let field = tabbableFields[i];
 					let tabIndexHere = parseInt(field.getAttribute('ztabindex'));
 					if (tabIndexHere !== -1 && tabIndexHere < tabindex) {
+						this._lastTabIndex = i;
 						next = tabbableFields[i];
 						break;
 					}
@@ -2382,6 +2387,7 @@
 					let field = tabbableFields[pos];
 					let tabIndexHere = parseInt(field.getAttribute('ztabindex'));
 					if (tabIndexHere !== -1 && tabIndexHere >= tabindex) {
+						this._lastTabIndex = pos;
 						next = tabbableFields[pos];
 						break;
 					}

--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -469,7 +469,6 @@
 			}
 			if (this.showTypeMenu) {
 				this.updateItemTypeMenuSelection();
-				this.itemTypeMenu.parentNode.parentNode.style.display = 'contents';
 				this.itemTypeMenu.setAttribute('ztabindex', '0');
 			}
 			else {
@@ -901,7 +900,6 @@
 				th.appendChild(span);
 				th.setAttribute('ztabindex', tabindex);
 				th.setAttribute('role', 'button');
-				th.setAttribute('aria-describedby', 'creator-type-label-inner');
 				th.addEventListener('click', () => {
 					document.popupNode = th;
 					this._creatorTypeMenu.openPopup(th);
@@ -912,9 +910,9 @@
 			}
 			
 			var label = document.createElement("label");
-			label.setAttribute('id', 'creator-type-label-inner');
 			label.className = 'key';
 			label.textContent = Zotero.getString('creatorTypes.' + Zotero.CreatorTypes.getName(typeID));
+			th.setAttribute('aria-label', label.textContent);
 			th.appendChild(label);
 			
 			var td = document.createElement("td");
@@ -1483,10 +1481,10 @@
 			
 			// Regardless, align the text in the label consistently, following the locale's direction
 			if (Zotero.rtl) {
-				valueElement.style.textAlign = 'right';
+				valueElement.style.direction = 'rtl';
 			}
 			else {
-				valueElement.style.textAlign = 'left';
+				valueElement.style.direction = 'ltr';
 			}
 
 			if (isMultiline) {
@@ -1938,8 +1936,10 @@
 						this._focusNextField(this._lastTabIndex, true);
 					}
 					else {
-						// If on the last field, allow default tab action
+						// If on the last field, move to "New Collection" tool bar button
 						if (this._lastTabIndex == this._tabIndexMaxFields) {
+							focused.blur();
+							document.getElementById("menu_newCollection").focus();
 							return;
 						}
 						this._focusNextField(this._lastTabIndex + 1);
@@ -2359,7 +2359,7 @@
 		_focusNextField(tabindex, back) {
 			var box = this._infoTable;
 			tabindex = parseInt(tabindex);
-			
+
 			// Get all fields with ztabindex attributes
 			var tabbableFields = box.querySelectorAll('*[ztabindex]:not([disabled=true])');
 			

--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -1909,7 +1909,7 @@
 					focused.blur();
 					
 					// Return focus to items pane
-					tree = document.getElementById('zotero-items-tree');
+					tree = document.getElementById('item-tree-main-default');
 					if (tree) {
 						tree.focus();
 					}
@@ -1923,7 +1923,7 @@
 					focused.blur();
 					
 					// Return focus to items pane
-					tree = document.getElementById('zotero-items-tree');
+					tree = document.getElementById('item-tree-main-default');
 					if (tree) {
 						tree.focus();
 					}

--- a/chrome/content/zotero/elements/tagsBox.js
+++ b/chrome/content/zotero/elements/tagsBox.js
@@ -354,7 +354,7 @@
 					}
 
 					// TODO: Return focus to items pane
-					var tree = document.getElementById('zotero-items-tree');
+					var tree = document.getElementById('item-tree-main-default');
 					if (tree) {
 						tree.focus();
 					}
@@ -525,7 +525,7 @@
 					}
 					// Return focus to items pane
 					else {
-						var tree = document.getElementById('zotero-items-tree');
+						var tree = document.getElementById('item-tree-main-default');
 						if (tree) {
 							tree.focus();
 						}
@@ -542,7 +542,7 @@
 
 
 					// TODO: Return focus to items pane
-					var tree = document.getElementById('zotero-items-tree');
+					var tree = document.getElementById('item-tree-main-default');
 					if (tree) {
 						tree.focus();
 					}

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -1007,6 +1007,7 @@ class ReaderTab extends ReaderInstance {
 		this._iframe.setAttribute('flex', '1');
 		this._iframe.setAttribute('type', 'content');
 		this._iframe.setAttribute('src', 'resource://zotero/reader/reader.html');
+		this._iframe.setAttribute('aria-label', options.title || '');
 		this._tabContainer.appendChild(this._iframe);
 		this._iframe.docShell.windowDraggingAllowed = true;
 		
@@ -1073,6 +1074,7 @@ class ReaderTab extends ReaderInstance {
 	};
 
 	_setTitleValue(title) {
+		this._iframe.setAttribute('aria-label', title);
 		this._window.Zotero_Tabs.rename(this.tabID, title);
 	}
 

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -190,14 +190,13 @@ var ZoteroPane = new function()
 							// TODO: the notes are currently inaccessible to the keyboard
 						}
 						else if (tabBox.selectedIndex === 2) {
-							const tagContainer = document.getElementById("tags-box-container");
+							const tagContainer = document.getElementById("tags-box");
 							const tags = tagContainer.querySelectorAll("#tags-box-add-button,.zotero-clicky");
-							const last = tags[tags.length - 1];
-							if (last.id === "tags-box-add-button") {
-								last.focus();
+							if (tags.length == 1) {
+								tags[0].focus();
 							}
 							else {
-								last.click();
+								tags[0].click();
 							}
 						}
 						else if (tabBox.selectedIndex === 3) {

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -729,7 +729,7 @@
 							<button id="zotero-tb-toggle-notes-pane" class="toolbarButton notes" title="&zotero.toolbar.context.notes;" tabindex="-1"><span/></button>
 						</div>
 					</div>
-					<deck id="tabs-deck" flex="1">
+					<deck id="tabs-deck" flex="1" aria-role="tablist">
 						<vbox id="zotero-pane"
 							onkeydown="ZoteroPane_Local.handleKeyDown(event, this.id)"
 							onkeyup="ZoteroPane_Local.handleKeyUp(event, this.id)"
@@ -1090,26 +1090,26 @@
 												Keep in sync with contextPane.js (_addItemContext function) which
 												dynamically creates this itemPane part for each tab
 											-->
-											<tabbox id="zotero-view-tabbox" class="zotero-view-tabbox" flex="1" onselect="if (!ZoteroPane_Local.getCollectionTreeRow() || event.originalTarget.localName != 'tabpanels') { return; }; ZoteroItemPane.viewItem(ZoteroPane_Local.getSelectedItems()[0], ZoteroPane_Local.collectionsView.editable ? 'edit' : 'view', this.selectedIndex)">
+											<tabbox id="zotero-view-tabbox" role="tablist"  class="zotero-view-tabbox" flex="1" onselect="if (!ZoteroPane_Local.getCollectionTreeRow() || event.originalTarget.localName != 'tabpanels') { return; }; ZoteroItemPane.viewItem(ZoteroPane_Local.getSelectedItems()[0], ZoteroPane_Local.collectionsView.editable ? 'edit' : 'view', this.selectedIndex)">
 												<tabs id="zotero-editpane-tabs" class="zotero-editpane-tabs">
-													<tab id="zotero-editpane-info-tab" label="&zotero.tabs.info.label;"/>
-													<tab id="zotero-editpane-notes-tab" label="&zotero.tabs.notes.label;"/>
-													<tab id="zotero-editpane-tags-tab" label="&zotero.tabs.tags.label;"/>
-													<tab id="zotero-editpane-related-tab" label="&zotero.tabs.related.label;"/>
+													<tab id="zotero-editpane-info-tab" role="tab" label="&zotero.tabs.info.label;"/>
+													<tab id="zotero-editpane-notes-tab" role="tab" label="&zotero.tabs.notes.label;"/>
+													<tab id="zotero-editpane-tags-tab" role="tab" label="&zotero.tabs.tags.label;"/>
+													<tab id="zotero-editpane-related-tab" role="tab" label="&zotero.tabs.related.label;"/>
 												</tabs>
 												<tabpanels id="zotero-view-item" class="zotero-view-item" flex="1">
-													<tabpanel id="item-box-container"/>
+													<tabpanel id="item-box-container" role="tabpanel" aria-labelledby="zotero-editpane-info-tab"/>
 													
 													<tabpanel>
-														<notes-box id="zotero-editpane-notes" class="zotero-editpane-notes" flex="1"/>
+														<notes-box id="zotero-editpane-notes" class="zotero-editpane-notes" flex="1" role="tabpanel" aria-labelledby="zotero-editpane-notes-tab"/>
 													</tabpanel>
 													
 													<tabpanel>
-														<tags-box id="zotero-editpane-tags" class="zotero-editpane-tags" flex="1"/>
+														<tags-box id="zotero-editpane-tags" class="zotero-editpane-tags" flex="1" role="tabpanel" aria-labelledby="zotero-editpane-tags-tab"/>
 													</tabpanel>
 													
 													<tabpanel>
-														<related-box id="zotero-editpane-related" class="zotero-editpane-related" flex="1"/>
+														<related-box id="zotero-editpane-related" class="zotero-editpane-related" flex="1" role="tabpanel" aria-labelledby="zotero-editpane-related-tab"/>
 													</tabpanel>
 												</tabpanels>
 											</tabbox>

--- a/scss/elements/_itemBox.scss
+++ b/scss/elements/_itemBox.scss
@@ -14,25 +14,14 @@ item-box {
 	}
 
 	#info-table {
-		display: grid;
-		grid-template-columns: max-content 1fr;
-		// Make sure rows are at least --row-height tall, but no taller than their tallest child
-		// This lets rows expand for multi-line editors
-		grid-auto-rows: minmax(var(--row-height), max-content);
-		align-items: center;
 		width: 100%;
-	}
-
-	tr {
-		display: contents;
+		table-layout: fixed;
 	}
 
 	td {
-		display: flex;
 		min-width: 0;
-		align-self: stretch;
-		align-items: center;
-		margin-inline-end: 5px;
+		padding-inline-end: 5px;
+		display: flex;
 	}
 
 	td > input, .creator-name-box > input {
@@ -64,7 +53,6 @@ item-box {
 	.value {
 		min-height: 14px;
 		align-self: center;
-		padding-inline: 2px;
 	}
 
 	.value:not(.multiline) {
@@ -133,11 +121,11 @@ item-box {
 
 	/* metadata field names */
 	th {
-		display: flex;
+		width: 100px;
+		text-align: end;
+		vertical-align: top;
+		padding-top: 2px;
 		height: var(--row-height);
-		align-self: start;
-		align-items: center;
-		justify-content: end;
 		font-weight: normal;
 		margin-inline-start: 5px !important;
 		margin-inline-end: 0 !important;
@@ -186,7 +174,7 @@ item-box {
 
 		& > div:first-child[fieldMode="0"] {
 			// Cancel out padding before comma
-			margin-inline-end: -3px;
+			margin-inline-end: -1px;
 		}
 	}
 

--- a/scss/elements/_itemBox.scss
+++ b/scss/elements/_itemBox.scss
@@ -1,5 +1,5 @@
 item-box {
-	--row-height: 1.5em;
+	--row-height: 14px;
 	
 	display: flex;
 	min-width: 0;
@@ -22,6 +22,8 @@ item-box {
 		min-width: 0;
 		padding-inline-end: 5px;
 		display: flex;
+		padding-top: 0;
+		padding-bottom: 0;
 	}
 
 	td > input, .creator-name-box > input {
@@ -48,11 +50,13 @@ item-box {
 
 	td > [fieldname] {
 		width: 100%;
+		line-height: var(--row-height);
 	}
 
 	.value {
 		min-height: 14px;
 		align-self: center;
+		line-height: var(--row-height);
 	}
 
 	.value:not(.multiline) {
@@ -71,12 +75,9 @@ item-box {
 	}*/
 
 	#item-type-menu {
-		height: 1.5em !important;
-		min-height: 1.5em !important;
-		padding: 0 2px !important;
+		padding: 0;
 		margin: 0 !important;
 		margin-inline-end: 5px !important;
-		max-height: 1.5em !important;
 		flex: 1;
 
 		&::part(dropmarker) {
@@ -121,14 +122,11 @@ item-box {
 
 	/* metadata field names */
 	th {
-		width: 100px;
+		width: 110px;
 		text-align: end;
 		vertical-align: top;
-		padding-top: 2px;
 		height: var(--row-height);
 		font-weight: normal;
-		margin-inline-start: 5px !important;
-		margin-inline-end: 0 !important;
 	}
 
 	#more-creators-label
@@ -154,6 +152,7 @@ item-box {
 
 	.creator-type-label, .creator-type-value {
 		-moz-box-align: center;
+		align-items: center;
 	}
 
 	.creator-name-box {

--- a/scss/elements/_itemBox.scss
+++ b/scss/elements/_itemBox.scss
@@ -46,6 +46,7 @@ item-box {
 		margin-inline-start: 1px !important;
 		margin-inline-end: 5px !important;
 		padding: 0 2px;
+		white-space: nowrap;
 	}
 
 	td > [fieldname] {
@@ -127,6 +128,8 @@ item-box {
 		vertical-align: top;
 		height: var(--row-height);
 		font-weight: normal;
+		overflow: hidden;
+		text-overflow: ellipsis;
 	}
 
 	#more-creators-label


### PR DESCRIPTION
- Prevent multiline field from staying around and occupying space 
- Allow tab/shift-tab navigation through tags
- Added aria roles and labels to fields in itemBox to make it accessible to Wooshy and most screen readers (VoiceOver)
- CSS changes to itemBox to avoid `display:contents` and `display:grid` to make itemBox work with NVDA screen reader on windows.
- From the last filed in itemBox, move focus to `New Collection` button
- Set text direction via `style.direction` to show `...` on the correct side of the long text fields. (e.g. show `...` on the left for long text fields instead of right when `Zotero.rtl` is true.
- When ESC/Enter is pressed from items or tags pane, focus is returned to items list

Fixes: #3250
Fixes: #3334
Fixes: #3019 