### PR TITLE
Add regex replace feature for file renaming

### DIFF
--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -2178,12 +2178,15 @@ Zotero.Attachments = new function () {
 		};
 
 
-		const common = (value, { truncate = false, prefix = '', suffix = '', case: textCase = '' } = {}) => {
+		const common = (value, { truncate = false, prefix = '', suffix = '', replaceFrom = '', replaceTo = '', regexOpts = '', case: textCase = '' } = {}) => {
 			if (value === '' || value === null || typeof value === 'undefined') {
 				return '';
 			}
 			if (truncate) {
 				value = value.substr(0, truncate);
+			}
+			if (replaceFrom) {
+				value = value.replace(new RegExp(replaceFrom, regexOpts), replaceTo);
 			}
 			if (prefix) {
 				value = prefix + value;

--- a/test/tests/attachmentsTest.js
+++ b/test/tests/attachmentsTest.js
@@ -1350,6 +1350,10 @@ describe("Zotero.Attachments", function() {
 				'Barius and Pixelus - 1975 - Lorem Ipsum'
 			);
 			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{{firstCreator suffix=" - " replaceFrom=" *and *" replaceTo="&"}}{{year suffix=" - " replaceFrom="(\\d{2})(\\d{2})" replaceTo="$2"}}{{title truncate="50" replaceFrom=".m" replaceTo="a"}} - {{title truncate="50" replaceFrom=".m" replaceTo="a" regexOpts="g"}}'),
+				'Barius&Pixelus - 75 - Lora Ipsum - Lora Ipsa'
+			);
+			assert.equal(
 				Zotero.Attachments.getFileBaseNameFromItem(item, '{{year suffix="-"}}{{firstCreator truncate="10" suffix="-"}}{{title truncate="5" }}'),
 				'1975-Barius and-Lorem'
 			);


### PR DESCRIPTION
This PR adds the ability to perform regex replacements while defining names for file attachments. Multiple people have requested this feature on [this thread](https://forums.zotero.org/discussion/comment/443447).

### Example usage

I use Better Bibtex citekeys of the form [bibtex alpha citation]-[keyword, usually first word of the title]. For instance, _LLVM: A compilation framework for lifelong program analysis & transformation_ by Lattner and Adve, from 2004, would have the citekey `LA04-LLVM`.

I would like to have filenames containing the alphanumeric part of the citekey with the full title, e.g. "LA04 - LLVM A compilation framework for lifelong program analysis & transformation.pdf".

In Zotero 6 with Zotfile, I was able to use [user-defined wildcards](http://zotfile.com/index.html#user-defined-wildcards) to accomplish this, by defining the following custom format string:

```
{
  "B": {
    "field": "citekey",
    "operations": [
      {
        "function": "replace",
        "regex": "-.*$",
        "replacement": "",
        "flags": "g"
      }
    ]
  }
```

Unfortunately, Zotfile is no longer supported in Zotero 7. Its file renaming ability has been subsumed by Zotero's built-in one, which cannot perform substitutions.

This pull request addresses this issue by allowing regex substitutions in file renames. Specifically, the following format string can be used to accomplish the same function as the one above:

```{{ citationKey suffix=" - " replaceFrom = "-.*$"}}{{ title truncate="500" }}```

### Suggested Documentation Changes

Add a row to the "parameters" table on [this page](https://www.zotero.org/support/file_renaming#parameters).

**Parameter**: `replaceFrom`, `replaceTo`, `regexOpts`
**Variables**: all
**Default value**: "" (empty string)
**Description**: replaces regular expression `replaceFrom` with `replaceTo`. This uses Javascript's [`replace`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace) function, and supports replacement patterns (e.g. $1, $2, etc. to specify parts of the regex) and regex options, which are specified by `regexOpts`. In particular, set `regexOpts` to "g" to replace *all* instances of `replaceFrom` (instead of only the first).


