### PR TITLE
fx-compat: Copy over fx115 Window menu changes

### DIFF
--- a/chrome/content/scaffold/scaffold.xhtml
+++ b/chrome/content/scaffold/scaffold.xhtml
@@ -48,6 +48,7 @@
 
 	<linkset>
 		<html:link rel="localization" href="browser/menubar.ftl"/>
+		<html:link rel="localization" href="browser/browserSets.ftl"/>
 		<html:link rel="localization" href="toolkit/global/textActions.ftl"/>
 		<html:link rel="localization" href="zotero.ftl" />
 	</linkset>
@@ -267,18 +268,19 @@
 		
 					<commandset id="macCommandSet"> <!-- was mainCommandSet -->
 						<command id="minimizeWindow"
-								label="&minimizeWindow.label;"
+								data-l10n-id="window-minimize-command"
 								oncommand="window.minimize();" />
 						<command id="zoomWindow"
-								label="&zoomWindow.label;"
+								data-l10n-id="window-zoom-command"
 								oncommand="zoomWindow();" />
 					</commandset>
 		
 					<keyset id="macKeyset">  <!-- was mainKeySet -->
 						<key id="key_minimizeWindow"
 								command="minimizeWindow"
-								key="&minimizeWindow.key;"
-								modifiers="accel"/>
+								data-l10n-id="window-minimize-shortcut"
+								modifiers="accel"
+								internal="true"/>
 						<key id="key_quitApplication"
 								key="&quitApplicationCmdMac.key;"
 								command="cmd_quitApplication"
@@ -309,25 +311,11 @@
 					</menupopup>
 		
 					<menu id="windowMenu"
-							label="&windowMenu.label;"
-							datasources="rdf:window-mediator" ref="NC:WindowMediatorRoot"
-							onpopupshowing="macWindowMenuDidShow();"
-							onpopuphidden="macWindowMenuDidHide();"
-							hidden="false">
-						<template>
-							<rule>
-								<menupopup>
-									<menuitem uri="rdf:*"
-											label="rdf:http://home.netscape.com/NC-rdf#Name"
-											type="radio"
-											name="windowList"
-											oncommand="ShowWindowFromResource(event.target)"/>
-								</menupopup>
-							</rule>
-						</template>
+							data-l10n-id="menu-window-menu">
 						<menupopup id="windowPopup">
-							<menuitem command="minimizeWindow" label="&minimizeWindow.label;" key="key_minimizeWindow"/>
-							<menuitem command="zoomWindow" label="&zoomWindow.label;"/>
+							<menuseparator/>
+							<menuitem command="minimizeWindow" key="key_minimizeWindow"/>
+							<menuitem command="zoomWindow"/>
 							<!-- decomment when "BringAllToFront" is implemented
 								<menuseparator/>
 								<menuitem label="&bringAllToFront.label;" disabled="true"/> -->

--- a/chrome/content/zotero/reader.xhtml
+++ b/chrome/content/zotero/reader.xhtml
@@ -24,6 +24,7 @@
 >
 	<linkset>
 		<html:link rel="localization" href="browser/menubar.ftl"/>
+		<html:link rel="localization" href="browser/browserSets.ftl"/>
 		<html:link rel="localization" href="toolkit/global/textActions.ftl"/>
 		<html:link rel="localization" href="zotero.ftl" />
 	</linkset>
@@ -57,10 +58,10 @@
 
 		<!--WINDOW-->
 		<command id="minimizeWindow"
-				 label="&minimizeWindow.label;"
+				 data-l10n-id="window-minimize-command"
 				 oncommand="window.minimize();" />
 		<command id="zoomWindow"
-				 label="&zoomWindow.label;"
+				 data-l10n-id="window-zoom-command"
 				 oncommand="zoomWindow();" />
 	</commandset>
 	
@@ -69,8 +70,9 @@
 		<key id="key_forward"/>
 		<key id="key_minimizeWindow"
 			 command="minimizeWindow"
-			 key="&minimizeWindow.key;"
-			 modifiers="accel"/>
+			 data-l10n-id="window-minimize-shortcut"
+			 modifiers="accel"
+			 internal="true"/>
 		<key id="key_close" key="&closeCmd.key;" command="cmd_close" modifiers="accel"/>
 	</keyset>
 
