### PR TITLE
fx115: fix tagsbox autocomplete breakage

### DIFF
--- a/chrome/content/zotero/elements/tagsBox.js
+++ b/chrome/content/zotero/elements/tagsBox.js
@@ -75,26 +75,6 @@
 				removeAllItemTags.disabled = !this.count;
 				this._id('tags-context-menu').openPopupAtScreen(event.screenX, event.screenY, true);
 			});
-			
-			if (!document.getElementById('PopupAutoComplete')) {
-				let popupset = document.querySelector('popupset');
-				if (!popupset) {
-					popupset = document.createXULElement('popupset');
-					document.documentElement.append(popupset);
-				}
-				
-				let autocomplete = document.createXULElement('panel', { is: 'autocomplete-richlistbox-popup' });
-				autocomplete.id = 'PopupAutoComplete';
-				autocomplete.setAttribute('type', 'autocomplete-richlistbox');
-				autocomplete.setAttribute('role', 'group');
-				autocomplete.setAttribute('noautofocus', true);
-				autocomplete.setAttribute('hidden', true);
-				autocomplete.setAttribute('overflowpadding', 4);
-				autocomplete.setAttribute('norolluponanchor', true);
-				autocomplete.setAttribute('nomaxresults', true);
-				popupset.append(autocomplete);
-			}
-
 			// Register our observer with priority 101 (after Zotero.Tags) so we get updated tag colors
 			this._notifierID = Zotero.Notifier.registerObserver(this, ['item-tag', 'setting'], 'tagsBox', 101);
 		}

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -1410,4 +1410,18 @@
 			</stack>
 		</vbox>
 	</hbox>
+	<!-- fx115: the popupset has to be here to properly display autocomplete popup -->
+	<popupset>
+		<panel
+			is="autocomplete-richlistbox-popup"
+			type="autocomplete-richlistbox"
+			id="PopupAutoComplete"
+			role="group"
+			noautofocus="true"
+			hidden="true"
+			overflowpadding="4"
+			norolluponanchor="true"
+			nomaxresults="true"
+		/>
+	</popupset>
 </window>


### PR DESCRIPTION
With fx115, changes from 49fe2b98d97523174889ec86b9925e4e795ca034 made the autocomplete popup appear blank when the reader tab is opened. Not re-creating the PopupAutoComplete in tagsBox makes the items from autocomplete popup visible again. But it makes the autocomplete appear below the "Add tags" popup for annotations (what 49fe2b98d97523174889ec86b9925e4e795ca034 originally fixed), and it also creates a duplicate `popupset` with a new autocomplete panel at the bottom of the DOM every time autocomplete runs. The duplicate `panel`s do not have an id.

Manually adding a `popupset` with a `panel` whose id="PopupAutoComplete" does not create any duplicates and properly positions the popup.

Fixes: #3881

<img width="349" alt="Screenshot 2024-03-26 at 4 20 29 PM" src="https://github.com/zotero/zotero/assets/36271954/ae777834-1433-4175-b97a-1cc110e37476">
<img width="345" alt="Screenshot 2024-03-26 at 4 20 50 PM" src="https://github.com/zotero/zotero/assets/36271954/5a7472e8-2bef-4a9e-a0e7-b2e646534214">
