### PR TITLE
make opened tabs menu scrollable

### DIFF
--- a/chrome/content/zotero/tabs.js
+++ b/chrome/content/zotero/tabs.js
@@ -1008,17 +1008,22 @@ var Zotero_Tabs = new function () {
 			absoluteTabsMenuTop = window.screenY - panelRect.height + anchorRect.top;
 			absoluteTabsMenuBottom = window.screenY + panelRect.height + anchorRect.bottom;
 		}
+		// screen.availTop is not always right on Linux, so ignore it
+		let availableTop = Zotero.isLinux ? 0 : screen.availTop;
+
 		// Check if the end of the tabs menu is close to the edge of the screen
-		let atTopScreenEdge = valuesAreWithinMargin(absoluteTabsMenuTop, window.screen.availTop, gapBeforeScreenEdge);
-		let atBottomScreenEdge = valuesAreWithinMargin(absoluteTabsMenuBottom, screen.availHeight + screen.availTop, gapBeforeScreenEdge);
+		let atTopScreenEdge = valuesAreWithinMargin(absoluteTabsMenuTop, availableTop, gapBeforeScreenEdge);
+		let atBottomScreenEdge = valuesAreWithinMargin(absoluteTabsMenuBottom, screen.availHeight + availableTop, gapBeforeScreenEdge);
 
 		let gap;
