### PR TITLE
Parse dates in item tree

### DIFF
--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -1405,7 +1405,7 @@
 			ymd.id = 'zotero-date-field-status';
 			ymd.textContent = Zotero.Date.strToDate(Zotero.Date.multipartToStr(value))
 					.order.split('').join(' ');
-			ymd.className = "show-on-hover";
+			ymd.classList.add('show-on-focus', 'no-display');
 			rowData.appendChild(elem);
 			rowData.appendChild(ymd);
 			
@@ -1727,9 +1727,11 @@
 				case 'dateDue':
 				case 'accepted':
 					if (fieldName == 'date' && this.item._objectType != 'feedItem') {
-						break;
+						valueText = this.item.getDisplayDate();
 					}
-					valueText = this.dateTimeFromUTC(valueText);
+					else {
+						valueText = this.dateTimeFromUTC(valueText);
+					}
 					break;
 			}
 			
@@ -1883,6 +1885,10 @@
 							
 							// Don't show time in editor
 							value = value.replace(' 00:00:00', '');
+							elem.value = value;
+							break;
+						
+						case 'date':
 							elem.value = value;
 							break;
 					}
@@ -2232,6 +2238,7 @@
 							if (Zotero.ItemFields.isFieldOfBase(fieldName, 'date')) {
 								// Parse 'yesterday'/'today'/'tomorrow'
 								value = Zotero.Date.parseDescriptiveString(value);
+								textbox.value = this.item.getDisplayDate();
 							}
 					}
 				}

--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -1403,9 +1403,15 @@
 			// y-m-d status indicator
 			var ymd = document.createElement('span');
 			ymd.id = 'zotero-date-field-status';
-			ymd.textContent = Zotero.Date.strToDate(Zotero.Date.multipartToStr(value))
-					.order.split('').join(' ');
 			ymd.classList.add('show-on-focus', 'no-display');
+
+			let updateStatus = () => {
+				ymd.textContent = Zotero.Date.strToDate(Zotero.Date.multipartToStr(elem.value.trim()))
+					.order.split('').join(' ');
+			};
+			elem.addEventListener('focus', updateStatus);
+			elem.addEventListener('input', updateStatus);
+
 			rowData.appendChild(elem);
 			rowData.appendChild(ymd);
 			

