### PR TITLE
Show icon in Attachments column immediately

### DIFF
--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -229,6 +229,14 @@ var ItemTree = class ItemTree extends LibraryTree {
 					: newSearchItems.filter(item => !!item.parentItemID).map(item => item.parentItemID)
 			);
 			this._searchParentIDs = newSearchParentIDs;
+			
+			let t1 = Date.now();
+			await Promise.all(newSearchItems
+				.filter(i => this._canGetBestAttachmentState(i))
+				.map(i => i.getBestAttachmentState(false))
+			);
+			Zotero.debug(`Got best attachment states in ${Date.now() - t1} ms`);
+			
 			newSearchItems = new Set(newSearchItems);
 			
 			var newCellTextCache = {};
@@ -2672,7 +2680,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 					ariaLabel = Zotero.getString('pane.item.attachments.has');
 				}
 				
-				if (!exists) {
+				if (exists === false) {
 					icon.classList.add('icon-missing-file');
 				}
 			}

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -3787,32 +3787,39 @@ Zotero.Item.prototype.getBestAttachmentState = async function (checkIfExists = t
 	if (this._bestAttachmentState !== null && this._bestAttachmentState.type && (!checkIfExists || ('exists' in this._bestAttachmentState && this._bestAttachmentState.exists !== null))) {
 		return this._bestAttachmentState;
 	}
-	var item = this.isAttachment() && this.isTopLevelItem()
-		? this
-		: await this.getBestAttachment();
-	if (!item) {
-		return this._bestAttachmentState = {
-			type: 'none'
-		};
-	}
-	var type;
-	if (item.isPDFAttachment()) {
-		type = 'pdf';
-	}
-	else if (item.isSnapshotAttachment()) {
-		type = 'snapshot';
-	}
-	else if (item.isEPUBAttachment()) {
-		type = 'epub';
-	}
-	else if (item.isImageAttachment()) {
-		type = 'image';
-	}
-	else if (item.isVideoAttachment()) {
-		type = 'video';
+	var item;
+	if (!this._bestAttachmentState?.type || !this._bestAttachmentState.key) {
+		item = this.isAttachment() && this.isTopLevelItem()
+			? this
+			: await this.getBestAttachment();
+		if (!item) {
+			return this._bestAttachmentState = {
+				type: 'none'
+			};
+		}
+		var type;
+		if (item.isPDFAttachment()) {
+			type = 'pdf';
+		}
+		else if (item.isSnapshotAttachment()) {
+			type = 'snapshot';
+		}
+		else if (item.isEPUBAttachment()) {
+			type = 'epub';
+		}
+		else if (item.isImageAttachment()) {
+			type = 'image';
+		}
+		else if (item.isVideoAttachment()) {
+			type = 'video';
+		}
+		else {
+			type = 'other';
+		}
 	}
 	else {
-		type = 'other';
+		item = await this.ObjectsClass.getByLibraryAndKeyAsync(this.libraryID, this._bestAttachmentState.key);
+		type = this._bestAttachmentState.type;
 	}
 	
 	var exists = checkIfExists ? await item.fileExists() : null;

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -3774,15 +3774,17 @@ Zotero.Item.prototype.getBestAttachments = Zotero.Promise.coroutine(function* ()
 });
 
 
-
 /**
  * Return state of best attachment (or this item if it's a standalone attachment)
  *
- * @return {Promise<Object>} - Promise for object with string 'type' ('none'|'pdf'|'snapshot'|'epub'|'image'|'video'|'other')
- *     and boolean 'exists'
+ * @param {Boolean} [checkIfExists=true] - Whether to check if the attachment file exists
+ * @return {Promise<Object>} - Promise for object with the following properties:
+ *   - 'type': string, indicating the type of the best attachment ('none', 'pdf', 'snapshot', 'epub', 'image', 'video', 'other')
+ *   - 'key': string, the key of the best attachment
+ *   - 'exists': boolean, indicating whether the attachment file exists. `exists` is null if `checkIfExists` is false and no cached value is available
  */
-Zotero.Item.prototype.getBestAttachmentState = async function () {
-	if (this._bestAttachmentState !== null && this._bestAttachmentState.type) {
+Zotero.Item.prototype.getBestAttachmentState = async function (checkIfExists = true) {
+	if (this._bestAttachmentState !== null && this._bestAttachmentState.type && (!checkIfExists || ('exists' in this._bestAttachmentState && this._bestAttachmentState.exists !== null))) {
 		return this._bestAttachmentState;
 	}
 	var item = this.isAttachment() && this.isTopLevelItem()
@@ -3812,7 +3814,8 @@ Zotero.Item.prototype.getBestAttachmentState = async function () {
 	else {
 		type = 'other';
 	}
-	var exists = await item.fileExists();
+	
+	var exists = checkIfExists ? await item.fileExists() : null;
 	let key = item.key;
 	return this._bestAttachmentState = { type, exists, key };
 };


### PR DESCRIPTION
Instead of "popping", all items now have the correct icon for the best attachment column.

Unfortunately this introduces a small performance penalty for the initial load of the items as we run DB queries to check for the best attachment. Disk access is delayed until after the list is displayed and the row is scrolled into view.

On my system, for "My Library" with 2K items, ~10% has attachment, the impact is negligible (~40ms) but I can imagine that for large libraries full of attachments on slower machines this can become noticeable.

It does look much better without popping though:

https://github.com/zotero/zotero/assets/214628/ff2ed3e5-d0d2-435c-ab97-17b9f05a84c8


However, with this fix, the sorting by attachment bug (fixed in #3712 but probably slightly out-of-date now) is even more noticeable. Notice how items re-order after switching to another collection and back:

https://github.com/zotero/zotero/assets/214628/fc4cf6f6-7226-4252-94d1-becdc8ac3a4a

Resolve #3760

