### PR TITLE
Quick-format: do not hide reference panel

### DIFF
--- a/chrome/content/zotero-platform/mac/integration.css
+++ b/chrome/content/zotero-platform/mac/integration.css
@@ -3,10 +3,6 @@ body {
 	font-size: 15px;
 }
 
-body[multiline="true"] {
-	line-height: 26px;
-}
-
 window.citation-dialog {
 	background: transparent;
 	-moz-appearance: none;
@@ -18,13 +14,6 @@ window.citation-dialog {
 	height: 37px;
 }
 
-.citation-dialog.search {
-	padding: 2px 2px 0 2px;
-	margin: 2.5px 3.5px;
-	border: 1px solid rgba(0, 0, 0, 0.5);
-	-moz-appearance: none;
-	border-radius: 10px;
-}
 
 
 .citation-dialog.entry {
@@ -36,10 +25,6 @@ window.citation-dialog {
 	background: -moz-linear-gradient(-90deg, rgb(249, 231, 179) 0, rgb(228, 193, 94) 50%, rgb(221, 184, 81) 50%);
 }
 
-#zotero-icon {
-	margin: -1px 0 0 4px;
-	-moz-appearance: none;
-}
 
 #citation-properties menulist {
 	-moz-appearance: none; color: #fff;

--- a/chrome/content/zotero-platform/unix/integration.css
+++ b/chrome/content/zotero-platform/unix/integration.css
@@ -6,9 +6,3 @@ window.citation-dialog {
 	-moz-appearance: none;
 	padding: 5px;
 }
-
-#zotero-icon {
-	padding: 4px 4px 6px 4px !important;
-	margin: 2px 0;
-	-moz-appearance: none;
-}

--- a/chrome/content/zotero-platform/unix/integration.css
+++ b/chrome/content/zotero-platform/unix/integration.css
@@ -2,16 +2,6 @@ body {
 	line-height: 1.5em;
 }
 
