### PR TITLE
qf: fix suppress author checkbox click

### DIFF
--- a/chrome/content/zotero/integration/quickFormat.xhtml
+++ b/chrome/content/zotero/integration/quickFormat.xhtml
@@ -106,11 +106,9 @@
 			<html:input type="text" aria-labelledby="suffix-label" tabindex="6" class="citation-textbox" id="suffix" flex="1"
 					 oninput="window.setTimeout(function(event) { Zotero_QuickFormat.onCitationPropertiesChanged(event) }, 0)"/>
 			<html:div>
-				<html:input type="checkbox" id="suppress-author" native="true" tabindex="7"
-							onchange="Zotero_QuickFormat.onCitationPropertiesChanged(event)"/>
-				<html:label for="suppress-author">
-					&zotero.citation.suppressAuthor.label;
-				</html:label>
+				<checkbox type="checkbox" id="suppress-author" native="true" tabindex="7"
+						oncommand="Zotero_QuickFormat.onCitationPropertiesChanged(event)"
+						label="&zotero.citation.suppressAuthor.label;"/>
 			</html:div>
 		</html:div>
 		<vbox flex="1" align="center">


### PR DESCRIPTION
Use <checkbox> instead of <html:input type="checkbox"> for the suppress author checkbox. <html:input> on mousedown on the actual box looses focus, so the popover is immediately closed by focusout listener. Fixes: #3830