### PR TITLE
fix to wrong tab being selected after close tab undo

### DIFF
--- a/chrome/content/zotero/tabs.js
+++ b/chrome/content/zotero/tabs.js
@@ -350,7 +350,6 @@ var Zotero_Tabs = new function () {
 	this.undoClose = function () {
 		var historyEntry = this._history.pop();
 		if (historyEntry) {
-			let maxIndex = -1;
 			for (let tab of historyEntry) {
 				if (Zotero.Items.exists(tab.data.itemID)) {
 					Zotero.Reader.open(tab.data.itemID,
@@ -359,15 +358,12 @@ var Zotero_Tabs = new function () {
 							tabIndex: tab.index,
 							openInBackground: true
 						}
-					);
-					if (tab.index > maxIndex) {
-						maxIndex = tab.index;
-					}
+					).then((_) => {
+						if (tab.index > -1) {
+							this.jump(tab.index);
+						}
+					});
 				}
-			}
-			// Select last reopened tab
-			if (maxIndex > -1) {
-				this.jump(maxIndex);
 			}
 		}
 	};


### PR DESCRIPTION
Jump to reopened tab's index only after async Zotero.Reader.open that adds the tab in Zotero_Tabs.undoClose is finished.

Fixes: #3651