### PR TITLE
Implement better editable-text focus and context menu behavior, fix regressions

### DIFF
--- a/chrome/content/zotero/editMenuOverlay.js
+++ b/chrome/content/zotero/editMenuOverlay.js
@@ -101,16 +101,16 @@ function goBuildEditContextMenu() {
             MozXULElement.parseXULToFragment(`
               <popupset>
                 <menupopup id="textbox-contextmenu" class="textbox-contextmenu">
-                  <menuitem data-l10n-id="text-action-undo" command="cmd_undo"></menuitem>
-                  <menuitem data-l10n-id="text-action-redo" command="cmd_redo"></menuitem>
+                  <menuitem data-l10n-id="text-action-undo" command="cmd_undo" data-action="undo"></menuitem>
+                  <menuitem data-l10n-id="text-action-redo" command="cmd_redo" data-action="redo"></menuitem>
                   <menuseparator></menuseparator>
-                  <menuitem data-l10n-id="text-action-cut" command="cmd_cut"></menuitem>
-                  <menuitem data-l10n-id="text-action-copy" command="cmd_copy"></menuitem>
-                  <menuitem data-l10n-id="text-action-paste" command="cmd_paste"></menuitem>
-                  <menuitem data-l10n-id="text-action-delete" command="cmd_delete"></menuitem>
-                  <menuitem data-l10n-id="text-action-select-all" command="cmd_selectAll"></menuitem>
+                  <menuitem data-l10n-id="text-action-cut" command="cmd_cut" data-action="cut"></menuitem>
+                  <menuitem data-l10n-id="text-action-copy" command="cmd_copy" data-action="copy"></menuitem>
+                  <menuitem data-l10n-id="text-action-paste" command="cmd_paste" data-action="paste"></menuitem>
+                  <menuitem data-l10n-id="text-action-delete" command="cmd_delete" data-action="delete"></menuitem>
+                  <menuitem data-l10n-id="text-action-select-all" command="cmd_selectAll" data-action="selectAll"></menuitem>
                   <menuseparator></menuseparator>
-                  <menuitem data-l10n-id="menu-edit-bidi-switch-text-direction" command="cmd_switchTextDirection"></menuitem>
+                  <menuitem data-l10n-id="menu-edit-bidi-switch-text-direction" command="cmd_switchTextDirection" data-action="switchTextDirection"></menuitem>
                 </menupopup>
               </popupset>
             `)

--- a/chrome/content/zotero/elements/editableText.js
+++ b/chrome/content/zotero/elements/editableText.js
@@ -235,12 +235,6 @@
 						event.preventDefault();
 					}
 				});
-				input.addEventListener('contextmenu', (event) => {
-					// Prevent the text editing context menu from opening when unfocused
-					if (document.activeElement !== this._input) {
-						event.preventDefault();
-					}
-				});
 				
 				let focused = false;
 				let selectionStart = this._input?.selectionStart;
@@ -309,4 +303,33 @@
 		}
 	}
 	customElements.define("editable-text", EditableText);
+	
+	document.addEventListener('contextmenu', (event) => {
+		if (event.defaultPrevented
+				|| !event.target.closest('editable-text')
+				|| document.activeElement && event.target.contains(document.activeElement)) {
+			return;
+		}
+		
+		event.preventDefault();
+		
+		let editableText = event.target.closest('editable-text');
+		let menupopup = document.getElementById('zotero-editable-text-menu');
+		if (!menupopup) {
+			menupopup = document.createXULElement('menupopup');
+			menupopup.id = 'zotero-editable-text-menu';
+			
+			let popupset = document.querySelector('popupset');
+			if (!popupset) {
+				popupset = document.createXULElement('popupset');
+				document.documentElement.append(popupset);
+			}
+			popupset.append(menupopup);
+		}
+
+		menupopup.addEventListener('popupshowing', () => {
+			Zotero.Utilities.Internal.updateEditContextMenu(menupopup, editableText);
+		}, { once: true });
+		menupopup.openPopupAtScreen(event.screenX + 1, event.screenY + 1, true);
+	});
 }

--- a/chrome/content/zotero/elements/editableText.js
+++ b/chrome/content/zotero/elements/editableText.js
@@ -229,6 +229,18 @@
 						this._input.blur();
 					}
 				});
+				input.addEventListener('mousedown', (event) => {
+					// Prevent a right-click from focusing the input when unfocused
+					if (event.button === 2 && document.activeElement !== this._input) {
+						event.preventDefault();
+					}
+				});
+				input.addEventListener('contextmenu', (event) => {
+					// Prevent the text editing context menu from opening when unfocused
+					if (document.activeElement !== this._input) {
+						event.preventDefault();
+					}
+				});
 				
 				let focused = false;
 				let selectionStart = this._input?.selectionStart;

--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -218,7 +218,7 @@
 				copy.disabled = !link;
 				copy.hidden = link === val;
 				
-				let existingCopyMenuitem = menu.querySelector('menuitem[data-action="cmd_copy"]');
+				let existingCopyMenuitem = menu.querySelector('menuitem[data-action="copy"]');
 				if (existingCopyMenuitem) {
 					existingCopyMenuitem.after(copy);
 				}

--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -592,6 +592,7 @@
 					valueElement.setAttribute('aria-labelledby', label.id);
 				}
 				let openLinkButton;
+				let link = val;
 				let addContextMenu = false;
 				// TEMP - NSF (homepage)
 				if ((fieldName == 'url' || fieldName == 'homepage')
@@ -612,6 +613,7 @@
 								.replace(/%/g, '%25')
 								.replace(/"/g, '%22');
 						openLinkButton = this.createOpenLinkIcon(doi);
+						link = doi;
 						addContextMenu = true;
 					}
 				}
