### PR TITLE
Fully block all HTTP requests in the reader

### DIFF
--- a/chrome/content/zotero/BlockingObserver.jsm
+++ b/chrome/content/zotero/BlockingObserver.jsm
@@ -1,0 +1,75 @@
+/*
+    ***** BEGIN LICENSE BLOCK *****
+    
+    Copyright © 2024 Corporation for Digital Scholarship
+                     Vienna, Virginia, USA
+                     https://www.zotero.org
+    
+    This file is part of Zotero.
+    
+    Zotero is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    
+    Zotero is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+    
+    You should have received a copy of the GNU Affero General Public License
+    along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
+    
+    ***** END LICENSE BLOCK *****
+*/
+
+const { XPCOMUtils } = ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+
+XPCOMUtils.defineLazyModuleGetters(this, {
+	Services: "resource://gre/modules/Services.jsm",
+	Zotero: "chrome://zotero/content/include.jsm"
+});
+
+var EXPORTED_SYMBOLS = ["BlockingObserver"];
+
+class BlockingObserver {
+	shouldBlock;
+	
+	_observerAdded = false;
+	_ids = new Set();
+	
+	/**
+	 * @param {(uri: nsIURI) => boolean} shouldBlock
+	 */
+	constructor({ shouldBlock }) {
+		this.shouldBlock = shouldBlock;
+	}
+
+	register(browser) {
+		let id = Zotero.platformMajorVersion > 102 ? browser.browserId : browser.browsingContext.top.id;
+		this._ids.add(id);
+		if (!this._observerAdded) {
+			Services.obs.addObserver(this, 'http-on-modify-request');
+			Zotero.debug('BlockingObserver: Added observer');
+			this._observerAdded = true;
+		}
+	}
+
+	unregister(browser) {
+		let id = Zotero.platformMajorVersion > 102 ? browser.browserId : browser.browsingContext.top.id;
+		this._ids.delete(id);
+		if (this._observerAdded && !this._ids.size) {
+			Services.obs.removeObserver(this, 'http-on-modify-request');
+			Zotero.debug('BlockingObserver: Removed observer');
+			this._observerAdded = false;
+		}
+	}
+
+	observe(subject) {
+		let channel = subject.QueryInterface(Ci.nsIHttpChannel);
+		let id = Zotero.platformMajorVersion > 102 ? channel.browserId : channel.topBrowsingContextId;
+		if (this._ids.has(id) && this.shouldBlock(channel.URI)) {
+			channel.cancel(Cr.NS_BINDING_ABORTED);
+		}
+	}
+}


### PR DESCRIPTION
So it's still not completely clear to me what was going on here.

When using the reader in Firefox/Chrome/Safari, everything is fine. Remote requests are fully and immediately blocked due to CSP. No data goes out and no data comes in.

In the client, though, things are weird. When a snapshot includes a remote resource - `<iframe>`, `<img>`, etc. - it's as if the CSP kicks in late. The request goes out, the server starts sending a response and the response headers get read, *then* Firefox remembers that it was supposed to be paying attention to the CSP, and it cuts off the response. Future resources added after the page is done loading (e.g. you go into the console and programmatically append an `https://example.com/` iframe) are fully blocked - no requests at all.

I'm not sure why that's happening, and why only in the client. I did a bunch of trawling through Searchfox, Firefox bugs, etc., and didn't find anything relevant. So I just adapted the remote request blocking observer that we've been using in `HiddenBrowser.jsm` to catch anything that gets through the CSP. I wish could find the root cause, but this fix does the trick for now.

(I applied the blocking observer to all reader types - couldn't think of any reason why the PDF reader would need to make an HTTP request, and couldn't find anywhere that it does. @mrtcode, let me know if that's right.)