### PR TITLE
additions to keyboard nav for toolbar buttons and reader

### DIFF
--- a/chrome/content/zotero/contextPane.js
+++ b/chrome/content/zotero/contextPane.js
@@ -277,8 +277,9 @@ var ZoteroContextPane = new function () {
 
 		if (splitter.getAttribute('state') != 'collapsed') {
 			if (_panesDeck.selectedIndex == 0) {
-				var node = _itemPaneDeck.selectedPanel;
-				node.focus();
+				// Focus the title in the header
+				var header = _itemPaneDeck.selectedPanel.querySelector("pane-header editable-text");
+				header.focus();
 				return true;
 			}
 			else {
@@ -873,6 +874,7 @@ var ZoteroContextPane = new function () {
 		// div
 		var div = document.createElement('div');
 		div.className = 'zotero-view-item';
+		div.setAttribute("tabindex", "0");
 		main.append(div);
 		
 		// Info

--- a/chrome/content/zotero/itemPane.js
+++ b/chrome/content/zotero/itemPane.js
@@ -180,19 +180,22 @@ var ZoteroItemPane = new function() {
 		let sidenav = document.getElementById(
 			isLibraryTab ? 'zotero-view-item-sidenav' : 'zotero-context-pane-sidenav'
 		);
+
+		// Shift-tab from title when reader is opened focuses the last button in tabs toolbar
+		if (event.target.closest(".title") && event.key == "Tab"
+			&& event.shiftKey && Zotero_Tabs.selectedType == "reader") {
+			let focusable = [...document.querySelectorAll("#zotero-tabs-toolbar toolbarbutton:not([disabled]):not([hidden])")];
+			let btn = focusable[focusable.length - 1];
+			btn.focus();
+			stopEvent();
+			return;
+		}
 		// Tab from the scrollable area focuses the pinned pane if it exists
 		if (event.target.classList.contains("zotero-view-item") && event.key == "Tab" && !event.shiftKey && sidenav.pinnedPane) {
 			let pane = sidenav.getPane(sidenav.pinnedPane);
 			pane.firstChild._head.focus();
 			stopEvent();
 			return;
-		}
-		// Space or Enter on a button or 'keyboard-clickable' triggers a click
-		if ([" ", "Enter"].includes(event.key)
-			&& (event.target.tagName == "toolbarbutton"
-				|| event.target.classList.contains("keyboard-clickable"))) {
-			event.target.click();
-			stopEvent();
 		}
 		// Tab tavigation between entries and buttons within library, related and notes boxes
 		if (event.key == "Tab" && event.target.closest(".box")) {

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -1018,7 +1018,6 @@ var ZoteroPane = new function()
 		if ([" ", "Enter"].includes(event.key)
 			&& (["button", "toolbarbutton"].includes(tgt.tagName)
 				|| tgt.classList.contains("keyboard-clickable"))) {
-			console.log("SHOULD OPEN THE THING", event);
 			if (event.target.querySelector("menupopup")) {
 				event.target.open = true;
 			}

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -1233,7 +1233,7 @@
 												<html:div class="zotero-view-item-main">
 													<pane-header id="zotero-item-pane-header" />
 													
-													<html:div id="zotero-view-item" class="zotero-view-item">
+													<html:div id="zotero-view-item" class="zotero-view-item" tabindex="0">
 														<item-box id="zotero-editpane-item-box" data-pane="info"/>
 														
 														<abstract-box id="zotero-editpane-abstract" class="zotero-editpane-abstract" data-pane="abstract"/>

--- a/scss/elements/_paneHeader.scss
+++ b/scss/elements/_paneHeader.scss
@@ -32,5 +32,8 @@ pane-header {
 	
 	.menu-button toolbarbutton {
 		@include svgicon-menu("go-to", "universal", "20");
+		--radius-focus-border: 5px;
+		--width-focus-border: 2px;
+		@include focus-ring;
 	}
 }


### PR DESCRIPTION
- Space/Enter open the menus of "add note" and "add attachment" buttons
- Enter triggers the "New Collection" button for consistency
- Added locate button accessibility via tab from itemPane header or via shift-tab from the scrollable area of itemPane.

Fixes: #3593