### PR TITLE
Search improvements

### DIFF
--- a/chrome/content/zotero/elements/zoteroSearch.js
+++ b/chrome/content/zotero/elements/zoteroSearch.js
@@ -142,11 +142,20 @@
 			var conditionsBox = this.querySelector('#conditions');
 			
 			this.search.removeCondition(id);
-			
+			let found = false;
 			for (var i = 0, len=conditionsBox.childNodes.length; i < len; i++){
 				if (conditionsBox.childNodes[i].conditionID == id){
 					conditionsBox.removeChild(conditionsBox.childNodes[i]);
-					break;
+					found = true;
+					i--;
+					len--;
+					continue;
+				}
+				// When a condition is removed, ids of remaining conditions
+				// are shifted to remain in arithmetic sequence. The conditionID
+				// of the nodes need to be updated accordingly
+				if (found) {
+					conditionsBox.childNodes[i].conditionID--;
 				}
 			}
 			

--- a/chrome/content/zotero/xpcom/data/search.js
+++ b/chrome/content/zotero/xpcom/data/search.js
@@ -478,7 +478,20 @@ Zotero.Search.prototype.removeCondition = function (searchConditionID) {
 		throw new Error('Invalid searchConditionID ' + searchConditionID + ' in removeCondition()');
 	}
 	
-	delete this._conditions[searchConditionID];
+	searchConditionID = String(searchConditionID);
+	// Decrement the id of all conditions following
+	// the condition to be deleted. It ensures that
+	// all conditions remain in stict arithmetic sequence and prevents
+	// conditionIDs from colliding
+	let conditionIDs = Object.keys(this._conditions);
+	let conditionIndex = conditionIDs.indexOf(searchConditionID);
+	for (let i = conditionIndex + 1; i < conditionIDs.length; i++) {
+		let conditionID = conditionIDs[i];
+		this._conditions[conditionID - 1] = this._conditions[conditionID];
+		this._conditions[conditionID - 1].id = conditionID - 1;
+	}
+	// After all conditions are shifted, delete the last, empty one
+	delete this._conditions[this._maxSearchConditionID];
 	this._maxSearchConditionID--;
 	this._markFieldChange('conditions', this._conditions);
 	this._changed.conditions = true;
@@ -856,7 +869,10 @@ Zotero.Search.prototype.fromJSON = function (json, options = {}) {
 		this.name = json.name;
 	}
 	
