### PR TITLE
Scaffold: Fix MARC template

### DIFF
--- a/chrome/content/scaffold/templates/newWeb.js
+++ b/chrome/content/scaffold/templates/newWeb.js
@@ -1,7 +1,7 @@
 /*
     ***** BEGIN LICENSE BLOCK *****
 
-    Copyright © 2022 YOUR_NAME <- TODO
+    Copyright © 2024 YOUR_NAME <- TODO
 
     This file is part of Zotero.
 

--- a/chrome/content/scaffold/templates/scrapeMARC.js
+++ b/chrome/content/scaffold/templates/scrapeMARC.js
@@ -6,7 +6,7 @@ async function scrape(doc, url = doc.location.href) {
 	translator.setTranslator('a6ee60df-1ddc-4aae-bb25-45e0537be973'); // MARC
 	let MARC = await translator.getTranslatorObject();
 
-	let record = new MARC.Record();
+	let record = new MARC.record();
 	let item = new Zotero.Item();
 	// ignore the table headings in lines[0]
 	record.leader = text(lines[1], 'td', 4);


### PR DESCRIPTION
Update the License year while I'm at it.

Question: I think it'd be useful to have a sample `POST` request with `requestText` in the templates. I could update the RIS example with one if you agree?