### PR TITLE
Enable wayland backend when available.

### DIFF
--- a/app/linux/zotero
+++ b/app/linux/zotero
@@ -13,6 +13,8 @@ ulimit -n 4096
 export MOZ_ALLOW_DOWNGRADE=1
 # Don't create dedicated profile (default-esr)
 export MOZ_LEGACY_PROFILES=1
+# Use wayland backend when available
+export MOZ_ENABLE_WAYLAND=1
 
 CALLDIR="$(dirname "$(readlink -f "$0")")"
 "$CALLDIR/zotero-bin" -app "$CALLDIR/app/application.ini" "$@"


### PR DESCRIPTION
This will become obsolete with firefox >= 121. X11-only desktops are not affected by this.