### PR TITLE
`subprocess()`: Use `isAbsolute` instead of checking for slash

### DIFF
--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -615,7 +615,7 @@ Zotero.Utilities.Internal = {
 	 */
 	subprocess: async function (command, args = []) {
 		// eslint-disable-next-line no-undef
-		command = command.includes('/') ? command : await Subprocess.pathSearch(command);
+		command = PathUtils.isAbsolute(command) ? command : await Subprocess.pathSearch(command);
 		
 		Zotero.debug("Running " + command + " " + args.map(arg => "'" + arg + "'").join(" "));
 		


### PR DESCRIPTION
We only call this from one codepath that only runs on macOS right now, but it would break when passed an absolute path on Windows.