### PR TITLE
Fix error when dealing with invalid certificates

### DIFF
--- a/chrome/content/zotero/xpcom/http.js
+++ b/chrome/content/zotero/xpcom/http.js
@@ -1268,7 +1268,7 @@ Zotero.HTTP = new function() {
 			secInfo.QueryInterface(Ci.nsITransportSecurityInfo);
 			if ((secInfo.securityState & Ci.nsIWebProgressListener.STATE_IS_INSECURE)
 					== Ci.nsIWebProgressListener.STATE_IS_INSECURE) {
-				msg = Zotero.getString('networkError.connectionNotSecure', Zotero.appName) + (secInfo.errorCodeString ? ` ${secInfo.errorCodeString}` : '');
+				msg = secInfo.errorCodeString;
 				if (channel.originalURI?.spec.includes(ZOTERO_CONFIG.DOMAIN_NAME)
 					|| channel.originalURI?.spec.includes(ZOTERO_CONFIG.PROXY_AUTH_URL.match(/^https:\/\/([^\/]+)\//)[1])) {
 					msg = Zotero.getString('networkError.connectionMonitored', Zotero.appName)
@@ -1285,7 +1285,7 @@ Zotero.HTTP = new function() {
 			}
 			else if ((secInfo.securityState & Ci.nsIWebProgressListener.STATE_IS_BROKEN)
 					== Ci.nsIWebProgressListener.STATE_IS_BROKEN) {
-				msg = Zotero.getString('networkError.connectionNotSecure', Zotero.appName) + (secInfo.errorCodeString ? ` ${secInfo.errorCodeString}` : '');
+				msg = secInfo.errorCodeString;
 			}
 			if (msg) {
 				throw new Zotero.HTTP.SecurityException(

--- a/chrome/content/zotero/xpcom/http.js
+++ b/chrome/content/zotero/xpcom/http.js
@@ -1268,17 +1268,15 @@ Zotero.HTTP = new function() {
 			secInfo.QueryInterface(Ci.nsITransportSecurityInfo);
 			if ((secInfo.securityState & Ci.nsIWebProgressListener.STATE_IS_INSECURE)
 					== Ci.nsIWebProgressListener.STATE_IS_INSECURE) {
-				// Show actual error from the networking stack, with the hyperlink around the
-				// error code removed
-				msg = Zotero.Utilities.unescapeHTML(secInfo.errorMessage);
-				if (msg.includes('.' + ZOTERO_CONFIG.DOMAIN_NAME + ' ')
-						|| msg.includes(ZOTERO_CONFIG.PROXY_AUTH_URL.match(/^https:\/\/([^\/]+)\//)[1] + ' ')) {
+				msg = Zotero.getString('networkError.connectionNotSecure', Zotero.appName) + (secInfo.errorCodeString ? ` ${secInfo.errorCodeString}` : '');
+				if (channel.originalURI?.spec.includes(ZOTERO_CONFIG.DOMAIN_NAME)
+					|| channel.originalURI?.spec.includes(ZOTERO_CONFIG.PROXY_AUTH_URL.match(/^https:\/\/([^\/]+)\//)[1])) {
 					msg = Zotero.getString('networkError.connectionMonitored', Zotero.appName)
 						+ "\n\n"
 						+ (isProxyAuthRequest
 							? Zotero.getString('startupError.internetFunctionalityMayNotWork') + "\n\n"
 							: "")
-						+ Zotero.getString('general.error') + ": " + msg.split(/\n/)[0];
+						+ msg;
 				}
 				dialogButtonText = Zotero.getString('general.moreInformation');
 				dialogButtonCallback = function () {
@@ -1287,8 +1285,7 @@ Zotero.HTTP = new function() {
 			}
 			else if ((secInfo.securityState & Ci.nsIWebProgressListener.STATE_IS_BROKEN)
 					== Ci.nsIWebProgressListener.STATE_IS_BROKEN) {
-				msg = Zotero.getString('networkError.connectionNotSecure')
-					+ Zotero.Utilities.unescapeHTML(secInfo.errorMessage);
+				msg = Zotero.getString('networkError.connectionNotSecure', Zotero.appName) + (secInfo.errorCodeString ? ` ${secInfo.errorCodeString}` : '');
 			}
 			if (msg) {
 				throw new Zotero.HTTP.SecurityException(


### PR DESCRIPTION
Fix #3892 

This is the simplest solution with no additional messages. I think it works well enough, given that previously error message also included the raw string error code.

Before:
<img width="1249" alt="Screenshot 2024-03-28 at 17 26 32" src="https://github.com/zotero/zotero/assets/214628/ec84e1cf-32ce-47f4-9d11-2102b81d0e1b">

After:
<img width="1249" alt="Screenshot 2024-03-28 at 17 33 15" src="https://github.com/zotero/zotero/assets/214628/8053b5f1-8771-4330-84b0-9318974d5c38">