### PR TITLE
annotations showing in itemTree

### DIFF
--- a/chrome/content/zotero/customElements.js
+++ b/chrome/content/zotero/customElements.js
@@ -68,6 +68,7 @@ Services.scriptloader.loadSubScript('chrome://zotero/content/elements/itemTreeMe
 		['attachment-row', 'chrome://zotero/content/elements/attachmentRow.js'],
 		['attachment-annotations-box', 'chrome://zotero/content/elements/attachmentAnnotationsBox.js'],
 		['annotation-row', 'chrome://zotero/content/elements/annotationRow.js'],
+		['annotation-items-pane', 'chrome://zotero/content/elements/annotationItemsPane.js'],
 		['context-notes-list', 'chrome://zotero/content/elements/contextNotesList.js'],
 		['note-row', 'chrome://zotero/content/elements/noteRow.js'],
 		['notes-context', 'chrome://zotero/content/elements/notesContext.js'],

--- a/chrome/content/zotero/elements/annotationItemsPane.js
+++ b/chrome/content/zotero/elements/annotationItemsPane.js
@@ -52,7 +52,7 @@
 			if (action == 'modify') {
 				for (let id of ids) {
 					let updatedItem = Zotero.Items.get(id);
-					// If a selected annotation is renamed, re-render it's annotation row
+					// If a selected annotation is renamed, re-render its annotation row
 					if (updatedItem.isAnnotation()) {
 						let row = this.querySelector(`annotation-row[annotation-id="${id}"]`);
 						if (row) {

--- a/chrome/content/zotero/elements/annotationItemsPane.js
+++ b/chrome/content/zotero/elements/annotationItemsPane.js
@@ -87,17 +87,15 @@
 				// Create a collapsible section for each top-level item if it does not exist yet
 				let section = this.querySelector(`[data-pane="annotations-${parentItem.id}"]`);
 				if (!section) {
-					section = MozXULElement.parseXULToFragment(
-						`<collapsible-section
-							data-l10n-id="section-attachments-annotations"
-							data-pane="annotations-${parentItem.id}"
-							summary="${parentItem.getDisplayTitle()}"
-							data-item-id="${parentItem.id}">
+					section = document.createXULElement("collapsible-section");
+					section.dataset.l10nId = "section-attachments-annotations";
+					section.dataset.pane = `annotations-${parentItem.id}`;
+					section.summary = parentItem.getDisplayTitle();
 
-							<html:div class="body"></html:div>
+					let sectionBody = document.createElement("div");
+					sectionBody.classList.add("body");
 
-						</collapsible-section>`
-					).querySelector("collapsible-section");
+					section.appendChild(sectionBody);
 					this._body.append(section);
 				}
 				document.l10n.setArgs(section, { count: selectedAnnotations.length });

--- a/chrome/content/zotero/elements/annotationItemsPane.js
+++ b/chrome/content/zotero/elements/annotationItemsPane.js
@@ -1,0 +1,136 @@
+/*
+	***** BEGIN LICENSE BLOCK *****
+	
+	Copyright © 2024 Corporation for Digital Scholarship
+					 Vienna, Virginia, USA
+					 https://www.zotero.org
+	
+	This file is part of Zotero.
+	
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+	
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+	
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
+	
+	***** END LICENSE BLOCK *****
+*/
+
+{
+	class AnnotationItemsPane extends XULElementBase {
+		content = MozXULElement.parseXULToFragment(`
+			<html:div class="custom-head"></html:div>
+			<html:div class="body zotero-view-item"> </html:div>
+		`);
+
+		set items(items) {
+			if (items.some(item => !item.isAnnotation())) return;
+			this._items = items;
+		}
+
+		get items() {
+			return this._items || [];
+		}
+
+		init() {
+			this._body = this.querySelector('.body');
+			this._notifierID = Zotero.Notifier.registerObserver(this, ['item']);
+		}
+
+		destroy() {
+			Zotero.Notifier.unregisterObserver(this._notifierID);
+		}
+
+		notify(action, type, ids) {
+			if (action == 'modify') {
+				for (let id of ids) {
+					let updatedItem = Zotero.Items.get(id);
+					// If a selected annotation is renamed, re-render it's annotation row
+					if (updatedItem.isAnnotation()) {
+						let row = this.querySelector(`annotation-row[annotation-id="${id}"]`);
+						if (row) {
+							row.render();
+						}
+					}
+					// Update name of collapsible section if item is renamed
+					else if (updatedItem.isRegularItem()) {
+						let section = this.querySelector(`collapsible-section[data-item-id="${id}"]`);
+						if (section) {
+							section.summary = updatedItem.getDisplayTitle();
+						}
+					}
+				}
+			}
+		}
+
+		render() {
+			if (!this.initialized) return;
+
+			let topLevelItems = Zotero.Items.getTopLevel(this.items);
+
+			// Remove collapsible sections for top-level items whose annotations are no longer selected
+			for (let section of [...this.querySelectorAll("collapsible-section")]) {
+				let parentID = section.dataset.pane.split("-")[1];
+				if (!topLevelItems.some(item => item.id == parentID)) {
+					section.remove();
+				}
+			}
+			for (let parentItem of topLevelItems) {
+				let selectedAnnotations = this.items.filter(item => item.topLevelItem.id == parentItem.id);
+				// Create a collapsible section for each top-level item if it does not exist yet
+				let section = this.querySelector(`[data-pane="annotations-${parentItem.id}"]`);
+				if (!section) {
+					section = MozXULElement.parseXULToFragment(
+						`<collapsible-section
+							data-l10n-id="section-attachments-annotations"
+							data-pane="annotations-${parentItem.id}"
+							summary="${parentItem.getDisplayTitle()}"
+							data-item-id="${parentItem.id}">
+
+							<html:div class="body"></html:div>
+
+						</collapsible-section>`
+					).querySelector("collapsible-section");
+					this._body.append(section);
+				}
+				document.l10n.setArgs(section, { count: selectedAnnotations.length });
+				// Add annotations into this collapsible section
+				for (let annotation of selectedAnnotations) {
+					// Skip rows that already exist
+					if (this.querySelector(`annotation-row[annotation-id="${annotation.id}"]`)) continue;
+					let row = document.createXULElement('annotation-row');
+					row.annotation = annotation;
+					section.querySelector('.body').append(row);
+				}
+			}
+			// Remove annotation rows for annotations that are no longer selected
+			for (let row of [...this.querySelectorAll("annotation-row")]) {
+				let rowID = row.getAttribute("annotation-id");
+				if (!this.items.some(obj => obj.id == rowID)) {
+					row.remove();
+				}
+			}
+		}
+
+		renderCustomHead(callback) {
+			let customHead = this.querySelector(".custom-head");
+			customHead.replaceChildren();
+			let append = (...args) => {
+				customHead.append(...args);
+			};
+			if (callback) callback({
+				doc: document,
+				append,
+			});
+		}
+	}
+
+	customElements.define("annotation-items-pane", AnnotationItemsPane);
+}

--- a/chrome/content/zotero/elements/annotationRow.js
+++ b/chrome/content/zotero/elements/annotationRow.js
@@ -84,20 +84,18 @@
 			if (['image', 'ink'].includes(this._annotation.annotationType)) {
 				let imagePath = Zotero.Annotations.getCacheImagePath(this._annotation);
 				if (imagePath) {
-					// If the file actually exists, display it. Otherwise, show a placeholder.
-					let file = Zotero.File.pathToFile(imagePath);
-					if (file.exists()) {
-						let img = document.createElement('img');
-						img.src = Zotero.File.pathToFileURI(imagePath);
-						img.draggable = false;
-						this._body.append(img);
-					}
-					else {
+					let img = document.createElement('img');
+					img.src = Zotero.File.pathToFileURI(imagePath);
+					img.draggable = false;
+					this._body.append(img);
+					// if the image could not be loaded for some reason (e.g. file is not there),
+					// show a placeholder text
+					img.addEventListener('error', () => {
 						let placeholder = document.createElement('div');
 						placeholder.classList.add('comment');
 						document.l10n.setAttributes(placeholder, 'annotation-image-not-found');
-						this._body.append(placeholder);
-					}
+						this._body.replaceChildren(placeholder);
+					});
 				}
 			}
 			

--- a/chrome/content/zotero/elements/annotationRow.js
+++ b/chrome/content/zotero/elements/annotationRow.js
@@ -91,28 +91,23 @@
 				}
 			}
 			
+			// Strip all html tags from comment and text for now until the algorithm for safe
+			// rendering of relevant html tags is carried over from the reader
+			let parserUtils = Cc["@mozilla.org/parserutils;1"].getService(Ci.nsIParserUtils);
+
 			if (this._annotation.annotationText) {
 				let text = document.createElement('div');
 				text.classList.add('quote');
-				// Try to sanitize annotation text
-				let parserUtils = Cc["@mozilla.org/parserutils;1"].getService(Ci.nsIParserUtils);
-				let sanitizedHtml = parserUtils.sanitize(this._annotation.annotationText,
-					Ci.nsIParserUtils.SanitizerDropForms | Ci.nsIParserUtils.SanitizerDropMedia);
-				// The content will be wrapped in <body></body>
-				let sanitizedBody = sanitizedHtml.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
-				if (sanitizedBody) {
-					text.innerHTML = sanitizedBody[0];
-				}
-				else {
-					text.textContent = this._annotation.annotationText;
-				}
+				let plainQuote = parserUtils.convertToPlainText(this._annotation.annotationText, Ci.nsIDocumentEncoder.OutputRaw, 0);
+				text.textContent = plainQuote;
 				this._body.append(text);
 			}
 			
 			if (this._annotation.annotationComment) {
 				let comment = document.createElement('div');
 				comment.classList.add('comment');
-				comment.textContent = this._annotation.annotationComment;
+				let plainComment = parserUtils.convertToPlainText(this._annotation.annotationComment, Ci.nsIDocumentEncoder.OutputRaw, 0);
+				comment.textContent = plainComment;
 				this._body.append(comment);
 			}
 			

--- a/chrome/content/zotero/elements/annotationRow.js
+++ b/chrome/content/zotero/elements/annotationRow.js
@@ -94,7 +94,7 @@
 			if (this._annotation.annotationText) {
 				let text = document.createElement('div');
 				text.classList.add('quote');
-				text.textContent = this._annotation.annotationText;
+				text.innerHTML = this._annotation.annotationText;
 				this._body.append(text);
 			}
 			
@@ -110,6 +110,9 @@
 			this._tags.textContent = tags.map(tag => tag.tag).sort(Zotero.localeCompare).join(Zotero.getString('punctuation.comma') + ' ');
 			
 			this.style.setProperty('--annotation-color', this._annotation.annotationColor);
+			// A11y - make focusable + add screen reader's labels
+			this.setAttribute("tabindex", 0);
+			this.setAttribute("aria-label", this.annotation.getDisplayTitle());
 		}
 	}
 

--- a/chrome/content/zotero/elements/annotationRow.js
+++ b/chrome/content/zotero/elements/annotationRow.js
@@ -94,7 +94,18 @@
 			if (this._annotation.annotationText) {
 				let text = document.createElement('div');
 				text.classList.add('quote');
-				text.innerHTML = this._annotation.annotationText;
+				// Try to sanitize annotation text
+				let parserUtils = Cc["@mozilla.org/parserutils;1"].getService(Ci.nsIParserUtils);
+				let sanitizedHtml = parserUtils.sanitize(this._annotation.annotationText,
+					Ci.nsIParserUtils.SanitizerDropForms | Ci.nsIParserUtils.SanitizerDropMedia);
+				// The content will be wrapped in <body></body>
+				let sanitizedBody = sanitizedHtml.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
+				if (sanitizedBody) {
+					text.innerHTML = sanitizedBody[0];
+				}
+				else {
+					text.textContent = this._annotation.annotationText;
+				}
 				this._body.append(text);
 			}
 			

--- a/chrome/content/zotero/elements/annotationRow.js
+++ b/chrome/content/zotero/elements/annotationRow.js
@@ -93,7 +93,7 @@
 					img.addEventListener('error', () => {
 						let placeholder = document.createElement('div');
 						placeholder.classList.add('comment');
-						document.l10n.setAttributes(placeholder, 'annotation-image-not-found');
+						document.l10n.setAttributes(placeholder, 'annotation-image-not-available');
 						this._body.replaceChildren(placeholder);
 					});
 				}

