### PR TITLE
collection filter: include children of matches

### DIFF
--- a/test/tests/collectionTreeTest.js
+++ b/test/tests/collectionTreeTest.js
@@ -1737,8 +1737,13 @@ describe("Zotero.CollectionTree", function() {
 			let colTree = win.document.getElementById('collection-tree');
 			await cv.setFilter("_2");
 			cv.focusFirstMatchingRow();
+			
+			// Escape will trigger setFilter that we need to await for
+			let setFilterSpy = sinon.spy(cv, 'setFilter');
 			colTree.dispatchEvent(keyboardClick("Escape"));
-			await Zotero.Promise.delay(10);
+			await setFilterSpy.returnValues[0];
+			setFilterSpy.restore();
+			
 			assert.equal(cv._filter, "");
 			assert.equal(cv.getSelectedCollection(true), collection2.id);
 		});

--- a/test/tests/collectionTreeTest.js
+++ b/test/tests/collectionTreeTest.js
@@ -1586,13 +1586,35 @@ describe("Zotero.CollectionTree", function() {
 			assert.sameMembers(displayedRowNames, expectedNames);
 		});
 
-		it('should not move focus from selected collection during filtering', async function () {
+		it('should be able to expand to see non-passing subcollections', async function () {
+			await cv.setFilter("collection_level_one_1");
+			// After filtering, only the matching collection is displayed
+			let displayedRowNames = cv._rows.filter(row => row.type == "collection").map(row => row.ref.name);
+			let expectedNames = [
+				"collection_level_one_1"
+			];
+			assert.sameMembers(displayedRowNames, expectedNames);
+
+			await cv.expandLibrary(userLibraryID, true);
+			// But it can be expanded to reveal subcollections even if they don't match
+			displayedRowNames = cv._rows.filter(row => row.type == "collection").map(row => row.ref.name);
+			expectedNames = [
+				"collection_level_one_1",
+				"collection_level_two_21",
+				"collection_level_two_22",
+			];
+			assert.sameMembers(displayedRowNames, expectedNames);
+		});
+
+		it('should not change itemTree view during filtering', async function () {
 			await cv.selectByID("C" + collection5.id);
+			// await Zotero.Promise.delay(1000);
 			await cv.setFilter("three");
-			let focusedRow = cv.getRow(cv.selection.focused);
+			// await Zotero.Promise.delay(1000);
+			let focusedRow = zp.itemsView.collectionTreeRow;
 			assert.equal(focusedRow.id, "C" + collection5.id);
 			await cv.setFilter("two");
-			focusedRow = cv.getRow(cv.selection.focused);
+			focusedRow = zp.itemsView.collectionTreeRow;
 			assert.equal(focusedRow.id, "C" + collection5.id);
 		});
 
@@ -1629,9 +1651,10 @@ describe("Zotero.CollectionTree", function() {
 
 		for (let type of ['collection', 'search']) {
 			// eslint-disable-next-line no-loop-func
-			it(`should only hide ${type} if it's renamed to not match the filter`, async function () {
-				await cv.setFilter(type);
-				let objectToSelect = type == 'collection' ? collection5 : search2;
+			it(`should hide ${type} if it's renamed to not match the filter`, async function () {
+				let objectToSelect = type == 'collection' ? collection1 : search1;
+				await cv.setFilter(objectToSelect.name);
+				let originalName = objectToSelect.name;
 				objectToSelect.name += "_updated";
 				await objectToSelect.saveTx();
 				let displayedRowNames = cv._rows.map(row => row.getName());
@@ -1641,6 +1664,9 @@ describe("Zotero.CollectionTree", function() {
 				await objectToSelect.saveTx();
 				displayedRowNames = cv._rows.map(row => row.getName());
 				assert.notInclude(displayedRowNames, objectToSelect.name);
+
+				objectToSelect.name = originalName;
+				await objectToSelect.saveTx();
 			});
 		}
 
@@ -1712,6 +1738,7 @@ describe("Zotero.CollectionTree", function() {
 			await cv.setFilter("_2");
 			cv.focusFirstMatchingRow();
 			colTree.dispatchEvent(keyboardClick("Escape"));
+			await Zotero.Promise.delay(10);
 			assert.equal(cv._filter, "");
 			assert.equal(cv.getSelectedCollection(true), collection2.id);
 		});


### PR DESCRIPTION
- subcollections of matching collections are included in collectionTree after filtering
- if a matching collection row has no matching children, it is collapsed
- that row can be expanded to reveal all of its subcollections that appear as context rows 
- parents of all matching collections are expanded to preserve behavior similar to current
- now that the collections end up being expanded and collapsed, after filtering we restore the original state of collections, regardless if the selection changed. The path to the selected row is always expanded so that it is visible

No changes to keyboard navigation (?)


Fixes: #3838


