### PR TITLE
qf: fix insertNote dialog breakage

### DIFF
--- a/chrome/content/zotero/integration/insertNoteDialog.js
+++ b/chrome/content/zotero/integration/insertNoteDialog.js
@@ -27,5 +27,5 @@ var defaultBubbleizeSelected = Zotero_QuickFormat._bubbleizeSelected;
 Zotero_QuickFormat.citingNotes = true;
 Zotero_QuickFormat._bubbleizeSelected = async function () {
 	await defaultBubbleizeSelected();
-	await Zotero_QuickFormat._accept();
+	await Zotero_QuickFormat.accept();
 }

--- a/chrome/content/zotero/integration/insertNoteDialog.xhtml
+++ b/chrome/content/zotero/integration/insertNoteDialog.xhtml
@@ -53,8 +53,8 @@
 			<hbox class="citation-dialog main" flex="1" align="start">
 				<hbox flex="1">
 					<html:div flex="1" spellcheck="false" class="citation-dialog editor insert-note" role="application"></html:div>
-					<vbox class="citation-dialog spinner">
-						<image class="zotero-spinner-16"/>
+					<vbox class="citation-dialog icons end">
+						<image class="icon zotero-spinner-16"/>
 					</vbox>
 				</hbox>
 			</hbox>

--- a/chrome/content/zotero/integration/quickFormat.js
+++ b/chrome/content/zotero/integration/quickFormat.js
@@ -1188,8 +1188,11 @@ var Zotero_QuickFormat = new function () {
 	// window boundaries.
 	function _resizeEditor() {
 		let editorParentWidth = editor.parentNode.getBoundingClientRect().width;
-		let iconWrapperWidth = document.querySelector(".citation-dialog.icons").getBoundingClientRect().width;
-		let editorDesiredWidth = editorParentWidth - iconWrapperWidth * 2;
+		// Find the widths of all icon containers.
+		// Quick format dialog has 2 sets of icons but insert note dialog has only one
+		let iconWrappers = [...document.querySelectorAll(".citation-dialog.icons")];
+		let iconWrapperWidth = iconWrappers.reduce((totalWidth, iconWrapper) => totalWidth + iconWrapper.getBoundingClientRect().width, 0);
+		let editorDesiredWidth = editorParentWidth - iconWrapperWidth;
 		// Sanity check: editor width should never be that small
 		if (editorDesiredWidth > 700) {
 			editor.style.width = `${editorDesiredWidth}px`;
@@ -1584,7 +1587,9 @@ var Zotero_QuickFormat = new function () {
 	function _resetSearchTimer() {
 		// Show spinner
 		var spinner = document.querySelector('.citation-dialog.icons.end image');
-		spinner.nextElementSibling.style.display = "none";
+		// Accept button does not exist in insertNote dialog
+		let acceptButton = spinner.nextElementSibling;
+		if (acceptButton) acceptButton.style.display = "none";
 		spinner.setAttribute("status", "animate");
 		// Cancel current search if active
 		if (_searchPromise && _searchPromise.isPending()) {
@@ -1596,7 +1601,7 @@ var Zotero_QuickFormat = new function () {
 			.then(() => {
 				_searchPromise = null;
 				spinner.removeAttribute("status");
-				spinner.nextElementSibling.style.removeProperty("display");
+				if (acceptButton) acceptButton.style.removeProperty("display");
 			});
 	}
 

--- a/chrome/skin/default/zotero/integration.css
+++ b/chrome/skin/default/zotero/integration.css
@@ -192,10 +192,6 @@
 	color: black;
 }
 
-.citation-dialog.editor.insert-note {
-	width: 750px;
-}
-
 .citation-dialog.editor::selection {
 	color: white;
 	background: var(--color-accent);


### PR DESCRIPTION
Fix breakage in insert note dialog caused by missing icon container after 1eaff81

Since `insertNote` dialog uses the same exact code as `quickFormat` dialog, any DOM-related changes need to account for both of them, and I think I missed it last time. 

This simply adds a wrapper container to the spinner, same as in `quickformat`, and does not break if the spinner does not have the "Accept" button sibling.

