### PR TITLE
Create Bibliography: Fix "Language:" label alignment

### DIFF
--- a/chrome/skin/default/zotero/bibliography.css
+++ b/chrome/skin/default/zotero/bibliography.css
@@ -10,6 +10,7 @@
 
 #locale-box h2 {
 	font-size: 14px;
+	margin-block: 0;
 }
 
 radio:not(:first-child)


### PR DESCRIPTION
Before:
![Screenshot 2024-04-03 at 3 17 47 PM](https://github.com/zotero/zotero/assets/1770299/eb6b829d-d4b6-4d6e-887c-f7259c8d41db)

After:
![Screenshot 2024-04-03 at 3 17 21 PM](https://github.com/zotero/zotero/assets/1770299/24d1f949-2aab-45c6-b681-96df8c206808)
