### PR TITLE
Increase collapsible-section padding in Comfortable and other UI fixes

### DIFF
--- a/scss/abstracts/_mixins.scss
+++ b/scss/abstracts/_mixins.scss
@@ -111,6 +111,10 @@
 	
 	.icon, .label {
 		padding-block: 2px;
+
+		@include comfortable {
+			padding-block: 4px;
+		}
 	}
 }
 
@@ -118,7 +122,7 @@
 	display: grid;
 	grid-template-columns: max-content 1fr;
 	column-gap: 8px;
-	row-gap: 2px;
+	row-gap: 0px;
 	width: inherit;
 
 	.show-on-hover {

--- a/scss/abstracts/_mixins.scss
+++ b/scss/abstracts/_mixins.scss
@@ -239,7 +239,7 @@
 @mixin focus-ring {
 	&:focus-visible {
 	  outline: none;
-	  box-shadow: 0 0 0 var(--width-focus-border) -moz-accent-color;
+	  box-shadow: 0 0 0 var(--width-focus-border) var(--color-focus-border);
 	  border-radius: var(--radius-focus-border);
 	}
   }

--- a/scss/components/_clicky.scss
+++ b/scss/components/_clicky.scss
@@ -1,5 +1,5 @@
 .zotero-clicky {
-	border-radius: 6px;
+	border-radius: 5px;
 	padding: 2px;
 
 	&:not([disabled=true]) {

--- a/scss/components/_search.scss
+++ b/scss/components/_search.scss
@@ -5,6 +5,7 @@
 
 	input {
 		background: var(--material-background);
+		background-clip: padding-box;
 		border-radius: 5px;
 		border: var(--material-border-quinary);
 		color: var(--fill-primary);
@@ -43,6 +44,7 @@
 search-textbox {
 	appearance: none;
 	background: var(--material-background);
+	background-clip: padding-box;
 	border-radius: 5px;
 	border: var(--material-border-quinary);
 	color: var(--fill-primary);

--- a/scss/components/_virtualized-table.scss
+++ b/scss/components/_virtualized-table.scss
@@ -222,12 +222,12 @@
 	align-items: center;
 	width: 100%;
 	background: var(--material-background);
-	height: 1.83333333em; // 22px @ 12px font size
+	height: calc(1.33333333em + 6px); // 24px @ 13px font size
 	overflow: hidden;
 	border-bottom: 1px solid var(--material-border-quarternary);
 
 	@include comfortable {
-		height: 2.33333333em; // 28px @ 12px font size
+		height: calc(1.33333333em + 10px); // 28px @ 13px font size
 		padding: 0 8px;
 	}
 
@@ -242,13 +242,13 @@
 		height: 1px;
 		width: 100%;
 		position: absolute;
-		top: calc(1.83333333em - 1px);
+		top: calc(1.33333333em + 5px);
 		left: 0;
 		right: 0;
 		z-index: 1;
 
 		@include comfortable {
-			top: calc(2.33333333em - 1px);
+			top: calc(1.33333333em + 9px);
 		}
 	}
 
@@ -275,7 +275,7 @@
 		}
 
 		.resizer {
-			background: linear-gradient(var(--fill-quarternary), var(--fill-quarternary)) no-repeat center/1px 66.666667%; // 14px @ 12px font size
+			background: linear-gradient(var(--fill-quarternary), var(--fill-quarternary)) no-repeat center/1px calc(1.33333333em - 2px); // 16px @ 13px font size
 			cursor: col-resize;
 			height: 100%;
 			content: "\00a0";
@@ -285,7 +285,7 @@
 			min-width: 10px;
 
 			@include comfortable {
-				background-size: 1px 74.074074%; // 20px @ 12px font size
+				background-size: 1px calc(1.33333333em + 2px); // 20px @ 13px font size
 			}
 		}
 
@@ -293,6 +293,11 @@
 			overflow: hidden;
 			text-overflow: ellipsis;
 			flex: 1;
+
+			&.numNotes, &.hasAttachment {
+				display: flex;
+				justify-content: center;
+			}
 		}
 
 		&.cell-icon {

--- a/scss/elements/_annotationRow.scss
+++ b/scss/elements/_annotationRow.scss
@@ -6,6 +6,14 @@ annotation-row {
 	border: 1px solid var(--color-quinary-on-sidepane);
 	background: var(--material-background);
 
+	&:first-child {
+		margin-top: 2px;
+
+		@include comfortable {
+			margin-top: 4px;
+		}
+	}
+
 	.head {
 		display: flex;
 		padding: 4px 8px;

--- a/scss/elements/_attachmentPreview.scss
+++ b/scss/elements/_attachmentPreview.scss
@@ -1,6 +1,11 @@
 attachment-preview {
 	width: 100%;
-	padding: 2px 0px 4px 0px;
+	padding-block: 2px;
+
+	@include comfortable {
+		padding-block: 4px;
+	}
+
 	display: flex;
 	flex-direction: column;
 	align-items: center;

--- a/scss/elements/_attachmentRow.scss
+++ b/scss/elements/_attachmentRow.scss
@@ -9,7 +9,7 @@ attachment-row {
 
 	& > .head {
 		display: flex;
-		align-items: baseline;
+		align-items: flex-start;
 		gap: 4px;
 		
 		.clicky-item {
@@ -22,6 +22,7 @@ attachment-row {
 		.annotation-btn {
 			flex-grow: 0;
 			flex-basis: content;
+			align-items: center;
 
 			&[hidden] {
 				display: none;

--- a/scss/elements/_attachmentsBox.scss
+++ b/scss/elements/_attachmentsBox.scss
@@ -60,10 +60,6 @@ attachments-box {
 			padding-left: 12px;
 			display: flex;
 			flex-direction: column;
-
-			@include comfortable {
-				gap: 4px;
-			}
 		}
 	}
 }

--- a/scss/elements/_collapsibleSection.scss
+++ b/scss/elements/_collapsibleSection.scss
@@ -1,8 +1,11 @@
 collapsible-section {
 	display: flex;
 	flex-direction: column;
-	gap: 2px;
 	padding-block: 4px;
+
+	@include comfortable {
+		padding-block: 8px;
+	}
 
 	--width-focus-border: 2px;
 	--radius-focus-border: 5px;

--- a/scss/elements/_collapsibleSection.scss
+++ b/scss/elements/_collapsibleSection.scss
@@ -13,21 +13,22 @@ collapsible-section {
 
 	& > .head {
 		@include focus-ring;
-		@include comfortable {
-			padding-block: 2px;
-		}
 		
 		display: flex;
 		align-items: center;
 		
 		.title {
 			flex: 1;
-			
 			display: flex;
 			align-items: center;
 			gap: 4px;
 			color: var(--fill-secondary);
 			font-weight: 600;
+			padding-block: 2px;
+
+			@include comfortable {
+				padding-block: 4px;
+			}
 		}
 		
 		toolbarbutton {

--- a/scss/elements/_editableText.scss
+++ b/scss/elements/_editableText.scss
@@ -1,6 +1,6 @@
 @include comfortable {
 	--editable-text-padding-inline: 4px;
-	--editable-text-padding-block: 4px;
+	--editable-text-padding-block: 3px;
 }
 
 @include compact {
@@ -16,7 +16,7 @@ editable-text {
 	&[tight] {
 		@include comfortable {
 			--editable-text-padding-inline: 4px;
-			--editable-text-padding-block: 2px;
+			--editable-text-padding-block: 3px;
 		}
 		
 		@include compact {
@@ -80,8 +80,8 @@ editable-text {
 		-moz-default-appearance: textarea;
 		
 		min-height: calc(2ex * var(--min-visible-lines));
-		margin: 0;
-		border: 1px solid transparent;
+		margin: 1px;
+		border: 0px solid transparent;
 
 		font: inherit;
 		line-height: inherit;

--- a/scss/elements/_itemBox.scss
+++ b/scss/elements/_itemBox.scss
@@ -29,14 +29,14 @@ item-box {
 	#item-type-menu {
 		@include focus-ring;
 		margin: 0;
-		margin-inline-end: 5px !important;
 		flex: 1;
-		padding-inline-start: 5px;
+		// Padding = editable-text[tight] + 1
+		padding-inline: 4px;
+		padding-block: 2px;
 
-		// Same padding as editable-text
 		@include comfortable {
-			padding-top: 3px;
-			padding-bottom: 3px;
+			padding-inline: 5px;
+			padding-block: 4px;
 		}	
 
 		&::part(dropmarker) {
@@ -92,6 +92,10 @@ item-box {
 		margin-inline-end: -4px;
 		padding-left: 4px;
 		padding-right: 4px;
+
+		@include comfortable {
+			padding-block: 4px;
+		}
 		
 		&:hover, &:focus {
 			.creator-type-dropmarker {

--- a/scss/elements/_librariesCollectionsBox.scss
+++ b/scss/elements/_librariesCollectionsBox.scss
@@ -17,10 +17,6 @@ libraries-collections-box {
 			gap: 4px;
 			margin-inline-start: calc(16px * var(--level, 0));
 			
-			@include comfortable {
-				padding-block: 2px;
-			}
-			
 			&.context {
 				color: var(--fill-secondary);
 

--- a/scss/elements/_notesBox.scss
+++ b/scss/elements/_notesBox.scss
@@ -22,10 +22,6 @@ notes-box, related-box {
 			display: flex;
 			gap: 4px;
 			align-items: flex-start;
-			
-			@include comfortable {
-				padding-block: 2px;
-			}
 	
 			.box {
 				@include clicky-item;


### PR DESCRIPTION
The item pane in Comfortable and Compact, current beta:

<img width="351" alt="current-comfortable" src="https://github.com/zotero/zotero/assets/57771795/a6ae3b30-59ec-465e-8c68-20fd14c980c0">
<img width="351" alt="current-compact" src="https://github.com/zotero/zotero/assets/57771795/43a7e376-ce20-4055-b182-ee8bf30eca82">


This PR:

<img width="350" alt="updated-comfortable" src="https://github.com/zotero/zotero/assets/57771795/032ba29b-af4b-4ac0-a169-ca761bd89370">
<img width="350" alt="updated-compact" src="https://github.com/zotero/zotero/assets/57771795/086d2f37-6056-4f8c-bcaf-1216abb15c37">


Or, as [this comment](https://forums.zotero.org/discussion/comment/455710/#Comment_455710) suggests, we could add spacing only at the end of open sections. I actually quite like this, since the collapsed sections take up less space:

<img width="350" alt="alt-comfortable" src="https://github.com/zotero/zotero/assets/57771795/ddb7b9ac-f91f-4b1f-9dd3-c703a6165b20">
<img width="350" alt="alt-compact" src="https://github.com/zotero/zotero/assets/57771795/51d2ef05-c981-4352-a219-413fda949f09">
