### PR TITLE
[TAS-37] Bugfix: mktemp error when building on macOS and pako package lost problem.

### DIFF
--- a/app/config.sh
+++ b/app/config.sh
@@ -54,7 +54,7 @@ BUILD_PLATFORMS=""
 NUM_INCREMENTALS=6
 
 if [ "`uname`" = "Darwin" ]; then
-	alias mktemp='mktemp -t tmp'
+	alias mktemp='mktemp -t tmp.XXXXXXXXXX'
 	shopt -s expand_aliases
 fi
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "jspath": "^0.4.0",
     "mocha": "^3.5.3",
     "multimatch": "^2.1.0",
+    "pako": "^2.1.0",
     "react-virtualized": "^9.22.4",
     "sass": "^1.28.0",
     "sinon": "^7.3.2",


### PR DESCRIPTION
fix: 
```
mktemp: too few X's in template ‘tmp’
```
fix: 
```
symlink has no referent: "/Users/jzl/code/zotero/build/resource/pako.js"
rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1356) [sender=3.2.7]

Traceback (most recent call last):
  File "/Users/jzl/code/zotero/app/scripts/prepare_build", line 75, in main
    subprocess.check_call([
  File "/Users/jzl/miniforge3/lib/python3.9/subprocess.py", line 373, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['rsync', '-aL', '--exclude', '.*', '--exclude', '#*', '--exclude', 'package.json', '--exclude', 'package-lock.json', './', '/Users/jzl/code/zotero/app/tmp/zotero/']' returned non-zero exit status 23.
```