### PR TITLE
Replace calls to keepParents() with keepTopLevel()

### DIFF
--- a/chrome/content/zotero/collectionTree.jsx
+++ b/chrome/content/zotero/collectionTree.jsx
@@ -1529,7 +1529,7 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 
 				var ids = data;
 				var items = Zotero.Items.get(ids);
-				items = Zotero.Items.keepParents(items);
+				items = Zotero.Items.keepTopLevel(items);
 				var skip = true;
 				for (let item of items) {
 					// Can only drag top-level items
@@ -2047,7 +2047,7 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 			}
 			
 			if (targetTreeRow.isPublications()) {
-				items = Zotero.Items.keepParents(items);
+				items = Zotero.Items.keepTopLevel(items);
 				let io = window.ZoteroPane.showPublicationsWizard(items);
 				if (!io) {
 					return;

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -4015,7 +4015,7 @@ var ZoteroPane = new function()
 		// Add to collection
 		if (!collectionTreeRow.isFeedsOrFeed()
 			&& collectionTreeRow.editable
-			&& Zotero.Items.keepParents(items).every(item => item.isTopLevelItem())
+			&& Zotero.Items.keepTopLevel(items).every(item => item.isTopLevelItem())
 		) {
 			menu.childNodes[m.addToCollection].setAttribute('label', Zotero.getString('pane.items.menu.addToCollection'));
 			show.add(m.addToCollection);
@@ -4080,7 +4080,7 @@ var ZoteroPane = new function()
 			popup.removeChild(popup.lastElementChild);
 		}
 
-		let items = Zotero.Items.keepParents(this.getSelectedItems());
+		let items = Zotero.Items.keepTopLevel(this.getSelectedItems());
 		let collections = Zotero.Collections.getByLibrary(this.getSelectedLibraryID());
 		for (let col of collections) {
 			let menuItem = Zotero.Utilities.Internal.createMenuForTarget(
@@ -4104,7 +4104,7 @@ var ZoteroPane = new function()
 
 	this.addSelectedItemsToCollection = async function (collection, createNew = false) {
 		// Get items first because newCollection() will deselect
-		let items = Zotero.Items.keepParents(this.getSelectedItems());
+		let items = Zotero.Items.keepTopLevel(this.getSelectedItems());
 
 		if (createNew) {
 			if (collection) {

--- a/test/tests/itemsTest.js
+++ b/test/tests/itemsTest.js
@@ -1243,7 +1243,7 @@ describe("Zotero.Items", function () {
 		});
 	});
 	
-	describe("#keepParents()", function () {
+	describe("#keepTopLevel()", function () {
 		it("should remove child items of passed items", async function () {
 			var item1 = await createDataObject('item');
 			var item2 = await createDataObject('item', { itemType: 'note', parentItemID: item1.id });
@@ -1253,7 +1253,7 @@ describe("Zotero.Items", function () {
 			var otherItem = await createDataObject('item');
 			var item6 = await createDataObject('item', { itemType: 'note', parentItemID: otherItem.id });
 			
-			var items = Zotero.Items.keepParents([item1, item2, item3, item4, item5, item6]);
+			var items = Zotero.Items.keepTopLevel([item1, item2, item3, item4, item5, item6]);
 			assert.sameMembers(
 				// Convert to ids for clearer output
 				items.map(item => item.id),
@@ -1265,7 +1265,7 @@ describe("Zotero.Items", function () {
 			var item1 = await createDataObject('item');
 			var item2 = await createDataObject('item', { itemType: 'note', parentItemID: item1.id });
 			var item3 = await createDataObject('item', { itemType: 'note', parentItemID: item1.id });
-			var items = Zotero.Items.keepParents([item2, item3]);
+			var items = Zotero.Items.keepTopLevel([item2, item3]);
 			assert.sameMembers(
 				items.map(item => item.id),
 				[item2.id, item3.id]


### PR DESCRIPTION
Eliminates debug spam.