### PR TITLE
collection highlight tweaks

### DIFF
--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -1034,7 +1034,10 @@ var ZoteroPane = new function()
 			//
 			// We use Control (17) on Windows because Alt triggers the menubar;
 			// 	otherwise we use Alt/Option (18)
-			if ((Zotero.isWin && event.keyCode == 17 && !event.altKey) ||
+			// On windows, do not highlight when an input is focused to not interfere with
+			// Ctrl-C/Ctrl-V copy-paste shortcuts
+			let inputFocused = ["input", "textarea"].includes(document.activeElement.tagName);
+			if ((Zotero.isWin && event.keyCode == 17 && !event.altKey && !inputFocused) ||
 					(!Zotero.isWin && event.keyCode == 18 && !event.ctrlKey)
 					&& !event.shiftKey && !event.metaKey) {
 				// On windows, the event is re-triggered multiple times

--- a/scss/components/_virtualized-table.scss
+++ b/scss/components/_virtualized-table.scss
@@ -147,7 +147,7 @@
 		}
 
 		&.highlighted {
-			background: #FFFF99;
+			background: var(--accent-highlight);
 		}
 
 		&.unread {

--- a/scss/themes/_dark.scss
+++ b/scss/themes/_dark.scss
@@ -16,6 +16,7 @@ $-colors: (
     accent-wood-dark: #996b6f,
     accent-wood: #cc7a52e5,
     accent-yellow: #faa700cc,
+    accent-highlight: #ffd40026,
     fill-primary: #ffffffe5,
     fill-secondary: #ffffff8c,
     fill-tertiary: #ffffff4d,

--- a/scss/themes/_light.scss
+++ b/scss/themes/_light.scss
@@ -16,6 +16,7 @@ $-colors: (
     accent-wood-dark: #996b6f,
     accent-wood: #cc7a52,
     accent-yellow: #faa700,
+    accent-highlight: #ffea0080,
     fill-primary: #000000d9,
     fill-secondary: #00000080,
     fill-tertiary: #00000040,


### PR DESCRIPTION
- Substituted previous yellow highlight color for `--accent-yellow`
- On windows, do not trigger collection highlighting when input is focused so that copy-paste Ctrl-C/Ctrl-V do not trigger highlighting

Addresses:  #3643