### PR TITLE
Preferences: Fix overflow at small window sizes

### DIFF
--- a/chrome/content/zotero/preferences/preferences_advanced.xhtml
+++ b/chrome/content/zotero/preferences/preferences_advanced.xhtml
@@ -54,9 +54,8 @@
 		<groupbox>
 			<label><html:h2>&zotero.preferences.attachmentBaseDir.caption;</html:h2></label>
 			
-			<!-- This doesn't wrap without an explicit width -->
 			<vbox>
-				<description style="width: 45em;">&zotero.preferences.attachmentBaseDir.message;</description>
+				<description>&zotero.preferences.attachmentBaseDir.message;</description>
 			</vbox>
 			
 			<hbox align="center">

--- a/resource/word-processor-plugin-installer.js
+++ b/resource/word-processor-plugin-installer.js
@@ -175,7 +175,6 @@ ZoteroPluginInstaller.prototype = {
 		groupbox.appendChild(label);
 
 		var description = document.createXULElement("description");
-		description.style.width = "45em";
 		description.appendChild(document.createTextNode(
 			isInstalled ?
 				Zotero.getString('zotero.preferences.wordProcessors.installed', this._addon.APP) :


### PR DESCRIPTION
These explicit widths aren't necessary to make descriptions wrap anymore, and they were causing overflow.