### PR TITLE
Improve file renaming preview in preferences

### DIFF
--- a/chrome/content/zotero/preferences/preferences_file_renaming.js
+++ b/chrome/content/zotero/preferences/preferences_file_renaming.js
@@ -40,10 +40,7 @@ Zotero_Preferences.FileRenaming = {
 			if (selectedItem.isRegularItem() && !selectedItem.parentKey) {
 				return [selectedItem, this.defaultExt];
 			}
-			if (selectedItem.isAttachment()
-				&& selectedItem.parentKey
-				&& [Zotero.Attachments.LINK_MODE_IMPORTED_FILE, Zotero.Attachments.LINK_MODE_LINKED_FILE].includes(selectedItem.attachmentLinkMode)
-			) {
+			if (selectedItem.isFileAttachment() && selectedItem.parentKey) {
 				const path = selectedItem.getFilePath();
 				const ext = Zotero.File.getExtension(Zotero.File.pathToFile(path));
 				return [Zotero.Items.getByLibraryAndKey(selectedItem.libraryID, selectedItem.parentKey), ext ?? this.defaultExt];

--- a/chrome/content/zotero/preferences/preferences_file_renaming.js
+++ b/chrome/content/zotero/preferences/preferences_file_renaming.js
@@ -26,6 +26,7 @@
 
 Zotero_Preferences.FileRenaming = {
 	mockItem: null,
+	defaultExt: 'pdf',
 	init: function () {
 		this.inputRef = document.getElementById('file-renaming-format-template');
 		this.updatePreview();
@@ -33,11 +34,30 @@ Zotero_Preferences.FileRenaming = {
 		Zotero.getActiveZoteroPane()?.itemsView.onSelect.addListener(this.updatePreview.bind(this));
 	},
 
+	getActiveTopLevelItem() {
+		const selectedItem = Zotero.getActiveZoteroPane()?.getSelectedItems()?.[0];
+		if (selectedItem) {
+			if (selectedItem.isRegularItem() && !selectedItem.parentKey) {
+				return [selectedItem, this.defaultExt];
+			}
+			if (selectedItem.isAttachment()
+				&& selectedItem.parentKey
+				&& [Zotero.Attachments.LINK_MODE_IMPORTED_FILE, Zotero.Attachments.LINK_MODE_LINKED_FILE].includes(selectedItem.attachmentLinkMode)
+			) {
+				const path = selectedItem.getFilePath();
+				const ext = Zotero.File.getExtension(Zotero.File.pathToFile(path));
+				return [Zotero.Items.getByLibraryAndKey(selectedItem.libraryID, selectedItem.parentKey), ext ?? this.defaultExt];
+			}
+		}
+
+		return null;
+	},
+
 	updatePreview() {
-		const item = Zotero.getActiveZoteroPane()?.getSelectedItems()?.[0] ?? this.mockItem ?? this.makeMockItem();
+		const [item, ext] = this.getActiveTopLevelItem() ?? [this.mockItem ?? this.makeMockItem(), this.defaultExt];
 		const tpl = document.getElementById('file-renaming-format-template').value;
 		const preview = Zotero.Attachments.getFileBaseNameFromItem(item, tpl);
-		document.getElementById('file-renaming-format-preview').innerText = `${preview}.pdf`;
+		document.getElementById('file-renaming-format-preview').innerText = `${preview}.${ext}`;
 	},
 
 	makeMockItem() {


### PR DESCRIPTION
Addresses #3340

The new logic is:

* Take selected item (or first selected item, if more than one is selected)
* If it's a regular, top-level item, use that item, assume default extension (`.pdf`)
* Otherwise, if it's an attachment that has a parent and is either imported or a linked file, use parent item and this attachment's extension
* Otherwise fall back to the mock item and default extension


