### PR TITLE
quick format: do not change input's colors in dark mode

### DIFF
--- a/chrome/skin/default/zotero/integration.css
+++ b/chrome/skin/default/zotero/integration.css
@@ -117,6 +117,9 @@
 	box-sizing: border-box; 
 	height: 15px;
 	margin: 0;
+	/* Keep the background and text color unchanged in dark mode */
+	background-color: transparent;
+	color: black;
 }
 
 .citation-dialog span {


### PR DESCRIPTION
Hardcode transparent background and black text color for inputs. Otherwise, the inputs end up with dark background and white text which does not work with the rest of the dialog that always has white background.
This is temporary until the rest of the dialog works with the dark mode.

Fixes: #3768