### PR TITLE
allow focus to move past the note to tags section

### DIFF
--- a/chrome/content/zotero/itemPane.js
+++ b/chrome/content/zotero/itemPane.js
@@ -197,23 +197,6 @@ var ZoteroItemPane = new function() {
 			stopEvent();
 			return;
 		}
-		// Tab tavigation between entries and buttons within library, related and notes boxes
-		if (event.key == "Tab" && event.target.closest(".box")) {
-			let next = null;
-			if (event.key == "Tab" && !event.shiftKey) {
-				next = event.target.nextElementSibling;
-			}
-			if (event.key == "Tab" && event.shiftKey) {
-				next = event.target.parentNode.previousElementSibling?.lastChild;
-			}
-			// Force the element to be visible before focusing
-			if (next) {
-				next.style.visibility = "visible";
-				next.focus();
-				next.style.removeProperty("visibility");
-				stopEvent();
-			}
-		}
 	};
 	
 	


### PR DESCRIPTION
- Make the actual core editor of the note focusable
- Shift-tab when the editor is active (the cursor is visible) will move focus to the core editor and add a box-shadow indicator, similar to focus-ring everywhere else.
- From the core editor, another shift-tab will focus the buttons, and tab will focus the first focusable section's header after the note (tags).
- Enter or space when the core editor is focused will move focus back inside of the editor and the cursor will appear.

Fixes: #3675

Some of this logic (`focusin` and `focusout` listeners) could be moved to the actual note editor module, and it would be more concise. It would boil down to adding a `:focus-visible` to `.editor-core` in `editor.scss` to display the box-shadow when the editor is focused, and adding `tabindex=0` to `<div className="editor-core">`. I wasn't sure if it's a good idea to mess with the submodule since the note editor is used is multiple places, so I kept everything in `noteEditor.js`