### PR TITLE
disable "Find available PDF" if files are not editable in a library

### DIFF
--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -3716,6 +3716,9 @@ var ZoteroPane = new function()
 					if (Zotero.Attachments.canFindPDFForItem(item)) {
 						show.add(m.findPDF);
 						show.add(m.sep3);
+						if (!collectionTreeRow.filesEditable) {
+							disable.add(m.findPDF);
+						}
 					}
 					
 					if (Zotero.RecognizeDocument.canUnrecognize(item)) {


### PR DESCRIPTION
For example, in a public group files are not editable, so this menu item should be disabled.

Fixes: #3428