### PR TITLE
Fix indexing files with text content types that Firefox won't display

### DIFF
--- a/chrome/content/zotero/HiddenBrowser.jsm
+++ b/chrome/content/zotero/HiddenBrowser.jsm
@@ -130,7 +130,7 @@ class HiddenBrowser {
 	async load(source, options) {
 		await this._createdPromise;
 		let url;
-		if (/^(file|https?|chrome|resource):/.test(source)) {
+		if (/^(file|https?|chrome|resource|blob):/.test(source)) {
 			url = source;
 		}
 		// Convert string path to file: URL

--- a/test/tests/data/test.sh
+++ b/test/tests/data/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "Nothing"


### PR DESCRIPTION
This fixes indexing of things like shell scripts (`text/x-shellscript`), which Firefox will try to save instead of displaying unless we override the content type.

As an aside, `isTypeSupported()` may be the answer to [this](https://github.com/AbeJellinek/zotero/blob/3b9afcc500a1e0537deb6398a4f8d23e3b3320ab/chrome/content/zotero/xpcom/mime.js#L101)! But that code is old enough that maybe we're better off just not touching it at this point...

Fixes #3704