### PR TITLE
Set main window min-width/height dynamically

### DIFF
--- a/chrome/content/zotero/standalone/standalone.js
+++ b/chrome/content/zotero/standalone/standalone.js
@@ -75,7 +75,7 @@ const ZoteroStandalone = new function() {
 								this.switchReaderSubtype(subtype);
 							}
 						}
-						setTimeout(() => ZoteroPane.updateToolbarPosition(), 0);
+						setTimeout(() => ZoteroPane.updateLayoutConstraints(), 0);
 					}
 				}
 			},
@@ -512,7 +512,7 @@ const ZoteroStandalone = new function() {
 					document.getElementById('zotero-collections-splitter').setAttribute('state', 'collapsed');
 					collectionsPane.setAttribute('collapsed', true);
 				}
-				ZoteroPane.updateToolbarPosition();
+				ZoteroPane.updateLayoutConstraints();
 				break;
 			
 			case 'item-pane':
@@ -527,7 +527,7 @@ const ZoteroStandalone = new function() {
 					document.getElementById('zotero-items-splitter').setAttribute('state', 'collapsed');
 					itemPane.setAttribute('collapsed', true);
 				}
-				ZoteroPane.updateToolbarPosition();
+				ZoteroPane.updateLayoutConstraints();
 				break;
 			
 			case 'tag-selector':

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -6085,8 +6085,8 @@ var ZoteroPane = new function()
 		
 		// Calculate the heights of the components that aren't able to shrink automatically
 		// when the window is resized
-		let fixedComponentWidth = trees.clientWidth - itemsPaneContainer.clientWidth;
-		let fixedComponentHeight = titlebar.clientHeight + trees.clientHeight - itemsPaneContainer.clientHeight;
+		let fixedComponentWidth = trees.scrollWidth - itemsPaneContainer.scrollWidth;
+		let fixedComponentHeight = titlebar.scrollHeight + trees.scrollHeight - itemsPaneContainer.scrollHeight;
 		document.documentElement.style.setProperty('--width-of-fixed-components', `${fixedComponentWidth}px`);
 		document.documentElement.style.setProperty('--height-of-fixed-components', `${fixedComponentHeight}px`);
 

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -5965,12 +5965,14 @@ var ZoteroPane = new function()
 			itemsSplitter.setAttribute("orient", "vertical");
 			sidenav.classList.add("stacked");
 			this.itemPane.classList.add("stacked");
+			document.documentElement.classList.add("stacked");
 		}
