### PR TITLE
Trim spaces from values in getFileBaseNameFromItem

### DIFF
--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -2187,6 +2187,9 @@ Zotero.Attachments = new function () {
 			if (truncate) {
 				value = value.substr(0, truncate);
 			}
+
+			value = value.trim();
+
 			if (prefix) {
 				value = prefix + value;
 			}

--- a/test/tests/attachmentsTest.js
+++ b/test/tests/attachmentsTest.js
@@ -1290,7 +1290,7 @@ describe("Zotero.Attachments", function() {
 	});
 	
 	describe("#getFileBaseNameFromItem()", function () {
-		var item, itemManyAuthors, itemPatent, itemIncomplete, itemBookSection;
+		var item, itemManyAuthors, itemPatent, itemIncomplete, itemBookSection, itemSpaces;
 
 		before(() => {
 			item = createUnsavedDataObject('item', { title: 'Lorem Ipsum', itemType: 'journalArticle' });
@@ -1331,6 +1331,7 @@ describe("Zotero.Attachments", function() {
 			itemIncomplete = createUnsavedDataObject('item', { title: 'Incomplete', itemType: 'preprint' });
 			itemBookSection = createUnsavedDataObject('item', { title: 'Book Section', itemType: 'bookSection' });
 			itemBookSection.setField('bookTitle', 'Book Title');
+			itemSpaces = createUnsavedDataObject('item', { title: ' Spaces! ', itemType: 'book' });
 		});
 
 		
@@ -1360,6 +1361,26 @@ describe("Zotero.Attachments", function() {
 			assert.equal(
 				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, '{{firstCreator suffix=" - "}}{{year suffix=" - "}}{{title}}'),
 				'Author et al. - 2000 - Has Many Authors'
+			);
+		});
+
+		it('should trim whitespaces from a value', function () {
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemSpaces, '{{ title }}'),
+				'Spaces!'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{{title truncate="6"}}'),
+				'Lorem'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{{firstCreator truncate="7"}}'),
+				'Barius'
+			);
+			// but preserve if it's configured as a prefix or suffix
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{{title prefix=" " suffix=" "}}'),
+				' Lorem Ipsum '
 			);
 		});
 


### PR DESCRIPTION
Not sure if we only want to trim only the truncated value or any value. I opted for the latter but happy to change it.

I'll update the documentation once this is merged.

Related: [#3701 ](https://github.com/zotero/zotero/issues/3701#issuecomment-1948140718)