### PR TITLE
Locate menu: Don't show "New Tab" when external, fix bugs

### DIFF
--- a/chrome/content/zotero/locateMenu.js
+++ b/chrome/content/zotero/locateMenu.js
@@ -390,7 +390,6 @@ var Zotero_LocateMenu = new function() {
 				}
 			},
 		});
-		this._mimeTypes = ["application/pdf", "application/epub+zip", "text/html"];
 
 		// Don't show alternate-behavior option ("in New Window" when openReaderInNewWindow is false,
 		// "in New Tab" when it's true) in toolbar Locate menu
@@ -419,7 +418,7 @@ var Zotero_LocateMenu = new function() {
 		});
 		
 		this.canHandleItem = async function (item) {
-			const attachment = await _getFirstAttachmentWithMIMEType(item, this._mimeTypes);
+			const attachment = await _getFirstUsableAttachment(item);
 			// Don't show alternate-behavior option when using an external PDF viewer
 			return attachment
 				&& !(alternateWindowBehavior && Zotero.Prefs.get(`fileHandler.${attachment.attachmentReaderType}`));
@@ -429,7 +428,7 @@ var Zotero_LocateMenu = new function() {
 			let attachmentType = null;
 			let numAttachments = 0;
 			for (let item of items) {
-				let attachment = await _getFirstAttachmentWithMIMEType(item, this._mimeTypes);
+				let attachment = await _getFirstUsableAttachment(item);
 				let thisAttachmentType = attachment?.attachmentReaderType;
 				if (!thisAttachmentType) {
 					continue;
@@ -451,7 +450,7 @@ var Zotero_LocateMenu = new function() {
 		this.handleItems = Zotero.Promise.coroutine(function* (items, event) {
 			var attachments = [];
 			for (let item of items) {
-				var attachment = yield _getFirstAttachmentWithMIMEType(item, this._mimeTypes);
+				var attachment = yield _getFirstUsableAttachment(item);
 				if (attachment) attachments.push(attachment.id);
 			}
 			
@@ -459,11 +458,11 @@ var Zotero_LocateMenu = new function() {
 				{ forceAlternateWindowBehavior: alternateWindowBehavior });
 		});
 		
-		var _getFirstAttachmentWithMIMEType = Zotero.Promise.coroutine(function* (item, mimeTypes) {
+		var _getFirstUsableAttachment = Zotero.Promise.coroutine(function* (item) {
 			var attachments = item.isAttachment() ? [item] : (yield item.getBestAttachments());
 			for (let i = 0; i < attachments.length; i++) {
 				let attachment = attachments[i];
-				if (mimeTypes.indexOf(attachment.attachmentContentType) !== -1
+				if (attachment.attachmentReaderType
 						&& attachment.attachmentLinkMode !== Zotero.Attachments.LINK_MODE_LINKED_URL) {
 					return attachment;
 				}

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -65,17 +65,23 @@ item-creator-moveUp =
     .label = Move Up
 
 item-menu-viewAttachment =
-    .label = Open {
-        $attachmentType ->
+    .label = Open { $numAttachments ->
+        [one] { $attachmentType ->
             [pdf] PDF
             [epub] EPUB
             [snapshot] Snapshot
-            *[multiple] Attachments
-    } in {
+        }
+        *[other] { $attachmentType ->
+            [pdf] PDFs
+            [epub] EPUBs
+            [snapshot] Snapshots
+            *[other] Attachments
+        }
+    } {
         $openIn ->
-            [tab] New Tab
-            [window] New Window
-            *[other] Reader
+            [tab] in New Tab
+            [window] in New Window
+            *[other] { "" }
     }
 
 item-menu-add-file =

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -70,6 +70,7 @@ item-menu-viewAttachment =
             [pdf] PDF
             [epub] EPUB
             [snapshot] Snapshot
+            *[other] Attachment
         }
         *[other] { $attachmentType ->
             [pdf] PDFs


### PR DESCRIPTION
- Run label update logic once instead of repeating on every item
- Show plural attachment type when multiple attachments of same type are selected (instead of "Attachments")
- Fix incorrect icon and label showing when `openReaderInNewWindow` = true
- Fix alternate-behavior item hiding for all item types when PDFs are set to open externally (and never hiding when other types are set to open externally)

Fixes #3741