--- a/chrome/content/zotero/elements/annotationRow.js
+++ b/chrome/content/zotero/elements/annotationRow.js
@@ -84,10 +84,20 @@
 			if (['image', 'ink'].includes(this._annotation.annotationType)) {
 				let imagePath = Zotero.Annotations.getCacheImagePath(this._annotation);
 				if (imagePath) {
-					let img = document.createElement('img');
-					img.src = Zotero.File.pathToFileURI(imagePath);
-					img.draggable = false;
-					this._body.append(img);
+					// If the file actually exists, display it. Otherwise, show a placeholder.
+					let file = Zotero.File.pathToFile(imagePath);
+					if (file.exists()) {
+						let img = document.createElement('img');
+						img.src = Zotero.File.pathToFileURI(imagePath);
+						img.draggable = false;
+						this._body.append(img);
+					}
+					else {
+						let placeholder = document.createElement('div');
+						placeholder.classList.add('comment');
+						document.l10n.setAttributes(placeholder, 'annotation-image-not-found');
+						this._body.append(placeholder);
+					}
 				}
 			}
 			

--- a/chrome/content/zotero/elements/collapsibleSection.js
+++ b/chrome/content/zotero/elements/collapsibleSection.js
@@ -372,11 +372,11 @@
 		}
 		
 		get _disableCollapsing() {
-			return !!this.closest('panel, menupopup, merge-pane, scaffold-item-preview');
+			return !!this.closest('panel, menupopup, merge-pane, scaffold-item-preview, annotation-items-pane');
 		}
 
 		get _disableSavingOpenState() {
-			return !!this.closest('merge-pane, scaffold-item-preview');
+			return !!this.closest('merge-pane, scaffold-item-preview, annotation-items-pane');
 		}
 
 		_handleClick = (event) => {

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -3233,10 +3233,9 @@ var ItemTree = class ItemTree extends LibraryTree {
 			let title;
 			if (["highlight", "underline"].includes(item.annotationType)) {
 				title = this._renderCell(index, item.annotationText || "", titleRowData, true);
-				// italicize non-CJK parts of the annotation quote
 				let titleCell = title.querySelector(".cell-text");
-				let nodes = Array.from(titleCell.childNodes).flatMap(child => this._italicizeNonCJK(child));
-				titleCell.replaceChildren(...nodes);
+				// Quote text is in italics
+				titleCell.classList.add("italics");
 				// Add quotation marks around the quoted text
 				titleCell.setAttribute("q-mark-open", Zotero.getString("punctuation.openingQMark"));
 				title.setAttribute("q-mark-close", Zotero.getString("punctuation.closingQMark"));
@@ -4095,54 +4094,6 @@ var ItemTree = class ItemTree extends LibraryTree {
 		];
 		return cjkRegexArray.some(exp => exp.test(str));
 	};
-
-
-	/**
-	 * Italicize non-CJK segments of a node from an annotation row by wrapping them in <i> tags.
-	 * @param {Node} node - The input node whose non-CJK characters are italicized.
-	 * @returns {Node[]} resultArr - An array of nodes preserving the original order, with non-CJK text segments italicized.
-	 * If the input node is not a text node, new segments are set as children of the input node, d
-	 * and the returned resultArr contains only the original node.
-	 */
-	_italicizeNonCJK(node) {
-		let str = node.innerHTML || node.textContent;
-		let resultArray = [];
-		let currentItalicizedSegment = document.createElement("i");
-		let currentNonItalicizedSegment = document.createTextNode("");
-	
-		for (let char of str) {
-			// If the character should be italicized, add it to the current italicized segment
-			if (!this._containsCJKCharacters(char)) {
-				currentItalicizedSegment.innerText += char;
-				if (currentNonItalicizedSegment.textContent.length) {
-					resultArray.push(currentNonItalicizedSegment);
-					currentNonItalicizedSegment = document.createTextNode(""); // Reset the non-italicized segment
-				}
-			}
-			else {
-				// If the character should not be italicized, add it to the non-italicized segment
-				currentNonItalicizedSegment.textContent += char;
-				if (currentItalicizedSegment.textContent.length) {
-					resultArray.push(currentItalicizedSegment);
-					currentItalicizedSegment = document.createElement("i"); // Reset the italicized segment
-				}
-			}
-		}
-	
-		// Push any remaining segments to the result array
-		if (currentItalicizedSegment.textContent.length) {
-			resultArray.push(currentItalicizedSegment);
-		}
-		if (currentNonItalicizedSegment.textContent.length) {
-			resultArray.push(currentNonItalicizedSegment);
-		}
-		// If we can, set new segments as children of the original node
-		if (node.nodeName !== "#text") {
-			node.replaceChildren(...resultArray);
-			resultArray = [node];
-		}
-		return resultArray;
-	}
 };
 
 var ItemTreeRow = function(ref, level, isOpen)

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -1912,7 +1912,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 			let collectionTreeRow = this.collectionTreeRow;
 
 			// If all selected items are annotations, for now erase them skipping trash
-			if (selectedItems.every(item => item.isAnnotation())) {
+			if (selectedItems.length && selectedItems.every(item => item.isAnnotation())) {
 				await Zotero.Items.erase(selectedItemIDs);
 			}
 			else if (collectionTreeRow.isBucket()) {

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -3232,8 +3232,13 @@ var ItemTree = class ItemTree extends LibraryTree {
 			let titleRowData = Object.assign({}, columns.find(column => column.dataKey == "title"));
 			titleRowData.className = "title";
 			let title;
+			// Strip html tags from annotation comment and text until the algorithm
+			// for safe rendering of relevant html tags is carried over from the reader
+			let parserUtils = Cc["@mozilla.org/parserutils;1"].getService(Ci.nsIParserUtils);
+			let plainText = parserUtils.convertToPlainText(item.annotationText || "", Ci.nsIDocumentEncoder.OutputRaw, 0);
+			let plainComment = parserUtils.convertToPlainText(item.annotationComment || "", Ci.nsIDocumentEncoder.OutputRaw, 0);
 			if (["highlight", "underline"].includes(item.annotationType)) {
-				title = this._renderCell(index, item.annotationText || "", titleRowData, true);
+				title = this._renderCell(index, plainText, titleRowData, true);
 				let titleCell = title.querySelector(".cell-text");
 				// Quote text is in italics
 				titleCell.classList.add("italics");
@@ -3241,7 +3246,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 				titleCell.setAttribute("q-mark-open", Zotero.getString("punctuation.openingQMark"));
 				title.setAttribute("q-mark-close", Zotero.getString("punctuation.closingQMark"));
 				if (item.annotationComment) {
-					let comment = renderCell(null, item.annotationComment, { className: "annotation-comment" });
+					let comment = renderCell(null, plainComment, { className: "annotation-comment" });
 					div.appendChild(comment);
 				}
 				// only keep default wider spacing if there are CJK characters
@@ -3250,7 +3255,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 			}
 			else if (item.annotationComment) {
 				// If there is a comment for image, ink, note annotations, use that as the title
-				title = this._renderCell(index, item.annotationComment || "", titleRowData, true);
+				title = this._renderCell(index, plainComment, titleRowData, true);
 			}
 			else {
 				// Catch all - use annotation type as the title

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -1778,10 +1778,10 @@ var ItemTree = class ItemTree extends LibraryTree {
 			}
 			let item = this.getRow(i).ref;
 			let attachments = item.isRegularItem() ? item.getAttachments() : [];
-			if (attachments.some(id => searchParentIDs.has(id))) {
-				this.toggleOpenState(i, true);
-			}
-			if (searchParentIDs.has(item.id)) {
+			// expand item row if it is a parent of a match
+			// OR if it has a child that is a parent of a match
+			let shouldBeOpened = searchParentIDs.has(item.id) || attachments.some(id => searchParentIDs.has(id));
+			if (shouldBeOpened) {
 				this.toggleOpenState(i, true);
 			}
 		}

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -2323,7 +2323,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 						return false;
 					}
 
-					// Disallow drop of annotation items
+					// Disallow drag of annotation items
 					if (item.isAnnotation()) {
 						return false;
 					}
@@ -2350,7 +2350,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 						return false;
 					}
 
-					// Disallow drop of annotation items
+					// Disallow drag of annotation items
 					if (item.isAnnotation()) {
 						return false;
 					}
@@ -3208,8 +3208,10 @@ var ItemTree = class ItemTree extends LibraryTree {
 
 		let item = this.getRow(index).ref;
 		for (let column of columns) {
-			// special treatment for annotation item
-			if (column.hidden || item.isAnnotation()) continue;
+			if (column.hidden) continue;
+			// Annotation rows have a single cell, created below
+			if (item.isAnnotation()) continue;
+			
 			div.appendChild(this._renderCell(index, rowData[column.dataKey], column, column === firstColumn));
 		}
 
@@ -3254,7 +3256,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 			}
 		}
 
-		// Special treatment for annotation rows whose title and comment do not correspond to existing columns
+		// Render annotation rows as a single cell with title/text and comment
 		div.classList.toggle("annotation-row", item.isAnnotation());
 		div.classList.remove("tight");
 		if (item.isAnnotation()) {

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -2323,6 +2323,11 @@ var ItemTree = class ItemTree extends LibraryTree {
 						return false;
 					}
 
+					// Disallow drop of annotation items
+					if (item.isAnnotation()) {
+						return false;
+					}
+
 					// Disallow cross-library child drag
 					if (item.libraryID != collectionTreeRow.ref.libraryID) {
 						return false;
@@ -2342,6 +2347,11 @@ var ItemTree = class ItemTree extends LibraryTree {
 				for (let item of items) {
 					// Don't allow drag if any top-level items
 					if (item.isTopLevelItem()) {
+						return false;
+					}
+
+					// Disallow drop of annotation items
+					if (item.isAnnotation()) {
 						return false;
 					}
 

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -3259,7 +3259,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 			}
 			else {
 				// Catch all - use annotation type as the title
-				let annotationTypeName = `${Zotero.Utilities.capitalize(item.annotationType)} ${Zotero.getString("itemTypes.annotation")}`;
+				let annotationTypeName = Zotero.getString(`pdfReader.${item.annotationType}Annotation`);
 				title = this._renderCell(index, annotationTypeName, titleRowData, true);
 			}
 			div.prepend(title);

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -3226,6 +3226,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 
 		// Special treatment for annotation rows whose title and comment do not correspond to existing columns
 		div.classList.toggle("annotation-row", item.isAnnotation());
+		div.classList.remove("tight");
 		if (item.isAnnotation()) {
 			// Use "title" column  as a blueprint to render the first part of annotation row
 			let titleRowData = Object.assign({}, columns.find(column => column.dataKey == "title"));
@@ -3244,7 +3245,8 @@ var ItemTree = class ItemTree extends LibraryTree {
 					div.appendChild(comment);
 				}
 				// only keep default wider spacing if there are CJK characters
-				div.classList.toggle("tight", !this._containsCJKCharacters(item.annotationText));
+				let containsCJK = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u.test(item.annotationText);
+				div.classList.toggle("tight", !containsCJK);
 			}
 			else if (item.annotationComment) {
 				// If there is a comment for image, ink, note annotations, use that as the title
@@ -4072,28 +4074,6 @@ var ItemTree = class ItemTree extends LibraryTree {
 			resolve();
 		}));
 	}
-
-	// Check if text quoted in an annotation row contains CJK characters to determine
-	// if it should be italicized or not
-	_containsCJKCharacters = (str) => {
-		let cjkRegexArray = [
-			new RegExp("[\u2E80-\u2EFF]"), // CJK Radicals Supplement
-			new RegExp("[\u3000-\u303F]"), // CJK Symbols and Punctuation
-			new RegExp("[\u3040-\u309F]"), // Hiragana (Japanese)
-			new RegExp("[\u30A0-\u30FF]"), // Katakana (Japanese)
-			new RegExp("[\u1100-\u11FF]"), // Hangul Jamo (Korean)
-			new RegExp("[\u3200-\u32FF]"), // Enclosed CJK Letters and Months
-			new RegExp("[\u3300-\u33FF]"), // CJK Compatibility
-			new RegExp("[\u3400-\u4DBF]"), // CJK Unified Ideographs Extension A
-			new RegExp("[\u4E00-\u9FFF]"), // CJK Unified Ideographs
-			new RegExp("[\uAC00-\uD7AF]"), // Hangul Syllables (Korean)
-			new RegExp("[\uF900-\uFAFF]"), // CJK Compatibility Ideographs
-			new RegExp("[\uFE30-\uFE4F]"), // CJK Compatibility Forms
-			new RegExp("[\u{20000}-\u{2A6DF}]", "u"), // CJK Unified Ideographs Extension B
-			new RegExp("[\u{2F800}-\u{2FA1F}]", "u") // CJK Compatibility Ideographs Supplement
-		];
-		return cjkRegexArray.some(exp => exp.test(str));
-	};
 };
 
 var ItemTreeRow = function(ref, level, isOpen)

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -1253,6 +1253,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 						let cleared2 = window.ZoteroPane.tagSelector
 							&& window.ZoteroPane.tagSelector.clearTagSelection();
 						if (cleared1 || cleared2) {
+							console.log("!!!!!");
 							return this.selectItems(ids, true);
 						}
 					}
@@ -1276,7 +1277,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 			}
 			rowsToSelect.push(row);
 		}