-		else { // three-vertical-pane
+		else {  // three-vertical-pane
 			layoutSwitcher.setAttribute("orient", "horizontal");
 			itemsSplitter.setAttribute("orient", "horizontal");
 			sidenav.classList.remove("stacked");
 			this.itemPane.classList.remove("stacked");
+			document.documentElement.classList.remove("stacked");
 		}
 
 		this.updateToolbarPosition();
@@ -6076,9 +6078,19 @@ var ZoteroPane = new function()
 		var paneStack = document.getElementById("zotero-pane-stack");
 		if (paneStack.hidden) return;
 
+		var titlebar = document.getElementById('zotero-title-bar');
+		var trees = document.getElementById('zotero-trees');
+		var itemsPaneContainer = document.getElementById('zotero-items-pane-container');
 		var collectionsPane = document.getElementById("zotero-collections-pane");
 		var tagSelector = document.getElementById("zotero-tag-selector");
 		
+		// Calculate the heights of the components that aren't able to shrink automatically
+		// when the window is resized
+		let fixedComponentWidth = trees.clientWidth - itemsPaneContainer.clientWidth;
+		let fixedComponentHeight = titlebar.clientHeight + trees.clientHeight - itemsPaneContainer.clientHeight;
+		document.documentElement.style.setProperty('--width-of-fixed-components', `${fixedComponentWidth}px`);
+		document.documentElement.style.setProperty('--height-of-fixed-components', `${fixedComponentHeight}px`);
+
 		var collectionsPaneWidth = collectionsPane.getBoundingClientRect().width;
 		tagSelector.style.maxWidth = collectionsPaneWidth + 'px';
 		if (ZoteroPane.itemsView) {

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -116,16 +116,16 @@ var ZoteroPane = new function()
 		Zotero.UIProperties.registerRoot(document.getElementById('zotero-context-pane'));
 		this.itemPane = document.querySelector("#zotero-item-pane");
 		ZoteroPane_Local.updateLayout();
-		ZoteroPane_Local.updateToolbarPosition();
+		ZoteroPane_Local.updateLayoutConstraints();
 		this.updateWindow();
 		window.addEventListener("resize", () => {
 			this.updateWindow();
 			let tabsDeck = document.querySelector('#tabs-deck')
 			if (!tabsDeck || tabsDeck.getAttribute('selectedIndex') == 0) {
-				this.updateToolbarPosition();
+				this.updateLayoutConstraints();
 			}
 		});
-		window.setTimeout(this.updateToolbarPosition.bind(this), 0);
+		window.setTimeout(this.updateLayoutConstraints.bind(this), 0);
 		
 		Zotero.updateQuickSearchBox(document);
 		
@@ -769,7 +769,7 @@ var ZoteroPane = new function()
 
 		this.unserializePersist();
 		this.updateLayout();
-		this.updateToolbarPosition();
+		this.updateLayoutConstraints();
 		this.initContainers();
 		
 		// Focus the quicksearch on pane open
@@ -5975,7 +5975,7 @@ var ZoteroPane = new function()
 			document.documentElement.classList.remove("stacked");
 		}
 
-		this.updateToolbarPosition();
+		this.updateLayoutConstraints();
 		if (ZoteroPane.itemsView) {
 			// Need to immediately rerender the items here without any debouncing
 			// since tree height will have changed
@@ -6072,9 +6072,10 @@ var ZoteroPane = new function()
 	
 	
 	/**
-	 * Moves around the toolbar when the user moves around the pane
+	 * Update the window min-width/height, collections search width, tag selector, and sidenav
+	 * when the window or elements within it are resized.
 	 */
-	this.updateToolbarPosition = function () {
+	this.updateLayoutConstraints = function () {
 		var paneStack = document.getElementById("zotero-pane-stack");
 		if (paneStack.hidden) return;
 

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -116,7 +116,6 @@ var ZoteroPane = new function()
 		Zotero.UIProperties.registerRoot(document.getElementById('zotero-context-pane'));
 		this.itemPane = document.querySelector("#zotero-item-pane");
 		ZoteroPane_Local.updateLayout();
-		ZoteroPane_Local.updateLayoutConstraints();
 		this.updateWindow();
 		window.addEventListener("resize", () => {
 			this.updateWindow();
@@ -769,7 +768,6 @@ var ZoteroPane = new function()
 
 		this.unserializePersist();
 		this.updateLayout();
-		this.updateLayoutConstraints();
 		this.initContainers();
 		
 		// Focus the quicksearch on pane open

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -1036,8 +1036,8 @@
 								
 								<splitter id="zotero-collections-splitter" resizebefore="closest" resizeafter="closest" collapse="before"
 									zotero-persist="state"
-									onmousemove="document.getElementById('zotero-items-toolbar').setAttribute('state', this.getAttribute('state'));ZoteroPane_Local.updateToolbarPosition();"
-									oncommand="ZoteroPane_Local.updateToolbarPosition()">
+									onmousemove="document.getElementById('zotero-items-toolbar').setAttribute('state', this.getAttribute('state'));ZoteroPane_Local.updateLayoutConstraints();"
+									oncommand="ZoteroPane_Local.updateLayoutConstraints()">
 									<grippy id="zotero-collections-grippy"/>
 								</splitter>
 								
@@ -1155,8 +1155,8 @@
 									
 				
 									<splitter id="zotero-items-splitter" resizebefore="closest" resizeafter="closest" collapse="after" orient="horizontal" zotero-persist="state orient"
-										onmousemove="ZoteroPane.updateToolbarPosition()"
-										oncommand="ZoteroPane.updateToolbarPosition()">
+										onmousemove="ZoteroPane.updateLayoutConstraints()"
+										oncommand="ZoteroPane.updateLayoutConstraints()">
 										<grippy id="zotero-items-grippy"/>
 									</splitter>
 				

--- a/chrome/skin/default/zotero/overlay.css
+++ b/chrome/skin/default/zotero/overlay.css
@@ -182,8 +182,11 @@ TODO: Replace with SVG
 	them here with !important.
 */
 #zotero-layout-switcher[orient="horizontal"] :is(#zotero-items-pane-container, #zotero-item-pane) {
-	width: auto !important;
 	height: auto !important;
+}
+
+#zotero-layout-switcher[orient="horizontal"] #zotero-items-pane-container {
+	width: auto !important;
 }
 
 #zotero-layout-switcher[orient="vertical"],

--- a/chrome/skin/default/zotero/overlay.css
+++ b/chrome/skin/default/zotero/overlay.css
@@ -174,15 +174,15 @@ TODO: Replace with SVG
 	text-decoration: underline;
 }
 
-#zotero-layout-switcher
-{
-	min-width: 560px;
-}
-
 /*
-	Fx115: make panes occupy all availabel width/height after layout switch
+	Fx115: make panes occupy all available width/height after layout switch
+	or splitter expand/collapse.
+	The splitter element stores state in the style attribute's width/height
+	properties, and if we remove them, the splitter breaks. So we override
+	them here with !important.
 */
 #zotero-layout-switcher[orient="horizontal"] :is(#zotero-items-pane-container, #zotero-item-pane) {
+	width: auto !important;
 	height: auto !important;
 }
 

--- a/scss/abstracts/_variables.scss
+++ b/scss/abstracts/_variables.scss
@@ -107,8 +107,12 @@ $tagColorsLookup: (
 
 // Layout constants
 // --------------------------------------------------
+$min-width-tabs-deck: 570px;
 $min-width-collections-pane: 200px;
 $min-width-items-pane: 370px;
 $min-width-item-pane: 300px;
 $min-width-context-pane: 300px;
 $width-sidenav: 37px;
+
+$height-toolbar: 41px;
+$min-height-items-pane: 150px;

--- a/scss/components/_contextPane.scss
+++ b/scss/components/_contextPane.scss
@@ -1,5 +1,5 @@
 #tabs-deck {
-	min-width: $min-width-collections-pane + $min-width-items-pane;
+	min-width: $min-width-tabs-deck;
 
 	& > :not(.deck-selected) {
 		// Hide all sub-trees that are in the invisible tab deck

--- a/scss/components/_item-tree.scss
+++ b/scss/components/_item-tree.scss
@@ -3,7 +3,7 @@
 #zotero-items-pane-container {
 	min-width: $min-width-items-pane;
 	height: 150px;
-	min-height: 200px;
+	min-height: $min-height-items-pane;
 }
 
 #zotero-items-pane {

--- a/scss/components/_mainWindow.scss
+++ b/scss/components/_mainWindow.scss
@@ -3,8 +3,12 @@
 }
 
 #main-window {
-	min-width: $min-width-collections-pane + $min-width-items-pane + $min-width-item-pane + $width-sidenav;
+	min-width: max(var(--width-of-fixed-components) + $min-width-items-pane, $min-width-tabs-deck);
 	min-height: 300px;
+}
+
+#main-window.stacked {
+	min-height: calc(var(--height-of-fixed-components) + $min-height-items-pane + $height-toolbar);
 }
 
 #zotero-pane {

