### PR TITLE
do not trigger event causing autocomplete error

### DIFF
--- a/app/scripts/fetch_xulrunner
+++ b/app/scripts/fetch_xulrunner
@@ -82,7 +82,7 @@ function remove_line {
 		egrep -v "$pattern" "$file" > "$file.tmp"
 		mv "$file.tmp" "$file"
 	else
-		echo "$pattern" not found in "$infile" -- aborting 2>&1
+		echo "$pattern" not found in "$file" -- aborting 2>&1
 		exit 1
 	fi
 }
@@ -163,6 +163,9 @@ function modify_omni {
 	#  
 	# Disable unwanted components
 	remove_line '(RemoteSettings|services-|telemetry|Telemetry|URLDecorationAnnotationsService)' components/components.manifest
+	
+	# Do not trigger LoginManager event that logs an error on autocomplete submission
+	remove_line 'DOMInputPasswordAdded: \{\},' modules/ActorManagerParent.sys.mjs
 	
 	# On Mac/Linux, ignore relative paths in PATH in Subprocess.pathSearch(), used when a bare command is passed to Utilities.Internal.subprocess()
 	if [[ $platform != win* ]]; then


### PR DESCRIPTION
DOMInputPasswordAdded event is triggered on autocomplete submission which causes an error in LoginManager.
The error gets logged in the console, though the autocomplete does work. This just removes the event from ActorManagerParent.

Fixes: #3883