### PR TITLE
opened tabs menu visibility improvements

### DIFF
--- a/chrome/content/zotero/tabs.js
+++ b/chrome/content/zotero/tabs.js
@@ -845,6 +845,7 @@ var Zotero_Tabs = new function () {
 			tabName.setAttribute('class', 'zotero-tabs-menu-entry title');
 			tabName.setAttribute('tabindex', `${index++}`);
 			tabName.setAttribute('aria-label', tab.title);
+			tabName.setAttribute('tooltiptext', tab.title);
 
 			// Cross button to close a tab
 			let closeButton = document.createXULElement('toolbarbutton');

--- a/scss/components/_tabsMenu.scss
+++ b/scss/components/_tabsMenu.scss
@@ -44,6 +44,10 @@
 				// override default description margins
 				margin-bottom: 0;
 				margin-block-start: 0;
+				// show as much of the description as possible
+				white-space: nowrap;
+				min-width: 280px;
+				text-overflow: ellipsis;
 			}
 			.tab-icon {
 				width: 16px;


### PR DESCRIPTION
- Added tooltip to display the entire title of the tab on hover
- Ellipsize the text of the tab title to display as much of the last word as possible

Fixes: #3609