### PR TITLE
Fix attachment column sorting not always working

### DIFF
--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -1045,6 +1045,8 @@ var ItemTree = class ItemTree extends LibraryTree {
 
 		this.selection.clearSelection();
 		this.selection.focused = 0;
+		this._cachedBestAttachmentStates = false;
+
 		await this.refresh();
 		if (Zotero.CollectionTreeCache.error) {
 			return this.setItemsPaneMessage(Zotero.getString('pane.items.loadError'));
@@ -1264,11 +1266,26 @@ var ItemTree = class ItemTree extends LibraryTree {
 		var order = this.getSortDirection(sortFields);
 		var collation = Zotero.getLocaleCollation();
 		var sortCreatorAsString = Zotero.Prefs.get('sortCreatorAsString');
-		
+
 		Zotero.debug(`Sorting items list by ${sortFields.join(", ")} ${order == 1 ? "ascending" : "descending"} `
 			+ (itemIDs && itemIDs.length
 				? `for ${itemIDs.length} ` + Zotero.Utilities.pluralize(itemIDs.length, ['item', 'items'])
 				: ""));
+
+		if (sortFields.includes('hasAttachment')) {
+			Zotero.debug("Caching best attachment states");
+			if (!this._cachedBestAttachmentStates) {
+				let t = new Date();
+				for (let i = 0; i < this._rows.length; i++) {
+					let item = this.getRow(i).ref;
+					if (this._canGetBestAttachmentState(item)) {
+						await item.getBestAttachmentState();
+					}
+				}
+				Zotero.debug("Cached best attachment states in " + (new Date - t) + " ms");
+				this._cachedBestAttachmentStates = true;
+			}
+		}
 		
 		// Set whether rows with empty values should sort at the beginning
 		var emptyFirst = {
@@ -3471,20 +3488,6 @@ var ItemTree = class ItemTree extends LibraryTree {
 	_handleColumnSort = async (index, sortDirection) => {
 		let columnSettings = this._getColumnPrefs();
 		let column = this._getColumn(index);
-		if (column.dataKey == 'hasAttachment') {
-			Zotero.debug("Caching best attachment states");
-			if (!this._cachedBestAttachmentStates) {
-				let t = new Date();
-				for (let i = 0; i < this._rows.length; i++) {
-					let item = this.getRow(i).ref;
-					if (this._canGetBestAttachmentState(item)) {
-						await item.getBestAttachmentState();
-					}
-				}
-				Zotero.debug("Cached best attachment states in " + (new Date - t) + " ms");
-				this._cachedBestAttachmentStates = true;
-			}
-		}
 		if (this._sortedColumn && this._sortedColumn.dataKey == column.dataKey) {
 			this._sortedColumn.sortDirection = sortDirection;
 			if (columnSettings[column.dataKey]) {


### PR DESCRIPTION
This PR, together with #3645 (which introduced fallback attachment icon) hopefully makes attachment column more useful. However, this commit reduces the performance of the tree view.

Sorting by the `hasAttachment` column depends on having the `bestAttachmentState` determined for every item in the current view. Normally, this is not available for rows that are not currently visible, for performance reasons. There was a piece of logic that triggered `bestAttachmentState` logic for every item in the current view when the user initiated sorting by the `hasAttachment` column. Once this logic was executed, the tree set `_cachedBestAttachmentStates` to true and from that point onwards assumed that the `bestAttachmentState` was known for every item in the view.

However, to the best of my knowledge, this assumption is not always correct. Firstly, when the user navigates to another collection or library, the assumption may no longer hold true. Additionally, this method will not work after, for example, Zotero is restarted, in which case the sorting may have been configured to the `hasAttachment` column before the restart, but the `_cachedBestAttachmentStates` logic will not be triggered.

In this commit, I have moved that logic to the `sort` method. However, for a very large library, when many items with attachments are present in the current view, this might introduce some lag on less powerful hardware. This issue could perhaps be addressed by caching `bestAttachment` at the database layer?

Any suggestions welcome.