@@ -319,25 +321,11 @@
 			</menupopup>
 		</menu>
 		<menu id="windowMenu"
-			  label="&windowMenu.label;"
-			  datasources="rdf:window-mediator" ref="NC:WindowMediatorRoot"
-			  onpopupshowing="macWindowMenuDidShow();"
-			  onpopuphidden="macWindowMenuDidHide();"
-			  hidden="false">
-			<template>
-				<rule>
-					<menupopup>
-						<menuitem uri="rdf:*"
-								  label="rdf:http://home.netscape.com/NC-rdf#Name"
-								  type="radio"
-								  name="windowList"
-								  oncommand="ShowWindowFromResource(event.target)"/>
-					</menupopup>
-				</rule>
-			</template>
+				data-l10n-id="menu-window-menu">
 			<menupopup id="windowPopup">
-				<menuitem command="minimizeWindow" label="&minimizeWindow.label;" key="key_minimizeWindow"/>
-				<menuitem command="zoomWindow" label="&zoomWindow.label;"/>
+				<menuseparator/>
+				<menuitem command="minimizeWindow" key="key_minimizeWindow"/>
+				<menuitem command="zoomWindow"/>
 				<!-- decomment when "BringAllToFront" is implemented
                     <menuseparator/>
                     <menuitem label="&bringAllToFront.label;" disabled="true"/> -->

--- a/chrome/content/zotero/standalone/basicViewer.xhtml
+++ b/chrome/content/zotero/standalone/basicViewer.xhtml
@@ -49,6 +49,7 @@
 	
 	<linkset>
 		<html:link rel="localization" href="browser/menubar.ftl"/>
+		<html:link rel="localization" href="browser/browserSets.ftl"/>
 		<html:link rel="localization" href="toolkit/global/textActions.ftl"/>
 	</linkset>
 
@@ -178,33 +179,29 @@
 						</menupopup>
 					</menu>
 					
+					<commandset id="macCommandSet"> <!-- was mainCommandSet -->
+						<command id="minimizeWindow"
+								 data-l10n-id="window-minimize-command"
+								 oncommand="window.minimize();" />
+						<command id="zoomWindow"
+								 data-l10n-id="window-zoom-command"
+								 oncommand="zoomWindow();" />
+					</commandset>
+
 					<keyset id="macKeyset">  <!-- was mainKeySet -->
 						<key id="key_minimizeWindow"
 								command="minimizeWindow"
-								key="&minimizeWindow.key;"
-								modifiers="accel"/>
+								data-l10n-id="window-minimize-shortcut"
+								modifiers="accel"
+								internal="true"/>
 					</keyset>
 
 					<menu id="windowMenu"
-							label="&windowMenu.label;"
-							datasources="rdf:window-mediator" ref="NC:WindowMediatorRoot"
-							onpopupshowing="macWindowMenuDidShow();"
-							onpopuphidden="macWindowMenuDidHide();"
-							hidden="false">
-						<template>
-							<rule>
-								<menupopup>
-									<menuitem uri="rdf:*"
-											label="rdf:http://home.netscape.com/NC-rdf#Name"
-											type="radio"
-											name="windowList"
-											oncommand="ShowWindowFromResource(event.target)"/>
-								</menupopup>
-							</rule>
-						</template>
+							data-l10n-id="menu-window-menu">
 						<menupopup id="windowPopup">
-							<menuitem command="minimizeWindow" label="&minimizeWindow.label;" key="key_minimizeWindow"/>
-							<menuitem command="zoomWindow" label="&zoomWindow.label;"/>
+							<menuseparator/>
+							<menuitem command="minimizeWindow" key="key_minimizeWindow"/>
+							<menuitem command="zoomWindow"/>
 							<!-- decomment when "BringAllToFront" is implemented
 								<menuseparator/>
 								<menuitem label="&bringAllToFront.label;" disabled="true"/> -->

--- a/chrome/content/zotero/standalone/hiddenWindow.xhtml
+++ b/chrome/content/zotero/standalone/hiddenWindow.xhtml
@@ -147,17 +147,16 @@
 			</menupopup>
 		</menu>
 
-		<menu id="windowMenu" label="&windowMenu.label;">
-			<menupopup>
-				<menuitem command="minimizeWindow" label="&minimizeWindow.label;" key="key_minimizeWindow"/>
-				<menuitem command="zoomWindow" label="&zoomWindow.label;"/>
+		<menu id="windowMenu"
+				data-l10n-id="menu-window-menu">
+			<menupopup id="windowPopup">
 				<menuseparator/>