-	Object.keys(this.getConditions()).forEach(id => this.removeCondition(id));
+	// Remove all conditions
+	while (Object.keys(this._conditions).length) {
+		this.removeCondition(Object.keys(this._conditions)[0]);
+	}
 	for (let i = 0; i < json.conditions.length; i++) {
 		let condition = json.conditions[i];
 		this.addCondition(

--- a/chrome/content/zotero/xpcom/data/search.js
+++ b/chrome/content/zotero/xpcom/data/search.js
@@ -1368,6 +1368,10 @@ Zotero.Search.prototype._buildQuery = Zotero.Promise.coroutine(function* () {
 							}
 							
 							condSQL += 'collectionID IN (' + ids.join(', ') + ')';
+							let attachmentSQL = `) UNION SELECT itemID from itemAttachments WHERE parentItemID IN (${condSQL})`;
+							let noteSQL = `) UNION SELECT itemID from itemNotes WHERE parentItemID IN (${condSQL})`;
+							condSQL += attachmentSQL;
+							condSQL += noteSQL;
 						}
 						// Saved search
 						else {

--- a/test/tests/searchTest.js
+++ b/test/tests/searchTest.js
@@ -247,22 +247,42 @@ describe("Zotero.Search", function() {
 					assert.sameMembers(matches, [attachment.id]);
 				});
 
+
+				it("should match annotation even if none of its ancestors match query in collection", async function () {
+					var collection = await createDataObject('collection');
+					var parent = await createDataObject('item', { collections: [collection.id] });
+					var attachment = await importPDFAttachment(parent, { title: "test" });
+					var annotation = await createAnnotation('highlight', attachment);
+					var tag = Zotero.Utilities.randomString();
+					annotation.addTag(tag);
+					await annotation.saveTx();
+
+					var s = new Zotero.Search();
+					s.libraryID = parent.libraryID;
+					s.addCondition('collection', 'is', collection.key);
+					s.addCondition('tag', 'contains', tag);
+					var matches = await s.search();
+					assert.sameMembers(matches, [annotation.id]);
+				});
+
 				it("should have same result after the same search conditions is removed and added", async function () {
-					var itemOne = await createDataObject('item', { title: "One" });
-					var itemTwo = await createDataObject('item', { title: "Two" });
+					let titleOne = Zotero.Utilities.randomString();
+					let titleTwo = Zotero.Utilities.randomString();
+					var itemOne = await createDataObject('item', { title: titleOne });
+					var itemTwo = await createDataObject('item', { title: titleTwo });
 
 					var s = new Zotero.Search();
 					s.libraryID = itemOne.libraryID;
 					s.addCondition("joinMode", "any");
 					// Match both collections
-					s.addCondition('title', 'contains', 'One');
-					s.addCondition('title', 'contains', 'Two');
+					s.addCondition('title', 'contains', titleOne);
+					s.addCondition('title', 'contains', titleTwo);
 					var matches = await s.search();
 					assert.sameMembers(matches, [itemOne.id, itemTwo.id]);
 
 					// Remove the first condition and add it again
 					s.removeCondition(1);
-					s.addCondition('title', 'contains', 'One');
+					s.addCondition('title', 'contains', titleOne);
 					matches = await s.search();
 					// Result should be the same
 					assert.sameMembers(matches, [itemOne.id, itemTwo.id]);
@@ -270,8 +290,7 @@ describe("Zotero.Search", function() {
 			});
 			
 			describe("tag", function () {
-				// TEMP
-				it("should match parent attachments for annotation tags", async function () {
+				it("should match annotation by its tag", async function () {
 					var attachment = await importPDFAttachment();
 					var annotation = await createAnnotation('highlight', attachment);
 					var tag = Zotero.Utilities.randomString();
@@ -285,10 +304,9 @@ describe("Zotero.Search", function() {
 					assert.sameMembers(matches, [annotation.id]);
 				});
 				
-				// TEMP
-				it("shouldn't match parent attachments with annotations for 'tag' 'is not' condition", async function () {
+				it("should match annotation for 'tag' 'is not' condition", async function () {
 					var attachment = await importPDFAttachment();
-					await createAnnotation('highlight', attachment);
+					var annotation = await createAnnotation('highlight', attachment);
 					var tag = Zotero.Utilities.randomString();
 					attachment.addTag(tag);
 					await attachment.saveTx();
@@ -297,7 +315,7 @@ describe("Zotero.Search", function() {
 					s.libraryID = userLibraryID;
 					s.addCondition('tag', 'isNot', tag);
 					var matches = await s.search();
-					assert.notInclude(matches, attachment.id);
+					assert.includeMembers(matches, [annotation.id]);
 				});
 			});
 			
@@ -454,7 +472,6 @@ describe("Zotero.Search", function() {
 					s.addCondition('joinMode', 'any');
 					s.addCondition('annotationText', 'contains', str);
 					var matches = await s.search();
-					// TEMP: Match parent attachment
 					assert.sameMembers(matches, [annotation.id]);
 				});
 			});
@@ -470,7 +487,6 @@ describe("Zotero.Search", function() {
 					s.addCondition('joinMode', 'any');
 					s.addCondition('annotationComment', 'contains', str);
 					var matches = await s.search();
-					// TEMP: Match parent attachment
 					assert.sameMembers(matches, [annotation.id]);
 				});
 			});
@@ -546,6 +562,54 @@ describe("Zotero.Search", function() {
 					s.addCondition('includeParentsAndChildren', 'true');
 					var matches = await s.search();
 					assert.lengthOf(matches, 0);
+				});
+
+				it("should include annotations if top-level item matches", async function () {
+					var item = await createDataObject('item', { title: Zotero.Utilities.randomString() });
+					var attachment = await importPDFAttachment(item);
+					var annotation = await createAnnotation('highlight', attachment);
+					
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('title', 'contains', item.getDisplayTitle());
+					s.addCondition('includeParentsAndChildren', 'true');
+					var matches = await s.search();
+					
+					assert.includeMembers(matches, [item.id, attachment.id, annotation.id]);
+				});
+
+				it("should include annotations if attachment item matches", async function () {
+					var item = await createDataObject('item');
+					var attachment = await importPDFAttachment(item);
+					var tag = Zotero.Utilities.randomString();
+					attachment.addTag(tag);
+					await attachment.saveTx();
+					var annotation = await createAnnotation('highlight', attachment);
+					
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('tag', 'is', tag);
+					s.addCondition('includeParentsAndChildren', 'true');
+					var matches = await s.search();
+					
+					assert.includeMembers(matches, [item.id, attachment.id, annotation.id]);
+				});
+
+				it("should include top-level item and attachment if annotation matches", async function () {
+					var item = await createDataObject('item');
+					var attachment = await importPDFAttachment(item);
+					var annotation = await createAnnotation('highlight', attachment);
+					var tag = Zotero.Utilities.randomString();
+					annotation.addTag(tag);
+					await annotation.saveTx();
+					
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('tag', 'is', tag);
+					s.addCondition('includeParentsAndChildren', 'true');
+					var matches = await s.search();
+					
+					assert.includeMembers(matches, [item.id, attachment.id, annotation.id]);
 				});
 			});
 			
@@ -692,7 +756,6 @@ describe("Zotero.Search", function() {
 						s.libraryID = userLibraryID;
 						s.addCondition('quicksearch-fields', 'contains', tag);
 						var matches = await s.search();
-						// TEMP: Match parent attachment
 						assert.sameMembers(matches, [annotation.id]);
 					});
 				})
@@ -707,7 +770,6 @@ describe("Zotero.Search", function() {
 						s.libraryID = userLibraryID;
 						s.addCondition('quicksearch-everything', 'contains', comment);
 						var matches = await s.search();
-						// TEMP: Match parent attachment
 						assert.sameMembers(matches, [annotation.id]);
 					});
 					

--- a/test/tests/searchTest.js
+++ b/test/tests/searchTest.js
@@ -233,6 +233,27 @@ describe("Zotero.Search", function() {
 					var matches = await s.search();
 					assert.lengthOf(matches, 0);
 				});
+
+				it("should have same result after the same search conditions is removed and added", async function () {
+					var itemOne = await createDataObject('item', { title: "One" });
+					var itemTwo = await createDataObject('item', { title: "Two" });
+
+					var s = new Zotero.Search();
+					s.libraryID = itemOne.libraryID;
+					s.addCondition("joinMode", "any");
+					// Match both collections
+					s.addCondition('title', 'contains', 'One');
+					s.addCondition('title', 'contains', 'Two');
+					var matches = await s.search();
+					assert.sameMembers(matches, [itemOne.id, itemTwo.id]);
+
+					// Remove the first condition and add it again
+					s.removeCondition(1);
+					s.addCondition('title', 'contains', 'One');
+					matches = await s.search();
+					// Result should be the same
+					assert.sameMembers(matches, [itemOne.id, itemTwo.id]);
+				});
 			});
 			
 			describe("tag", function () {

--- a/test/tests/searchTest.js
+++ b/test/tests/searchTest.js
@@ -234,6 +234,19 @@ describe("Zotero.Search", function() {
 					assert.lengthOf(matches, 0);
 				});
 
+				it("should match child even if its parent does not match query in collection", async function () {
+					var collection = await createDataObject('collection');
+					var parent = await createDataObject('item', { collections: [collection.id] });
+					var attachment = await importPDFAttachment(parent, { title: "test" });
+					
+					var s = new Zotero.Search();
+					s.libraryID = parent.libraryID;
+					s.addCondition('collection', 'is', collection.key);
+					s.addCondition('title', 'contains', 'test');
+					var matches = await s.search();
+					assert.sameMembers(matches, [attachment.id]);
+				});
+
 				it("should have same result after the same search conditions is removed and added", async function () {
 					var itemOne = await createDataObject('item', { title: "One" });
 					var itemTwo = await createDataObject('item', { title: "Two" });


### PR DESCRIPTION
1. In advanced search, if 'collection' condition is present, return and display in itemTree item's children that match the query even if
parents do not match. [Brief demo video](https://www.dropbox.com/scl/fi/9ovwp64q5qskyiormwuxy/collections_match.mov?rlkey=6nv0p1d7usng9mxrgwsv12ers&dl=0). Fixes: #1838 

2. Fix to the bug that caused the conditions to be ignored when a search condition is removed and re-added. Fixes: #3434 

3. When search is opened and itemTree notifier receiver `item` `modify` message, do not do full reload. Instead, run a search with existing scope on given itemIDs and add/remove rows as needed depending on the output of the search. It makes longer operations, such as adding tags, faster for large libraries. 

