### PR TITLE
Set max-height on note-editor Tags/Related and allow to scroll

### DIFF
--- a/scss/elements/_noteEditor.scss
+++ b/scss/elements/_noteEditor.scss
@@ -2,6 +2,8 @@ links-box {
 	display: flex;
 	flex-direction: column;
 	padding-inline: 8px;
+	max-height: 50vh;
+	overflow-y: auto;
 
 	border-top: 1px solid var(--fill-quinary);
 }

--- a/scss/elements/_noteEditor.scss
+++ b/scss/elements/_noteEditor.scss
@@ -2,8 +2,16 @@ links-box {
 	display: flex;
 	flex-direction: column;
 	padding-inline: 8px;
-	max-height: 50vh;
-	overflow-y: auto;
 
 	border-top: 1px solid var(--fill-quinary);
+	
+	tags-box, related-box {
+		> collapsible-section > .body {
+			max-height: 25vh;
+			overflow-y: auto;
+			scrollbar-width: thin;
+			scrollbar-color: var(--color-scrollbar) var(--color-scrollbar-background);
+			padding-bottom: 1px; // Leave room for the editable-text focus ring
+		}
+	}
 }


### PR DESCRIPTION
Have to set an explicit `max-height` because of some weird `-moz-box`/`flex` interactions, as usual. Maybe we'll be able to do something better (e.g. `flex-grow: 2` on the note editor and `flex-grow: 1` on the Tags/Related container) once everything is flexbox!

Fixes #3686