### PR TITLE
feat: add linux arm64/aarch64 build

### DIFF
--- a/app/build.sh
+++ b/app/build.sh
@@ -828,7 +828,7 @@ if [ $BUILD_LINUX == 1 ]; then
 	if [[ "${ZOTERO_TEST:-}" = "1" ]] || [[ "${SKIP_32:-}" = "1" ]]; then
 		archs="x86_64"
 	else
-		archs="i686 x86_64"
+		archs="i686 x86_64 aarch64"
 	fi
 	
 	for arch in $archs; do
@@ -852,9 +852,12 @@ if [ $BUILD_LINUX == 1 ]; then
 		cp "$CALLDIR/linux/set_launcher_icon" "$APPDIR"
 		
 		# Use our own updater, because Mozilla's requires updates signed by Mozilla
-		check_lfs_file "$CALLDIR/linux/updater.tar.xz"
-		tar xf "$CALLDIR/linux/updater.tar.xz" --to-stdout updater-$arch > "$APPDIR/updater"
-		chmod 755 "$APPDIR/updater"
+		# aarch64 updater not supported yet
+		if [[ "$arch" != "aarch64" ]]; then
+			check_lfs_file "$CALLDIR/linux/updater.tar.xz"
+			tar xf "$CALLDIR/linux/updater.tar.xz" --to-stdout updater-$arch > "$APPDIR/updater"
+			chmod 755 "$APPDIR/updater"
+		fi
 
 		# Copy app files
 		rsync -a "$base_dir/" "$APPDIR/"

--- a/app/scripts/build_and_run
+++ b/app/scripts/build_and_run
@@ -69,7 +69,11 @@ fi
 if [ "`uname`" = "Darwin" ]; then
 	command="Zotero.app/Contents/MacOS/zotero"
 elif [ "`uname`" = "Linux" ]; then
-	command="Zotero_linux-x86_64/zotero"
+	if [[ "`arch`" = "aarch64" ]]; then
+		command="Zotero_linux-aarch64/zotero"
+	else
+		command="Zotero_linux-x86_64/zotero"
+	fi
 elif [ "`uname -o 2> /dev/null`" = "Cygwin" ]; then
 	command="Zotero_win-x64/zotero.exe"
 else

