### PR TITLE
Put the Advanced Search mode dropmarker back on the left

### DIFF
--- a/scss/elements/_zoteroSearch.scss
+++ b/scss/elements/_zoteroSearch.scss
@@ -65,12 +65,12 @@ zoterosearch {
 		cursor: default;
 		appearance: none;
 		justify-self: start;
-		margin-inline-start: 10px;
+		margin-inline-start: 12px;
 		align-self: center;
 	}
 
 	zoterosearchtextbox[hasOptions="true"] #search-textbox {
-		padding-inline-start: 16px;
+		padding-inline-start: 20px;
 	}
 
 	.search-in-the-last {

--- a/scss/elements/_zoteroSearch.scss
+++ b/scss/elements/_zoteroSearch.scss
@@ -64,9 +64,13 @@ zoterosearch {
 	#textbox-button {
 		cursor: default;
 		appearance: none;
-		justify-self: end;
-		margin-inline-end: 8px;
+		justify-self: start;
+		margin-inline-start: 10px;
 		align-self: center;
+	}
+
+	zoterosearchtextbox[hasOptions="true"] #search-textbox {
+		padding-inline-start: 16px;
 	}
 
 	.search-in-the-last {


### PR DESCRIPTION
Added a bit more padding because 8px looked too tight when positioned at the start of the input.

Fixes #3617