### PR TITLE
Fix missing date of feeds; change the sorting criteria from id to date

### DIFF
--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -1829,7 +1829,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 
 	getSortField() {
 		if (this.collectionTreeRow.isFeedsOrFeed()) {
-			return 'id';
+            return 'date';
 		}
 		var column = this._sortedColumn;
 		if (!column) {

--- a/chrome/content/zotero/xpcom/feedReader.js
+++ b/chrome/content/zotero/xpcom/feedReader.js
@@ -68,6 +68,13 @@ Zotero.FeedReader = function (url) {
 		info.subtitle = feed.subtitle ? feed.subtitle.plainText() : '';
 		
 		if (feed.updated) info.updated = new Date(feed.updated);
+
+        let infoDate = Zotero.FeedReader._getFeedField(feed, 'lastBuildDate', 'dc') 
+            || Zotero.FeedReader._getFeedField(feed, 'lastBuildDate') 
+            || Zotero.FeedReader._getFeedField(feed, 'date', 'dc') 
+            || Zotero.FeedReader._getFeedField(feed, 'date');
+        if (infoDate) info.date = infoDate;
+
 		
 		// categories: MDN says "not yet implemented"
 		
@@ -454,7 +461,8 @@ Zotero.FeedReader._getFeedItem = function (feedEntry, feedInfo) {
 		// DEBUG: Why not get these from the feedEntry?
 		|| Zotero.FeedReader._getFeedField(feedEntry, 'pubDate') // RSS
 		|| Zotero.FeedReader._getFeedField(feedEntry, 'updated', 'atom') // Atom
-		|| Zotero.FeedReader._getFeedField(feedEntry, 'published', 'atom'); // Atom
+		|| Zotero.FeedReader._getFeedField(feedEntry, 'published', 'atom') // Atom
+        || feedInfo.date; // If no date found, use date from feed info
 		
 	
 	if (date) item.date = date;


### PR DESCRIPTION
1. This PR fixes the bug of feeds that do not have a "date" label in the item, but in the feed info. 
2. Besides, I change the default sorting criteria from id to date, which is easier for researchers to follow new papers.

For [Arxiv rss](http://export.arxiv.org/rss/cs.RO) or [Robotics and Autonomous Systems rss](https://rss.sciencedirect.com/publication/science/09218890), the date info is not included in each item. I instead use the "date" or "lastBuildDate" label in the channel.

The Arxiv rss is listed below.
```xml
<channel rdf:about="http://arxiv.org/">
    <title>cs.RO updates on arXiv.org</title>
    \cdots
    <link>http://arxiv.org/</link>
    <description rdf:parseType="Literal">
    </description>
    <dc:language>en-us</dc:language>
    <dc:date>2024-01-11T20:30:00-05:00</dc:date>
    <dc:publisher>help@arxiv.org</dc:publisher>
    <dc:subject>Computer Science -- Robotics</dc:subject>
    <syn:updateBase>1901-01-01T00:00+00:00</syn:updateBase>
    <syn:updateFrequency>1</syn:updateFrequency>
    <syn:updatePeriod>daily</syn:updatePeriod>
    <image rdf:resource="http://arxiv.org/icons/sfx.gif"/>
</channel>
<image rdf:about="http://arxiv.org/icons/sfx.gif">
    <title>arXiv.org</title>
    <url>http://arxiv.org/icons/sfx.gif</url>
    <link>http://arxiv.org/</link>
</image>
<item rdf:about="http://arxiv.org/abs/2401.05346">
    <title>
        Task tree retrieval from FOON using search algorithms. (arXiv:2401.05346v1 [cs.RO])
    </title>
    <link>http://arxiv.org/abs/2401.05346</link>
    <description rdf:parseType="Literal">
        <p>Robots can be very useful to automate tasks and reduce the human effort required. . </p>
    </description>
    <dc:creator>
        <a href="http://arxiv.org/find/cs/1/au:+Attapu_A/0/1/0/all/0/1">Amitha Attapu</a>
    </dc:creator>
</item>
```

Without this PR, the date of Arxiv feeds is missing:
![2024-01-14_14-59](https://github.com/zotero/zotero/assets/39004670/73d25dbe-48eb-4b7d-9c10-3d65463c4124)
With this PR, everything is fine, ordered by date:
![2024-01-14_14-42](https://github.com/zotero/zotero/assets/39004670/b457cf05-4fa2-4c21-be5e-ddbb789e8a10)