--- a/app/scripts/fetch_xulrunner
+++ b/app/scripts/fetch_xulrunner
@@ -131,13 +131,15 @@ function modify_omni {
 	replace_line 'MOZ_MAINTENANCE_SERVICE:' 'MOZ_MAINTENANCE_SERVICE: false \&\&' modules/AppConstants.jsm
 	
 	# Prompt if major update is available instead of installing automatically on restart
-	replace_line 'if \(!updateAuto\) \{' 'if (update.type == "major") {
-      LOG("UpdateService:_selectAndInstallUpdate - prompting because it is a major update");
-      AUSTLMY.pingCheckCode(this._pingSuffix, AUSTLMY.CHK_SHOWPROMPT_PREF);
-      Services.obs.notifyObservers(update, "update-available", "show-prompt");
-      return;
-    }
-    if (!updateAuto) {' modules/UpdateService.jsm
+	if [[ "$1" != "aarch64" ]]; then
+		replace_line 'if \(!updateAuto\) \{' 'if (update.type == "major") {
+	      LOG("UpdateService:_selectAndInstallUpdate - prompting because it is a major update");
+	      AUSTLMY.pingCheckCode(this._pingSuffix, AUSTLMY.CHK_SHOWPROMPT_PREF);
+	      Services.obs.notifyObservers(update, "update-available", "show-prompt");
+	      return;
+	    }
+	    if (!updateAuto) {' modules/UpdateService.jsm
+	fi
 	
 	# Avoid console warning about resource://gre/modules/FxAccountsCommon.js
 	replace_line 'const logins = this._data.logins;' 'const logins = this._data.logins; if (this._data.logins.length != -1) return;' modules/LoginStore.jsm
@@ -473,7 +475,7 @@ if [ $BUILD_LINUX == 1 ]; then
 	if [[ "${CI:-}" = "1" ]] || [[ "${SKIP_32:-}" = "1" ]]; then
 		arches="x86_64"
 	else
-		arches="i686 x86_64"
+		arches="i686 x86_64 aarch64"
 	fi
 	for arch in $arches; do
 		xdir="firefox-$arch"
@@ -483,6 +485,14 @@ if [ $BUILD_LINUX == 1 ]; then
 		if [ -e "$archived_file" ]; then
 			echo "Using $archived_file"
 			cp "$archived_file" "firefox-$GECKO_VERSION.tar.bz2"
+		elif [[ "$arch" == "aarch64" ]]; then
+			curl -O "http://ftp.de.debian.org/debian/pool/main/f/firefox-esr/firefox-esr_102.15.0esr-1~deb11u1_arm64.deb"
+			ar xOf firefox-esr_102.15.0esr-1\~deb11u1_arm64.deb data.tar.xz
+			tar -xf data.tar.xz
+			mv ./usr/lib/firefox-esr ./firefox
+			mv ./firefox/firefox-esr ./firefox/firefox-bin
+			rm -rf ./etc ./usr data.tar.xz firefox-esr_102.15.0esr-1\~deb11u1_arm64.deb
+			tar -cvjSf firefox-102.15.1esr.tar.bz2 firefox
 		else
 			curl -O "$DOWNLOAD_URL/linux-$arch/en-US/firefox-$GECKO_VERSION.tar.bz2"
 		fi
@@ -491,7 +501,7 @@ if [ $BUILD_LINUX == 1 ]; then
 		mv firefox firefox-$arch
 
 		pushd firefox-$arch
-		modify_omni
+		modify_omni $arch
 		popd
 		echo $($SCRIPT_DIR/xulrunner_hash -p l) > hash-linux
 		rm "firefox-$GECKO_VERSION.tar.bz2"

--- a/app/scripts/fetch_xulrunner
+++ b/app/scripts/fetch_xulrunner
@@ -486,12 +486,12 @@ if [ $BUILD_LINUX == 1 ]; then
 			echo "Using $archived_file"
 			cp "$archived_file" "firefox-$GECKO_VERSION.tar.bz2"
 		elif [[ "$arch" == "aarch64" ]]; then
-			curl -O "http://ftp.de.debian.org/debian/pool/main/f/firefox-esr/firefox-esr_102.15.0esr-1~deb11u1_arm64.deb"
+			curl -O "https://ftp.debian.org/debian/pool/main/f/firefox-esr/firefox-esr_102.15.0esr-1~deb11u1_arm64.deb"
 			ar xOf firefox-esr_102.15.0esr-1\~deb11u1_arm64.deb data.tar.xz
 			tar -xf data.tar.xz
 			mv ./usr/lib/firefox-esr ./firefox
 			mv ./firefox/firefox-esr ./firefox/firefox-bin
-			rm -rf ./etc ./usr data.tar.xz firefox-esr_102.15.0esr-1\~deb11u1_arm64.deb
+			rm -rf etc usr data.tar.xz firefox-esr_102.15.0esr-1\~deb11u1_arm64.deb
 			tar -cvjSf firefox-102.15.1esr.tar.bz2 firefox
 		else
 			curl -O "$DOWNLOAD_URL/linux-$arch/en-US/firefox-$GECKO_VERSION.tar.bz2"

--- a/app/update-packaging/build_autoupdate.sh
+++ b/app/update-packaging/build_autoupdate.sh
@@ -141,13 +141,14 @@ for version in "$FROM" "$TO"; do
 	WIN64_ARCHIVE="Zotero-${version}_win-x64.zip"
 	LINUX_X86_ARCHIVE="Zotero-${version}_linux-i686.tar.bz2"
 	LINUX_X86_64_ARCHIVE="Zotero-${version}_linux-x86_64.tar.bz2"
+	LINUX_AARCH64_ARCHIVE="Zotero-${version}_linux-aarch64.tar.bz2"
 	
 	CACHE_DIR="$ROOT_DIR/cache"
 	if [ ! -e "$CACHE_DIR" ]; then
 		mkdir "$CACHE_DIR"
 	fi
 	
-	for archive in "$MAC_ARCHIVE" "$WIN32_ARCHIVE" "$WIN64_ARCHIVE" "$LINUX_X86_ARCHIVE" "$LINUX_X86_64_ARCHIVE"; do
+	for archive in "$MAC_ARCHIVE" "$WIN32_ARCHIVE" "$WIN64_ARCHIVE" "$LINUX_X86_ARCHIVE" "$LINUX_X86_64_ARCHIVE" "$LINUX_AARCH64_ARCHIVE"; do
 		if [[ $archive = "$MAC_ARCHIVE" ]] && [[ $BUILD_MAC != 1 ]]; then
 			continue
 		fi
@@ -161,6 +162,9 @@ for version in "$FROM" "$TO"; do
 			continue
 		fi
 		if [[ $archive = "$LINUX_X86_64_ARCHIVE" ]] && [[ $BUILD_LINUX != 1 ]]; then
+			continue
+		fi
+		if [[ $archive = "$LINUX_AARCH64_ARCHIVE" ]] && [[ $BUILD_LINUX != 1 ]]; then
 			continue
 		fi
 		
@@ -240,14 +244,14 @@ for version in "$FROM" "$TO"; do
 	
 	# Unpack Linux tarballs
 	if [ $BUILD_LINUX == 1 ]; then
-		if [[ -f "$LINUX_X86_ARCHIVE" ]] && [[ -f "$LINUX_X86_64_ARCHIVE" ]]; then
-			for build in "$LINUX_X86_ARCHIVE" "$LINUX_X86_64_ARCHIVE"; do
+		if [[ -f "$LINUX_X86_ARCHIVE" ]] && [[ -f "$LINUX_X86_64_ARCHIVE" ]] && [[ -f "$LINUX_AARCH64_ARCHIVE" ]]; then
+			for build in "$LINUX_X86_ARCHIVE" "$LINUX_X86_64_ARCHIVE" "$LINUX_AARCH64_ARCHIVE"; do
 				tar -xjf "$build"
 				rm "$build"
 			done
 			INCREMENTALS_FOUND=1
 		else
-			echo "$LINUX_X86_ARCHIVE/$LINUX_X86_64_ARCHIVE not found"
+			echo "$LINUX_X86_ARCHIVE/$LINUX_X86_64_ARCHIVE/$LINUX_AARCH64_ARCHIVE not found"
 		fi
 	fi
 	
@@ -259,7 +263,7 @@ export MOZ_PRODUCT_VERSION="$TO"
 export MAR_CHANNEL_ID="$CHANNEL"
 
 CHANGES_MADE=0
-for build in "mac" "win32" "win-x64" "linux-i686" "linux-x86_64"; do
+for build in "mac" "win32" "win-x64" "linux-i686" "linux-x86_64" "linux-aarch64"; do
 	if [[ $build == "mac" ]]; then
 		if [[ $BUILD_MAC == 0 ]]; then
 			continue
@@ -269,7 +273,7 @@ for build in "mac" "win32" "win-x64" "linux-i686" "linux-x86_64"; do
 		if [[ $build == "win32" ]] || [[ $build == "win-x64" ]] && [[ $BUILD_WIN == 0 ]]; then
 			continue
 		fi
-		if [[ $build == "linux-i686" ]] || [[ $build == "linux-x86_64" ]] && [[ $BUILD_LINUX == 0 ]]; then
+		if [[ $build == "linux-i686" ]] || [[ $build == "linux-x86_64" ]] || [[ $build == "linux-aarch64" ]] && [[ $BUILD_LINUX == 0 ]]; then
 			continue
 		fi
 		dir="Zotero_$build"


### PR DESCRIPTION
This code should enable builds on Linux ARM64, I have tested it on Asahi Linux Fedora 39 on a Macbook M1 Pro. (See #3515)

It would be nice if someone could test it on other machines. 

The link to the firefox `.deb` is hardcoded for now (Debian FTP), since not every version is available there.

Also, the sections about the updater are commented out for Linux aarch64, I haven't found out how I should make an arm64 updater yet. Maybe @dstillman you can help me understand how this should be done?

@dstillman would you like to review the PR?

On Fedora 39 I needed two dependencies to run this version of Firefox. Here are the commands I ran:
```sh
sudo dnf install ghc8.10-base # provides libffi.so.7
sudo ln -s /usr/lib64/ghc-8.10.7/rts/libffi.so.7.1.0 /usr/lib64/libffi.so.7
sudo ln -s /usr/lib64/libvpx.so.7.1.0 /usr/lib64/libvpx.so.6
```