-		
+		console.log("Rows to select ", rowsToSelect)
 		if (!rowsToSelect.length) {
 			return 0;
 		}
@@ -2115,17 +2116,19 @@ var ItemTree = class ItemTree extends LibraryTree {
 			item = Zotero.Items.get(item.parentItemID);
 			toExpand.push(item.id);
 		}
+		if (!this.getRow(this._rowMap[item.id])) return;
 		// Go through ancestors starting from the top-most one
 		// and expand them if needed
 		while (toExpand.length > 0) {
 			let ancestorID = toExpand.pop();
 			let ancestorRow = this._rowMap[ancestorID];
 
-			let nextAncestorID = toExpand[toExpand.length - 1];
-			let nextAncestorRow = this._rowMap[nextAncestorID];
-
-			// If the next ancestor we want is already available, just move one
-			if (this.getRow(nextAncestorRow)) continue;
+			// If the row for the next ancestor already exists, just move one
+			if (toExpand.length > 0) {
+				let nextAncestorID = toExpand[toExpand.length - 1];
+				let nextAncestorRow = this._rowMap[nextAncestorID];
+				if (this.getRow(nextAncestorRow)) continue;
+			}
 			
 			// Close and re-open the ancestor to reveal the next row until
 			// we reach the desired item

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -1253,7 +1253,6 @@ var ItemTree = class ItemTree extends LibraryTree {
 						let cleared2 = window.ZoteroPane.tagSelector
 							&& window.ZoteroPane.tagSelector.clearTagSelection();
 						if (cleared1 || cleared2) {
-							console.log("!!!!!");
 							return this.selectItems(ids, true);
 						}
 					}
@@ -1277,7 +1276,6 @@ var ItemTree = class ItemTree extends LibraryTree {
 			}
 			rowsToSelect.push(row);
 		}
