### PR TITLE
Activate collection tree row only if it's focused

### DIFF
--- a/chrome/content/zotero/collectionTree.jsx
+++ b/chrome/content/zotero/collectionTree.jsx
@@ -173,7 +173,7 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 	handleActivate = (event, indices) => {
 		let index = indices[0];
 		let treeRow = this.getRow(index);
-		if (treeRow.isCollection() && this.editable) {
+		if (treeRow.isCollection() && this.editable && this.selection.focused == index) {
 			this._editing = treeRow;
 			treeRow.editingName = treeRow.ref.name;
 			this.tree.invalidateRow(index);


### PR DESCRIPTION
Prevents being able to have multiple rows stuck in editing mode.

Fixes: #3426