### PR TITLE
Fix collections filter not hiding on windows

### DIFF
--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -2861,7 +2861,7 @@ var ZoteroPane = new function()
 		// Make sure that the filter ends up being hidden if the value is cleared
 		// after the blur event fires. This happens on windows on cross icon click.
 		if (collectionsSearchField.value.length == 0
-			&& document.activeElement !== collectionsSearchField) {
+				&& document.activeElement !== collectionsSearchField) {
 			this.hideCollectionSearch();
 		}
 	}

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -2858,6 +2858,12 @@ var ZoteroPane = new function()
 	this.handleCollectionSearchInput = function () {
 		let collectionsSearchField = document.getElementById("zotero-collections-search");
 		this.collectionsView.setFilter(collectionsSearchField.value);
+		// Make sure that the filter ends up being hidden if the value is cleared
+		// after the blur event fires. This happens on windows on cross icon click.
+		if (collectionsSearchField.value.length == 0
+			&& document.activeElement !== collectionsSearchField) {
+			this.hideCollectionSearch();
+		}
 	}
 	
 	


### PR DESCRIPTION
On windows, if the cross icon from the collection filter search-textbox is clicked, the 'blur' event fires before the input is cleared, and the filter is never hidden. To make sure that the search field ends up going away, hide it if the field is empty and not focused in input handler.

Fixes: #3840