### PR TITLE
Bring Check for Updates to front if re-triggered, unify functions

### DIFF
--- a/chrome/content/zotero/standalone/standalone.js
+++ b/chrome/content/zotero/standalone/standalone.js
@@ -739,7 +739,8 @@ const ZoteroStandalone = new function() {
 	 * Checks for updates
 	 */
 	this.checkForUpdates = function() {
-		window.open('chrome://zotero/content/update/updates.xhtml', 'updateChecker', 'chrome,centerscreen');
+		Zotero.debug('ZoteroStandalone.checkForUpdates is deprecated -- use Zotero.openCheckForUpdatesWindow() instead');
+		Zotero.openCheckForUpdatesWindow();
 	}
 	
 	/**

--- a/chrome/content/zotero/xpcom/sync/syncRunner.js
+++ b/chrome/content/zotero/xpcom/sync/syncRunner.js
@@ -1339,7 +1339,7 @@ Zotero.Sync.Runner_Module = function (options = {}) {
 				e.errorType = 'warning';
 				e.dialogButtonText = Zotero.getString('general.checkForUpdates');
 				e.dialogButtonCallback = () => {
-					Zotero.openCheckForUpdatesWindow();
+					Zotero.openCheckForUpdatesWindow({ modal: true });
 				};
 				e.dialogButton2Text = Zotero.getString('general.moreInformation');
 				e.dialogButton2Callback = () => {

--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -654,7 +654,7 @@ Services.scriptloader.loadSubScript("resource://zotero/polyfill.js");
 						
 						// "Check for Update" button
 						if (index === 0) {
-							Zotero.openCheckForUpdatesWindow();
+							Zotero.openCheckForUpdatesWindow({ modal: true });
 						}
 						// Load More Info page
 						else if (index == 2) {
@@ -982,9 +982,19 @@ Services.scriptloader.loadSubScript("resource://zotero/polyfill.js");
 	}
 	
 	
-	this.openCheckForUpdatesWindow = function () {
-		Services.ww.openWindow(null, 'chrome://zotero/content/update/updates.xhtml',
-			'updateChecker', 'chrome,centerscreen,modal', null);
+	this.openCheckForUpdatesWindow = function ({ modal } = {}) {
+		let win = Services.wm.getMostRecentWindow('Update:Wizard');
+		if (win) {
+			win.focus();
+		}
+		else {
+			let flags = 'chrome,centerscreen';
+			if (modal) {
+				flags += ',modal';
+			}
+			Services.ww.openWindow(null, 'chrome://zotero/content/update/updates.xhtml',
+				'updateChecker', flags, null);
+		}
 	};
 	
 	

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -789,7 +789,7 @@
 							<menuitem id="checkForUpdates"
 									  accesskey="&helpCheckForUpdates.accesskey;"
 									  label="&helpCheckForUpdates.label;"
-									  oncommand="ZoteroStandalone.checkForUpdates();"/>
+									  oncommand="Zotero.openCheckForUpdatesWindow();"/>
 							<menuitem id="aboutName"
 									  accesskey="&aboutProduct.accesskey;"
 									  label="&aboutProduct.label;"


### PR DESCRIPTION
`ZoteroStandalone.checkForUpdates()` and `Zotero.openCheckForUpdatesWindow()` were essentially the same, except that the latter opened it as a modal. Unified and added bring-to-front behavior.

Fixes #3104