### PR TITLE
fix to "show in library" not focusing the itemTree

### DIFF
--- a/chrome/content/zotero/tabs.js
+++ b/chrome/content/zotero/tabs.js
@@ -410,6 +410,9 @@ var Zotero_Tabs = new function () {
 		// Move focus to the last focused element of zoteroPane if any or itemTree otherwise
 		let focusZoteroPane = () => {
 			if (tab.id !== 'zotero-pane') return;
+			if (options.focusElementID) {
+				tab.lastFocusedElement = document.getElementById(options.focusElementID);
+			}
 			// Small delay to make sure the focus does not remain on the actual
 			// tab after mouse click
 			setTimeout(() => {
@@ -658,7 +661,6 @@ var Zotero_Tabs = new function () {
 						itemID = item.parentItemID;
 					}
 					ZoteroPane_Local.selectItem(itemID);
-					this.select('zotero-pane');
 				}
 			});
 			popup.appendChild(menuitem);

--- a/chrome/content/zotero/xpcom/editorInstance.js
+++ b/chrome/content/zotero/xpcom/editorInstance.js
@@ -315,7 +315,6 @@ class EditorInstance {
 		let win = Zotero.getMainWindow();
 		if (win) {
 			win.ZoteroPane.selectItems(ids);
-			win.Zotero_Tabs.select('zotero-pane');
 			win.focus();
 		}
 	}

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -730,7 +730,6 @@ class ReaderInstance {
 			let item = Zotero.Items.get(this._item.id);
 			let id = item.parentID || item.id;
 			win.ZoteroPane.selectItems([id]);
-			win.Zotero_Tabs.select('zotero-pane');
 			win.focus();
 		}
 	}

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -3110,7 +3110,7 @@ var ZoteroPane = new function()
 			document.getElementById(ZoteroPane.itemsView.id).focus();
 		}
 		
-		Zotero_Tabs.select('zotero-pane');
+		Zotero_Tabs.select('zotero-pane', false, { focusElementID: ZoteroPane.itemsView.id });
 	};
 	
 	


### PR DESCRIPTION
- handle additional zpRefocusID options value in Zotero_Tabs.select to focus a node with the specified ID, instead of what was recorded as last focused element
- use that parameter in ZoteroPane.selectItems to make sure that itemTree is focused after the tab is switched to zotero-pane
- removed redundant calls to Zotero_Tabs.select('zotero-pane') after Zotero_Pane.selectItems

Fixes: #3783