### PR TITLE
update tab when collection row is updated

### DIFF
--- a/chrome/content/zotero/collectionTree.jsx
+++ b/chrome/content/zotero/collectionTree.jsx
@@ -252,6 +252,7 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 		treeRow.ref.name = treeRow.editingName;
 		delete treeRow.editingName;
 		await treeRow.ref.saveTx();
+		window.Zotero_Tabs.rename("zotero-pane", treeRow.ref.name);
 	}
 	
 	startEditing = (treeRow) => {

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -2665,6 +2665,7 @@ var ZoteroPane = new function()
 				if (io.dataOut) {
 					row.ref.fromJSON(io.dataOut.json);
 					yield row.ref.saveTx();
+					Zotero_Tabs.rename("zotero-pane", row.ref.name);
 				}
 			}
 		}
@@ -2708,6 +2709,7 @@ var ZoteroPane = new function()
 		feed.cleanupReadAfter = data.cleanupReadAfter;
 		feed.cleanupUnreadAfter = data.cleanupUnreadAfter;
 		yield feed.saveTx();
+		Zotero_Tabs.rename("zotero-pane", feed.name);
 	});
 	
 	this.refreshFeed = function() {


### PR DESCRIPTION
When a saved search, collection or feed is renamed, update the `zotero-pane` tab so that it has the new title.

Fixes: #3664