### PR TITLE
editable-text: Make dropping text work when field is unfocused

### DIFF
--- a/chrome/content/zotero/elements/abstractBox.js
+++ b/chrome/content/zotero/elements/abstractBox.js
@@ -114,9 +114,13 @@
 
 			let abstract = this.item.getField('abstractNote');
 			this._section.summary = abstract;
-			if (!this._abstractField.initialValue || this._abstractField.initialValue !== abstract) {
+			// If focused, update the value that will be restored on Escape;
+			// otherwise, update the displayed value
+			if (this._abstractField.focused) {
+				this._abstractField.initialValue = abstract;
+			}
+			else {
 				this._abstractField.value = abstract;
-				this._abstractField.initialValue = '';
 			}
 			this._abstractField.readOnly = this._mode == 'view';
 			this._abstractField.setAttribute('aria-label', Zotero.ItemFields.getLocalizedString('abstractNote'));

--- a/chrome/content/zotero/elements/editableText.js
+++ b/chrome/content/zotero/elements/editableText.js
@@ -254,6 +254,31 @@
 						event.preventDefault();
 					}
 				});
+				input.addEventListener('dragover', (event) => {
+					// If the input is not focused, override the default drop behavior
+					if ((document.activeElement !== this._input || Services.focus.activeWindow !== window)
+							&& event.dataTransfer.getData('text/plain')) {
+						event.preventDefault();
+						event.dataTransfer.dropEffect = 'copy';
+					}
+				});
+				input.addEventListener('drop', (event) => {
+					let text = event.dataTransfer.getData('text/plain');
+					// If the input is not focused, replace its entire value with the dropped text
+					// Otherwise, the normal drop effect takes place and the text is inserted at the cursor
+					if ((document.activeElement !== this._input || Services.focus.activeWindow !== window)
+							&& text) {
+						event.preventDefault();
+						document.activeElement?.blur();
+						// Wait a tick to work around an apparent Firefox bug where the cursor stays inside the old
+						// input even though the new input becomes visually focused
+						setTimeout(() => {
+							this.focus();
+							this._input.value = text;
+							handleInput();
+						});
+					}
+				});
 				
 				let focused = false;
 				let selectionStart = this._input?.selectionStart;

--- a/chrome/content/zotero/elements/editableText.js
+++ b/chrome/content/zotero/elements/editableText.js
@@ -109,11 +109,11 @@
 		}
 		
 		get initialValue() {
-			return this._input?.dataset.initialValue || '';
+			return this._input?.dataset.initialValue ?? '';
 		}
 		
 		set initialValue(initialValue) {
-			this._input.dataset.initialValue = initialValue || '';
+			this._input.dataset.initialValue = initialValue ?? '';
 		}
 		
 		get autocomplete() {
@@ -365,6 +365,10 @@
 		
 		blur() {
 			this._input?.blur();
+		}
+		
+		get focused() {
+			return this._input && document.activeElement === this._input;
 		}
 	}
 	customElements.define("editable-text", EditableText);

--- a/chrome/content/zotero/elements/editableText.js
+++ b/chrome/content/zotero/elements/editableText.js
@@ -203,7 +203,7 @@
 				input.addEventListener('change', handleChange);
 				input.addEventListener('focus', () => {
 					// If the last blur was ignored because it was caused by the window becoming inactive,
-					// ignore this focus event as well, so we don't reset initialValue
+					// ignore this focus event as well
 					if (this._ignoredWindowInactiveBlur) {
 						this._ignoredWindowInactiveBlur = false;
 						return;
@@ -215,7 +215,9 @@
 					if (!this.getAttribute("mousedown")) {
 						this._input.setSelectionRange(0, this._input.value.length, "backward");
 					}
-					this._input.dataset.initialValue = this._input.value;
+					if (!('initialValue' in this._input.dataset)) {
+						this._input.dataset.initialValue = this._input.value;
+					}
 				});
 				input.addEventListener('blur', () => {
 					// Ignore this blur if it was caused by the window becoming inactive (see above)
@@ -353,6 +355,11 @@
 		}
 		
 		focus(options) {
+			// If the window isn't active, the focus event won't fire yet,
+			// so store the initial value now
+			if (this._input && Services.focus.activeWindow !== window && !('initialValue' in this._input.dataset)) {
+				this._input.dataset.initialValue = this._input.value;
+			}
 			this._input?.focus(options);
 		}
 		

--- a/chrome/content/zotero/elements/paneHeader.js
+++ b/chrome/content/zotero/elements/paneHeader.js
@@ -142,9 +142,13 @@
 			this._titleFieldID = Zotero.ItemFields.getFieldIDFromTypeAndBase(this.item.itemTypeID, 'title');
 			
 			let title = this.item.getField(this._titleFieldID);
-			if (!this.titleField.initialValue || this.titleField.initialValue !== title) {
+			// If focused, update the value that will be restored on Escape;
+			// otherwise, update the displayed value
+			if (this.titleField.focused) {
+				this.titleField.initialValue = title;
+			}
+			else {
 				this.titleField.value = title;
-				this.titleField.initialValue = '';
 			}
 			this.titleField.readOnly = this._mode == 'view';
 			if (this._titleFieldID) {


### PR DESCRIPTION
Previously, dropping text on an unfocused item box field would make the text appear for a second at the drop position, then the field would focus and the added text would disappear. If you dragged the text from another item box field, it would disappear from _both_ fields. Pretty broken.

Now, dropping text works like Paste:

- If the field is focused when you drag text into it, e.g. when you drag text from another application, switch to Zotero, and drop into the focused field, it'll be added at the cursor position like normal.
- If the field is unfocused when you drag text into it, e.g. when you drag text from the focused field onto an unfocused field, or another application onto a field in the unfocused Zotero window, it'll replace the entire value of the field. We set the Copy cursor to make the difference clear. After drop, pressing Escape restores the previous value; pressing Enter commits.

So dropping onto an unfocused field works like Paste on an unfocused field (overwrites whole contents), and dropping onto a focused field works like Paste on a focused field (adds at cursor).

Also includes `initialValue` fixes that were necessary to allow reverting a drop onto an unfocused window.