### PR TITLE
Update `prepare_build` for Python 3.12

### DIFF
--- a/app/scripts/prepare_build
+++ b/app/scripts/prepare_build
@@ -118,7 +118,7 @@ def main():
             with open(os.path.join(translators_dir, fn), 'r', encoding='utf-8') as f:
                 contents = f.read()
             # Parse out the JSON metadata block
-            m = re.match('^\s*{[\S\s]*?}\s*?[\r\n]', contents)
+            m = re.match(r'^\s*{[\S\s]*?}\s*?[\r\n]', contents)
             if not m:
                 raise Exception("Metadata block not found in " + f.name)
             metadata = json.loads(m.group(0))


### PR DESCRIPTION
Python 3.12 includes [this change](https://docs.python.org/dev/whatsnew/3.12.html#other-language-changes):

> A backslash-character pair that is not a valid escape sequence now generates a [SyntaxWarning](https://docs.python.org/dev/library/exceptions.html#SyntaxWarning), instead of [DeprecationWarning](https://docs.python.org/dev/library/exceptions.html#DeprecationWarning). For example, re.compile("\d+\.\d+") now emits a [SyntaxWarning](https://docs.python.org/dev/library/exceptions.html#SyntaxWarning) ("\d" is an invalid escape sequence, use raw strings for regular expression: re.compile(r"\d+\.\d+")). In a future Python version, [SyntaxError](https://docs.python.org/dev/library/exceptions.html#SyntaxError) will eventually be raised, instead of [SyntaxWarning](https://docs.python.org/dev/library/exceptions.html#SyntaxWarning).

(We were already getting a `DeprecationWarning`, but those are not logged by default.)

Might be more regex strings to fix, but this is the only one that was printing a warning on build.