### PR TITLE
Fix editable-text height on Windows

### DIFF
--- a/scss/win/elements/_editableText.scss
+++ b/scss/win/elements/_editableText.scss
@@ -1,6 +1,6 @@
 editable-text {
 	.input {
-		height: unset;
+		height: unset !important;
 		// Disable focus ring
 		outline: none;
 		padding-inline-start: unset;


### PR DESCRIPTION
fix: #3821