### PR TITLE
Few fixes to `ftl-to-json` and `localize-ftl` scripts

### DIFF
--- a/js-build/ftl-to-json.mjs
+++ b/js-build/ftl-to-json.mjs
@@ -14,17 +14,17 @@ async function getJSON() {
 		const sourceFile = join(sourceDir, sourceFileBaseName + '.ftl');
 		const destFile = join(sourceDir, sourceFileBaseName + '.json');
 		const ftl = await fs.readFile(sourceFile, 'utf8');
-		const json = ftlToJSON(ftl, { transformTerms: false, storeTermsInJSON: false });
+		const json = ftlToJSON(ftl, { transformTerms: false, storeTermsInJSON: false, skipRefOnly: true });
 		await fs.outputJSON(destFile, json, { spaces: '\t' });
 		onProgress(destFile, destFile, 'json');
 	}
 	const t2 = performance.now();
-		return ({
-			action: 'ftl->json',
-			count: sourceFileBaseNames.length,
-			totalCount: sourceFileBaseNames.length,
-			processingTime: t2 - t1
-		});
+	return ({
+		action: 'ftl->json',
+		count: sourceFileBaseNames.length,
+		totalCount: sourceFileBaseNames.length,
+		processingTime: t2 - t1
+	});
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/js-build/localize-ftl.mjs
+++ b/js-build/localize-ftl.mjs
@@ -38,6 +38,16 @@ async function getFTL() {
 			console.error(`File ${fallbackJSONPath} does not exist -- please run 'ftl-to-json' first`);
 			exit(1);
 		}
+
+		let jsonFromEnUSFTL = {};
+		try {
+			const enUSFtlPath = join(getLocaleDir('en-US'), sourceFileBaseName + '.ftl');
+			const ftl = await fs.readFile(enUSFtlPath, 'utf8');
+			jsonFromEnUSFTL = ftlToJSON(ftl, { transformTerms: false, storeTermsInJSON: false });
+		}
+		catch (e) {
+			console.warn(`No en-US .ftl file for ${sourceFileBaseName}.`);
+		}
 		
 		const fallbackJSON = await fs.readJSON(fallbackJSONPath);
 		
@@ -67,7 +77,7 @@ async function getFTL() {
 				// no .json file from transifex
 			}
 			
-			const mergedJSON = { ...fallbackJSON, ...jsonFromLocalFTL, ...jsonFromTransifex };
+			const mergedJSON = { ...fallbackJSON, ...jsonFromEnUSFTL, ...jsonFromLocalFTL, ...jsonFromTransifex };
 			const ftl = JSONToFtl(mergedJSON, { addTermsToFTL: false, storeTermsInJSON: false, transformTerms: false, terms });
 			
 			const outFtlPath = join(getLocaleDir(locale), sourceFileBaseName + '.ftl');

--- a/js-build/utils.js
+++ b/js-build/utils.js
@@ -30,7 +30,7 @@ function onProgress(sourcefile, outfile, operation) {
 	if ('isError' in global && global.isError) {
 		return;
 	}
-	if (NODE_ENV == 'debug') {
+	if (NODE_ENV === 'debug' && outfile) {
 		console.log(`${colors.blue(`[${operation}]`)} ${sourcefile} -> ${outfile}`);
 	}
 	else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "eslint-plugin-react": "^7.28.0",
         "eslint-plugin-react-hooks": "^4.0.4",
         "fs-extra": "^3.0.1",
-        "ftl-tx": "^0.6.0",
+        "ftl-tx": "^0.8.0",
         "globby": "^6.1.0",
         "jspath": "^0.4.0",
         "mocha": "^10.4.0",
@@ -3667,9 +3667,9 @@
       }
     },
     "node_modules/ftl-tx": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/ftl-tx/-/ftl-tx-0.6.0.tgz",
-      "integrity": "sha512-w7s0p6RNsaUKpiuQZ5Q0KIyiX2JIDItqI4qRKt49u0aMqdGp0gDc5G5Qnubgu6l2ww5PDt4wsyL7A1iZo1VGMQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/ftl-tx/-/ftl-tx-0.8.0.tgz",
+      "integrity": "sha512-JmTL6++k3ISlAUhsEUxBAw8xSULr6SfE2/M9bRPbfSagOHe1AmoC5rBRNRJrq/0kU92q8tzj1Og3TyxVea8VUw==",
       "dev": true,
       "dependencies": {
         "@fluent/syntax": "^0.19.0"
@@ -10588,9 +10588,9 @@
       }
     },
     "ftl-tx": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/ftl-tx/-/ftl-tx-0.6.0.tgz",
