### PR TITLE
Fix a bug where first column is clipped if it has fixed or static width

### DIFF
--- a/chrome/content/zotero/components/virtualized-table.jsx
+++ b/chrome/content/zotero/components/virtualized-table.jsx
@@ -444,6 +444,7 @@ class VirtualizedTable extends React.Component {
 
 		onDragOver: PropTypes.func,
 		onDrop: PropTypes.func,
+		onSetOrder: PropTypes.func,
 
 		// Enter, double-clicking
 		onActivate: PropTypes.func,
@@ -1569,6 +1570,10 @@ var Columns = class {
 			if (a.ordinal == b.ordinal) return a == column ? -1 : 1;
 			return a.ordinal - b.ordinal;
 		});
+
+		this._virtualizedTable.props.onSetOrder?.(this._columns);
+		this.onResize(Object.fromEntries(this._columns.map(c => [c.dataKey, c.width])));
+
 		let prefs = this._getPrefs();
 		// reassign columns their ordinal values and set the prefs
 		this._columns.forEach((column, index) => {

--- a/chrome/content/zotero/components/virtualized-table.jsx
+++ b/chrome/content/zotero/components/virtualized-table.jsx
@@ -36,7 +36,7 @@ const TYPING_TIMEOUT = 1000;
 const MINIMUM_ROW_HEIGHT = 20; // px
 const RESIZER_WIDTH = 5; // px
 const COLUMN_MIN_WIDTH = 20;
-const COLUMN_PADDING = 10; // N.B. MUST BE INLINE WITH CSS!!!
+const COLUMN_PADDING = 16; // N.B. MUST BE INLINE WITH CSS!!!
 
 const noop = () => 0;
 
@@ -849,8 +849,8 @@ class VirtualizedTable extends React.Component {
 			offset += resizingRect.width;
 		}
 		const widthSum = aRect.width + bRect.width;
-		const aSpacingOffset = (aColumn.minWidth ? aColumn.minWidth : COLUMN_MIN_WIDTH) + COLUMN_PADDING;
-		const bSpacingOffset = (bColumn.minWidth ? bColumn.minWidth : COLUMN_MIN_WIDTH) + COLUMN_PADDING;
+		const aSpacingOffset = (aColumn.minWidth ? aColumn.minWidth : COLUMN_MIN_WIDTH) + (aColumn.noPadding ? 0 : COLUMN_PADDING);
+		const bSpacingOffset = (bColumn.minWidth ? bColumn.minWidth : COLUMN_MIN_WIDTH) + (bColumn.noPadding ? 0 : COLUMN_PADDING);
 		const aColumnWidth = Math.min(widthSum - bSpacingOffset, Math.max(aSpacingOffset, event.clientX - (RESIZER_WIDTH / 2) - offset));
 		const bColumnWidth = widthSum - aColumnWidth;
 		let onResizeData = {};

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -44,7 +44,6 @@ const CHILD_INDENT = 16;
 const COLORED_TAGS_RE = new RegExp("^(?:Numpad|Digit)([0-" + Zotero.Tags.MAX_COLORED_TAGS + "]{1})$");
 const COLUMN_PREFS_FILEPATH = OS.Path.join(Zotero.Profile.dir, "treePrefs.json");
 const ATTACHMENT_STATE_LOAD_DELAY = 150; //ms
-const FIRST_COLUMN_EXTRA_WIDTH = 28; // 16px for twisty + 16px for icon - 8px column padding + 4px margin
 
 var ItemTree = class ItemTree extends LibraryTree {
 	static async init(domEl, opts={}) {
@@ -943,21 +942,6 @@ var ItemTree = class ItemTree extends LibraryTree {
 			this.selection.select(this.selection.focused);
 		}
 	};
-
-	adjustColumnWidths = (columns) => {
-		const columnDefs = this.getColumns();
-		columns.filter(c => !c.hidden).forEach((column, index) => {
-			const isFirstColumn = index === 0;
-			const columnDef = columnDefs.find(c => c.dataKey === column.dataKey);
-			if (column.fixedWidth) {
-				column.width = isFirstColumn ? parseInt(columnDef.width) + FIRST_COLUMN_EXTRA_WIDTH : columnDef.width;
-			}
-			if (column.staticWidth) {
-				column.minWidth = isFirstColumn ? (columnDef?.minWidth ?? 20) + FIRST_COLUMN_EXTRA_WIDTH : columnDef.minWidth;
-				column.width = isFirstColumn ? Math.max(parseInt(column.width) ?? 0, column.minWidth) : column.width;
-			}
-		});
-	};
 	
 	render() {
 		const itemsPaneMessageHTML = this._itemsPaneMessage || this.props.emptyMessage;
@@ -1001,6 +985,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 					storeColumnPrefs: this._storeColumnPrefs,
 					getDefaultColumnOrder: this._getDefaultColumnOrder,
 					containerWidth: this.domEl.clientWidth,
+					firstColumnExtraWidth: 28, // 16px for twisty + 16px for icon - 8px column padding + 4px margin
 
 					multiSelect: true,
 
@@ -1021,7 +1006,6 @@ var ItemTree = class ItemTree extends LibraryTree {
 					onActivate: this.handleActivate,
 
 					onItemContextMenu: (...args) => this.props.onContextMenu(...args),
-					onSetOrder: this.adjustColumnWidths,
 					
 					role: 'tree',
 					label: Zotero.getString('pane.items.title'),
@@ -3181,18 +3165,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 			this._columns.push(column);
 		}
 
-		let sortedColumns = this._columns.sort((a, b) => a.ordinal - b.ordinal);
-		let firstColumn = sortedColumns.filter(column => !column.hidden)[0];
-		
-		if (firstColumn.fixedWidth) {
-			firstColumn.width = parseInt(firstColumn.width) + FIRST_COLUMN_EXTRA_WIDTH;
-		}
-		if (firstColumn.staticWidth) {
-			firstColumn.minWidth = (firstColumn.minWidth ?? 0) + FIRST_COLUMN_EXTRA_WIDTH;
-			firstColumn.width = Math.max(parseInt(firstColumn.width), firstColumn.minWidth);
-		}
-
-		return sortedColumns;
+		return this._columns.sort((a, b) => a.ordinal - b.ordinal);
 	}
 	
 	_getColumn(index) {
@@ -3569,11 +3542,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 			menuitem.setAttribute('type', 'checkbox');
 			menuitem.setAttribute('label', label);
 			menuitem.setAttribute('colindex', i);
-			menuitem.addEventListener('command', () => {
-				this.tree._columns.toggleHidden(i);
-				this.adjustColumnWidths(this.tree._columns._columns);
-				this.tree._columns.onResize(Object.fromEntries(this.tree._columns._columns.map(c => [c.dataKey, c.width])));
-			});
+			menuitem.addEventListener('command', () => this.tree._columns.toggleHidden(i));
 			if (!column.hidden) {
 				menuitem.setAttribute('checked', true);
 			}

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -2721,6 +2721,10 @@ var ItemTree = class ItemTree extends LibraryTree {
 			}
 		}
 
+		if (column.noPadding) {
+			cell.classList.add('no-padding');
+		}
+
 		if (isFirstColumn) {
 			// Add depth indent, twisty and icon
 			const depth = this.getLevel(index);

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -953,7 +953,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 				column.width = isFirstColumn ? parseInt(columnDef.width) + FIRST_COLUMN_EXTRA_WIDTH : columnDef.width;
 			}
 			if (column.staticWidth) {
-				column.minWidth = isFirstColumn ? (columnDef?.minWidth ?? 0) + FIRST_COLUMN_EXTRA_WIDTH : columnDef.minWidth;
+				column.minWidth = isFirstColumn ? (columnDef?.minWidth ?? 20) + FIRST_COLUMN_EXTRA_WIDTH : columnDef.minWidth;
 				column.width = isFirstColumn ? Math.max(parseInt(column.width) ?? 0, column.minWidth) : column.width;
 			}
 		});

--- a/chrome/content/zotero/itemTreeColumns.jsx
+++ b/chrome/content/zotero/itemTreeColumns.jsx
@@ -40,6 +40,7 @@ const Icons = require('components/icons');
  * @property {string} [width] - A column width instead of flex ratio. See above.
  * @property {boolean} [fixedWidth] - Default: false. Set to true to disable column resizing
  * @property {boolean} [staticWidth] - Default: false. Set to true to prevent columns from changing width when the width of the tree increases or decreases
+ * @property {boolean} [noPadding] - Set to true for columns with padding disabled in stylesheet
  * @property {number} [minWidth] - Override the default [20px] column min-width for resizing
  * @property {React.Component} [iconLabel] - Set an Icon label instead of a text-based one
  * @property {string} [iconPath] - Set an Icon path, overrides {iconLabel}
@@ -338,6 +339,7 @@ const COLUMNS = [
 		iconLabel: <Icons.IconAttachSmall />,
 		fixedWidth: true,
 		width: "32",
+		noPadding: true,
 		zoteroPersist: ["hidden", "sortDirection"]
 	},
 	{
@@ -346,9 +348,10 @@ const COLUMNS = [
 		showInColumnPicker: true,
 		label: "zotero.tabs.notes.label",
 		iconLabel: <Icons.IconTreeitemNoteSmall />,
-		width: "32",
-		minWidth: 32,
+		width: "26",
+		minWidth: 26,
 		staticWidth: true,
+		noPadding: true,
 		zoteroPersist: ["width", "hidden", "sortDirection"]
 	},
 	{

--- a/chrome/content/zotero/itemTreeColumns.jsx
+++ b/chrome/content/zotero/itemTreeColumns.jsx
@@ -337,7 +337,7 @@ const COLUMNS = [
 		label: "zotero.tabs.attachments.label",
 		iconLabel: <Icons.IconAttachSmall />,
 		fixedWidth: true,
-		width: "16",
+		width: "32",
 		zoteroPersist: ["hidden", "sortDirection"]
 	},
 	{
@@ -346,8 +346,8 @@ const COLUMNS = [
 		showInColumnPicker: true,
 		label: "zotero.tabs.notes.label",
 		iconLabel: <Icons.IconTreeitemNoteSmall />,
-		width: "14",
-		minWidth: 14,
+		width: "32",
+		minWidth: 32,
 		staticWidth: true,
 		zoteroPersist: ["width", "hidden", "sortDirection"]
 	},

--- a/scss/components/_item-tree.scss
+++ b/scss/components/_item-tree.scss
@@ -21,6 +21,16 @@
 		padding-inline-end: calc(8px + var(--scrollbar-width, 0px));
 		box-sizing: border-box;
 
+		.cell.hasAttachment,
+		.cell.numNotes {
+			padding: 0;
+			text-align: center;
+
+			&.first-column {
+				padding-inline-start: 28px;
+			}
+		}
+
 		.first-column {
 			&::before {
 				content: "";
@@ -159,8 +169,12 @@
 			}
 		}
 		
-		.cell.numNotes {
+		.numNotes {
 			text-align: center;
+
+			.cell-text {
+				text-align: center;
+			}
 		}
 	}
 }

--- a/scss/components/_item-tree.scss
+++ b/scss/components/_item-tree.scss
@@ -151,7 +151,6 @@
 		}
 		
 		.cell.hasAttachment {
-			box-sizing: content-box;
 			// Don't show ellipsis
 			text-overflow: unset;
 			

--- a/scss/components/_item-tree.scss
+++ b/scss/components/_item-tree.scss
@@ -165,8 +165,17 @@
 		}
 		
 		.cell.hasAttachment {
-			// Don't show ellipsis
 			text-overflow: unset;
+			align-items: center;
+			display: flex;
+			justify-content: center;
+
+			.cell-text {
+				text-overflow: unset;
+				align-items: center;
+				display: flex;
+				justify-content: center;
+			}
 			
 			.icon-missing-file {
 				opacity: 0.4;

--- a/scss/components/_item-tree.scss
+++ b/scss/components/_item-tree.scss
@@ -27,7 +27,7 @@
 			text-align: center;
 
 			&.first-column {
-				padding-inline-start: 28px;
+				padding-inline-start: 32px;
 			}
 		}
 
@@ -159,6 +159,10 @@
 				margin-inline-start: 3px;
 			}
 		}
+
+		.cell.no-padding {
+			padding: 0;
+		}
 		
 		.cell.hasAttachment {
 			// Don't show ellipsis
@@ -169,7 +173,7 @@
 			}
 		}
 		
