### PR TITLE
fixes to itemBox creator functionality

### DIFF
--- a/chrome/content/zotero/elements/editableText.js
+++ b/chrome/content/zotero/elements/editableText.js
@@ -140,7 +140,7 @@
 		sizeToContent = () => {
 			// Add a temp span, fetch its width with current paddings and set max-width based on that
 			let span = document.createElement("span");
-			span.innerText = this.value;
+			span.innerText = this.value || this.placeholder;
 			this.append(span);
 			let size = span.getBoundingClientRect();
 			this.style['max-width'] = `calc(${size.width}px)`;

--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -50,7 +50,7 @@
 			this._editableFields = [];
 			this._fieldAlternatives = {};
 			this._fieldOrder = [];
-			this._tabIndexMinCreators = 10;
+			this._tabIndexMinCreators = 100;
 			this._tabIndexMaxFields = 0;
 			this._initialVisibleCreators = 5;
 			this._draggedCreator = false;


### PR DESCRIPTION
- Instead of adding/removing the default names to the fields of empty creator names, set them as placeholders - that way they appear only when the actual creator name field is empty, and it requires no additional logic to add/remove them.
- Re-do of `capitalizeCreatorName` so that it works when the creator name field is focused. https://forums.zotero.org/discussion/111304/zotero-7-beta-fix-case-on-author-field-is-not-working-from-the-right-click-menu
- Fix to get the creator name contextmenu to appear for un-saved creators. That way one can switch the `fieldMode` before saving the creator. https://forums.zotero.org/discussion/111297/impossible-to-select-single-field-before-entering-an-author-7-0-0-beta-56-9edfcba9a
- Fix to tab/Shift-tab focusing wrong element right after a new creator row is added

Fixes: #3610
Fixes: #3666