### PR TITLE
Remove useless parameter and comments for Item.getDisplayTitle

### DIFF
--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -869,7 +869,7 @@ Zotero.Item.prototype.setField = function(field, value, loadIn) {
  *
  * This is the same as the standard title field (with includeBaseMapped on)
  */
-Zotero.Item.prototype.getDisplayTitle = function (includeAuthorAndDate) {
+Zotero.Item.prototype.getDisplayTitle = function () {
 	if (this._displayTitle !== null) {
 		return this._displayTitle;
 	}

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -868,8 +868,6 @@ Zotero.Item.prototype.setField = function(field, value, loadIn) {
  * Get the title for an item for display in the interface
  *
  * This is the same as the standard title field (with includeBaseMapped on)
- * except for letters and interviews, which get placeholder titles in
- * square braces (e.g. "[Letter to Thoreau]"), and cases
  */
 Zotero.Item.prototype.getDisplayTitle = function (includeAuthorAndDate) {
 	if (this._displayTitle !== null) {


### PR DESCRIPTION
This feature was introduced with [3de1789](https://github.com/zotero/zotero/commit/3de1789f264930d581cd2e96b1a2d2df2b131e7e#diff-dd0592b92df236d68979095b15fee4d38ccc6b30b081412f3917a5a366f4e376R668-R751) , but it no longer exists in the latest version, so the comment needs to be updated.