### PR TITLE
Add configuration settings  for tab loading

### DIFF
--- a/chrome/content/zotero/tabs.js
+++ b/chrome/content/zotero/tabs.js
@@ -31,10 +31,9 @@ var ReactDOM = require('react-dom');
 import TabBar from 'components/tabBar';
 import { CSSIcon, CSSItemTypeIcon } from 'components/icons';
 
-// Reduce loaded tabs limit if the system has 8 GB or less memory.
-// TODO: Revise this after upgrading to Zotero 7
-const MAX_LOADED_TABS = Services.sysinfo.getProperty("memsize") / 1024 / 1024 / 1024 <= 8 ? 3 : 5;
-const UNLOAD_UNUSED_AFTER = 86400; // 24h
+// Configure loaded tabs limit
+const MAX_LOADED_TABS = Zotero.Prefs.get("tabs.maxLoadedTabs");
+const UNLOAD_UNUSED_AFTER = Zotero.Prefs.get("tabs.unloadUnusedAfter");
 
 var Zotero_Tabs = new function () {
 	Object.defineProperty(this, 'selectedID', {

--- a/defaults/preferences/zotero.js
+++ b/defaults/preferences/zotero.js
@@ -217,6 +217,8 @@ pref("extensions.zotero.scaffold.eslint.enabled", true);
 
 // Tabs
 pref("extensions.zotero.tabs.title.reader", "titleCreatorYear");
+pref("extensions.zotero.tabs.maxLoadedTabs", 3);
+pref("extensions.zotero.tabs.unloadUnusedAfter", 86400);
 
 // Reader
 pref("extensions.zotero.reader.contentDarkMode", true);


### PR DESCRIPTION
Introduce two about:config parameters to configure tab loading :
- extensions.zotero.tabs.maxLoadedTabs
- extensions.zotero.tabs.unloadUnusedAfter

Fix bug #3636.