### PR TITLE
itemBox: ensure the grippy is hidden if <2 authors

### DIFF
--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -1004,7 +1004,7 @@
 
 			// If not editable or only 1 creator row, hide grippy
 			if (!this.editable || this.item.numCreators() < 2) {
-				grippy.style.visibility = 'hidden';
+				grippy.classList.add("single-creator-grippy");
 				grippy.setAttribute('disabled', true);
 			}
 

--- a/scss/elements/_itemBox.scss
+++ b/scss/elements/_itemBox.scss
@@ -69,6 +69,11 @@ item-box {
 		padding: 0 !important;
 	}
 
+	// Do not display grippy if there is only one creator
+	.meta-label > .single-creator-grippy {
+		visibility: hidden !important;
+	}
+
 	textarea {
 		font: inherit;
 		resize: none;


### PR DESCRIPTION
When contextmenu closes, it clears visibility style from all components. It is added temporarily so that the options buttons do not disappear if the mouse leaves the row. The visibility setting for the grippy for items with only one author should be in a separate class so that grippy is not displayed by accident.

Fixes: #3732