### PR TITLE
Fix zotero://open/ and FileHandlers regressions

### DIFF
--- a/chrome/content/zotero/xpcom/fileHandlers.js
+++ b/chrome/content/zotero/xpcom/fileHandlers.js
@@ -81,7 +81,7 @@ Zotero.FileHandlers = {
 			handlers = this._handlersLinux[readerType];
 		}
 		
-		let page = location?.position?.pageIndex ?? undefined;
+		let page = location?.pageIndex ?? undefined;
 		// Add 1 to page index for external readers
 		if (page !== undefined && parseInt(page) == page) {
 			page = parseInt(page) + 1;
@@ -492,9 +492,7 @@ Zotero.OpenPDF = {
 		await Zotero.FileHandlers.open(pathOrItem, {
 			location: {
 				annotationID: annotationKey,
-				position: {
-					pageIndex: page,
-				}
+				pageIndex: page,
 			}
 		});
 	}

--- a/components/zotero-protocol-handler.js
+++ b/components/zotero-protocol-handler.js
@@ -1193,29 +1193,32 @@ function ZoteroProtocolHandler() {
 				return;
 			}
 			
-			var location = null;
-			if (page || annotation) {
-				location = {
-					pageIndex: page ? parseInt(page) : undefined,
-					annotationID: annotation
-				};
+			var location = {};
+			
+			if (page) {
+				location.pageIndex = parseInt(page);
 			}
-			else if (cfi) {
-				location = {
-					position: {
-						type: 'FragmentSelector',
-						conformsTo: 'http://www.idpf.org/epub/linking/cfi/epub-cfi.html',
-						value: cfi
-					}
+			if (annotation) {
+				location.annotationID = annotation;
+			}
+			
+			if (cfi) {
+				location.position = {
+					type: 'FragmentSelector',
+					conformsTo: 'http://www.idpf.org/epub/linking/cfi/epub-cfi.html',
+					value: cfi
 				};
 			}
 			else if (sel) {
-				location = {
-					position: {
-						type: 'CssSelector',
-						value: sel
-					}
+				location.position = {
+					type: 'CssSelector',
+					value: sel
 				};
+			}
+			
+			// Don't pass empty location
+			if (!Object.keys(location).length) {
+				location = null;
 			}
 
 			var openInWindow = Zotero.Prefs.get('openReaderInNewWindow');

--- a/components/zotero-protocol-handler.js
+++ b/components/zotero-protocol-handler.js
@@ -1194,11 +1194,9 @@ function ZoteroProtocolHandler() {
 			}
 			
 			var location = null;
-			if (page) {
+			if (page || annotation) {
 				location = {
-					position: {
-						pageIndex: page
-					},
+					pageIndex: page ? parseInt(page) : undefined,
 					annotationID: annotation
 				};
 			}


### PR DESCRIPTION
- PDF view wants `pageIndex` directly under the location object passed to `navigate()`, not under `location.position`
- Fix reader not navigating when only an annotation ID is passed
- Add test to make sure that the navigation works
- Pass multiple properties if multiple query params are provided

@mrtcode, let me know if the logic here looks right.

Fixes #3759