-      "integrity": "sha512-w7s0p6RNsaUKpiuQZ5Q0KIyiX2JIDItqI4qRKt49u0aMqdGp0gDc5G5Qnubgu6l2ww5PDt4wsyL7A1iZo1VGMQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/ftl-tx/-/ftl-tx-0.8.0.tgz",
+      "integrity": "sha512-JmTL6++k3ISlAUhsEUxBAw8xSULr6SfE2/M9bRPbfSagOHe1AmoC5rBRNRJrq/0kU92q8tzj1Og3TyxVea8VUw==",
       "dev": true,
       "requires": {
         "@fluent/syntax": "^0.19.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "eslint-plugin-react": "^7.28.0",
         "eslint-plugin-react-hooks": "^4.0.4",
         "fs-extra": "^3.0.1",
-        "ftl-tx": "^0.8.0",
+        "ftl-tx": "^0.9.0",
         "globby": "^6.1.0",
         "jspath": "^0.4.0",
         "mocha": "^10.4.0",
@@ -3667,9 +3667,9 @@
       }
     },
     "node_modules/ftl-tx": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/ftl-tx/-/ftl-tx-0.8.0.tgz",
-      "integrity": "sha512-JmTL6++k3ISlAUhsEUxBAw8xSULr6SfE2/M9bRPbfSagOHe1AmoC5rBRNRJrq/0kU92q8tzj1Og3TyxVea8VUw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/ftl-tx/-/ftl-tx-0.9.0.tgz",
+      "integrity": "sha512-cxjOfLulCEPL6K0boxTiHCYNs3UahgmfrC+u3a6oV665EWuR6LnZRWID2UKWv6JBIB4YU4k06Y5re5uA7HpEGg==",
       "dev": true,
       "dependencies": {
         "@fluent/syntax": "^0.19.0"
@@ -10588,9 +10588,9 @@
       }
     },
     "ftl-tx": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/ftl-tx/-/ftl-tx-0.8.0.tgz",
-      "integrity": "sha512-JmTL6++k3ISlAUhsEUxBAw8xSULr6SfE2/M9bRPbfSagOHe1AmoC5rBRNRJrq/0kU92q8tzj1Og3TyxVea8VUw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/ftl-tx/-/ftl-tx-0.9.0.tgz",
+      "integrity": "sha512-cxjOfLulCEPL6K0boxTiHCYNs3UahgmfrC+u3a6oV665EWuR6LnZRWID2UKWv6JBIB4YU4k06Y5re5uA7HpEGg==",
       "dev": true,
       "requires": {
         "@fluent/syntax": "^0.19.0"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "eslint-plugin-react": "^7.28.0",
     "eslint-plugin-react-hooks": "^4.0.4",
     "fs-extra": "^3.0.1",
-    "ftl-tx": "^0.8.0",
+    "ftl-tx": "^0.9.0",
     "globby": "^6.1.0",
     "jspath": "^0.4.0",
     "mocha": "^10.4.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "eslint-plugin-react": "^7.28.0",
     "eslint-plugin-react-hooks": "^4.0.4",
     "fs-extra": "^3.0.1",
-    "ftl-tx": "^0.6.0",
+    "ftl-tx": "^0.8.0",
     "globby": "^6.1.0",
     "jspath": "^0.4.0",
     "mocha": "^10.4.0",


### PR DESCRIPTION
This PR:

1. Fixes how messages that reference other messages are handled
2. Messages that only reference other messages are now omitted from produced JSON. This required a tweak to `localize-ftl` so that it now also parses en-US `.ftl` file to re-introduce these into localized `.ftl`. (I hoped that fluent would fallback for `en-US` for a missing string, find that it references something and take the reference again from a localized file, bit unfortunately it does not). Fix #3700. 
3. Removes shenanigans with maintaining list of terms/variables etc. Previously I've tried to keep track of what is a term, what a variable etc. without actually storing that information in the produced JSON. That introduced overhead and complexity. Instead now we just keep the prefix in JSON (i.e. where previously we had `{ var }` in JSON, we now have `{ $var }`. This is, as far as I can tell, not legal in `ICU Messages` (hence my earlier approach) but I don't think it actually matters for Transifex (we've discussed this before: https://github.com/zotero/zotero/pull/3058#issuecomment-1500192606)

Happy to answer any questions.