-		// Limit max height of the menu to leave the specified gap till the screen's edge
-		if (atTopScreenEdge) {
-			gap = gapBeforeScreenEdge - (absoluteTabsMenuTop - window.screen.availTop);
+		// Limit max height of the menu to leave the specified gap till the screen's edge.
+		// Due to screen.availTop behavior on linux, the menu can go outside of what is supposed
+		// to be the available screen area, so special treatment for those edge cases.
+		if (atTopScreenEdge || (Zotero.isLinux && absoluteTabsMenuTop < 0)) {
+			gap = gapBeforeScreenEdge - (absoluteTabsMenuTop - availableTop);
 		}
-		if (atBottomScreenEdge) {
-			gap = gapBeforeScreenEdge - (screen.availHeight + screen.availTop - absoluteTabsMenuBottom);
+		if (atBottomScreenEdge || (Zotero.isLinux && absoluteTabsMenuBottom > screen.availHeight)) {
+			gap = gapBeforeScreenEdge - (screen.availHeight + availableTop - absoluteTabsMenuBottom);
 		}
 		if (gap) {
 			panel.style.maxHeight = `${panelRect.height - gap}px`;

--- a/chrome/content/zotero/tabs.js
+++ b/chrome/content/zotero/tabs.js
@@ -985,6 +985,16 @@ var Zotero_Tabs = new function () {
 		focusTabsMenuEntry(0);
 	};
 
+	this.handleTabsMenuShowing = function (_) {
+		this.refreshTabsMenuList();
+
+		// Try to scroll selected tab into the center
+		let selectedTab = this.tabsMenuList.querySelector(".selected");
+		if (selectedTab) {
+			selectedTab.scrollIntoView({ block: 'center' });
+		}
+	};
+
 	/**
 	 * Record the value of the filter
 	 */

--- a/chrome/content/zotero/tabs.js
+++ b/chrome/content/zotero/tabs.js
@@ -979,6 +979,7 @@ var Zotero_Tabs = new function () {
 		let menuFilter = document.getElementById('zotero-tabs-menu-filter');
 		menuFilter.value = "";
 		this._tabsMenuFilter = "";
+		this.tabsMenuList.closest("panel").style.removeProperty('max-height');
 	};
 
 	this.handleTabsMenuShown = function (_) {
@@ -988,6 +989,40 @@ var Zotero_Tabs = new function () {
 	this.handleTabsMenuShowing = function (_) {
 		this.refreshTabsMenuList();
 
+		// Make sure that if the menu is very long, there is a small
+		// gap left between the top/bottom of the menu and the edge of the screen
+		let valuesAreWithinMargin = (valueOne, valueTwo, margin) => {
+			return Math.abs(valueOne - valueTwo) <= margin;
+		};
+		let panel = document.getElementById("zotero-tabs-menu-panel");
+		let panelRect = panel.getBoundingClientRect();
+		const gapBeforeScreenEdge = 25;
+		let absoluteTabsMenuTop = window.screenY - panelRect.height + panelRect.bottom;
+		let absoluteTabsMenuBottom = window.screenY + panelRect.height + panelRect.top;
+
+		// On windows, getBoundingClientRect does not give us correct top and bottom values
+		// until popupshown, so instead use the anchor's position
+		if (Zotero.isWin) {
+			let anchor = document.getElementById("zotero-tb-tabs-menu");
+			let anchorRect = anchor.getBoundingClientRect();
+			absoluteTabsMenuTop = window.screenY - panelRect.height + anchorRect.top;
+			absoluteTabsMenuBottom = window.screenY + panelRect.height + anchorRect.bottom;
+		}
+		// Check if the end of the tabs menu is close to the edge of the screen
+		let atTopScreenEdge = valuesAreWithinMargin(absoluteTabsMenuTop, window.screen.availTop, gapBeforeScreenEdge);
+		let atBottomScreenEdge = valuesAreWithinMargin(absoluteTabsMenuBottom, screen.availHeight + screen.availTop, gapBeforeScreenEdge);
+
+		let gap;
+		// Limit max height of the menu to leave the specified gap till the screen's edge
+		if (atTopScreenEdge) {
+			gap = gapBeforeScreenEdge - (absoluteTabsMenuTop - window.screen.availTop);
+		}
+		if (atBottomScreenEdge) {
+			gap = gapBeforeScreenEdge - (screen.availHeight + screen.availTop - absoluteTabsMenuBottom);
+		}
+		if (gap) {
+			panel.style.maxHeight = `${panelRect.height - gap}px`;
+		}
 		// Try to scroll selected tab into the center
 		let selectedTab = this.tabsMenuList.querySelector(".selected");
 		if (selectedTab) {

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -840,7 +840,7 @@
 			<div xmlns="http://www.w3.org/1999/xhtml" class="zotero-tb-separator"></div>
 			<panel id="zotero-tabs-menu-panel" type="arrow" 
 					onpopuphiding="Zotero_Tabs.handleTabsMenuHiding(event)"
-					onpopupshowing="Zotero_Tabs.refreshTabsMenuList()"
+					onpopupshowing="Zotero_Tabs.handleTabsMenuShowing(event)"
 					onpopupshown="Zotero_Tabs.handleTabsMenuShown(event)"
 					onkeydown="Zotero_Tabs.handleTabsMenuKeyPress(event)"
 					tabindex="-1"

--- a/scss/components/_tabsMenu.scss
+++ b/scss/components/_tabsMenu.scss
@@ -3,10 +3,6 @@
 	margin: 0;
 }
 
-#zotero-tabs-menu-panel {
-	min-height: 0;
-}
-
 #zotero-tabs-menu-wrapper {
 	width: 350px;
 	background: var(--material-sidepane);

--- a/scss/components/_tabsMenu.scss
+++ b/scss/components/_tabsMenu.scss
@@ -3,16 +3,23 @@
 	margin: 0;
 }
 
+#zotero-tabs-menu-panel {
+	min-height: 0;
+}
+
 #zotero-tabs-menu-wrapper {
 	width: 350px;
 	background: var(--material-sidepane);
-	padding: 7px;
+	padding: 0;
 	border-radius: 5px;
 	--width-focus-border: 2px;
+	display: flex;
+	flex-direction: column;
+	min-height: 0;
 }
 
 #zotero-tabs-menu-filter {
-	margin: 0 0 7px 0;
+	margin: 7px;
 	border-radius: 5px;
 	border: 1px solid transparent;
 	padding-inline-start: 5px !important;
@@ -26,6 +33,13 @@
 #zotero-tabs-menu-list {
 	appearance: none;
 	margin: 0;
+	overflow-x: hidden;
+	overflow-y: scroll;
+	scrollbar-width: thin;
+
+	& > toolbaritem {
+		margin: 0 7px;
+	}
 
 	.row {
 		display: flex;

--- a/scss/components/_tabsMenu.scss
+++ b/scss/components/_tabsMenu.scss
@@ -19,7 +19,7 @@
 }
 
 #zotero-tabs-menu-filter {
-	margin: 7px;
+	margin: 7px 7px 2px 7px;
 	border-radius: 5px;
 	border: 1px solid transparent;
 	padding-inline-start: 5px !important;
@@ -36,14 +36,11 @@
 	overflow-x: hidden;
 	overflow-y: scroll;
 	scrollbar-width: thin;
-
-	& > toolbaritem {
-		margin: 0 7px;
-	}
+	padding: 5px 0;
 
 	.row {
 		display: flex;
-		padding-inline-start: 4px;
+		padding-inline: 4px;
 	}
 
 	.zotero-tabs-menu-entry {


### PR DESCRIPTION
- if there are too many tabs opened to fit into the available space on the screen, set the menu's list height so that it becomes scrollable. As a cutoff for the necessary height, use 75% of `screen.height -  window.screenTop`:  this seems to give enough space to avoid overlap with the toolbar (dock) at the bottom. 
- this cutoff will become the menu's height if there are too many entries, so the menu will be shorter if the main window is dragged down closer to the bottom of the screen and longer if the window is at the very top.
- when tabs menu is refreshed, scroll to the selected tab.
- use margins instead of padding to that the scrollbar does not overlap with the cross button.

Fixes: #3822