### PR TITLE
Fix dates not following Zotero's locale.

### DIFF
--- a/chrome/content/zotero/dateOverrides.js
+++ b/chrome/content/zotero/dateOverrides.js
@@ -1,0 +1,18 @@
+/* eslint-disable no-extend-native */
+const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+
+let originalToLocaleString = Date.prototype.toLocaleString;
+Date.prototype.toLocaleString = function (locales, options) {
+	if (locales === undefined || (Array.isArray(locales) && !locales.length)) {
+		locales = Services.locale.requestedLocales;
+	}
+	return originalToLocaleString.call(this, locales, options);
+};
+
+let originalToLocaleDateString = Date.prototype.toLocaleDateString;
+Date.prototype.toLocaleDateString = function (locales, options) {
+	if (locales === undefined || (Array.isArray(locales) && !locales.length)) {
+		locales = Services.locale.requestedLocales;
+	}
+	return originalToLocaleDateString.call(this, locales, options);
+};

--- a/chrome/content/zotero/zotero.mjs
+++ b/chrome/content/zotero/zotero.mjs
@@ -221,6 +221,8 @@ XPCOMUtils.defineLazyModuleGetters(ZoteroContext.prototype, {
  * components may not have yet been initialized.
  */
 function makeZoteroContext() {
+	var subscriptLoader = Cc["@mozilla.org/moz/jssubscript-loader;1"].getService(Ci.mozIJSSubScriptLoader);
+	
 	if(zContext) {
 		// Swap out old zContext
 		var oldzContext = zContext;
@@ -232,9 +234,10 @@ function makeZoteroContext() {
 	} else {
 		zContext = new ZoteroContext();
 		zContext.Zotero = function() {};
+
+		// Override Date prototype to follow Zotero configured locale #3880
+		subscriptLoader.loadSubScript("chrome://zotero/content/dateOverrides.js");
 	}
-	
-	var subscriptLoader = Cc["@mozilla.org/moz/jssubscript-loader;1"].getService(Ci.mozIJSSubScriptLoader);
 	
 	// Load zotero.js first
 	subscriptLoader.loadSubScript("chrome://zotero/content/xpcom/" + xpcomFilesAll[0] + ".js", zContext, 'utf-8');


### PR DESCRIPTION
Behaviour of `toLocaleString` and `toLocaleDateString` seems to have changed between Firefox 68 and 102. Below is the same code running on my system configured to `en-GB` with Zotero configured to `en-US`.

Zotero 6:
![Screenshot 2024-03-25 at 13 44 18](https://github.com/zotero/zotero/assets/214628/7f3cbcb7-2719-4886-a3f3-2e919e936220)

Zotero 7:

![Screenshot 2024-03-25 at 13 44 59](https://github.com/zotero/zotero/assets/214628/66bfa2bf-999d-4209-96e4-4c0c4924d25a)

From what I can observe `toLocaleString` no longer respects locale configured in Zotero and instead uses system's locale. I've also checked current Firefox/Chromium and it seems to exhibit the same behavior.

To fix this, I've tweaked our code to explicitly call `toLocaleString` with `window.navigator.language` as the first argument. A similar treatment might be needed in zotero/utilities.

Resolves #3559