-				<menuitem command="cmd_mainWindow" label="&brandShortName;" key="key_mainWindow"/>
-				<!--
-					Prevent error from macWindowMenuDidShow(), which is called from a built-in
-					nWindowMenuShowing(), when opening menu
-				-->
-				<menuseparator id="sep-window-list" hidden="true"/>
+				<menuitem command="minimizeWindow" key="key_minimizeWindow"/>
+				<menuitem command="zoomWindow"/>
+				<!-- decomment when "BringAllToFront" is implemented
+					<menuseparator/>
+					<menuitem label="&bringAllToFront.label;" disabled="true"/> -->
+				<menuseparator id="sep-window-list"/>
 			</menupopup>
 		</menu>
 	</menubar>

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -51,6 +51,7 @@
 	
 	<linkset>
 		<html:link rel="localization" href="browser/menubar.ftl"/>
+		<html:link rel="localization" href="browser/browserSets.ftl"/>
 	</linkset>
 	
 	<script>
@@ -125,18 +126,19 @@
 
 	<commandset id="macCommandSet"> <!-- was mainCommandSet -->
 		<command id="minimizeWindow"
-				 label="&minimizeWindow.label;"
+				 data-l10n-id="window-minimize-command"
 				 oncommand="window.minimize();" />
 		<command id="zoomWindow"
-				 label="&zoomWindow.label;"
+				 data-l10n-id="window-zoom-command"
 				 oncommand="zoomWindow();" />
 	</commandset>
 
 	<keyset id="macKeyset">  <!-- was mainKeySet -->
 		<key id="key_minimizeWindow"
 			 command="minimizeWindow"
-			 key="&minimizeWindow.key;"
-			 modifiers="accel"/>
+			 data-l10n-id="window-minimize-shortcut"
+			 modifiers="accel"
+			 internal="true"/>
 		<key id="key_openHelpMac"
 			 oncommand="ZoteroStandalone.openHelp();"
 			 key="&helpMac.commandkey;"
@@ -702,25 +704,11 @@
 				
 					 <!-- Only on macOS -->
 					<menu id="windowMenu"
-							label="&windowMenu.label;"
-							datasources="rdf:window-mediator" ref="NC:WindowMediatorRoot"
-							onpopupshowing="macWindowMenuDidShow();"
-							onpopuphidden="macWindowMenuDidHide();"
-							hidden="false">
-						<template>
-							<rule>
-								<menupopup>
-									<menuitem uri="rdf:*"
-											label="rdf:http://home.netscape.com/NC-rdf#Name"
-											type="radio"
-											name="windowList"
-											oncommand="ShowWindowFromResource(event.target)"/>
-								</menupopup>
-							</rule>
-						</template>
+							data-l10n-id="menu-window-menu">
 						<menupopup id="windowPopup">
-							<menuitem command="minimizeWindow" label="&minimizeWindow.label;" key="key_minimizeWindow"/>
-							<menuitem command="zoomWindow" label="&zoomWindow.label;"/>
+							<menuseparator/>
+							<menuitem command="minimizeWindow" key="key_minimizeWindow"/>
+							<menuitem command="zoomWindow"/>
 							<!-- decomment when "BringAllToFront" is implemented
 								<menuseparator/>
 								<menuitem label="&bringAllToFront.label;" disabled="true"/> -->

--- a/chrome/locale/en-US/zotero/standalone.dtd
+++ b/chrome/locale/en-US/zotero/standalone.dtd
@@ -70,11 +70,7 @@
 <!ENTITY developer.label           "Developer">
 
 <!--WINDOW MENU-->
-<!ENTITY minimizeWindow.key       "m">
-<!ENTITY minimizeWindow.label     "Minimize">
 <!ENTITY bringAllToFront.label    "Bring All to Front">
-<!ENTITY zoomWindow.label         "Zoom">
-<!ENTITY windowMenu.label         "Window">
 
 <!--HELP MENU-->
 <!ENTITY helpMenu.label           "Help"> 


### PR DESCRIPTION
- Prevent an error when opening/closing Window menu
- Remove dead WindowMediator-related markup
- Use Mozilla strings