### PR TITLE
do not focus contextPane after it's toggled open

### DIFF
--- a/chrome/content/zotero/contextPane.js
+++ b/chrome/content/zotero/contextPane.js
@@ -376,10 +376,6 @@ var ZoteroContextPane = new function () {
 		
 		splitter.setAttribute('state', open ? 'open' : 'collapsed');
 		_update();
-
-		if (open) {
-			ZoteroContextPane.focus();
-		}
 	}
 	
 	function _getCurrentAttachment() {


### PR DESCRIPTION
When contextPane is toggled open, keep the focused element unaffected.

Fixes: #3716