### PR TITLE
Use HTTPS when opening DOIs via Locate menu and double-click

### DIFF
--- a/chrome/content/zotero/locateMenu.js
+++ b/chrome/content/zotero/locateMenu.js
@@ -475,7 +475,7 @@ var Zotero_LocateMenu = new function() {
 			if(doi && typeof doi === "string") {
 				doi = Zotero.Utilities.cleanDOI(doi);
 				if(doi) {
-					return "https://dx.doi.org/" + encodeURIComponent(doi);
+					return "https://doi.org/" + encodeURIComponent(doi);
 				}
 			}
 			

--- a/chrome/content/zotero/locateMenu.js
+++ b/chrome/content/zotero/locateMenu.js
@@ -475,7 +475,7 @@ var Zotero_LocateMenu = new function() {
 			if(doi && typeof doi === "string") {
 				doi = Zotero.Utilities.cleanDOI(doi);
 				if(doi) {
-					return "http://dx.doi.org/" + encodeURIComponent(doi);
+					return "https://dx.doi.org/" + encodeURIComponent(doi);
 				}
 			}
 			

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -4823,7 +4823,7 @@ var ZoteroPane = new function()
 						// Pull out DOI, in case there's a prefix
 						doi = Zotero.Utilities.cleanDOI(doi);
 						if (doi) {
-							uri = "http://dx.doi.org/" + encodeURIComponent(doi);
+							uri = "https://dx.doi.org/" + encodeURIComponent(doi);
 						}
 					}
 				}

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -4823,7 +4823,7 @@ var ZoteroPane = new function()
 						// Pull out DOI, in case there's a prefix
 						doi = Zotero.Utilities.cleanDOI(doi);
 						if (doi) {
-							uri = "https://dx.doi.org/" + encodeURIComponent(doi);
+							uri = "https://doi.org/" + encodeURIComponent(doi);
 						}
 					}
 				}


### PR DESCRIPTION
Not sure if there's a reason we stuck with http:// for this in the past (site didn't support HTTPS?), but it seems to work fine now.