### PR TITLE
Fix a memory leak in file renaming preferences pane

### DIFF
--- a/chrome/content/zotero/preferences/preferences.js
+++ b/chrome/content/zotero/preferences/preferences.js
@@ -102,6 +102,13 @@ var Zotero_Preferences = {
 			Zotero.Prefs.unregisterObserver(symbol);
 		}
 		this._observerSymbols.clear();
+
+		for (let [_key, pane] of this.panes) {
+			for (let child of pane.container.children) {
+				let event = new Event('unload');
+				child.dispatchEvent(event);
+			}
+		}
 	},
 	
 	waitForFirstPaneLoad: async function () {

--- a/chrome/content/zotero/preferences/preferences_file_renaming.js
+++ b/chrome/content/zotero/preferences/preferences_file_renaming.js
@@ -31,7 +31,16 @@ Zotero_Preferences.FileRenaming = {
 		this.inputRef = document.getElementById('file-renaming-format-template');
 		this.updatePreview();
 		this.inputRef.addEventListener('input', this.updatePreview.bind(this));
-		Zotero.getActiveZoteroPane()?.itemsView.onSelect.addListener(this.updatePreview.bind(this));
+
+		this._itemsView = Zotero.getActiveZoteroPane()?.itemsView;
+		this._updatePreview = this.updatePreview.bind(this);
+		if (this._itemsView) {
+			this._itemsView.onSelect.addListener(this._updatePreview);
+		}
+	},
+
+	uninit: function () {
+		this._itemsView.onSelect.removeListener(this._updatePreview);
 	},
 
 	getActiveTopLevelItem() {

--- a/chrome/content/zotero/preferences/preferences_file_renaming.xhtml
+++ b/chrome/content/zotero/preferences/preferences_file_renaming.xhtml
@@ -22,7 +22,11 @@
     
     ***** END LICENSE BLOCK *****
 -->
-<vbox class="main-section" id="zotero-prefpane-file-renaming-format" onload="Zotero_Preferences.FileRenaming.init()">
+<vbox
+	class="main-section" id="zotero-prefpane-file-renaming-format"
+	onload="Zotero_Preferences.FileRenaming.init()"
+	onunload="Zotero_Preferences.FileRenaming.uninit()"
+>
 	<hbox class="header">
 		<html:h1 data-l10n-id="preferences-file-renaming-format-title" />
 	</hbox>


### PR DESCRIPTION
This PR extends Preferences API to trigger "unload" on all panes when window unloads. This new event is used in file renaming pane to unregister item tree observer to avoid a memory leak.

@AbeJellinek I couldn't find any good place to register `uninit` to do the cleanup so I've introduced one. Any suggestions, please let me know.

Fix #3574