### PR TITLE
Add an "Open Documents" section to the citation dialog. Closes #3332

### DIFF
--- a/chrome/content/zotero/integration/quickFormat.js
+++ b/chrome/content/zotero/integration/quickFormat.js
@@ -631,7 +631,7 @@ var Zotero_QuickFormat = new function () {
 		}
 		
 		// Clear item list
-		while (referenceBox.hasChildNodes()) referenceBox.removeChild(referenceBox.firstChild);
+		_clearEntryList();
 		
 		// Take into account items cited in this citation. This means that the sorting isn't
 		// exactly by # of items cited from each library, but maybe it's better this way.
@@ -702,6 +702,7 @@ var Zotero_QuickFormat = new function () {
 			previousLibrary = libraryID;
 		}
 
+		_resize();
 		if (!referenceBox.children.length) {
 			return;
 		}
@@ -716,7 +717,6 @@ var Zotero_QuickFormat = new function () {
 			});
 		}
 		
-		_resize();
 		referenceBox.selectedIndex = selectedIndex;
 		referenceBox.ensureIndexIsVisible(selectedIndex);
 	}

--- a/chrome/content/zotero/integration/quickFormat.js
+++ b/chrome/content/zotero/integration/quickFormat.js
@@ -514,7 +514,7 @@ var Zotero_QuickFormat = new function () {
 		let win = Zotero.getMainWindow();
 		let selectedItems = [];
 		if (win.Zotero_Tabs.selectedType === "library" && !Zotero_QuickFormat.citingNotes) {
-			selectedItems = Zotero.getActiveZoteroPane().getSelectedItems();
+			selectedItems = Zotero.getActiveZoteroPane().getSelectedItems().filter(i => i.isRegularItem());
 		}
 		if (!searchString) {
 			return [selectedItems, []];

--- a/chrome/content/zotero/tabs.js
+++ b/chrome/content/zotero/tabs.js
@@ -132,6 +132,7 @@ var Zotero_Tabs = new function () {
 			var o = {
 				type,
 				title: tab.title,
+				timeUnselected: tab.timeUnselected
 			};
 			if (tab.data) {
 				o.data = tab.data;

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -936,6 +936,7 @@ integration.removeBibEntry.body		= Are you sure you want to omit it from your bi
 integration.cited						= Cited
 integration.cited.loading				= Loading Cited Items…
 integration.openTabs					= Open Documents
+integration.selectedItems				= Selected Items
 integration.ibid						= ibid
 integration.emptyCitationWarning.title	= Blank Citation
 integration.emptyCitationWarning.body	= The citation you have specified would be empty in the currently selected style. Are you sure you want to add it?

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -935,6 +935,7 @@ integration.removeBibEntry.body		= Are you sure you want to omit it from your bi
 
 integration.cited						= Cited
 integration.cited.loading				= Loading Cited Items…
+integration.openTabs					= Open Documents
 integration.ibid						= ibid
 integration.emptyCitationWarning.title	= Blank Citation
 integration.emptyCitationWarning.body	= The citation you have specified would be empty in the currently selected style. Are you sure you want to add it?


### PR DESCRIPTION
Adds an "Open Documents" section to the citation dialog that displays and searches currently opened document tabs in Zotero, which is displayed at the top, above other sections.