@@ -622,7 +624,6 @@
 					rowData.appendChild(openLinkButton);
 				}
 				if (addContextMenu) {
-					let link = val;
 					rowData.oncontextmenu = (event) => {
 						this._linkMenu.dataset.link = link;
 						document.popupNode = rowLabel.parentElement;

--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -438,6 +438,17 @@
 			return '(' + Zotero.getString('pane.item.defaultFullName') + ')';
 		}
 		
+		get _ignoreFields() {
+			let value = ['title', 'abstractNote']
+				.flatMap(field => [
+					field,
+					...(Zotero.ItemFields.getTypeFieldsFromBase(field, true) || [])
+				]);
+			// Cache the result
+			Object.defineProperty(this, '_ignoreFields', { value });
+			return value;
+		}
+
 		get _linkMenu() {
 			return this._id('zotero-link-menu');
 		}
@@ -526,7 +537,7 @@
 
 			for (let i = 0; i < fieldNames.length; i++) {
 				var fieldName = fieldNames[i];
-				if (["abstractNote", "title", "caseName", "subject"].includes(fieldName)) {
+				if (this._ignoreFields.includes(fieldName)) {
 					continue;
 				}
 				var val = '';

--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -628,7 +628,7 @@
 						document.popupNode = rowLabel.parentElement;
 						
 						let menupopup = this._id('zotero-link-menu');
-						Zotero.Utilities.Internal.updateEditContextMenu(menupopup, !event.target.closest('input'));
+						Zotero.Utilities.Internal.updateEditContextMenu(menupopup, event.target.closest('input'));
 						this.handlePopupOpening(event, menupopup);
 					};
 				}
@@ -643,9 +643,8 @@
 					optionsButton.setAttribute('data-l10n-id', "itembox-button-options");
 					// eslint-disable-next-line no-loop-func
 					let triggerPopup = (e) => {
-						let oldValue = valueElement.value;
 						let menupopup = ZoteroItemPane.buildFieldTransformMenu({
-							value: oldValue,
+							target: valueElement,
 							onTransform: (newValue) => {
 								this._setFieldTransformedValue(valueElement, newValue);
 							}
@@ -1068,8 +1067,7 @@
 				document.popupNode = firstlast;
 
 				let menupopup = this._id('zotero-creator-transform-menu');
-				let hideEditMenuItems = !e.target.closest('input');
-				Zotero.Utilities.Internal.updateEditContextMenu(menupopup, hideEditMenuItems);
+				Zotero.Utilities.Internal.updateEditContextMenu(menupopup, e.target.closest('input'));
 				
 				this._id('creator-transform-swap-names').hidden = fieldMode > 0;
 				this._id('creator-transform-capitalize').disabled = !this.canCapitalizeCreatorName(rowData.parentNode);

--- a/chrome/content/zotero/elements/paneHeader.js
+++ b/chrome/content/zotero/elements/paneHeader.js
@@ -85,13 +85,11 @@
 				if (!this._item) return;
 				
 				event.preventDefault();
-				let oldValue = this.titleField.value;
 				let menupopup = ZoteroItemPane.buildFieldTransformMenu({
-					value: oldValue,
+					target: this.titleField,
 					onTransform: (newValue) => {
-						this._setTransformedValue(oldValue, newValue);
+						this._setTransformedValue(newValue);
 					},
-					includeEditMenuOptions: true
 				});
 				this.ownerDocument.querySelector('popupset').append(menupopup);
 				menupopup.addEventListener('popuphidden', () => menupopup.remove());
@@ -111,7 +109,7 @@
 			}
 		}
 		
-		async _setTransformedValue(oldValue, newValue) {
+		async _setTransformedValue(newValue) {
 			await this.blurOpenField();
 			this._item.setField(this._titleFieldID, newValue);
 			let shortTitleVal = this._item.getField('shortTitle');

--- a/chrome/content/zotero/itemPane.js
+++ b/chrome/content/zotero/itemPane.js
@@ -325,15 +325,12 @@ var ZoteroItemPane = new function() {
 	};
 	
 	
-	this.buildFieldTransformMenu = function ({ value, onTransform, includeEditMenuOptions = false }) {
+	this.buildFieldTransformMenu = function ({ target, onTransform }) {
+		let value = target.value;
 		let valueTitleCased = Zotero.Utilities.capitalizeTitle(value.toLowerCase(), true);
 		let valueSentenceCased = Zotero.Utilities.sentenceCase(value);
 
 		let menupopup = document.createXULElement('menupopup');
-		if (includeEditMenuOptions) {
-			Zotero.Utilities.Internal.updateEditContextMenu(menupopup);
-			menupopup.append(document.createXULElement('menuseparator'));
-		}
 
 		let titleCase = document.createXULElement('menuitem');
 		titleCase.setAttribute('label', Zotero.getString('zotero.item.textTransform.titlecase'));
@@ -350,6 +347,8 @@ var ZoteroItemPane = new function() {
 		});
 		sentenceCase.disabled = valueSentenceCased == value;
 		menupopup.append(sentenceCase);
+
+		Zotero.Utilities.Internal.updateEditContextMenu(menupopup, target);
 
 		return menupopup;
 	};


### PR DESCRIPTION
- When right-clicking an unfocused field, only show Copy and Paste (as well as other actions, like View Online, Title Case, etc.) instead of a full text editing menu
	- Put Copy as URL below Copy
- Fix a redesign regression that broke Copy as URL and View Online for DOIs
- Don't trigger a save when an `editable-text` blurs because the window is becoming inactive
- Ignore base-mapped fields using `Zotero.ItemFields`

Fixes #3619, fixes #3588