### PR TITLE
Fix item pane expanding on each restart with note selected

### DIFF
--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -1993,8 +1993,10 @@ var ZoteroPane = new function()
 
 			if (!document.querySelector("#zotero-items-splitter").collapsed) {
 				let isStackedMode = Zotero.Prefs.get("layout") === "stacked";
+				let wasFillingHiddenSidenav = pane.hasAttribute("fill-hidden-sidenav");
 				const sidenavSize = 37;
-				if (hideSidenav && !sidenav.hidden) {
+				if (hideSidenav && !wasFillingHiddenSidenav) {
+					pane.setAttribute("fill-hidden-sidenav", true);
 					sidenav.hidden = true;
 					if (isStackedMode) {
 						pane.height = `${(pane.clientHeight) + sidenavSize}`;
@@ -2003,7 +2005,8 @@ var ZoteroPane = new function()
 						pane.width = `${(pane.clientWidth) + sidenavSize}`;
 					}
 				}
-				else if (!hideSidenav && sidenav.hidden) {
+				else if (!hideSidenav && wasFillingHiddenSidenav) {
+					pane.removeAttribute("fill-hidden-sidenav");
 					sidenav.hidden = false;
 					if (isStackedMode) {
 						pane.height = `${(pane.clientHeight) - sidenavSize}`;

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -1186,7 +1186,7 @@
 									</splitter>
 				
 									<!-- itemPane.xul -->
-									<vbox id="zotero-item-pane" flex="0" zotero-persist="width height" height="300">
+									<vbox id="zotero-item-pane" flex="0" zotero-persist="width height fill-hidden-sidenav" height="300">
 										<!-- My Publications -->
 										<hbox id="zotero-item-pane-top-buttons-my-publications" class="zotero-item-pane-top-buttons" hidden="true">
 											<button id="zotero-item-collection-show-hide"/>


### PR DESCRIPTION
Persist a new attribute that tracks whether the width/height has been expanded to cover a hidden sidenav. Use that to determine whether to adjust the width/height rather than the current visibility of the sidenav.

Fixes #3813