### PR TITLE
Fix `editable-text` expansion with non-overlay scrollbars on macOS

### DIFF
--- a/scss/elements/_editableText.scss
+++ b/scss/elements/_editableText.scss
@@ -100,10 +100,6 @@ editable-text {
 	}
 	
 	&[multiline] {
-		&::after, .input {
-			overflow-y: auto;
-		}
-		
 		.input {
 			min-height: 5em;
 		}

--- a/scss/elements/_editableText.scss
+++ b/scss/elements/_editableText.scss
@@ -56,6 +56,7 @@ editable-text {
 		font: inherit;
 		line-height: inherit;
 		overflow: hidden;
+		scrollbar-gutter: stable;
 	}
 	
 	&:not([nowrap])::after, &:not([nowrap]) .input {
@@ -63,7 +64,6 @@ editable-text {
 		overflow-wrap: anywhere;
 		white-space: pre-wrap;
 		max-height: calc(2ex * var(--max-visible-lines));
-		scrollbar-gutter: stable;
 	}
 	
 	.input {
@@ -116,9 +116,12 @@ editable-text {
 	&[hidden] {
 		display: none;
 	}
-	// Per https://stackoverflow.com/a/22700700, somehow this removes an extra half-line
-	// at the bottom of textarea on all platforms with non-overlay scrollbars 
 	textarea {
+		// Per https://stackoverflow.com/a/22700700, somehow this removes an extra half-line
+		// at the bottom of textarea on all platforms with non-overlay scrollbars
 		overflow-x: hidden;
+		
+		// Match the gutters we apply to ::after
+		overflow-y: scroll;
 	}
 }

--- a/scss/elements/_editableText.scss
+++ b/scss/elements/_editableText.scss
@@ -55,7 +55,7 @@ editable-text {
 		padding: var(--editable-text-padding-block) var(--editable-text-padding-inline);
 		font: inherit;
 		line-height: inherit;
-		color: inherit;
+		overflow: hidden;
 	}
 	
 	&:not([nowrap])::after, &:not([nowrap]) .input {
@@ -63,6 +63,7 @@ editable-text {
 		overflow-wrap: anywhere;
 		white-space: pre-wrap;
 		max-height: calc(2ex * var(--max-visible-lines));
+		scrollbar-gutter: stable;
 	}
 	
 	.input {


### PR DESCRIPTION
Simpler than I thought it would be! @abaevbog, see if this works for you?

(We should put together some sort of `editable-text` test suite/document with fields in various configurations, weird text that's likely to trigger wrapping edge cases, and so on.)