### PR TITLE
Fix inconsistent ESC behavior on text edit when reader is opened

### DIFF
--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -842,7 +842,7 @@ var ZoteroPane = new function()
 					if (reader) {
 						reader.focus();
 						// Keep propagating if current focus is on input or textarea
-						// The Escape event needs to handled by itemBox, tagBox, etc. to undo edits.
+						// The Escape event needs to be handled by itemBox, tagBox, etc. to undo edits.
 						if (!["input", "textarea"].includes(document.activeElement.tagName)) {
 							event.preventDefault();
 							event.stopPropagation();

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -841,8 +841,12 @@ var ZoteroPane = new function()
 					let reader = Zotero.Reader.getByTabID(Zotero_Tabs.selectedID);
 					if (reader) {
 						reader.focus();
-						event.preventDefault();
-						event.stopPropagation();
+						// Keep propagating if current focus is on input or textarea
+						// The Escape event needs to handled by itemBox, tagBox, etc. to undo edits.
+						if (!["input", "textarea"].includes(document.activeElement.tagName)) {
+							event.preventDefault();
+							event.stopPropagation();
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Allow ESC event propagating when reader is opened

This is needed to let itemBox, tagBox, etc. to handle ESC events to revent any edits made to textfields. Only applied if the currently focused element is input or textarea.

Fixes: #3246