### PR TITLE
Fix Zotero_Preference#_showPane event target

### DIFF
--- a/chrome/content/zotero/preferences/preferences.js
+++ b/chrome/content/zotero/preferences/preferences.js
@@ -328,7 +328,17 @@ var Zotero_Preferences = {
 		let pane = this.panes.get(id);
 
 		pane.container.hidden = false;
-		pane.container.children[0].dispatchEvent(new Event('showing'));
+		// The automatic <h1> is introduced by commit 784f877
+		let target;
+		if (pane.container.childElementCount == 1) {
+			// If there is only one child element
+			target = pane.container.children[0];
+		}
+		else {
+			// Otherwise dispatch to the first non-h1 child element
+			target = Array.from(pane.container.children).find(elem => elem.tagName != 'h1');
+		}
+		target.dispatchEvent(new Event('showing'));
 	},
 	
 	_parseXHTMLToFragment(str, entities = []) {


### PR DESCRIPTION
Fix the wrong event target of `showing`. This bug was introduced with the automatic <h1> of preference panes.