-		.numNotes {
+		.numNotes, .hasAttachment {
 			text-align: center;
 
 			.cell-text {

--- a/scss/components/_virtualized-table.scss
+++ b/scss/components/_virtualized-table.scss
@@ -71,7 +71,9 @@
 				overflow: hidden;
 
 				&:not(:first-child) {
-					margin-inline-start: 4px;
+					@include state(".cell.first-column:not(.hasAttachment)") {
+						margin-inline-start: 4px;
+					}
 				}
 			}
 


### PR DESCRIPTION
This PR addresses issues #3582 and #3595.

The solution implemented here is functional, but there may be room for a more elegant approach. Given number of reports we had for the first column bug, we could opt to merge this as a quick fix and refine it later.

Changes include:

* A new handler `onSetOrder` in the virtualized table.
* Virtualized table now invokes onResize after the order of columns changes.
* The Items table uses `onSetOrder` to adjust the width of fixed/static width columns when they become the first columns.
* Similarly, when a column is toggled between visible and hidden states, and it becomes the first fixed/static column, its width needs adjustment.
* The exception for attachment column to use a different box-sizing has been removed. The fixed width has been adjusted to include column padding.


https://github.com/zotero/zotero/assets/214628/8bbbd308-939d-4218-92f6-d18038314c35