--- a/scss/components/_toolbar.scss
+++ b/scss/components/_toolbar.scss
@@ -1,6 +1,6 @@
 .toolbar {
-	height: 41px !important; /* Hard-code this to fix toolbar icon compression on Linux */
-	min-height: 41px; /* Needed to prevent squashing by stretched tag selector */
+	height: $height-toolbar !important; /* Hard-code this to fix toolbar icon compression on Linux */
+	min-height: $height-toolbar; /* Needed to prevent squashing by stretched tag selector */
 	margin: 0;
 	padding: 0px 8px 0px 8px;
 	min-width: 1px;

--- a/scss/components/_toolbar.scss
+++ b/scss/components/_toolbar.scss
@@ -116,7 +116,6 @@
 	margin-top: 1px;
 }
 
-
 toolbox {
 	@media (-moz-platform: linux) {
 		background: Menu;

--- a/scss/components/_toolbar.scss
+++ b/scss/components/_toolbar.scss
@@ -116,6 +116,7 @@
 	margin-top: 1px;
 }
 
+
 toolbox {
 	@media (-moz-platform: linux) {
 		background: Menu;


### PR DESCRIPTION
Now the window size constraints depend on the current sizes of the sidebars. So if the item pane is collapsed, you can make the window very narrow; if the item pane is very wide, the window can't be made very narrow. Adjusts automatically for Stacked mode.

Fixes #3607