-		console.log("Rows to select ", rowsToSelect)
 		if (!rowsToSelect.length) {
 			return 0;
 		}

--- a/chrome/content/zotero/locateMenu.js
+++ b/chrome/content/zotero/locateMenu.js
@@ -349,7 +349,7 @@ var Zotero_LocateMenu = new function() {
 		var selectedItems = [];
 		while (selectedItems.length < 50 && allSelectedItems.length) {
 			var item = allSelectedItems.shift();
-			if (!item.isNote()) selectedItems.push(item);
+			if (!item.isNote() && !item.isAnnotation()) selectedItems.push(item);
 		}
 		return selectedItems;
 	}

--- a/chrome/content/zotero/standalone/standalone.js
+++ b/chrome/content/zotero/standalone/standalone.js
@@ -322,7 +322,8 @@ const ZoteroStandalone = new function() {
 
 		var format = Zotero.QuickCopy.getFormatFromURL(Zotero.QuickCopy.lastActiveURL);
 		var exportingNotes = selected.every(item => item.isNote() || item.isAttachment());
-		if (exportingNotes) {
+		var exportingAnnotations = selected.every(item => item.isAnnotation());
+		if (exportingNotes || exportingAnnotations) {
 			format = Zotero.QuickCopy.getNoteFormat();
 		}
 		format = Zotero.QuickCopy.unserializeSetting(format);
@@ -331,11 +332,14 @@ const ZoteroStandalone = new function() {
 		var copyBibliography = document.getElementById('menu_copyBibliography');
 		var copyExport = document.getElementById('menu_copyExport');
 		var copyNote = document.getElementById('menu_copyNote');
+		var copyAnnotation = document.getElementById('menu_copyAnnotation');
 		
 		copyCitation.hidden = !selected.length || format.mode != 'bibliography';
 		copyBibliography.hidden = !selected.length || format.mode != 'bibliography';
 		copyExport.hidden = !selected.length || format.mode != 'export' || exportingNotes;
 		copyNote.hidden = !selected.length || format.mode != 'export' || !exportingNotes;
+		copyAnnotation.hidden = !selected.length || format.mode != 'export' || !exportingAnnotations;
+		
 		if (format.mode == 'export') {
 			try {
 				let obj = Zotero.Translators.get(format.id);

--- a/chrome/content/zotero/standalone/standalone.js
+++ b/chrome/content/zotero/standalone/standalone.js
@@ -339,6 +339,7 @@ const ZoteroStandalone = new function() {
 		copyExport.hidden = !selected.length || format.mode != 'export' || exportingNotes;
 		copyNote.hidden = !selected.length || format.mode != 'export' || !exportingNotes;
 		copyAnnotation.hidden = !selected.length || format.mode != 'export' || !exportingAnnotations;
+		document.l10n.setAttributes(copyAnnotation, "menu-edit-copy-annotation", { count: selected.length });
 		
 		if (format.mode == 'export') {
 			try {

--- a/chrome/content/zotero/xpcom/annotations.js
+++ b/chrome/content/zotero/xpcom/annotations.js
@@ -116,7 +116,7 @@ Zotero.Annotations = new function () {
 	};
 	
 	
-	this.toJSON = async function (item) {
+	this.toJSONSync = function (item) {
 		var o = {};
 		o.libraryID = item.libraryID;
 		o.key = item.key;
@@ -141,12 +141,6 @@ Zotero.Annotations = new function () {
 		o.readOnly = o.isExternal || !isAuthor;
 		if (['highlight', 'underline'].includes(o.type)) {
 			o.text = item.annotationText;
-		}
-		else if (['image', 'ink'].includes(o.type)) {
-			let file = this.getCacheImagePath(item);
-			if (await OS.File.exists(file)) {
-				o.image = await Zotero.File.generateDataURI(file, 'image/png');
-			}
 		}
 		o.comment = item.annotationComment;
 		o.pageLabel = item.annotationPageLabel;
@@ -182,6 +176,17 @@ Zotero.Annotations = new function () {
 		}
 		
 		o.dateModified = Zotero.Date.sqlToISO8601(item.dateModified);
+		return o;
+	};
+
+	this.toJSON = async function (item) {
+		var o = this.toJSONSync(item);
+		if (['image', 'ink'].includes(o.type)) {
+			let file = this.getCacheImagePath(item);
+			if (await OS.File.exists(file)) {
+				o.image = await Zotero.File.generateDataURI(file, 'image/png');
+			}
+		}
 		return o;
 	};
 	

--- a/chrome/content/zotero/xpcom/data/items.js
+++ b/chrome/content/zotero/xpcom/data/items.js
@@ -254,11 +254,14 @@ Zotero.Items = function() {
 				item.updateDisplayTitle()
 			}
 			catch (e) {
-				// A few item types need creators to be loaded. Instead of making
-				// updateDisplayTitle() async and loading conditionally, just catch the error
+				// A few item types need creators or tags to be loaded. Annotations need to be loaded
+				// to be displayed in itemTree.
+				// Instead of making updateDisplayTitle() async and loading conditionally, just catch the error
 				// and load on demand
 				if (e instanceof Zotero.Exception.UnloadedDataException) {
 					yield item.loadDataType('creators');
+					yield item.loadDataType('annotation');
+					yield item.loadDataType('tags');
 					item.updateDisplayTitle()
 				}
 				else {

--- a/chrome/content/zotero/xpcom/data/search.js
+++ b/chrome/content/zotero/xpcom/data/search.js
@@ -607,7 +607,10 @@ Zotero.Search.prototype.search = Zotero.Promise.coroutine(function* (asTempTable
 				sql += " OR itemID IN (SELECT itemID FROM itemAttachments"
 				+ " WHERE parentItemID IN (SELECT itemID FROM " + tmpTable + ")) OR "
 				+ "itemID IN (SELECT itemID FROM itemNotes"
-				+ " WHERE parentItemID IN (SELECT itemID FROM " + tmpTable + "))";
+				+ " WHERE parentItemID IN (SELECT itemID FROM " + tmpTable + "))"
+				+ " OR itemID IN ( SELECT itemID FROM itemAnnotations WHERE "
+				+ " parentItemID IN ( SELECT itemID FROM itemAttachments WHERE "
+				+ " parentItemID IN ( SELECT itemID FROM " + tmpTable + ")))";
 			}
 			sql += ")";
 			
@@ -948,10 +951,7 @@ Zotero.Search.idsToTempTable = Zotero.Promise.coroutine(function* (ids) {
 Zotero.Search.prototype._buildQuery = Zotero.Promise.coroutine(function* () {
 	this._requireData('conditions');
 	
-	// TEMP: Match parent attachment for annotation matches
-	// var sql = 'SELECT itemID FROM items';
-	var sql = "SELECT COALESCE(IA.parentItemID, itemID) AS itemID FROM items "
-		+ "LEFT JOIN itemAnnotations IA USING (itemID)";
+	var sql = 'SELECT itemID FROM items';
 	
 	var sqlParams = [];
 	// Separate ANY conditions for 'required' condition support
@@ -1216,16 +1216,14 @@ Zotero.Search.prototype._buildQuery = Zotero.Promise.coroutine(function* () {
 					}
 					
 					switch (condition.name) {
-						// TEMP: Match parent attachments of matching annotations
 						case 'tag':
-							condSQL += "SELECT COALESCE(IAnT.parentItemID, itemID) FROM itemTags "
+							condSQL += "SELECT itemID FROM itemTags "
 								+ "LEFT JOIN itemAnnotations IAnT USING (itemID) WHERE (";
 							break;
 						
-						// TEMP: Match parent attachments of matching annotations
 						case 'annotationText':
 						case 'annotationComment':
-							condSQL += `SELECT parentItemID FROM ${condition.table} WHERE (`
+							condSQL += `SELECT itemID FROM ${condition.table} WHERE (`
 							break;
 							
 						default:
@@ -1807,11 +1805,7 @@ Zotero.Search.prototype._buildQuery = Zotero.Promise.coroutine(function* () {
 		
 		// Add on quicksearch conditions
 		if (quicksearchSQLSet) {
-			// TEMP: Match parent attachments for annotations
-			//sql = "SELECT itemID FROM items WHERE itemID IN (" + sql + ") "
-			sql = "SELECT COALESCE(IAn.parentItemID, itemID) AS itemID FROM items "
-				+ "LEFT JOIN itemAnnotations IAn USING (itemID) "
-				+ "WHERE itemID IN (" + sql + ") "
+			sql = "SELECT itemID FROM items WHERE itemID IN (" + sql + ") "
 				+ "AND ((" + quicksearchSQLSet.join(') AND (') + "))";
 			
 			for (var k=0; k<quicksearchParamsSet.length; k++) {

--- a/chrome/content/zotero/xpcom/data/searchConditions.js
+++ b/chrome/content/zotero/xpcom/data/searchConditions.js
@@ -572,7 +572,7 @@ Zotero.SearchConditions = new function(){
 				},
 				table: 'itemAnnotations',
 				field: 'text',
-				special: true,
+				special: false,
 			},
 			
 			{
@@ -583,7 +583,7 @@ Zotero.SearchConditions = new function(){
 				},
 				table: 'itemAnnotations',
 				field: 'comment',
-				special: true,
+				special: false,
 			},
 			
 			{

--- a/chrome/content/zotero/xpcom/editorInstance.js
+++ b/chrome/content/zotero/xpcom/editorInstance.js
@@ -1308,7 +1308,7 @@ class EditorInstance {
 	 * @param {Integer} options.collectionID - Only valid if parentID not provided
 	 * @returns {Promise<Zotero.Item>}
 	 */
-	static async createNoteFromAnnotations(annotations, { parentID, collectionID } = {}) {
+	static async createNoteFromAnnotations(annotations, { parentID, collectionID, skipFirstSave } = {}) {
 		if (!annotations.length) {
 			throw new Error("No annotations provided");
 		}
@@ -1335,7 +1335,11 @@ class EditorInstance {
 		else if (collectionID) {
 			note.addToCollection(collectionID);
 		}
-		await note.saveTx();
+		// Each save causes change of focus, so for standalone notes from
+		// itemTree attachments, skip it to avoid blinking
+		if (!skipFirstSave) {
+			await note.saveTx();
+		}
 		let editorInstance = new EditorInstance();
 		editorInstance._item = note;
 		let jsonAnnotations = [];

--- a/chrome/content/zotero/xpcom/editorInstance.js
+++ b/chrome/content/zotero/xpcom/editorInstance.js
@@ -1308,7 +1308,7 @@ class EditorInstance {
 	 * @param {Integer} options.collectionID - Only valid if parentID not provided
 	 * @returns {Promise<Zotero.Item>}
 	 */
-	static async createNoteFromAnnotations(annotations, { parentID, collectionID, skipFirstSave } = {}) {
+	static async createNoteFromAnnotations(annotations, { parentID, collectionID } = {}) {
 		if (!annotations.length) {
 			throw new Error("No annotations provided");
 		}
@@ -1335,11 +1335,7 @@ class EditorInstance {
 		else if (collectionID) {
 			note.addToCollection(collectionID);
 		}
-		// Each save causes change of focus, so for standalone notes from
-		// itemTree attachments, skip it to avoid blinking
-		if (!skipFirstSave) {
-			await note.saveTx();
-		}
+		await note.saveTx();
 		let editorInstance = new EditorInstance();
 		editorInstance._item = note;
 		let jsonAnnotations = [];

--- a/chrome/content/zotero/xpcom/quickCopy.js
+++ b/chrome/content/zotero/xpcom/quickCopy.js
@@ -317,7 +317,7 @@ Zotero.QuickCopy = new function() {
 	 * If an array of Zotero.Items is passed, they will be converted to JSON.
 	 * @returns {Zotero.Item} - A note item with the annotations serialized as HTML.
 	 */
-	this.wrapAnnotationsAsNote = function (annotations) {
+	this.annotationsToNote = function (annotations) {
 		let jsonAnnotations = [];
 		for (let annotation of annotations) {
 			if (annotation instanceof Zotero.Item) {

--- a/chrome/content/zotero/xpcom/quickCopy.js
+++ b/chrome/content/zotero/xpcom/quickCopy.js
@@ -339,10 +339,10 @@ Zotero.QuickCopy = new function() {
 				delete annotation.image;
 			}
 		}
-		let res = Zotero.EditorInstanceUtilities.serializeAnnotations(jsonAnnotations);
+		let { html } = Zotero.EditorInstanceUtilities.serializeAnnotations(jsonAnnotations);
 		let tmpNote = new Zotero.Item('note');
 		tmpNote.libraryID = Zotero.Libraries.userLibraryID;
-		tmpNote.setNote(res.html);
+		tmpNote.setNote(html);
 		return tmpNote;
 	};
 	

--- a/chrome/content/zotero/xpcom/quickCopy.js
+++ b/chrome/content/zotero/xpcom/quickCopy.js
@@ -310,19 +310,18 @@ Zotero.QuickCopy = new function() {
 	};
 
 	/**
-	 * Generate a note item from an array of annotations.
-	 * This is a workaround to be able to translate annotations in getContentFromItems
-	 * even though annotations do not have a cslType.
-	 * @param {Zotero.Item|Object[]} annotations - Array of JSON annotations or Zotero.Item annotations.
-	 * If an array of Zotero.Items is passed, they will be converted to JSON.
-	 * @returns {Zotero.Item} - A note item with the annotations serialized as HTML.
+	 * Generate a note item to pass to getContentFromItems() from an array of annotations
+	 *
+	 * @param {Zotero.Item[]|Object[]} annotations - An array of Zotero.Item annotations or JSON
+	 *    annotations from Zotero.Annotations.toJSON()
+	 * @return {Zotero.Item} - A note item with the annotations serialized as HTML
 	 */
 	this.annotationsToNote = function (annotations) {
 		let jsonAnnotations = [];
 		for (let annotation of annotations) {
 			if (annotation instanceof Zotero.Item) {
 				// Skip ink and image annotations because fetching them
-				// requires await-ing for Zotero.Annotations.toJSON
+				// requires awaiting Zotero.Annotations.toJSON()
 				if (["ink", "image"].includes(annotation.type)) {
 					continue;
 				}

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -368,7 +368,7 @@ class ReaderInstance {
 						return;
 					}
 					// annotations are wrapped in a temp note for translation
-					let items = [Zotero.QuickCopy.wrapAnnotationsAsNote(annotations)];
+					let items = [Zotero.QuickCopy.annotationsToNote(annotations)];
 					let format = Zotero.QuickCopy.getNoteFormat();
 					Zotero.debug(`Copying/dragging (${annotations.length}) annotation(s) with ${format}`);
 					format = Zotero.QuickCopy.unserializeSetting(format);

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -367,17 +367,8 @@ class ReaderInstance {
 					if (fromText) {
 						return;
 					}
-					for (let annotation of annotations) {
-						if (annotation.image && !annotation.imageAttachmentKey) {
-							annotation.imageAttachmentKey = 'none';
-							delete annotation.image;
-						}
-					}
-					let res = Zotero.EditorInstanceUtilities.serializeAnnotations(annotations);
-					let tmpNote = new Zotero.Item('note');
-					tmpNote.libraryID = Zotero.Libraries.userLibraryID;
-					tmpNote.setNote(res.html);
-					let items = [tmpNote];
+					// annotations are wrapped in a temp note for translation
+					let items = [Zotero.QuickCopy.wrapAnnotationsAsNote(annotations)];
 					let format = Zotero.QuickCopy.getNoteFormat();
 					Zotero.debug(`Copying/dragging (${annotations.length}) annotation(s) with ${format}`);
 					format = Zotero.QuickCopy.unserializeSetting(format);

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -1939,6 +1939,7 @@ class Reader {
 	}
 
 	notify(event, type, ids, extraData) {
+		console.log("Notify reader", event, type, ids);
 		if (type === 'tab') {
 			if (event === 'close') {
 				for (let id of ids) {

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -1939,7 +1939,6 @@ class Reader {
 	}
 
 	notify(event, type, ids, extraData) {
-		console.log("Notify reader", event, type, ids);
 		if (type === 'tab') {
 			if (event === 'close') {
 				for (let id of ids) {

--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -3359,6 +3359,12 @@ Zotero.Utilities.Internal.onDragItems = function (event, itemIDs, dragImage = ev
 		format = Zotero.QuickCopy.getNoteFormat();
 	}
 
+	// If all items are annotations, wrap them in a note object for translation
+	if (items.every(item => item.isAnnotation())) {
+		format = Zotero.QuickCopy.getNoteFormat();
+		items = [Zotero.QuickCopy.wrapAnnotationsAsNote(items)];
+	}
+
 	Zotero.debug("Dragging with format " + format);
 	format = Zotero.QuickCopy.unserializeSetting(format);
 	try {

--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -3362,7 +3362,7 @@ Zotero.Utilities.Internal.onDragItems = function (event, itemIDs, dragImage = ev
 	// If all items are annotations, wrap them in a note object for translation
 	if (items.every(item => item.isAnnotation())) {
 		format = Zotero.QuickCopy.getNoteFormat();
-		items = [Zotero.QuickCopy.wrapAnnotationsAsNote(items)];
+		items = [Zotero.QuickCopy.annotationsToNote(items)];
 	}
 
 	Zotero.debug("Dragging with format " + format);

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -5781,7 +5781,7 @@ var ZoteroPane = new function()
 			else if (isAttachmentWithExtractableAnnotations(item)) {
 				attachments.push(item);
 			}
-			else if (item.isAnnotation() && !["ink", "image"].includes(item.annotationType)) {
+			else if (item.isAnnotation() && item.annotationType != 'ink') {
 				annotations.push(item);
 			}
 			else {
@@ -5803,13 +5803,12 @@ var ZoteroPane = new function()
 					Zotero.logError(e);
 				}
 			}
-			annotations.push(...attachment.getAnnotations().filter(x => x.annotationType != 'ink' && x.annotationType != 'image'));
+			annotations.push(...attachment.getAnnotations().filter(x => x.annotationType != 'ink'));
 		}
 		var note = await Zotero.EditorInstance.createNoteFromAnnotations(
 			annotations,
 			{
-				parentID: topLevelItem.id,
-				skipFirstSave: true
+				parentID: topLevelItem.id
 			}
 		);
 		await this.selectItem(note.id);
@@ -5917,8 +5916,7 @@ var ZoteroPane = new function()
 		var note = await Zotero.EditorInstance.createNoteFromAnnotations(
 			annotations,
 			{
-				collectionID: this.getSelectedCollection(true),
-				skipFirstSave: true
+				collectionID: this.getSelectedCollection(true)
 			}
 		);
 		await this.selectItem(note.id);

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -2677,7 +2677,7 @@ var ZoteroPane = new function()
 		// to copy annotations, they are wrapped in a temp note
 		if (items.every(item => item.isAnnotation())) {
 			format = Zotero.QuickCopy.getNoteFormat();
-			items = [Zotero.QuickCopy.wrapAnnotationsAsNote(items)];
+			items = [Zotero.QuickCopy.annotationsToNote(items)];
 		}
 		format = Zotero.QuickCopy.unserializeSetting(format);
 		

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -2674,7 +2674,7 @@ var ZoteroPane = new function()
 		if (items.every(item => item.isNote() || item.isAttachment())) {
 			format = Zotero.QuickCopy.getNoteFormat();
 		}
-		// to copy annotations, they are wrapped in a temp note
+		// To copy annotations, wrap them in a temp note
 		if (items.every(item => item.isAnnotation())) {
 			format = Zotero.QuickCopy.getNoteFormat();
 			items = [Zotero.QuickCopy.annotationsToNote(items)];
@@ -4026,7 +4026,7 @@ var ZoteroPane = new function()
 			show.add(m.changeParentItem);
 		}
 
-		// Only keep annotations-specitic options if annotations are selected
+		// Only keep annotation-specific options if annotations are selected
 		let annotationsSelected = items.some(item => item.isAnnotation());
 		if (annotationsSelected) {
 			for (let i in m) {

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -2009,7 +2009,7 @@ var ZoteroPane = new function()
 			let format = Zotero.QuickCopy.getFormatFromURL(Zotero.QuickCopy.lastActiveURL);
 			format = Zotero.QuickCopy.unserializeSetting(format);
 			if (format.mode == 'bibliography') {
-				canCopy = selectedItems.some(item => item.isRegularItem());
+				canCopy = selectedItems.some(item => item.isRegularItem() || item.isAnnotation());
 			}
 			else {
 				canCopy = true;
@@ -2018,6 +2018,7 @@ var ZoteroPane = new function()
 		
 		document.getElementById('cmd_zotero_copyCitation').setAttribute('disabled', !canCopy);
 		document.getElementById('cmd_zotero_copyBibliography').setAttribute('disabled', !canCopy);
+		document.getElementById('cmd_zotero_copyAnnotation').setAttribute('disabled', !canCopy);
 	};
 	
 	
@@ -2672,6 +2673,11 @@ var ZoteroPane = new function()
 		var format = Zotero.QuickCopy.getFormatFromURL(Zotero.QuickCopy.lastActiveURL);
 		if (items.every(item => item.isNote() || item.isAttachment())) {
 			format = Zotero.QuickCopy.getNoteFormat();
+		}
+		// to copy annotations, they are wrapped in a temp note
+		if (items.every(item => item.isAnnotation())) {
+			format = Zotero.QuickCopy.getNoteFormat();
+			items = [Zotero.QuickCopy.wrapAnnotationsAsNote(items)];
 		}
 		format = Zotero.QuickCopy.unserializeSetting(format);
 		

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -3945,16 +3945,6 @@ var ZoteroPane = new function()
 			}
 		}
 		
-		// Remove irrelevant options when all nnotations are selected
-		let allAnnotations = items.every(item => item.isAnnotation());
-		if (allAnnotations) {
-			show.delete(m.exportItems);
-			show.delete(m.createBib);
-			show.delete(m.loadReport);
-			show.delete(m.moveToTrash);
-			show.delete(m.duplicateItem);
-		}
-		
 		// Disable Create Bibliography if no regular items
 		if (show.has(m.createBib) && !items.some(item => item.isRegularItem())) {
 			show.delete(m.createBib);
@@ -4030,6 +4020,17 @@ var ZoteroPane = new function()
 			show.add(m.changeParentItem);
 		}
 
+		// Only keep annotations-specitic options if annotations are selected
+		let annotationsSelected = items.some(item => item.isAnnotation());
+		if (annotationsSelected) {
+			for (let i in m) {
+				if (i == 'createNoteFromAnnotations') {
+					continue;
+				}
+				show.delete(m[i]);
+			}
+		}
+
 		// Set labels, plural if necessary
 		menu.childNodes[m.findFile].setAttribute('label', Zotero.getString('pane.items.menu.findAvailableFile'));
 		menu.childNodes[m.moveToTrash].setAttribute('label', Zotero.getString('pane.items.menu.moveToTrash' + multiple));
@@ -4056,7 +4057,10 @@ var ZoteroPane = new function()
 		for (let x of show) {
 			menu.childNodes[x].setAttribute('hidden', false);
 		}
-		
+
+		// No locate menu options if annotations are selected
+		if (annotationsSelected) return;
+
 		// add locate menu options
 		yield Zotero_LocateMenu.buildContextMenu(menu, true);
 	});

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -110,6 +110,9 @@
 		<command id="cmd_zotero_copyBibliography"
 				 oncommand="ZoteroPane_Local.copySelectedItemsToClipboard();"
 				 disabled="true"/>
+		<command id="cmd_zotero_copyAnnotation"
+				 oncommand="ZoteroPane_Local.copySelectedItemsToClipboard();"
+				 disabled="true"/>
 		<command id="cmd_zotero_createTimeline" oncommand="Zotero_Timeline_Interface.loadTimeline();"/>
 		<command id="cmd_zotero_rtfScan" oncommand="window.openDialog('chrome://zotero/content/rtfScan.xhtml', 'rtfScan', 'chrome,centerscreen')"/>
 		<command id="cmd_zotero_newCollection" oncommand="ZoteroPane_Local.newCollection(ZoteroPane_Local.getSelectedCollection()?.key)"/>
@@ -386,6 +389,11 @@
 							<menuitem id="menu_copyNote"
 									label="&copyNoteCmd.label;"
 									command="cmd_zotero_copyBibliography"
+									key="key_copyBibliography"
+									hidden="true"/>
+							<menuitem id="menu_copyAnnotation"
+									data-l10n-id="menu-edit-copy-annotation"
+									command="cmd_zotero_copyAnnotation"
 									key="key_copyBibliography"
 									hidden="true"/>
 							<menuitem id="menu_paste"

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -97,7 +97,10 @@ menu-view-columns-move-right =
     .label = Move Column Right
 
 menu-edit-copy-annotation =
-    .label = Copy Annotation
+    .label = { $count ->
+        [one] Copy Annotation
+        *[other] Copy { $count } Annotations 
+    }
 
 main-window-command =
     .label = Library

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -96,6 +96,9 @@ menu-view-columns-move-left =
 menu-view-columns-move-right =
     .label = Move Column Right
 
+menu-edit-copy-annotation =
+    .label = Copy Annotation
+
 main-window-command =
     .label = Library
 main-window-key =

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -592,6 +592,8 @@ toggle-preview =
             *[unknown] Toggle
     } Attachment Preview
 
+annotation-image-not-found = [Image not available]
+
 quicksearch-mode =
     .aria-label = Quick Search mode
 quicksearch-input =

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -598,7 +598,7 @@ toggle-preview =
             *[unknown] Toggle
     } Attachment Preview
 
-annotation-image-not-found = [Image not available]
+annotation-image-not-available = [Image not available]
 
 quicksearch-mode =
     .aria-label = Quick Search mode

--- a/scss/_zotero.scss
+++ b/scss/_zotero.scss
@@ -102,6 +102,7 @@
 @import "elements/librariesCollectionsBox";
 @import "elements/duplicatesMergePane";
 @import "elements/itemMessagePane";
+@import "elements/itemPaneAnnotations";
 @import "elements/itemDetails";
 @import "elements/itemPane";
 @import "elements/itemPaneCustomSection";

--- a/scss/abstracts/_variables.scss
+++ b/scss/abstracts/_variables.scss
@@ -29,6 +29,9 @@ $font-size-base:   13px;
 $font-size-h1: 20px;
 $font-size-h2: 16px;
 
+// Font size used in tag selector and annotation rows of itemTree
+$font-size-small: 0.923076923em;
+
 $line-height-base:           1.539;
 $line-height-computed:       ceil($font-size-base * $line-height-base);
 

--- a/scss/components/_item-tree.scss
+++ b/scss/components/_item-tree.scss
@@ -113,7 +113,9 @@
 			}
 
 			.icon-item-type + .tag-swatch,
-			.icon-item-type + .colored-tag-swatches {
+			.icon-item-type + .colored-tag-swatches,
+			.annotation-icon + .tag-swatch,
+			.annotation-icon + .colored-tag-swatches {
 				margin-inline-start: 4px;
 			}
 
@@ -217,6 +219,35 @@
 			.icon-missing-file {
 				opacity: 0.4;
 			}
+		}
+
+		.annotation-row {
+			.cell {
+				font-size: $font-size-small;
+				max-width: fit-content;
+				&.title {
+					flex-grow: 1;
+					flex-basis: 0;
+					max-width: fit-content;
+					.cell-text::before {
+						content: attr(q-mark-open)
+					}
+					&::after {
+						content: attr(q-mark-close)
+					}
+				}
+				&.annotation-comment {
+					flex-grow: 2;
+					flex-basis: 0;
+				}
+			}
+			&.tight .cell {
+				padding: 0 2px;
+			}
+		}
+		
+		.cell .annotation-icon {
+			-moz-context-properties: fill;
 		}
 		
 		.numNotes, .hasAttachment {

--- a/scss/components/_item-tree.scss
+++ b/scss/components/_item-tree.scss
@@ -225,6 +225,8 @@
 			.cell {
 				font-size: $font-size-small;
 				max-width: fit-content;
+				// Do not italicize CJK characters
+				font-synthesis: none;
 				&.title {
 					flex-grow: 1;
 					flex-basis: 0;
@@ -234,6 +236,9 @@
 					}
 					&::after {
 						content: attr(q-mark-close)
+					}
+					.italics {
+						font-style: italic;
 					}
 				}
 				&.annotation-comment {

--- a/scss/components/_tagSelector.scss
+++ b/scss/components/_tagSelector.scss
@@ -103,7 +103,7 @@
 .tag-selector-item {
 	border-radius: 4px;
 	cursor: pointer;
-	font-size: 0.916666667em;
+	font-size: $font-size-small;
 	line-height: 1.272727273;
 	overflow: hidden;
 	padding: 1px 4px;

--- a/scss/elements/_annotationRow.scss
+++ b/scss/elements/_annotationRow.scss
@@ -5,6 +5,7 @@ annotation-row {
 	border-radius: 5px;
 	border: 1px solid var(--color-quinary-on-sidepane);
 	background: var(--material-background);
+	@include focus-ring;
 
 	.head {
 		display: flex;
@@ -56,7 +57,7 @@ annotation-row {
 			padding: 3px 8px;
 			
 			@include comfortable {
-				padding-block: 4px;
+				margin-block: 4px;
 			}
 		}
 	}

--- a/scss/elements/_itemMessagePane.scss
+++ b/scss/elements/_itemMessagePane.scss
@@ -11,6 +11,7 @@ item-message-pane {
 		background: var(--material-toolbar);
 		border-bottom: var(--material-panedivider);
 		height: 28px;
+		align-items: center;
 
 		&:empty {
 			display: none;
@@ -19,6 +20,9 @@ item-message-pane {
 		button {
 			height: 26px;
 			margin: 0;
+			@media (-moz-platform: macos) {
+				margin: 0px -2px;
+			}
 			flex-grow: 1;
 		}
 	}

--- a/scss/elements/_itemPaneAnnotations.scss
+++ b/scss/elements/_itemPaneAnnotations.scss
@@ -1,0 +1,69 @@
+annotation-items-pane {
+
+	display: flex;
+	flex-direction: column;
+	
+	.custom-head {
+		display: flex;
+		flex-direction: row;
+		align-self: stretch;
+		gap: 8px;
+		padding: 6px 8px;
+		background: var(--material-sidepane);
+		border-bottom: var(--material-panedivider);
+		height: 28px;
+		align-items: center;
+
+		&:empty {
+			display: none;
+		}
+
+		button {
+			height: 26px;
+			margin: 0;
+			@media (-moz-platform: macos) {
+				margin: 0px -2px;
+			}
+			flex-grow: 1;
+		}
+	}
+
+	// Make sure the summary containing name of top-level item is always visible
+	// and titles are cutoff by letter and not by word
+	collapsible-section > .head .title-box .summary {
+		opacity: 1 !important;
+		width: 0;
+		white-space: nowrap;
+		display: inline;
+	}
+
+	// Annotation icon for collapsible section
+	collapsible-section > .head .title::before {
+		content: '';
+		width: 16px;
+		height: 16px;
+		background: icon-url("itempane/16/attachment-annotations.svg") no-repeat center;
+		-moz-context-properties: fill, fill-opacity, stroke, stroke-opacity;
+		fill: var(--tag-purple);
+		stroke: var(--tag-purple);
+	}
+
+	collapsible-section > .body {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		@include comfortable {
+			gap: 8px;
+		}
+	}
+
+	collapsible-section:not(:last-child) {
+		border-bottom: 1px solid var(--fill-quinary);
+	}
+
+	// Do not cut off annotation text and comment
+	annotation-row .body .comment,
+	annotation-row .body .quote {
+		-webkit-line-clamp: inherit !important;
+	}
+}

--- a/scss/elements/_itemPaneAnnotations.scss
+++ b/scss/elements/_itemPaneAnnotations.scss
@@ -29,7 +29,7 @@ annotation-items-pane {
 	}
 
 	// Make sure the summary containing name of top-level item is always visible
-	// and titles are cutoff by letter and not by word
+	// and titles are cut off by letter and not by word
 	collapsible-section > .head .title-box .summary {
 		opacity: 1 !important;
 		width: 0;

--- a/test/tests/itemTreeTest.js
+++ b/test/tests/itemTreeTest.js
@@ -225,23 +225,28 @@ describe("Zotero.ItemTree", function() {
 			var note1 = await createDataObject('item', { itemType: 'note', parentID: item1.id });
 			var note2 = await createDataObject('item', { itemType: 'note', parentID: item2.id });
 			var note3 = await createDataObject('item', { itemType: 'note', parentID: item3.id });
+
+			// one of the items has an attachment with annotations
+			var attachment = await importFileAttachment('test.pdf', { title: 'PDF', parentItemID: item1.id });
+			var highlight = await createAnnotation('highlight', attachment);
+			var underline = await createAnnotation('underline', attachment);
 			
-			var toSelect = [note1.id, note2.id, note3.id];
+			var toSelect = [note1.id, note2.id, note3.id, highlight.id, underline.id];
 			itemsView.collapseAllRows();
 
 			var numSelected = await itemsView.selectItems(toSelect);
-			assert.equal(numSelected, 3);
+			assert.equal(numSelected, 5);
 			var selected = itemsView.getSelectedItems(true);
-			assert.lengthOf(selected, 3);
+			assert.lengthOf(selected, 5);
 			assert.sameMembers(selected, toSelect);
 			
 			// Again with the ids given in reverse order
 			itemsView.collapseAllRows();
 			toSelect = toSelect.reverse();
-			var numSelected = await itemsView.selectItems(toSelect);
-			assert.equal(numSelected, 3);
-			var selected = itemsView.getSelectedItems(true);
-			assert.lengthOf(selected, 3);
+			numSelected = await itemsView.selectItems(toSelect);
+			assert.equal(numSelected, 5);
+			selected = itemsView.getSelectedItems(true);
+			assert.lengthOf(selected, 5);
 			assert.sameMembers(selected, toSelect);
 		});
 	});

--- a/test/tests/itemTreeTest.js
+++ b/test/tests/itemTreeTest.js
@@ -1669,23 +1669,6 @@ describe("Zotero.ItemTree", function() {
 			assert.isFalse(zp.itemsView.getRowIndexByID(inkID));
 		});
 
-		it("should display non-CJK quote segments in italics", async () => {
-			let highlight = await createAnnotation('highlight', attachment);
-			highlight.annotationText = "Test 木";
-			await highlight.saveTx();
-			zp.itemsView.expandAllRows();
-
-			let rowIndex = zp.itemsView.getRowIndexByID(highlight.id);
-			let cellText = win.document.querySelector(`#item-tree-main-default-row-${rowIndex} .cell-text`);
-			assert.equal(cellText.childNodes.length, 2);
-			// Non-CJK string is wrapped in <i>
-			assert.equal(cellText.firstChild.nodeName, "i");
-			assert.equal(cellText.firstChild.textContent, "Test ");
-			// CJK character is left as is
-			assert.equal(cellText.lastChild.nodeName, "#text");
-			assert.equal(cellText.lastChild.textContent, "木");
-		});
-
 		it("should add note from selected annotation rows of the same parent item ", async () => {
 			zp.itemsView.expandAllRows();
 

--- a/test/tests/itemTreeTest.js
+++ b/test/tests/itemTreeTest.js
@@ -1593,7 +1593,7 @@ describe("Zotero.ItemTree", function() {
 		});
 	});
 	
-	describe("annotations", function() {
+	describe("Annotations", function() {
 		let toplevelItem, attachment, highlight, underline, ink, image, note;
 	
 		before(async () => {
@@ -1674,7 +1674,7 @@ describe("Zotero.ItemTree", function() {
 			assert.isFalse(zp.itemsView.getRowIndexByID(inkID));
 		});
 
-		it("should add note from selected annotation rows of the same parent item ", async () => {
+		it("should add note from selected annotation rows of the same parent item", async () => {
 			zp.itemsView.expandAllRows();
 
 			// make sure underline has some text, just like highlight
@@ -1695,7 +1695,7 @@ describe("Zotero.ItemTree", function() {
 			assert.equal(text.split("<p>").length - 1, 2);
 		});
 
-		it("should create note from selected annotation rows of different parent items ", async () => {
+		it("should create note from selected annotation rows of different parent items", async () => {
 			let toplevelItemTwo = await createDataObject('item', { title: "Another entry" });
 			let attachmentTwo = await importFileAttachment('test.pdf', { title: 'PDF two', parentItemID: toplevelItemTwo.id });
 			let highlightTwo = await createAnnotation('highlight', attachmentTwo);

--- a/test/tests/searchTest.js
+++ b/test/tests/searchTest.js
@@ -248,7 +248,7 @@ describe("Zotero.Search", function() {
 					s.libraryID = userLibraryID;
 					s.addCondition('tag', 'is', tag);
 					var matches = await s.search();
-					assert.sameMembers(matches, [attachment.id]);
+					assert.sameMembers(matches, [annotation.id]);
 				});
 				
 				// TEMP
@@ -421,7 +421,7 @@ describe("Zotero.Search", function() {
 					s.addCondition('annotationText', 'contains', str);
 					var matches = await s.search();
 					// TEMP: Match parent attachment
-					assert.sameMembers(matches, [attachment.id]);
+					assert.sameMembers(matches, [annotation.id]);
 				});
 			});
 			
@@ -437,7 +437,7 @@ describe("Zotero.Search", function() {
 					s.addCondition('annotationComment', 'contains', str);
 					var matches = await s.search();
 					// TEMP: Match parent attachment
-					assert.sameMembers(matches, [attachment.id]);
+					assert.sameMembers(matches, [annotation.id]);
 				});
 			});
 			
@@ -659,7 +659,7 @@ describe("Zotero.Search", function() {
 						s.addCondition('quicksearch-fields', 'contains', tag);
 						var matches = await s.search();
 						// TEMP: Match parent attachment
-						assert.sameMembers(matches, [attachment.id]);
+						assert.sameMembers(matches, [annotation.id]);
 					});
 				})
 				
@@ -674,7 +674,7 @@ describe("Zotero.Search", function() {
 						s.addCondition('quicksearch-everything', 'contains', comment);
 						var matches = await s.search();
 						// TEMP: Match parent attachment
-						assert.sameMembers(matches, [attachment.id]);
+						assert.sameMembers(matches, [annotation.id]);
 					});
 					
 					it("should not include items outside of scope during phrase search", async function () {


### PR DESCRIPTION
 - Annotations are displayed in itemTree under their file attachments on a third level. The annotation spans the entire row.
  - Search matches the actual attachment instead of it's parent file.
  - Can create child notes from annotations of the same item or standalone notes from annotations across different items from the context menu.