### PR TITLE
Fix to the bug that dragged the entire window when tabs are rearranged on linux.

### DIFF
--- a/scss/linux/_tabBar.scss
+++ b/scss/linux/_tabBar.scss
@@ -1,0 +1,7 @@
+.tabs {
+	-moz-window-dragging: drag;
+}
+
+.tab {
+	-moz-window-dragging: no-drag;
+}

--- a/scss/zotero-unix.scss
+++ b/scss/zotero-unix.scss
@@ -16,6 +16,7 @@
 @import "linux/tagsBox";
 @import "linux/tagSelector";
 @import "linux/virtualized-table";
+@import "linux/tabBar";
 
 // Elements
 


### PR DESCRIPTION
set -moz-window-dragging=no-drag for .tab on unix

Same thing that is done for macOS.
This prevents the entire window from being dragged when tabs are being rearranged by drag.

Fixes: #3185