### PR TITLE
Right-click does not behave as left-click and does not change table selection

### DIFF
--- a/chrome/content/zotero/collectionTree.jsx
+++ b/chrome/content/zotero/collectionTree.jsx
@@ -1242,7 +1242,7 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 	 * @returns {Promise<void>}
 	 */
 	async deleteSelection(deleteItems) {
-		var treeRow = this.getRow(this.selection.focused);
+		var treeRow = this.getSelectedRow();
 		if (treeRow.isCollection() || treeRow.isFeed()) {
 			await treeRow.ref.eraseTx({ deleteItems });
 		}
@@ -1287,6 +1287,15 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 		return this.getRow(index).getName();
 	}
 	
+	// Get the currently active row: the right-clicked row if it exists,
+	// or the selected row.
+	getSelectedRow() {
+		if (this.selection.contextMenuRowExists) {
+			return this.getRow(this.selection.contextMenuRow);
+		}
+		return this.getRow(this.selection.focused);
+	}
+
 	/**
 	 * Return libraryID of selected row (which could be a collection, etc.)
 	 */
@@ -1297,28 +1306,25 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 	}
 	
 	getSelectedCollection(asID) {
-		var collection = this.getRow(this.selection.focused);
+		var collection = this.getSelectedRow();
 		if (collection && collection.isCollection()) {
 			return asID ? collection.ref.id : collection.ref;
 		}
+		return false;
 	}
 	
 	getSelectedSearch(asID) {
-		if (this.getRow(this.selection.focused)) {
-			var search = this.getRow(this.selection.focused);
-			if (search && search.isSearch()) {
-				return asID ? search.ref.id : search.ref;
-			}
+		var search = this.getSelectedRow();
+		if (search && search.isSearch()) {
+			return asID ? search.ref.id : search.ref;
 		}
 		return false;
 	}
 	
 	getSelectedGroup(asID) {
-		if (this.getRow(this.selection.focused)) {
-			var group = this.getRow(this.selection.focused);
-			if (group && group.isGroup()) {
-				return asID ? group.ref.id : group.ref;
-			}
+		let group = this.getSelectedRow();
+		if (group && group.isGroup()) {
+			return asID ? group.ref.id : group.ref;
 		}
 		return false;
 	}

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -1724,7 +1724,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 			throw new Error("ItemTree.deleteSelection() no longer takes two parameters");
 		}
 
-		if (this.selection.count == 0) {
+		if (!this.selection.actionableRowExists) {
 			return;
 		}
 		
@@ -1741,7 +1741,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 			this.tree.invalidate();
 
 			// Create an array of selected items
-			var ids = Array.from(this.selection.selected).map(index => this.getRow(index).id);
+			var ids = this.getSelectedItems(true);
 
 			var collectionTreeRow = this.collectionTreeRow;
 
@@ -1787,7 +1787,13 @@ var ItemTree = class ItemTree extends LibraryTree {
 	}
 	
 	getSelectedItems(asIDs) {
-		var items = this.selection ? Array.from(this.selection.selected) : [];
+		let items = [];
+		if (this.selection.contextMenuRowExists) {
+			items = [this.selection.contextMenuRow];
+		}
+		else if (this.selection?.selected) {
+			items = Array.from(this.selection.selected);
+		}
 		items = items.filter(index => index < this._rows.length);
 		try {
 			if (asIDs) return items.map(index => this.getRow(index).ref.id);

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -572,7 +572,7 @@ var ZoteroPane = new function()
 										.getService(Components.interfaces.nsIPromptService);
 				var buttonFlags = (ps.BUTTON_POS_0) * (ps.BUTTON_TITLE_IS_STRING)
 									+ (ps.BUTTON_POS_1) * (ps.BUTTON_TITLE_CANCEL);
-				var index = ps.confirmEx(
+				var index = this._openConfirmPromptEx(
 					null,
 					"Zotero Restore",
 					"The local Zotero database has been cleared."
@@ -825,7 +825,7 @@ var ZoteroPane = new function()
 					+ "If you’re new to Zotero, you can ignore this message.";
 				var url = 'https://www.zotero.org/support/kb/data_missing_after_zotero_5_upgrade';
 				var dontShowAgain = {};
-				let index = ps.confirmEx(null,
+				let index = this._openConfirmPromptEx(null,
 					Zotero.getString('general.warning'),
 					text,
 					buttonFlags,
@@ -1866,8 +1866,13 @@ var ZoteroPane = new function()
 	
 	
 	this.getCollectionTreeRow = function () {
-		return this.collectionsView && this.collectionsView.selection.count
-			&& this.collectionsView.getRow(this.collectionsView.selection.focused);
+		if (!(this.collectionsView && this.collectionsView.selection.actionableRowExists)) {
+			return false;
+		}
+		if (this.collectionsView.selection.contextMenuRowExists) {
+			return this.collectionsView.getRow(this.collectionsView.selection.contextMenuRow);
+		}
+		return this.collectionsView.getRow(this.collectionsView.selection.focused);
 	}
 	
 	
@@ -2331,7 +2336,7 @@ var ZoteroPane = new function()
 	this.canDeleteSelectedItems = function () {
 		let collectionTreeRow = this.getCollectionTreeRow();
 		if (collectionTreeRow.isTrash()) {
-			for (let index of this.itemsView.selection.selected) {
+			for (let index of getSelectedItems()) {
 				while (index != -1 && !this.itemsView.getRow(index).ref.deleted) {
 					index = this.itemsView.getParentIndex(index);
 				}
@@ -2360,7 +2365,7 @@ var ZoteroPane = new function()
 	 * @param  {Boolean}  [fromMenu=false]  If triggered from context menu, which always prompts for deletes
 	 */
 	this.deleteSelectedItems = function (force, fromMenu) {
-		if (!this.itemsView || !this.itemsView.selection.count) {
+		if (!this.itemsView || !this.itemsView.selection.actionableRowExists) {
 			return;
 		}
 		var collectionTreeRow = this.getCollectionTreeRow();
@@ -2449,9 +2454,7 @@ var ZoteroPane = new function()
 			var prompt = toDelete;
 		}
 		
-		var promptService = Components.classes["@mozilla.org/embedcomp/prompt-service;1"]
-										.getService(Components.interfaces.nsIPromptService);
-		if (!prompt || promptService.confirm(window, prompt.title, prompt.text)) {
+		if (!prompt || this._openConfirmPrompt(window, prompt.title, prompt.text)) {
 			this.itemsView.deleteSelection(force);
 		}
 	}
@@ -2537,7 +2540,7 @@ var ZoteroPane = new function()
 			}
 			
 			// Display prompt
-			var index = ps.confirmEx(
+			var index = this._openConfirmPromptEx(
 				null,
 				title,
 				message,
@@ -2643,10 +2646,7 @@ var ZoteroPane = new function()
 	this.emptyTrash = Zotero.Promise.coroutine(function* () {
 		var libraryID = this.getSelectedLibraryID();
 		
-		var ps = Components.classes["@mozilla.org/embedcomp/prompt-service;1"]
-								.getService(Components.interfaces.nsIPromptService);
-		
-		var result = ps.confirm(
+		var result = this._openConfirmPrompt(
 			null,
 			"",
 			Zotero.getString('pane.collections.emptyTrash') + "\n\n"
@@ -3393,7 +3393,7 @@ var ZoteroPane = new function()
 				let ps = Services.prompt;
 				let buttonFlags = (ps.BUTTON_POS_0) * (ps.BUTTON_TITLE_IS_STRING)
 					+ (ps.BUTTON_POS_1) * (ps.BUTTON_TITLE_CANCEL);
-				let index = ps.confirmEx(
+				let index = this._openConfirmPromptEx(
 					null,
 					Zotero.getString('pane.collections.removeLibrary'),
 					Zotero.getString('pane.collections.removeLibrary.text', library.name),
@@ -5326,7 +5326,7 @@ var ZoteroPane = new function()
 		if (noLocate) {
 			let buttonFlags = ps.BUTTON_POS_0 * ps.BUTTON_TITLE_OK
 				+ ps.BUTTON_POS_1 * ps.BUTTON_TITLE_IS_STRING;
-			let index = ps.confirmEx(null,
+			let index = this._openConfirmPromptEx(null,
 				title,
 				text,
 				buttonFlags,
@@ -5343,7 +5343,7 @@ var ZoteroPane = new function()
 		var buttonFlags = ps.BUTTON_POS_0 * ps.BUTTON_TITLE_IS_STRING
 			+ ps.BUTTON_POS_1 * ps.BUTTON_TITLE_CANCEL
 			+ ps.BUTTON_POS_2 * ps.BUTTON_TITLE_IS_STRING;
-		var index = ps.confirmEx(null,
+		var index = this._openConfirmPromptEx(null,
 			title,
 			text,
 			buttonFlags,
@@ -5382,7 +5382,7 @@ var ZoteroPane = new function()
 		let buttonFlags = ps.BUTTON_POS_0 * ps.BUTTON_TITLE_IS_STRING
 			+ ps.BUTTON_POS_1 * ps.BUTTON_TITLE_CANCEL
 			+ ps.BUTTON_POS_2 * ps.BUTTON_TITLE_IS_STRING;
-		let index = ps.confirmEx(null,
+		let index = this._openConfirmPromptEx(null,
 			title,
 			text,
 			buttonFlags,
@@ -5410,7 +5410,7 @@ var ZoteroPane = new function()
 		text = Zotero.getString('pane.item.attachments.autoRelinkOthers.text', numOthers, numOthers);
 		buttonFlags = ps.BUTTON_POS_0 * ps.BUTTON_TITLE_IS_STRING
 			+ ps.BUTTON_POS_1 * ps.BUTTON_TITLE_CANCEL;
-		index = ps.confirmEx(null,
+		index = this._openConfirmPromptEx(null,
 			title,
 			text,
 			buttonFlags,
@@ -5451,7 +5451,7 @@ var ZoteroPane = new function()
 			
 			let buttonFlags = ps.BUTTON_POS_0 * ps.BUTTON_TITLE_OK
 				+ ps.BUTTON_POS_1 * ps.BUTTON_TITLE_IS_STRING;
-			let index = ps.confirmEx(
+			let index = this._openConfirmPromptEx(
 				null,
 				title,
 				msg,
@@ -5895,7 +5895,7 @@ var ZoteroPane = new function()
 		var buttonFlags = ps.BUTTON_POS_0 * ps.BUTTON_TITLE_IS_STRING
 			+ ps.BUTTON_POS_1 * ps.BUTTON_TITLE_CANCEL;
 		var deleteOriginal = {};
-		var index = ps.confirmEx(null,
+		var index = this._openConfirmPromptEx(null,
 			Zotero.getString('attachment.convertToStored.title', [num], num),
 			Zotero.getString('attachment.convertToStored.text', [num], num),
 			buttonFlags,
@@ -6277,7 +6277,7 @@ var ZoteroPane = new function()
 		var ps = Services.prompt;
 		var buttonFlags = ps.BUTTON_POS_0 * ps.BUTTON_TITLE_IS_STRING
 			+ ps.BUTTON_POS_1 * ps.BUTTON_TITLE_CANCEL;
-		let index = ps.confirmEx(
+		let index = this._openConfirmPromptEx(
 			null,
 			Zotero.getString('retraction.replacedItem.title'),
 			Zotero.getString('retraction.replacedItem.text1')
@@ -6453,6 +6453,51 @@ var ZoteroPane = new function()
 	 */
 	this.openAboutDialog = function() {
 		window.openDialog('chrome://zotero/content/about.xhtml', 'about', 'chrome,centerscreen');
+	}
+
+	this._openConfirmPromptEx = function (...args) {
+		return this._openPrompt(true, ...args);
+	}
+
+	this._openConfirmPrompt = function (...args) {
+		return this._openPrompt(false, ...args);
+	}
+	
+	// Wrapper to open up the prompt dialog. If applicable,
+	// lock the context menu row before the dialog is opened
+	// and release it after. Otherwise, the context menu row gets
+	// cleared as soon as the contextmenu disappears, and the dialog
+	// confirms action on the wrong entry.
+	this._openPrompt = function (ex = false, ...args) {
+		var ps = Components.classes["@mozilla.org/embedcomp/prompt-service;1"]
+			.getService(Components.interfaces.nsIPromptService);
+		let selection;
+		if (this.collectionsView.selection.contextMenuRowExists) {
+			selection = this.collectionsView.selection;
+		}
+		else if (this.itemsView.selection.contextMenuRowExists) {
+			selection = this.itemsView.selection;
+		}
+		if (selection) {
+			selection.keepContextRow();
+		}
+		
+		let result;
+		if (ex) {
+			result = ps.confirmEx(...args);
+		}
+		else {
+			result = ps.confirm(...args);
+		}
+		if (selection) {
+			// After the _openPrompt returns, remaining handlers rely on the
+			// contextRow still being present. For now, just delay to give
+			// them enough time to fetch the row before it's cleared
+			setTimeout(() => {
+				selection.releaseContextRow();
+			});
+		}
+		return result;
 	}
 	
 	/**

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -484,6 +484,29 @@ var ZoteroPane = new function()
 		});
 	}
 
+	// On windows, right click may dispatch 'click' event on toolbarbuttons.
+	// Checks which button was clicked and stops the 'click' event if it
+	// was not triggered via left-click.
+	// Instead, dispatch 'contextmenu' event on the target
+	function filterUndesiredClickEvents() {
+		if (!Zotero.isWin) return;
+		document.addEventListener("click", (e) => {
+			if (e.target.tagName == "toolbarbutton" && e.button !== 0) {
+				e.stopPropagation();
+				e.preventDefault();
+				if (e.button == 2) {
+					e.target.dispatchEvent(new MouseEvent('contextmenu', {
+						bubbles: true,
+						clientX: e.clientX,
+						clientY: e.clientY,
+						screenX: e.screenX,
+						screenY: e.screenY
+					}));
+				}
+			}
+		}, true);
+	}
+
 	/**
 	 * Called on window load or when pane has been reloaded after switching into or out of connector
 	 * mode
@@ -639,6 +662,7 @@ var ZoteroPane = new function()
 			Zotero.logError(e);
 		}
 		addFocusHandlers();
+		filterUndesiredClickEvents();
 	}
 	
 	

--- a/scss/components/_virtualized-table.scss
+++ b/scss/components/_virtualized-table.scss
@@ -154,6 +154,10 @@
 			color: var(--fill-secondary);
 		}
 
+		&.context-menu-row {
+			background-color: var(--accent-azure) !important;
+		}
+
 		.spacer-twisty {
 			display: inline-block;
 			min-width: 16px;


### PR DESCRIPTION
- On windows, right-click on `toolbarbutton` when its parent has `contextmenu` listener triggers `click` event on the actual `toolbarbutton`. To avoid that, capture click events and if they were caused not by left-button click, ignore them and dispatch `contextmenu` event on the event's target.
- Do not change selection of on right-click in `virtualTable`  similar to thunderbird https://forums.zotero.org/discussion/comment/458310/#Comment_458310:
  - on right key down in virtualized table, record the receiving table row as `contextMenuRow`, and mark it with a `accent-azure` color (maybe a different color or out line is better)
  - `contextMenuRow` is cleared when the main `menupopup` is hidden
  - when a selected row is fetched in `itemTree`/`collectionTree` or `ZoteroPane`, return the `contextMenuRow` if it exists. It ensures that the selected action will run on the right-clicked row and not the row currently selected
  - some actions run only after the confirmation from a dialog. By default, `contextMenuRow` wants to be cleared when the `menupopup` is hidden. To make sure it remains until the dialgo is closed, create a promise that is awaited in `popuphidden` handler, which is resolved when the dialog is confirmed/cancelled. ZoteroPane has a wrapper function through which all dialogs are opened which creates and releases the promises.
  - minor tweaks to run `ZoteroPan`e functions when the selection is not empty OR when there is a context menu row

Addresses: #3852 