### PR TITLE
editable-text: Clean up `render()`

### DIFF
--- a/chrome/content/zotero/elements/editableText.js
+++ b/chrome/content/zotero/elements/editableText.js
@@ -194,7 +194,7 @@
 				input.addEventListener('dragover', this._handleDragOver);
 				input.addEventListener('drop', this._handleDrop);
 				
-				let focused = this._input && document.activeElement === this._input;
+				let focused = this.focused;
 				let selectionStart = this._input?.selectionStart;
 				let selectionEnd = this._input?.selectionEnd;
 				let selectionDirection = this._input?.selectionDirection;


### PR DESCRIPTION
Things were getting a bit out of hand with the anonymous listeners, and this should be clearer and more maintainable in the future.

Event handlers extracted with no code changes. Moved one line in `render()` to make the conditions that set `focused` to true clearer.