### PR TITLE
Fix progress window title bar on win and linux

### DIFF
--- a/chrome/content/zotero/progressWindow.xhtml
+++ b/chrome/content/zotero/progressWindow.xhtml
@@ -33,6 +33,8 @@
         xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
 		xmlns:html="http://www.w3.org/1999/xhtml"
 		title="&zotero.progress.title;"
+        no-titlebar-icon="true"
+        drawintitlebar-platforms="win,linux"
         width="300"
         windowtype="alert:alert">
 		
@@ -42,6 +44,9 @@
 		</hbox>
 	</vbox>
 	<script>
+        var {Services} = ChromeUtils.import("resource://gre/modules/Services.jsm");
+        var { Zotero } = ChromeUtils.importESModule("chrome://zotero/content/zotero.mjs");
+        Services.scriptloader.loadSubScript("chrome://zotero/content/titlebar.js", this);
 		window.addEventListener("DOMContentLoaded", () => window.sizeToContent())
 	</script>
 </window>

--- a/chrome/content/zotero/titlebar.js
+++ b/chrome/content/zotero/titlebar.js
@@ -52,7 +52,7 @@ window.addEventListener("load", function () {
 		window.document.documentElement.setAttribute('sizemode', 'normal');
 	}
 
-	if (Zotero.isWin) {
+	if (Zotero.isWin && !document.querySelector("window")?.hasAttribute("no-titlebar-icon")) {
 		let windowIcon = document.querySelector(".titlebar-icon");
 		// Simulate Windows window control
 		windowIcon.addEventListener("dblclick", (ev) => {


### PR DESCRIPTION
Before:
Windows:
![image](https://github.com/zotero/zotero/assets/33902321/d2ed7fd4-ad1a-4741-8b18-976321429a63)

Linux:
![image](https://github.com/zotero/zotero/assets/33902321/4d64e468-c99e-46d9-bc2b-2b0716472949)

After:

Windows:
![image](https://github.com/zotero/zotero/assets/33902321/9f3c9834-7d8e-4bb9-8edf-349c5c519ba7)

Linux:
![image](https://github.com/zotero/zotero/assets/33902321/692727bb-2bd9-4770-9cdd-023abb5dd0f7)

