### PR TITLE
Fix progress queue segfault

### DIFF
--- a/chrome/content/zotero/components/progressQueueTable.jsx
+++ b/chrome/content/zotero/components/progressQueueTable.jsx
@@ -68,6 +68,14 @@ const ProgressQueueTable = ({ onActivate = noop, progressQueue }) => {
 		for (let column of columns) {
 			if (column.dataKey === 'success') {
 				let span = document.createElement('span');
+				if (!span.ownerGlobal) {
+					// If this script was imported from a non-window context, we'll have a global object that looks like
+					// a Window and document.createElement() will succeed, but the returned Element object won't have
+					// an ownerGlobal. Trying to append a child or set its innerHTML will segfault Zotero. For now,
+					// let's just abort if we get an invalid Element.
+					// TODO: Remove once we're using ES modules
+					return div;
+				}
 				span.className = `cell icon ${column.className}`;
 				span.appendChild(getImageByStatus(row.status));
 				div.appendChild(span);


### PR DESCRIPTION
Crazy stuff going on here. When `require()` is invoked from a non-window context, `require.js` creates a fake window global. The fake window is window-y enough to make library code work, but nodes created under it end up with a null `ownerGlobal`, because it isn't _actually_ a window. And when a node's `ownerGlobal` is null, appending children or setting its `innerHTML` causes a segfault in the XUL process. Because `ProgressQueueTable`'s `rowToTreeItem` sometimes gets called by an event that's triggered in a non-window context, it ends up creating `ownerGlobal`-less nodes and triggering the segfault.

I tried creating the nodes under another window (like `Zotero.getMainWindow()`). This does not change anything. What matters is that the `ProgressQueueTable` code is being called by something with a fake-window global. Even if it has access to a real window, the nodes it creates are cursed to forever cause segfaults.

The crash can be reproduced easily on `main` by running Retrieve Metadata on a standalone attachment that doesn't exist (causes an immediate failure), closing the progress queue window, and then running it again. Sometimes one extra run is required before you get a crash.

This is a temporary fix. The long-term fix is probably to ditch `require.js` and use ES modules, but that might need to wait until fx115.

Fixes #2688.