### PR TITLE
fx115: Fix detecting insecure connection no longer works

### DIFF
--- a/chrome/content/zotero/preferences/preferences_sync.jsx
+++ b/chrome/content/zotero/preferences/preferences_sync.jsx
@@ -145,11 +145,7 @@ Zotero_Preferences.Sync = {
 		}
 		catch (e) {
 			setTimeout(function () {
-				Zotero.alert(
-					window,
-					Zotero.getString('general.error'),
-					e.message
-				);
+				Zotero.Sync.Runner.alert(e);
 			});
 			throw e;
 		}

--- a/chrome/content/zotero/xpcom/http.js
+++ b/chrome/content/zotero/xpcom/http.js
@@ -1269,16 +1269,19 @@ Zotero.HTTP = new function() {
 		let dialogButtonCallback;
 		if (state !== 'secure') {
 			if (state === 'broken' || state === 'insecure') {
-				msg = errorMessage ?? channel.securityInfo?.errorCodeString ?? '';
+				let domain = channel.originalURI?.host ?? '';
+				msg = Zotero.getString('networkError.insecureConnectionTo', [Zotero.appName, domain])
+					 + "\n\n";
 				if (channel.originalURI?.spec.includes(ZOTERO_CONFIG.DOMAIN_NAME)
-					|| channel.originalURI?.spec.includes(ZOTERO_CONFIG.PROXY_AUTH_URL.match(/^https:\/\/([^\/]+)\//)[1])) {
-					msg = Zotero.getString('networkError.connectionMonitored', Zotero.appName)
+						|| channel.originalURI?.spec.includes(ZOTERO_CONFIG.PROXY_AUTH_URL.match(/^https:\/\/([^\/]+)\//)[1])) {
+					msg += Zotero.getString('networkError.connectionMonitored', Zotero.appName)
 						+ "\n\n"
 						+ (isProxyAuthRequest
 							? Zotero.getString('startupError.internetFunctionalityMayNotWork') + "\n\n"
-							: "")
-						+ msg;
+							: "");
 				}
+				msg += errorMessage ?? channel.securityInfo?.errorCodeString ?? '';
+				msg = msg.trim();
 				dialogButtonText = Zotero.getString('general.moreInformation');
 				dialogButtonCallback = function () {
 					Zotero.launchURL('https://www.zotero.org/support/kb/ssl_certificate_error');
@@ -1288,10 +1291,7 @@ Zotero.HTTP = new function() {
 				throw new Zotero.HTTP.SecurityException(
 					msg,
 					{
-						dialogHeader: Zotero.getString(
-							'networkError.connectionNotSecure',
-							Zotero.clientName
-						),
+						dialogHeader: Zotero.getString('networkError.connectionNotSecure'),
 						dialogButtonText,
 						dialogButtonCallback
 					}

--- a/chrome/content/zotero/xpcom/http.js
+++ b/chrome/content/zotero/xpcom/http.js
@@ -1263,41 +1263,37 @@ Zotero.HTTP = new function() {
 		}
 		
 		let { state, errorMessage } = SecurityInfo.getSecurityInfo(channel);
+		if (state != 'broken') {
+			return;
+		}
 		
-		let msg;
 		let dialogButtonText;
 		let dialogButtonCallback;
-		if (state !== 'secure') {
-			if (state === 'broken' || state === 'insecure') {
-				let domain = channel.originalURI?.host ?? '';
-				msg = Zotero.getString('networkError.insecureConnectionTo', [Zotero.appName, domain])
-					 + "\n\n";
-				if (channel.originalURI?.spec.includes(ZOTERO_CONFIG.DOMAIN_NAME)
-						|| channel.originalURI?.spec.includes(ZOTERO_CONFIG.PROXY_AUTH_URL.match(/^https:\/\/([^\/]+)\//)[1])) {
-					msg += Zotero.getString('networkError.connectionMonitored', Zotero.appName)
-						+ "\n\n"
-						+ (isProxyAuthRequest
-							? Zotero.getString('startupError.internetFunctionalityMayNotWork') + "\n\n"
-							: "");
-				}
-				msg += errorMessage ?? channel.securityInfo?.errorCodeString ?? '';
-				msg = msg.trim();
-				dialogButtonText = Zotero.getString('general.moreInformation');
-				dialogButtonCallback = function () {
-					Zotero.launchURL('https://www.zotero.org/support/kb/ssl_certificate_error');
-				};
-			}
-			if (msg) {
-				throw new Zotero.HTTP.SecurityException(
-					msg,
-					{
-						dialogHeader: Zotero.getString('networkError.connectionNotSecure'),
-						dialogButtonText,
-						dialogButtonCallback
-					}
-				);
-			}
+		let domain = channel.originalURI?.host ?? '';
+		let msg = Zotero.getString('networkError.insecureConnectionTo', [Zotero.appName, domain])
+			 + "\n\n";
+		if (channel.originalURI?.spec.includes(ZOTERO_CONFIG.DOMAIN_NAME)
+				|| channel.originalURI?.spec.includes(ZOTERO_CONFIG.PROXY_AUTH_URL.match(/^https:\/\/([^\/]+)\//)[1])) {
+			msg += Zotero.getString('networkError.connectionMonitored', Zotero.appName)
+				+ "\n\n"
+				+ (isProxyAuthRequest
+					? Zotero.getString('startupError.internetFunctionalityMayNotWork') + "\n\n"
+					: "");
 		}
+		msg += errorMessage ?? channel.securityInfo?.errorCodeString ?? '';
+		msg = msg.trim();
+		dialogButtonText = Zotero.getString('general.moreInformation');
+		dialogButtonCallback = function () {
+			Zotero.launchURL('https://www.zotero.org/support/kb/ssl_certificate_error');
+		};
+		throw new Zotero.HTTP.SecurityException(
+			msg,
+			{
+				dialogHeader: Zotero.getString('networkError.connectionNotSecure'),
+				dialogButtonText,
+				dialogButtonCallback
+			}
+		);
 	};
 	
 	async function _checkRetry(req) {

--- a/chrome/content/zotero/xpcom/sync/syncRunner.js
+++ b/chrome/content/zotero/xpcom/sync/syncRunner.js
@@ -1593,6 +1593,53 @@ Zotero.Sync.Runner_Module = function (options = {}) {
 	}
 	
 	
+	this.alert = function (e) {
+		e = Zotero.Sync.Runner.parseError(e);
+		var ps = Services.prompt;
+		var buttonText = e.dialogButtonText;
+		var buttonCallback = e.dialogButtonCallback;
+		
+		if (e.errorType == 'warning' || e.errorType == 'error') {
+			let title = Zotero.getString('general.' + e.errorType);
+			// TODO: Display header in bold
+			let msg = (e.dialogHeader ? e.dialogHeader + '\n\n' : '') + e.message;
+			
+			if (e.errorType == 'warning' || buttonText === null) {
+				ps.alert(null, title, e.message);
+				return;
+			}
+			
+			if (!buttonText) {
+				buttonText = Zotero.getString('errorReport.reportError');
+				buttonCallback = function () {
+					ZoteroPane.reportErrors();
+				};
+			}
+			
+			let buttonFlags = ps.BUTTON_POS_0 * ps.BUTTON_TITLE_OK
+				+ ps.BUTTON_POS_1 * ps.BUTTON_TITLE_IS_STRING;
+			let index = ps.confirmEx(
+				null,
+				title,
+				msg,
+				buttonFlags,
+				"",
+				buttonText,
+				"", null, {}
+			);
+			
+			if (index == 1) {
+				setTimeout(buttonCallback, 1);
+			}
+		}
+		// Upgrade message
+		else if (e.errorType == 'upgrade') {
+			ps.alert(null, "", e.message);
+			return;
+		}
+	};
+	
+	
 	/**
 	 * Register labels in sync icon tooltip to receive updates
 	 *

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -4799,7 +4799,7 @@ var ZoteroPane = new function()
 			catch (e) {
 				// TODO: show error somewhere else
 				Zotero.debug(e, 1);
-				ZoteroPane_Local.syncAlert(e);
+				Zotero.Sync.Runner.alert(e);
 				return;
 			}
 			
@@ -5140,53 +5140,6 @@ var ZoteroPane = new function()
 		);
 		
 		return index == 0 ? 'all' : 'one';
-	};
-	
-	
-	this.syncAlert = function (e) {
-		e = Zotero.Sync.Runner.parseError(e);
-		var ps = Services.prompt;
-		var buttonText = e.dialogButtonText;
-		var buttonCallback = e.dialogButtonCallback;
-		
-		if (e.errorType == 'warning' || e.errorType == 'error') {
-			let title = Zotero.getString('general.' + e.errorType);
-			// TODO: Display header in bold
-			let msg = (e.dialogHeader ? e.dialogHeader + '\n\n' : '') + e.message;
-			
-			if (e.errorType == 'warning' || buttonText === null) {
-				ps.alert(null, title, e.message);
-				return;
-			}
-			
-			if (!buttonText) {
-				buttonText = Zotero.getString('errorReport.reportError');
-				buttonCallback = function () {
-					ZoteroPane.reportErrors();
-				};
-			}
-			
-			let buttonFlags = ps.BUTTON_POS_0 * ps.BUTTON_TITLE_OK
-				+ ps.BUTTON_POS_1 * ps.BUTTON_TITLE_IS_STRING;
-			let index = ps.confirmEx(
-				null,
-				title,
-				msg,
-				buttonFlags,
-				"",
-				buttonText,
-				"", null, {}
-			);
-			
-			if (index == 1) {
-				setTimeout(buttonCallback, 1);
-			}
-		}
-		// Upgrade message
-		else if (e.errorType == 'upgrade') {
-			ps.alert(null, "", e.message);
-			return;
-		}
 	};
 	
 	

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -115,7 +115,8 @@ general.operationInProgress = A Zotero operation is currently in progress.
 general.operationInProgress.waitUntilFinished = Please wait until it has finished.
 general.operationInProgress.waitUntilFinishedAndTryAgain = Please wait until it has finished and try again.
 
-networkError.connectionNotSecure = %S could not make a secure connection.
+networkError.connectionNotSecure = Insecure Connection
+networkError.insecureConnectionTo = %S could not make a secure connection to %S.
 networkError.errorViaProxy = Error connecting via proxy server
 networkError.connectionMonitored = Your connection is likely being monitored, and %S has not been configured to trust the intermediate server.
 


### PR DESCRIPTION
It seems in fx115 this no longer works:

https://github.com/zotero/zotero/blob/751457268bd84e6c49d29044ca86d804db75cb13/chrome/content/zotero/xpcom/http.js#L1269C9-L1269C31

I'm getting generic "Error connecting to server. Check your Internet connection." for expired/revoked certificate. From what I can see `secInfo.securityState` is always 0, even though `errorCodeString` might actually be populated.

Looking for a solution I've found [`SecurityInfo` utility](https://searchfox.org/comm-central/source/mozilla/toolkit/components/extensions/webrequest/SecurityInfo.sys.mjs#27) which seems to contain the logic we need, although it doesn't seem to return value for `errorMessage` contradictory to what the comment says so we still need to use `errorCodeString`.

Any suggestions welcome.