### PR TITLE
Fix attachment column icon flickering upon selection

### DIFF
--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -2729,7 +2729,13 @@ Zotero.Item.prototype._updateAttachmentStates = function (exists) {
 		Zotero.logError(`Attachment parent ${this.libraryID}/${parentKey} doesn't exist`);
 		return;
 	}
-	item.clearBestAttachmentState();
+
+	if (item._bestAttachmentState?.key && this.key === item._bestAttachmentState.key) {
+		item._bestAttachmentState.exists = exists;
+	}
+	else {
+		item.clearBestAttachmentState();
+	}
 };
 
 
@@ -3701,7 +3707,11 @@ Zotero.Item.prototype.getBestAttachment = Zotero.Promise.coroutine(function* () 
 		throw ("getBestAttachment() can only be called on regular items");
 	}
 	var attachments = yield this.getBestAttachments();
-	return attachments ? attachments[0] : false;
+	let bestAttachment = attachments ? attachments[0] : false;
+	if (bestAttachment) {
+		this._bestAttachmentState = { key: bestAttachment.key, ...(this._bestAttachmentState || {}) };
+	}
+	return bestAttachment;
 });
 
 


### PR DESCRIPTION
This PR is a fix for a visual glitch where attachments column flickers when being selected for some items:

https://github.com/zotero/zotero/assets/214628/b50a8a32-0fdb-495f-8083-439ed33b39c6

This is a regression related to the attachment preview generation which calls [`fileExists`](https://github.com/zotero/zotero/blob/872e7b24278a2f00d7558aa9055d7f641c1a768a/chrome/content/zotero/elements/attachmentPreview.js#L208) which results in `bestAttachmentState` cache being cleared for this particular item before being checked again in `itemTree` on a 150ms timeout (hence the flicker).

While this is a very small change, I'd appreciate feedback if this is the right approach to fix the issue.


