### PR TITLE
Make preferences less janky, preload panes on hover, allow panes to delay visibility until promise resolves

### DIFF
--- a/chrome/content/zotero/preferences/preferences.js
+++ b/chrome/content/zotero/preferences/preferences.js
@@ -481,7 +481,13 @@ ${str}
 		}
 
 		for (let child of container.children) {
-			child.dispatchEvent(new Event('load'));
+			let event = new Event('load');
+			let promises = [];
+			event.waitUntil = (promise) => {
+				promises.push(promise);
+			};
+			child.dispatchEvent(event);
+			await Promise.allSettled(promises);
 		}
 
 		// If this is the first pane to be loaded, notify anyone waiting

--- a/chrome/content/zotero/preferences/preferences.js
+++ b/chrome/content/zotero/preferences/preferences.js
@@ -435,9 +435,13 @@ ${str}
 			}
 		};
 
+		let awaitBeforeShowing = [];
+
 		// Activate `preference` attributes
+		// Do not await anything between here and the 'load' event dispatch below! That would cause 'syncfrompreference'
+		// events to be fired before 'load'!
 		for (let elem of container.querySelectorAll('[preference]')) {
-			await attachToPreference(elem);
+			awaitBeforeShowing.push(attachToPreference(elem));
 		}
 		
 		new MutationObserver((mutations) => {
@@ -485,13 +489,13 @@ ${str}
 
 		for (let child of container.children) {
 			let event = new Event('load');
-			let promises = [];
 			event.waitUntil = (promise) => {
-				promises.push(promise);
+				awaitBeforeShowing.push(promise);
 			};
 			child.dispatchEvent(event);
-			await Promise.allSettled(promises);
 		}
+
+		await Promise.allSettled(awaitBeforeShowing);
 
 		// If this is the first pane to be loaded, notify anyone waiting
 		// (for tests)

--- a/chrome/content/zotero/preferences/preferences_cite.xhtml
+++ b/chrome/content/zotero/preferences/preferences_cite.xhtml
@@ -23,7 +23,7 @@
     ***** END LICENSE BLOCK *****
 -->
 
-<vbox id="zotero-prefpane-cite" onload="Zotero_Preferences.Cite.init()">
+<vbox id="zotero-prefpane-cite" onload="event.waitUntil(Zotero_Preferences.Cite.init())">
 	<vbox class="main-section" id="styles">
 		<html:h1>&zotero.preferences.cite.styles;</html:h1>
 

--- a/chrome/content/zotero/preferences/preferences_export.jsx
+++ b/chrome/content/zotero/preferences/preferences_export.jsx
@@ -31,11 +31,11 @@ var VirtualizedTable = require('components/virtualized-table');
 var { makeRowRenderer } = VirtualizedTable;
 
 Zotero_Preferences.Export = {
-	init: Zotero.Promise.coroutine(function* () {
+	init: async function () {
 		this.updateQuickCopyInstructions();
-		yield this.populateQuickCopyList();
-		yield this.populateNoteQuickCopyList();
-	}),
+		await this.populateQuickCopyList();
+		await this.populateNoteQuickCopyList();
+	},
 	
 	
 	getQuickCopyTranslators: async function () {

--- a/chrome/content/zotero/preferences/preferences_export.xhtml
+++ b/chrome/content/zotero/preferences/preferences_export.xhtml
@@ -23,7 +23,7 @@
     ***** END LICENSE BLOCK *****
 -->
 
-<vbox id="zotero-prefpane-export" onload="Zotero_Preferences.Export.init()">	
+<vbox id="zotero-prefpane-export" onload="event.waitUntil(Zotero_Preferences.Export.init())">	
 	<groupbox id="zotero-prefpane-export-groupbox">
 		<vbox>
 			<label><html:h2>&zotero.preferences.quickCopy.caption;</html:h2></label>

--- a/test/content/support.js
+++ b/test/content/support.js
@@ -113,14 +113,7 @@ var loadPrefPane = async function (paneName) {
 	var win = await loadWindow("chrome://zotero/content/preferences/preferences.xhtml", {
 		pane: id
 	});
-	var doc = win.document;
-	while (true) {
-		var pane = doc.getElementById(id);
-		if (pane) {
-			break;
-		}
-		await delay(1);
-	}
+	await win.Zotero_Preferences.waitForFirstPaneLoad();
 	return win;
 };
 


### PR DESCRIPTION
- Prevent flashes of unlocalized labels and controls without values set
- Preload panes on hover so there's usually no delay when switching
- Allow panes to delay visibility until a promise/promises resolve, and use that in Cite and Export to prevent flashes of empty tables
- Eliminate some race conditions

I thought there was an issue for the flashes of uninitialized content but can't find it now.