-.citation-dialog.search:not([multiline="true"]) {
-	height: 29px !important;
-}
-
-.citation-dialog.search {
-	padding: 0 2px 0 0;
-	border: 1px solid rgba(0, 0, 0, 0.5);
-	-moz-appearance: textfield;
-}
-
 window.citation-dialog {
 	-moz-appearance: none;
 	padding: 5px;

--- a/chrome/content/zotero-platform/win/integration.css
+++ b/chrome/content/zotero-platform/win/integration.css
@@ -19,10 +19,6 @@ window.citation-dialog {
 	border-radius: 15px;
 }
 
-#zotero-icon {
-	margin: -1px 0 0 4px;
-	-moz-appearance: none;
-}
 
 body {
 	line-height: 1.65em;

--- a/chrome/content/zotero-platform/win/integration.css
+++ b/chrome/content/zotero-platform/win/integration.css
@@ -4,16 +4,6 @@ window.citation-dialog {
 	-moz-appearance: none;
 }
 
-.citation-dialog.search {
-	padding: 2px 2px 2px 0;
-	border: 1px solid rgba(0, 0, 0, 0.5);
-	border-radius: 10px;
-	-moz-appearance: none;
-}
-
-.citation-dialog.search:not([multiline="true"]) {
-	height: 28px !important;
-}
 
 .citation-dialog.entry {
 	background: -moz-linear-gradient(-90deg, rgb(243,123,119) 0, rgb(180,47,38) 50%, rgb(156,36,27) 50%);

--- a/chrome/content/zotero/integration/quickFormat.js
+++ b/chrome/content/zotero/integration/quickFormat.js
@@ -1114,7 +1114,7 @@ var Zotero_QuickFormat = new function () {
 	this._bubbleizeSelected = Zotero.Promise.coroutine(function* () {
 		const panelShowing = referencePanel.state === "open" || referencePanel.state === "showing";
 		let inputExists = _lastFocusedInput || _getCurrentInput()
-		if(!panelShowing || !referenceBox.hasChildNodes() || !referenceBox.selectedItem) return false;
+		if(!panelShowing || !referenceBox.hasChildNodes() || !referenceBox.selectedItem || _searchPromise?.isPending()) return false;
 
 		if(!referenceBox.hasChildNodes() || !referenceBox.selectedItem || !inputExists) return false;
 		var citationItem = {"id":referenceBox.selectedItem.getAttribute("zotero-item")};
@@ -1436,7 +1436,7 @@ var Zotero_QuickFormat = new function () {
 	 * Accepts current selection and adds citation
 	 */
 	this.accept = function() {
-		if(accepted) return;
+		if (accepted || _searchPromise?.isPending()) return;
 		accepted = true;
 		try {
 			_updateCitationObject();

--- a/chrome/content/zotero/integration/quickFormat.js
+++ b/chrome/content/zotero/integration/quickFormat.js
@@ -84,6 +84,7 @@ var Zotero_QuickFormat = new function () {
 			
 			dialog = document.querySelector(".citation-dialog.entry");
 			editor = document.querySelector(".citation-dialog.editor");
+			_resizeEditor();
 			dialog.addEventListener("click", _onQuickSearchClick, false);
 			dialog.addEventListener("keypress", _onQuickSearchKeyPress, false);
 			editor.addEventListener("dragover", _onEditorDragOver);
@@ -1182,6 +1183,19 @@ var Zotero_QuickFormat = new function () {
 		e.preventDefault();
 	}
 
+	// Set the editor's width so that it fills up all remaining space in the window.
+	// It should be window.width - padding - icon wrappers width. The is needed to be explicitly set
+	// so that the editor's height expands/shrinks vertically without going outside of the
+	// window boundaries.
+	function _resizeEditor() {
+		let editorParentWidth = editor.parentNode.getBoundingClientRect().width;
+		let iconWrapperWidth = document.querySelector(".citation-dialog.icons").getBoundingClientRect().width;
+		let editorDesiredWidth = editorParentWidth - iconWrapperWidth * 2;
+		// Sanity check: editor width should never be that small
+		if (editorDesiredWidth > 700) {
+			editor.style.width = `${editorDesiredWidth}px`;
+		}
+	}
 	function _resizeWindow() {
 		let box = document.querySelector(".citation-dialog.entry");
 		let contentHeight = box.getBoundingClientRect().height;
@@ -1560,7 +1574,7 @@ var Zotero_QuickFormat = new function () {
 	 */
 	function _resetSearchTimer() {
 		// Show spinner
-		var spinner = document.querySelector('.citation-dialog.icons image');
+		var spinner = document.querySelector('.citation-dialog.icons.end image');
 		spinner.nextElementSibling.style.display = "none";
 		spinner.setAttribute("status", "animate");
 		// Cancel current search if active

--- a/chrome/content/zotero/integration/quickFormat.js
+++ b/chrome/content/zotero/integration/quickFormat.js
@@ -117,7 +117,14 @@ var Zotero_QuickFormat = new function () {
 					_lastFocusedInput.focus();
 				}
 				else if (["ArrowDown", "ArrowUp"].includes(event.key)) {
-					handleItemSelection(event);
+					// ArrowUp from first item focuses the input
+					if (referenceBox.selectedIndex == 1 && event.key == "ArrowUp") {
+						_lastFocusedInput.focus();
+						referenceBox.selectedIndex = -1;
+					}
+					else {
+						handleItemSelection(event);
+					}
 				}
 				// Right/Left arrow will hide ref panel and move focus to the previour/next element
 				else if ("ArrowLeft" == event.key) {
@@ -1714,6 +1721,10 @@ var Zotero_QuickFormat = new function () {
 			_resetSearchTimer();
 		}
 		else if (["ArrowDown", "ArrowUp"].includes(event.key) && referencePanel.state === "open") {
+			// ArrowUp when item is selected does nothing
+			if (referenceBox.selectedIndex < 1 && event.key == "ArrowUp") {
+				return;
+			}
 			// Arrow up/down will navigate the references panel if that's opened
 			if (referenceBox.selectedIndex < 1) {
 				referenceBox.selectedIndex = 1;

--- a/chrome/content/zotero/integration/quickFormat.js
+++ b/chrome/content/zotero/integration/quickFormat.js
@@ -1414,7 +1414,7 @@ var Zotero_QuickFormat = new function () {
 	/**
 	 * Accepts current selection and adds citation
 	 */
-	this._accept = function() {
+	this.accept = function() {
 		if(accepted) return;
 		accepted = true;
 		try {
@@ -1450,7 +1450,7 @@ var Zotero_QuickFormat = new function () {
 		}
 		else if (event.key == "Enter") {
 			event.preventDefault();
-			Zotero_QuickFormat._accept();
+			Zotero_QuickFormat.accept();
 		}
 		// In rare circumstances, the focus can get lost (e.g. if the focus is on an item
 		// in reference panel when it is refreshed and all nodes are deleted).
@@ -1553,7 +1553,8 @@ var Zotero_QuickFormat = new function () {
 	 */
 	function _resetSearchTimer() {
 		// Show spinner
-		var spinner = document.querySelector('.citation-dialog.spinner image');
+		var spinner = document.querySelector('.citation-dialog.icons image');
+		spinner.nextElementSibling.style.display = "none";
 		spinner.setAttribute("status", "animate");
 		// Cancel current search if active
 		if (_searchPromise && _searchPromise.isPending()) {
@@ -1565,6 +1566,7 @@ var Zotero_QuickFormat = new function () {
 			.then(() => {
 				_searchPromise = null;
 				spinner.removeAttribute("status");
+				spinner.nextElementSibling.style.removeProperty("display");
 			});
 	}
 
@@ -1879,7 +1881,7 @@ var Zotero_QuickFormat = new function () {
 		else if (keyCode == "Enter" && event.shiftKey) {
 			event.preventDefault();
 			event.stopPropagation();
-			this._accept();
+			this.accept();
 		}
 		else {
 			isPaste = false;

--- a/chrome/content/zotero/integration/quickFormat.xhtml
+++ b/chrome/content/zotero/integration/quickFormat.xhtml
@@ -70,8 +70,9 @@
 						</toolbarbutton>
 					</vbox>
 					<html:div flex="1" spellcheck="false" class="citation-dialog editor" role="application"></html:div>
-					<vbox class="citation-dialog spinner">
-						<image class="zotero-spinner-16"/>
+					<vbox class="citation-dialog icons">
+						<image class="icon zotero-spinner-16"/>
+						<toolbarbutton class="icon accept-button" onclick="Zotero_QuickFormat.accept()" data-l10n-id="quickformat-accept"></toolbarbutton>
 					</vbox>
 				</hbox>
 			</hbox>

--- a/chrome/content/zotero/integration/quickFormat.xhtml
+++ b/chrome/content/zotero/integration/quickFormat.xhtml
@@ -55,7 +55,7 @@
 		<deck class="citation-dialog deck" selectedIndex="0" flex="1">
 			<hbox class="citation-dialog main" flex="1" align="start">
 				<hbox flex="1">
-					<vbox flex="1" align="center" style="display: flex;align-items: center;max-width: 38px;justify-content: center;">
+					<vbox class="citation-dialog icons start">
 						<toolbarbutton id="zotero-icon" type="menu" tabindex="0" disabled="true">
 							<menupopup>
 								<menuitem id="keep-sorted" label="&zotero.citation.keepSorted.label;"
@@ -70,7 +70,7 @@
 						</toolbarbutton>
 					</vbox>
 					<html:div flex="1" spellcheck="false" class="citation-dialog editor" role="application"></html:div>
-					<vbox class="citation-dialog icons">
+					<vbox class="citation-dialog icons end">
 						<image class="icon zotero-spinner-16"/>
 						<toolbarbutton class="icon accept-button" onclick="Zotero_QuickFormat.accept()" data-l10n-id="quickformat-accept"></toolbarbutton>
 					</vbox>

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -437,3 +437,5 @@ toggle-preview =
 quickformat-aria-bubble = Press Down Arrow to open citation properties.
 quickformat-aria-input = Type your search term. Use Down Arrow and Up Arrow to navigate the search results.
 quickformat-aria-item = Press { return-or-enter } to select this item. Press Tab to return to the search field.
+quickformat-accept = 
+    .tooltiptext = Save edits to this citation

--- a/chrome/skin/default/zotero/integration.css
+++ b/chrome/skin/default/zotero/integration.css
@@ -206,14 +206,15 @@
 	align-items: end;
 	flex-direction: column;
 	width: 30px;
+	justify-content: center;
 }
 
 .citation-dialog .icons .icon {
 	margin-right: 3px;
+	width: 100%;
 }
 
 .citation-dialog .icons .zotero-spinner-16 {
-	margin-top: 5px;
 	margin-right: 5px;
 }
 

--- a/chrome/skin/default/zotero/integration.css
+++ b/chrome/skin/default/zotero/integration.css
@@ -185,7 +185,7 @@
 	font: -moz-field;
 	outline: none;
 	line-height: 2em;
-	width: 710px;
+	width: 700px; /* initial editor width - adjusted after dom load */
 	height: 28px;
 	font-size: 13px;
 	background: white;
@@ -203,19 +203,15 @@
 
 .citation-dialog.icons {
 	display: flex;
-	align-items: end;
+	align-items: center;
 	flex-direction: column;
-	width: 30px;
 	justify-content: center;
+	width: 36px;
 }
 
-.citation-dialog .icons .icon {
-	margin-right: 3px;
-	width: 100%;
-}
-
-.citation-dialog .icons .zotero-spinner-16 {
-	margin-right: 5px;
+.citation-dialog.entry {
+	max-width: 800px;
+	min-width: 800px;
 }
 
 .citation-dialog .accept-button {

--- a/chrome/skin/default/zotero/integration.css
+++ b/chrome/skin/default/zotero/integration.css
@@ -201,9 +201,25 @@
 	background: var(--color-accent);
 }
 
-.citation-dialog.spinner {
+.citation-dialog.icons {
 	display: flex;
-	align-items: center;
+	align-items: end;
+	flex-direction: column;
+	width: 30px;
+}
+
+.citation-dialog .icons .icon {
+	margin-right: 3px;
+}
+
+.citation-dialog .icons .zotero-spinner-16 {
+	margin-top: 5px;
+	margin-right: 5px;
+}
+
+.citation-dialog .accept-button {
+	list-style-image: url("chrome://zotero/skin/20/universal/arrow-right.svg");
+	fill: currentColor;
 }
 
 .citation-dialog.item {


### PR DESCRIPTION
- Reference panel remains opened while the focus is on an input
- The first item from the reference panel is no longer selected by default to avoid unwanted items being added as a bubble
- The first item from the reference panel is selected only when the dialog has no bubbles or when a search for a non-empty input just ran
- Shift-Enter from input or reference panel will accept the dialog's state instead of creating a bubble
- Ensure that the reference panel reloads when a bubble is deleted

Addresses: #3811, #3671