### PR TITLE
Move tags back to beginning of item rows

### DIFF
--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -2616,7 +2616,12 @@ var ItemTree = class ItemTree extends LibraryTree {
 		textSpan.dir = 'auto';
 		textSpan.setAttribute('aria-label', textSpanAriaLabel);
 
-		span.append(retracted, textSpan, ...tagSpans);
+		if (Zotero.Prefs.get('ui.tagsAfterTitle')) {
+			span.append(retracted, textSpan, ...tagSpans);
+		}
+		else {
+			span.append(retracted, ...tagSpans, textSpan);
+		}
 
 		return span;
 	}

--- a/scss/components/_item-tree.scss
+++ b/scss/components/_item-tree.scss
@@ -103,6 +103,11 @@
 				transform: scaleX(-1);
 				display: flex;
 			}
+
+			.icon-item-type + .tag-swatch,
+			.icon-item-type + .colored-tag-swatches {
+				margin-left: 4px;
+			}
 			
 			.tag-swatch {
 				display: inline-block;


### PR DESCRIPTION
This brings back order from before the redesign (tags before title). To get the current behavior (tags after title), one can set pref `extensions.zotero.ui.tagsAfterTitle` to `true`.

Resolve #3781