### PR TITLE
Fix segfault when hyphenating text in main process

### DIFF
--- a/app/build.sh
+++ b/app/build.sh
@@ -219,15 +219,15 @@ cd "$app_dir"
 set +e
 if [ $BUILD_MAC == 1 ]; then
 	cp -Rp "$MAC_RUNTIME_PATH"/Contents/Resources/browser/omni "$app_dir"
-  unzip -qj "$MAC_RUNTIME_PATH"/Contents/Resources/omni.ja "hyphenation/*" -d "$app_dir"/hyphenation/
+	unzip -qj "$MAC_RUNTIME_PATH"/Contents/Resources/omni.ja "hyphenation/*" -d "$app_dir"/hyphenation/
 elif [ $BUILD_WIN == 1 ]; then
 	# Non-arch-specific files, so just use 64-bit version
 	cp -Rp "${WIN_RUNTIME_PATH_PREFIX}win-x64"/browser/omni "$app_dir"
-  unzip -qj "${WIN_RUNTIME_PATH_PREFIX}win-x64"/omni.ja "hyphenation/*" -d "$app_dir"/hyphenation/
+	unzip -qj "${WIN_RUNTIME_PATH_PREFIX}win-x64"/omni.ja "hyphenation/*" -d "$app_dir"/hyphenation/
 elif [ $BUILD_LINUX == 1 ]; then
 	# Non-arch-specific files, so just use 64-bit version
 	cp -Rp "${LINUX_RUNTIME_PATH_PREFIX}x86_64"/browser/omni "$app_dir"
-  unzip -qj "${LINUX_RUNTIME_PATH_PREFIX}x86_64"/omni.ja "hyphenation/*" -d "$app_dir"/hyphenation/
+	unzip -qj "${LINUX_RUNTIME_PATH_PREFIX}x86_64"/omni.ja "hyphenation/*" -d "$app_dir"/hyphenation/
 fi
 set -e
 cd $omni_dir

--- a/app/build.sh
+++ b/app/build.sh
@@ -213,15 +213,21 @@ cd "$app_dir"
 # Copy 'browser' files from Firefox
 #
 # omni.ja is left uncompressed within the Firefox application files by fetch_xulrunner
+#
+# TEMP: Also extract .hyf hyphenation files from the outer (still compressed) omni.ja
+# This works around https://bugzilla.mozilla.org/show_bug.cgi?id=1772900
 set +e
 if [ $BUILD_MAC == 1 ]; then
 	cp -Rp "$MAC_RUNTIME_PATH"/Contents/Resources/browser/omni "$app_dir"
+  unzip -qj "$MAC_RUNTIME_PATH"/Contents/Resources/omni.ja "hyphenation/*" -d "$app_dir"/hyphenation/
 elif [ $BUILD_WIN == 1 ]; then
 	# Non-arch-specific files, so just use 64-bit version
 	cp -Rp "${WIN_RUNTIME_PATH_PREFIX}win-x64"/browser/omni "$app_dir"
+  unzip -qj "${WIN_RUNTIME_PATH_PREFIX}win-x64"/omni.ja "hyphenation/*" -d "$app_dir"/hyphenation/
 elif [ $BUILD_LINUX == 1 ]; then
 	# Non-arch-specific files, so just use 64-bit version
 	cp -Rp "${LINUX_RUNTIME_PATH_PREFIX}x86_64"/browser/omni "$app_dir"
+  unzip -qj "${LINUX_RUNTIME_PATH_PREFIX}x86_64"/omni.ja "hyphenation/*" -d "$app_dir"/hyphenation/
 fi
 set -e
 cd $omni_dir

--- a/test/content/hyphenationTest.xhtml
+++ b/test/content/hyphenationTest.xhtml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<window xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
+	<browser remote="false" />
+	<script>
+		var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+		document.querySelector('browser').loadURI('chrome://zotero-unit/content/hyphenationTestContent.html', {
+			triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal()
+		});
+	</script>
+</window>

--- a/test/content/hyphenationTestContent.html
+++ b/test/content/hyphenationTestContent.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="de-DE">
+
+<div style="hyphens: auto">
+	Am 15. Juli 2017 wäre Walter Benjamin (1892-1940) 125 Jahre alt
+	geworden. Ottmar Fuchs erschließt einige Grundzüge seines Denkens.
+</div>

--- a/test/tests/hyphenationTest.js
+++ b/test/tests/hyphenationTest.js
@@ -1,0 +1,8 @@
+describe("Hyphenation", function () {
+	it("should not cause a segfault", async function () {
+		// Files in test/tests/data/ (resources://) can't be parsed as XUL/XHTML, so the data for this test is in
+		// test/content/ (chrome://), which can
+		window.openDialog('chrome://zotero-unit/content/hyphenationTest.xhtml', 'test', 'chrome');
+		await Zotero.Promise.delay(200);
+	});
+});


### PR DESCRIPTION
This will let us enable hyphenation in EPUBs again (and not disable it in snapshots).

https://forums.zotero.org/discussion/107328/report-id-1522731840-zotero-7-beta