### PR TITLE
Fix empty Quick Copy locale dropdown (without a freeze)

### DIFF
--- a/chrome/content/zotero/preferences/preferences_export.jsx
+++ b/chrome/content/zotero/preferences/preferences_export.jsx
@@ -69,10 +69,11 @@ Zotero_Preferences.Export = {
 		// Initialize locale drop-down
 		var localeMenulist = document.getElementById("zotero-quickCopy-locale-menu");
 		Zotero.Styles.populateLocaleList(localeMenulist);
+		localeMenulist.addEventListener('syncfrompreference', () => {
+			this._lastSelectedLocale = Zotero.Prefs.get("export.quickCopy.locale");
+			this.updateQuickCopyUI();
+		});
 		localeMenulist.setAttribute('preference', "extensions.zotero.export.quickCopy.locale");
-		
-		this._lastSelectedLocale = Zotero.Prefs.get("export.quickCopy.locale");
-		this.updateQuickCopyUI();
 		
 		yield this.refreshQuickCopySiteList();
 	}),


### PR DESCRIPTION
The issue before was that setting the `menulist`'s value would remove and re-add its internal label child, which would trigger our mutation observer, which would set its value, ...

This PR re-applies the empty label fix and uses a more robust approach for syncing when a menuitem is added:

- Only sync when a menuitem child is added with a value matching the current preference value, so we don't sync on internal changes like the label replacement that was causing the infinite loop above
- Don't fire `syncfrompreference` when doing one of these MutationObserver-triggered syncs - the element's value was already correct, we're just updating its visual properties, and firing `syncfrompreference` could cause infinite loops in cases where a listener on that event adds a menuitem (although that's much less likely now that we're only paying attention to relevant mutations)

Also:
- Disconnect the MutationObserver when detaching (e.g. if the preference attribute changes)

I'm no longer able to produce a freeze with any value of the various Quick Copy preferences.

Fixes #3254