--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -1733,7 +1733,7 @@
 				case 'dateDue':
 				case 'accepted':
 					if (fieldName == 'date' && this.item._objectType != 'feedItem') {
-						valueText = this.item.getDisplayDate();
+						valueText = this.item.getDisplayDate({ strict: true });
 					}
 					else {
 						valueText = this.dateTimeFromUTC(valueText);
@@ -2244,7 +2244,7 @@
 							if (Zotero.ItemFields.isFieldOfBase(fieldName, 'date')) {
 								// Parse 'yesterday'/'today'/'tomorrow'
 								value = Zotero.Date.parseDescriptiveString(value);
-								textbox.value = this.item.getDisplayDate();
+								textbox.value = this.item.getDisplayDate({ strict: true });
 							}
 					}
 				}

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -3467,36 +3467,8 @@ var ItemTree = class ItemTree extends LibraryTree {
 						}
 					}
 					else {
-						// key == 'date' and we aren't in a feed
-						// Try to parse the date
-						let { year, month, day, part } = Zotero.Date.strToDate(val);
-						// See strToMultipart() - discard year if it contains a suffix
-						if (!/^\d{1,4}$/.test(year)) {
-							year = undefined;
-						}
-						year = parseInt(year);
-						if (isNaN(year)) {
-							year = undefined;
-						}
-						// Use parsed value as long as we got a year and one other part,
-						// and there wasn't any leftover content in the field that
-						// couldn't be parsed
-						if (year !== undefined && !part && (month !== undefined || day !== undefined)) {
-							try {
-								let date = new Date();
-								// Passing two-digit year to Date constructor parses it as 1900-1999,
-								// so use setFullYear() instead
-								date.setFullYear(year || 0, month || 0, day || 1);
-								val = new Intl.DateTimeFormat(Zotero.locale, {
-									year: year === undefined ? undefined : 'numeric',
-									month: month === undefined ? undefined : 'numeric',
-									day: day === undefined ? undefined : 'numeric',
-								}).format(date);
-							}
-							catch (e) {
-								// Error parsing or formatting date - keep raw value
-							}
-						}
+						// key == 'date' and we aren't in a feed - use human-readable date
+						val = treeRow.ref.getDisplayDate();
 					}
 				}
 			}

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -3469,7 +3469,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 					else {
 						// key == 'date' and we aren't in a feed
 						// Try to parse the date
-						let { year, month, day } = Zotero.Date.strToDate(val);
+						let { year, month, day, part } = Zotero.Date.strToDate(val);
 						// See strToMultipart() - discard year if it contains a suffix
 						if (!/^\d{1,4}$/.test(year)) {
 							year = undefined;
@@ -3478,15 +3478,10 @@ var ItemTree = class ItemTree extends LibraryTree {
 						if (isNaN(year)) {
 							year = undefined;
 						}
-						month = parseInt(month);
-						if (isNaN(month)) {
-							month = undefined;
-						}
-						day = parseInt(day);
-						if (isNaN(day)) {
-							day = undefined;
-						}
-						if (year !== undefined || month !== undefined || day !== undefined) {
+						// Use parsed value as long as we got a year and one other part,
+						// and there wasn't any leftover content in the field that
+						// couldn't be parsed
+						if (year !== undefined && !part && (month !== undefined || day !== undefined)) {
 							try {
 								let date = new Date();
 								// Passing two-digit year to Date constructor parses it as 1900-1999,

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -1076,7 +1076,11 @@ Zotero.Item.prototype.getTabTitle = async function () {
 };
 
 
-Zotero.Item.prototype.getDisplayDate = function () {
+/**
+ * @param {boolean} [strict] Return the input string unchanged if it contains unparseable components
+ * @returns {string}
+ */
+Zotero.Item.prototype.getDisplayDate = function ({ strict } = {}) {
 	let rawDate = this.getField('date', false, true);
 	if (!rawDate) {
 		return '';
@@ -1090,8 +1094,9 @@ Zotero.Item.prototype.getDisplayDate = function () {
 	if (isNaN(year)) {
 		year = undefined;
 	}
-	// Use parsed value as long as we got a year and one other part
-	if (year !== undefined && !part && (month !== undefined || day !== undefined)) {
+	// Use parsed value as long as we got a year and, in strict mode,
+	// there were no unparseable components
+	if (year !== undefined && (!part || !strict)) {
 		try {
 			let date = new Date();
 			// Passing two-digit year to Date constructor parses it as 1900-1999,

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -1076,6 +1076,41 @@ Zotero.Item.prototype.getTabTitle = async function () {
 };
 
 
+Zotero.Item.prototype.getDisplayDate = function () {
+	let rawDate = this.getField('date', false, true);
+	if (!rawDate) {
+		return '';
+	}
+	let { year, month, day, part } = Zotero.Date.strToDate(rawDate);
+	// See strToMultipart() - discard year if it contains a suffix
+	if (!/^\d{1,4}$/.test(year)) {
+		year = undefined;
+	}
+	year = parseInt(year);
+	if (isNaN(year)) {
+		year = undefined;
+	}
+	// Use parsed value as long as we got a year and one other part
+	if (year !== undefined && !part && (month !== undefined || day !== undefined)) {
+		try {
+			let date = new Date();
+			// Passing two-digit year to Date constructor parses it as 1900-1999,
+			// so use setFullYear() instead
+			date.setFullYear(year || 0, month || 0, day || 1);
+			return new Intl.DateTimeFormat(Zotero.locale, {
+				year: year === undefined ? undefined : 'numeric',
+				month: month === undefined ? undefined : 'numeric',
+				day: day === undefined ? undefined : 'numeric',
+			}).format(date);
+		}
+		catch (e) {
+			// Error parsing or formatting date - keep raw value
+		}
+	}
+	return rawDate;
+};
+
+
 /*
  * Returns the number of creators for this item
  */

--- a/scss/abstracts/_mixins.scss
+++ b/scss/abstracts/_mixins.scss
@@ -167,7 +167,8 @@
 		}	
 
 		&:not(:hover):not(:focus-within) .show-on-hover,
-		&.noHover .show-on-hover {
+		&.noHover .show-on-hover,
+		&:not(:focus-within) .show-on-focus {
 			clip-path: inset(50%);
 			&.no-display {
 				width: 0;

--- a/test/tests/dateTest.js
+++ b/test/tests/dateTest.js
@@ -299,6 +299,107 @@ describe("Zotero.Date", function () {
 			await translation.translate();
 			assert.ok(called);
 		});
+
+		describe("Time parsing", function () {
+			it("should parse simple AM/PM time", function () {
+				let o = Zotero.Date.strToDate('2pm');
+				assert.equal(o.hour, 14);
+				assert.isUndefined(o.minute);
+				assert.isUndefined(o.second);
+			});
+
+			it("should parse AM/PM time with minutes", function () {
+				let o = Zotero.Date.strToDate('2:30pm');
+				assert.equal(o.hour, 14);
+				assert.equal(o.minute, 30);
+				assert.isUndefined(o.second);
+			});
+
+			it("should parse AM/PM time with minutes and seconds", function () {
+				let o = Zotero.Date.strToDate('2:30:45 pm');
+				assert.equal(o.hour, 14);
+				assert.equal(o.minute, 30);
+				assert.equal(o.second, 45);
+			});
+
+			it("should parse uppercase AM/PM", function () {
+				let o = Zotero.Date.strToDate('3:15 PM');
+				assert.equal(o.hour, 15);
+				assert.equal(o.minute, 15);
+			});
+
+			it("should parse AM time", function () {
+				let o = Zotero.Date.strToDate('9:30am');
+				assert.equal(o.hour, 9);
+				assert.equal(o.minute, 30);
+			});
+
+			it("should parse 12am as midnight (hour 0)", function () {
+				let o = Zotero.Date.strToDate('12am');
+				assert.equal(o.hour, 0);
+			});
+
+			it("should parse 12pm as noon (hour 12)", function () {
+				let o = Zotero.Date.strToDate('12pm');
+				assert.equal(o.hour, 12);
+			});
+
+			it("should parse 12:30am as 00:30", function () {
+				let o = Zotero.Date.strToDate('12:30am');
+				assert.equal(o.hour, 0);
+				assert.equal(o.minute, 30);
+			});
+
+			it("should parse 24-hour time", function () {
+				let o = Zotero.Date.strToDate('14:00');
+				assert.equal(o.hour, 14);
+				assert.equal(o.minute, 0);
+				assert.isUndefined(o.second);
+			});
+
+			it("should parse 24-hour time with seconds", function () {
+				let o = Zotero.Date.strToDate('14:30:45');
+				assert.equal(o.hour, 14);
+				assert.equal(o.minute, 30);
+				assert.equal(o.second, 45);
+			});
+
+			it("should parse midnight in 24-hour format", function () {
+				let o = Zotero.Date.strToDate('00:00');
+				assert.equal(o.hour, 0);
+				assert.equal(o.minute, 0);
+			});
+
+			it("should parse time with a.m./p.m. format", function () {
+				let o = Zotero.Date.strToDate('3:30 p.m.');
+				assert.equal(o.hour, 15);
+				assert.equal(o.minute, 30);
+			});
+
+			it("should parse date with time", function () {
+				let o = Zotero.Date.strToDate('June 26, 2010 2:30pm');
+				assert.equal(o.month, 5);
+				assert.equal(o.day, 26);
+				assert.equal(o.year, 2010);
+				assert.equal(o.hour, 14);
+				assert.equal(o.minute, 30);
+			});
+
+			it("should parse date with 24-hour time", function () {
+				let o = Zotero.Date.strToDate('2010-06-26 14:30');
+				assert.equal(o.year, 2010);
+				assert.equal(o.month, 5);
+				assert.equal(o.day, 26);
+				assert.equal(o.hour, 14);
+				assert.equal(o.minute, 30);
+			});
+
+			it("should not confuse AM/PM time hour with day", function () {
+				let o = Zotero.Date.strToDate('2pm');
+				assert.equal(o.hour, 14);
+				assert.isUndefined(o.day);
+			});
+		});
 	});
 	
 	describe("#isHTTPDate()", function () {

--- a/test/tests/itemPaneTest.js
+++ b/test/tests/itemPaneTest.js
@@ -683,6 +683,36 @@ describe("Item pane", function () {
 			assert.equal(doc.activeElement.parentNode.id, "itembox-field-value-series");
 			assert.equal(doc.activeElement.value, "Series name");
 		});
+
+		it("should parse dates strictly", async function () {
+			let testCases = {
+				'15th May, 2024': '5/15/2024',
+				'15th of May, 2024': '15th of May, 2024',
+				'2013': '2013',
+				'Published 2013': 'Published 2013',
+				'12 AD, January 10': '12 AD, January 10',
+				'Jan 1, 2020': '1/1/2020',
+				'March 11, 076': '3/11/76',
+				'11 March, 1000': '3/11/1000',
+				'2013-12-05 03:30:01': '12/5/2013',
+				'xyz': 'xyz',
+			};
+
+			let itemDetails = ZoteroPane.itemPane._itemDetails;
+			let infoBox = itemDetails.getPane("info");
+
+			let origLocale = Zotero.locale;
+			Zotero.locale = 'en-US';
+
+			for (let [unparsed, parsed] of Object.entries(testCases)) {
+				let item = await createDataObject('item');
+				item.setField('date', unparsed);
+				await item.saveTx();
+				assert.equal(infoBox.querySelectorAll('[fieldname="date"]')[1].value, parsed);
+			}
+
+			Zotero.locale = origLocale;
+		});
 	});
 
 	describe("Libraries and collections pane", function () {

--- a/test/tests/itemTreeTest.js
+++ b/test/tests/itemTreeTest.js
@@ -261,12 +261,12 @@ describe("Zotero.ItemTree", function () {
 			assert.notEqual(itemsView.getCellText(row, 'title'), str);
 		});
 
-		it("should parse dates", async function () {
+		it("should parse dates permissively", async function () {
 			let testCases = {
 				'15th May, 2024': '5/15/2024',
-				'15th of May, 2024': '15th of May, 2024',
+				'15th of May, 2024': '5/15/2024',
 				'2013': '2013',
-				'Published 2013': 'Published 2013',
+				'Published 2013': '2013',
 				'12 AD, January 10': '12 AD, January 10',
 				'Jan 1, 2020': '1/1/2020',
 				'March 11, 076': '3/11/76',

--- a/test/tests/itemTreeTest.js
+++ b/test/tests/itemTreeTest.js
@@ -259,7 +259,34 @@ describe("Zotero.ItemTree", function () {
 			assert.equal(itemsView.getCellText(row, 'title'), str);
 			await modifyDataObject(item);
 			assert.notEqual(itemsView.getCellText(row, 'title'), str);
-		})
+		});
+
+		it("should parse dates", async function () {
+			let testCases = {
+				'15th of May, 2024': '5/15/2024',
+				'2013': '2013',
+				'Published 2013': '2013',
+				'12 AD, January 10': '1/10',
+				'Jan 1, 2020': '1/1/2020',
+				'March 11': '3/11',
+				'11 March': '3/11',
+				'2013-12-05 03:30:01': '12/5/2013',
+				'xyz': 'xyz',
+			};
+			
+			let origLocale = Zotero.locale;
+			Zotero.locale = 'en-US';
+			
+			for (let [unparsed, parsed] of Object.entries(testCases)) {
+				let item = await createDataObject('item');
+				item.setField('date', unparsed);
+				await item.saveTx();
+				let row = itemsView.getRowIndexByID(item.id);
+				assert.equal(itemsView.getCellText(row, 'date'), parsed);
+			}
+			
+			Zotero.locale = origLocale;
+		});
 	})
 	
 	describe.skip("#sort()", function () {

--- a/test/tests/itemTreeTest.js
+++ b/test/tests/itemTreeTest.js
@@ -263,13 +263,14 @@ describe("Zotero.ItemTree", function () {
 
 		it("should parse dates", async function () {
 			let testCases = {
-				'15th of May, 2024': '5/15/2024',
+				'15th May, 2024': '5/15/2024',
+				'15th of May, 2024': '15th of May, 2024',
 				'2013': '2013',
-				'Published 2013': '2013',
-				'12 AD, January 10': '1/10',
+				'Published 2013': 'Published 2013',
+				'12 AD, January 10': '12 AD, January 10',
 				'Jan 1, 2020': '1/1/2020',
-				'March 11': '3/11',
-				'11 March': '3/11',
+				'March 11, 076': '3/11/76',
+				'11 March, 1000': '3/11/1000',
 				'2013-12-05 03:30:01': '12/5/2013',
 				'xyz': 'xyz',
 			};


### PR DESCRIPTION
`strToDate()` and `Intl.DateTimeFormat` can be a little heavy, but this is cached at the row level. We could consider caching at the item level instead if we want to show parsed dates in the Info box like we do for `accessDate`.

If the date fails to parse, it's displayed unchanged.

Fixes #3917