### PR TITLE
Add "Copy Zotero URL" to context menu for selected item

### DIFF
--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -3425,6 +3425,8 @@ var ZoteroPane = new function()
 			'createParent',
 			'renameAttachments',
 			'reindexItem',
+			'sep6',
+			'copyAppUrl',
 		];
 		
 		var m = {};
@@ -3721,6 +3723,9 @@ var ZoteroPane = new function()
 
 						show.add(m.duplicateItem);
 					}
+
+					show.add(m.sep6);
+					show.add(m.copyAppUrl);
 				}
 				
 				// Update attachment submenu
@@ -3846,6 +3851,7 @@ var ZoteroPane = new function()
 		menu.childNodes[m.recognizePDF].setAttribute('label', Zotero.getString('pane.items.menu.recognizeDocument'));
 		menu.childNodes[m.renameAttachments].setAttribute('label', Zotero.getString('pane.items.menu.renameAttachments' + multiple));
 		menu.childNodes[m.reindexItem].setAttribute('label', Zotero.getString('pane.items.menu.reindexItem' + multiple));
+		menu.childNodes[m.copyAppUrl].setAttribute('label', Zotero.getString('pane.items.menu.copyAppUrl'));
 		
 		// Hide and enable all actions by default (so if they're shown they're enabled)
 		for (let i in m) {
@@ -5142,6 +5148,24 @@ var ZoteroPane = new function()
 	};
 	
 	
+	this.copyAppUrlForSelectedItem = function () {
+		const items = ZoteroPane.getSelectedItems();
+
+		if (!items || !items.length) {
+			throw new Error('No items currently selected');
+		}
+
+		if (items.length !== 1) {
+			throw new Error('Unable to copy the URL for more than one item at a time');
+		}
+
+		const selectedItem = items[0];
+		const url = `zotero://select/library/items/${selectedItem.key}`;
+
+		Zotero.Utilities.Internal.copyTextToClipboard(url);
+	};
+
+
 	this.recognizeSelected = function() {
 		Zotero.RecognizeDocument.recognizeItems(ZoteroPane.getSelectedItems());
 		Zotero.ProgressQueues.get('recognize').getDialog().open();

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -985,6 +985,8 @@
 									<menuitem class="menuitem-iconic zotero-menuitem-create-parent" oncommand="ZoteroPane_Local.createParentItemsFromSelected();"/>
 									<menuitem class="menuitem-iconic zotero-menuitem-rename-from-parent" oncommand="ZoteroPane_Local.renameSelectedAttachmentsFromParents()"/>
 									<menuitem class="menuitem-iconic zotero-menuitem-reindex" oncommand="ZoteroPane_Local.reindexItem();"/>
+									<menuseparator/>
+									<menuitem class="menuitem-iconic zotero-menuitem-copy-app-url" oncommand="ZoteroPane.copyAppUrlForSelectedItem();"/>
 								</menupopup>
 								
 							</popupset>

--- a/chrome/locale/af-ZA/zotero/zotero.properties
+++ b/chrome/locale/af-ZA/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=Rename Files from Parent Metadata
 pane.items.menu.duplicateAndConvert.toBookSection=Create Book Section
 pane.items.menu.duplicateAndConvert.toBook=Create Book from Book Section
 pane.items.menu.showInFeed=Show in Feed
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Show Item in Library
 
 pane.items.letter.oneParticipant=Letter to %S

--- a/chrome/locale/ar/zotero/zotero.properties
+++ b/chrome/locale/ar/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=إعادة تسمية الملفات 
 pane.items.menu.duplicateAndConvert.toBookSection=Create Book Section
 pane.items.menu.duplicateAndConvert.toBook=Create Book from Book Section
 pane.items.menu.showInFeed=Show in Feed
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=عرض العنصر في المكتبة
 
 pane.items.letter.oneParticipant=خطاب إلى %S

--- a/chrome/locale/bg-BG/zotero/zotero.properties
+++ b/chrome/locale/bg-BG/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=Преименува файловет
 pane.items.menu.duplicateAndConvert.toBookSection=Create Book Section
 pane.items.menu.duplicateAndConvert.toBook=Create Book from Book Section
 pane.items.menu.showInFeed=Show in Feed
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Show Item in Library
 
 pane.items.letter.oneParticipant=Писмо до %S

--- a/chrome/locale/br/zotero/zotero.properties
+++ b/chrome/locale/br/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=Adenvel ar restroù diwar ar meta-roa
 pane.items.menu.duplicateAndConvert.toBookSection=Create Book Section
 pane.items.menu.duplicateAndConvert.toBook=Create Book from Book Section
 pane.items.menu.showInFeed=Show in Feed
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Diskouez an elfenn el levraoueg
 
 pane.items.letter.oneParticipant=Lizher da %S

--- a/chrome/locale/ca-AD/zotero/zotero.properties
+++ b/chrome/locale/ca-AD/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=Canvia els noms del fitxers amb les m
 pane.items.menu.duplicateAndConvert.toBookSection=Crea una secció de llibre
 pane.items.menu.duplicateAndConvert.toBook=Crea un llibre d'una secció de llibre
 pane.items.menu.showInFeed=Mostra-ho en el canal
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Mostra l'element a la biblioteca
 
 pane.items.letter.oneParticipant=Carta a %S

--- a/chrome/locale/cs-CZ/zotero/zotero.properties
+++ b/chrome/locale/cs-CZ/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=Přejmenovat soubory z rodičovských
 pane.items.menu.duplicateAndConvert.toBookSection=Vytvořit kapitolu knihy
 pane.items.menu.duplicateAndConvert.toBook=Vytvořit knihu z kapitoly 
 pane.items.menu.showInFeed=Show in Feed
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Zobrazit položku v Knihovně.
 
 pane.items.letter.oneParticipant=Dopis pro %S

--- a/chrome/locale/da-DK/zotero/zotero.properties
+++ b/chrome/locale/da-DK/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=Omdøb filer fra moder-metadata
 pane.items.menu.duplicateAndConvert.toBookSection=Create Book Section
 pane.items.menu.duplicateAndConvert.toBook=Create Book from Book Section
 pane.items.menu.showInFeed=Show in Feed
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Vis element i Bibliotek
 
 pane.items.letter.oneParticipant=Brev til %S

--- a/chrome/locale/de/zotero/zotero.properties
+++ b/chrome/locale/de/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=Dateien nach Metadaten des übergeord
 pane.items.menu.duplicateAndConvert.toBookSection=Buchteil erstellen
 pane.items.menu.duplicateAndConvert.toBook=Buch aus Buchteil erstellen
 pane.items.menu.showInFeed=Im Feed anzeigen
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Eintrag in Bibliothek anzeigen
 
 pane.items.letter.oneParticipant=Brief an %S

--- a/chrome/locale/el-GR/zotero/zotero.properties
+++ b/chrome/locale/el-GR/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=Μετονομασία Αρχείων
 pane.items.menu.duplicateAndConvert.toBookSection=Create Book Section
 pane.items.menu.duplicateAndConvert.toBook=Create Book from Book Section
 pane.items.menu.showInFeed=Show in Feed
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Εμφάνιση Στοιχείου στη Βιβλιοθήκη
 
 pane.items.letter.oneParticipant=Επιστολή προς %S

--- a/chrome/locale/en-GB/zotero/zotero.properties
+++ b/chrome/locale/en-GB/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=Rename Files from Parent Metadata
 pane.items.menu.duplicateAndConvert.toBookSection=Create Book Section
 pane.items.menu.duplicateAndConvert.toBook=Create Book from Book Section
 pane.items.menu.showInFeed=Show in Feed
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Show Item in Library
 
 pane.items.letter.oneParticipant=Letter to %S

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -373,6 +373,7 @@ pane.items.menu.renameAttachments.multiple = Rename Files from Parent Metadata
 pane.items.menu.duplicateAndConvert.toBookSection = Create Book Section
 pane.items.menu.duplicateAndConvert.toBook = Create Book from Book Section
 pane.items.menu.showInFeed = Show in Feed
+pane.items.menu.copyAppUrl = Copy Zotero URL
 pane.items.showItemInLibrary = Show Item in Library
 
 pane.items.letter.oneParticipant		= Letter to %S

--- a/chrome/locale/es-ES/zotero/zotero.properties
+++ b/chrome/locale/es-ES/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=Renombrar archivos a partir de los me
 pane.items.menu.duplicateAndConvert.toBookSection=Crear sección de un libro
 pane.items.menu.duplicateAndConvert.toBook=Crear libro desde sección de un libro
 pane.items.menu.showInFeed=Mostrar en canal
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Mostrar elemento en la biblioteca
 
 pane.items.letter.oneParticipant=Carta a %S

--- a/chrome/locale/et-EE/zotero/zotero.properties
+++ b/chrome/locale/et-EE/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=Nimetada failid ülemkirjete metadata
 pane.items.menu.duplicateAndConvert.toBookSection=Create Book Section
 pane.items.menu.duplicateAndConvert.toBook=Create Book from Book Section
 pane.items.menu.showInFeed=Show in Feed
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Show Item in Library
 
 pane.items.letter.oneParticipant=Kiri %S-le

--- a/chrome/locale/eu-ES/zotero/zotero.properties
+++ b/chrome/locale/eu-ES/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=Berrizendatu fitxategiak gurasoen met
 pane.items.menu.duplicateAndConvert.toBookSection=Sortu liburu-atala
 pane.items.menu.duplicateAndConvert.toBook=Sortu liburua liburu-ataletik abiatuta
 pane.items.menu.showInFeed=Erakutsi jarioan
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Erakutsi elementua liburutegian
 
 pane.items.letter.oneParticipant=Gutuna %S-(r)i

--- a/chrome/locale/fa/zotero/zotero.properties
+++ b/chrome/locale/fa/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=تغییر نام پرونده‌ها
 pane.items.menu.duplicateAndConvert.toBookSection=Create Book Section
 pane.items.menu.duplicateAndConvert.toBook=Create Book from Book Section
 pane.items.menu.showInFeed=Show in Feed
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=نمایش آیتم در کتابخانه
 
 pane.items.letter.oneParticipant=نامه به %S

--- a/chrome/locale/fi-FI/zotero/zotero.properties
+++ b/chrome/locale/fi-FI/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=Muuta tiedostojen nimet ylänimikkeen
 pane.items.menu.duplicateAndConvert.toBookSection=Luo kirjan osa
 pane.items.menu.duplicateAndConvert.toBook=Luo kirja kirjan osasta
 pane.items.menu.showInFeed=Näytä syötteessä
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Näytä nimike kirjastossa
 
 pane.items.letter.oneParticipant=Kirje henkilölle %S

--- a/chrome/locale/fr-FR/zotero/zotero.properties
+++ b/chrome/locale/fr-FR/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=Renommer les fichiers à partir des m
 pane.items.menu.duplicateAndConvert.toBookSection=Créer un Chapitre de livre
 pane.items.menu.duplicateAndConvert.toBook=Créer un Livre à partir du Chapitre de livre
 pane.items.menu.showInFeed=Afficher dans le flux
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Afficher le document dans la bibliothèque
 
 pane.items.letter.oneParticipant=Lettre à %S

--- a/chrome/locale/gl-ES/zotero/zotero.properties
+++ b/chrome/locale/gl-ES/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=Cambiar os nomes dos ficheiros dos me
 pane.items.menu.duplicateAndConvert.toBookSection=Crear sección de libro
 pane.items.menu.duplicateAndConvert.toBook=Crear libro desde sección de libro
 pane.items.menu.showInFeed=Mostrar nas fontes
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Mostrar na biblioteca
 
 pane.items.letter.oneParticipant=Carta a %S

--- a/chrome/locale/he-IL/zotero/zotero.properties
+++ b/chrome/locale/he-IL/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=שינוי שמות קבצים מנת
 pane.items.menu.duplicateAndConvert.toBookSection=Create Book Section
 pane.items.menu.duplicateAndConvert.toBook=Create Book from Book Section
 pane.items.menu.showInFeed=Show in Feed
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=הצגת פריט בספרייה
 
 pane.items.letter.oneParticipant=מכתב אל %S

--- a/chrome/locale/hr-HR/zotero/zotero.properties
+++ b/chrome/locale/hr-HR/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=Rename Files from Parent Metadata
 pane.items.menu.duplicateAndConvert.toBookSection=Create Book Section
 pane.items.menu.duplicateAndConvert.toBook=Create Book from Book Section
 pane.items.menu.showInFeed=Show in Feed
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Show Item in Library
 
 pane.items.letter.oneParticipant=Letter to %S

--- a/chrome/locale/hu-HU/zotero/zotero.properties
+++ b/chrome/locale/hu-HU/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=A fájlok átnevezése a szülők met
 pane.items.menu.duplicateAndConvert.toBookSection=Könyvfejezet létrehozása
 pane.items.menu.duplicateAndConvert.toBook=Könyv létrehozása a könyvfejezetből
 pane.items.menu.showInFeed=Show in Feed
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Az elem megjelenítése könyvtárban
 
 pane.items.letter.oneParticipant=Levél (címzett: %S)

--- a/chrome/locale/id-ID/zotero/zotero.properties
+++ b/chrome/locale/id-ID/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=Namai Ulang Berkas-berkas dari Metada
 pane.items.menu.duplicateAndConvert.toBookSection=Create Book Section
 pane.items.menu.duplicateAndConvert.toBook=Create Book from Book Section
 pane.items.menu.showInFeed=Show in Feed
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Show Item in Library
 
 pane.items.letter.oneParticipant=Surat kepada %S

--- a/chrome/locale/is-IS/zotero/zotero.properties
+++ b/chrome/locale/is-IS/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=Endurnefna skrár í samræmi við l�
 pane.items.menu.duplicateAndConvert.toBookSection=Create Book Section
 pane.items.menu.duplicateAndConvert.toBook=Create Book from Book Section
 pane.items.menu.showInFeed=Show in Feed
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Sýna færslu í safni
 
 pane.items.letter.oneParticipant=Bréf til %S

--- a/chrome/locale/it-IT/zotero/zotero.properties
+++ b/chrome/locale/it-IT/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=Rinominare i file in base ai metadati
 pane.items.menu.duplicateAndConvert.toBookSection=Crea una sezione del libro
 pane.items.menu.duplicateAndConvert.toBook=Crea il libro dalla sezione
 pane.items.menu.showInFeed=Mostra nei feed
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Mostra l'elemento nella biblioteca
 
 pane.items.letter.oneParticipant=Lettera a %S

--- a/chrome/locale/ja-JP/zotero/zotero.properties
+++ b/chrome/locale/ja-JP/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=親メータデータからファイ�
 pane.items.menu.duplicateAndConvert.toBookSection=書籍の章を作る
 pane.items.menu.duplicateAndConvert.toBook=書籍の章から書籍を作る
 pane.items.menu.showInFeed=Show in Feed
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=ライブラリの中のアイテムを表示する
 
 pane.items.letter.oneParticipant=%S への手紙

--- a/chrome/locale/km/zotero/zotero.properties
+++ b/chrome/locale/km/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=ប្តូរឈ្មោះឯក�
 pane.items.menu.duplicateAndConvert.toBookSection=Create Book Section
 pane.items.menu.duplicateAndConvert.toBook=Create Book from Book Section
 pane.items.menu.showInFeed=Show in Feed
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Show Item in Library
 
 pane.items.letter.oneParticipant=សំបុត្រទៅកាន់ %S

--- a/chrome/locale/ko-KR/zotero/zotero.properties
+++ b/chrome/locale/ko-KR/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=부모 메타데이터로부터 파�
 pane.items.menu.duplicateAndConvert.toBookSection=Create Book Section
 pane.items.menu.duplicateAndConvert.toBook=Create Book from Book Section
 pane.items.menu.showInFeed=Show in Feed
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=라이브러리의 항목 보기
 
 pane.items.letter.oneParticipant=수신: %S

--- a/chrome/locale/lt-LT/zotero/zotero.properties
+++ b/chrome/locale/lt-LT/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=Failus pervadinti pagal meta duomenis
 pane.items.menu.duplicateAndConvert.toBookSection=Create Book Section
 pane.items.menu.duplicateAndConvert.toBook=Create Book from Book Section
 pane.items.menu.showInFeed=Show in Feed
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Parodyti bibliotekoje
 
 pane.items.letter.oneParticipant=Laiškas, kurį gavo %S

--- a/chrome/locale/mn-MN/zotero/zotero.properties
+++ b/chrome/locale/mn-MN/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=Rename Files from Parent Metadata
 pane.items.menu.duplicateAndConvert.toBookSection=Create Book Section
 pane.items.menu.duplicateAndConvert.toBook=Create Book from Book Section
 pane.items.menu.showInFeed=Show in Feed
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Show Item in Library
 
 pane.items.letter.oneParticipant=Letter to %S

--- a/chrome/locale/nb-NO/zotero/zotero.properties
+++ b/chrome/locale/nb-NO/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=Gi filene nye navn fra overordnede me
 pane.items.menu.duplicateAndConvert.toBookSection=Opprett del av bok
 pane.items.menu.duplicateAndConvert.toBook=Opprett bok fra del av bok
 pane.items.menu.showInFeed=Vis i nyhetsstrøm
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Vis element i bibliotek
 
 pane.items.letter.oneParticipant=Brev til %S

--- a/chrome/locale/nl-NL/zotero/zotero.properties
+++ b/chrome/locale/nl-NL/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=Bestanden hernoemen op basis van besc
 pane.items.menu.duplicateAndConvert.toBookSection=Create Book Section
 pane.items.menu.duplicateAndConvert.toBook=Create Book from Book Section
 pane.items.menu.showInFeed=Toon in feed
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Geef item weer in de bibliotheek
 
 pane.items.letter.oneParticipant=Brief naar %S

--- a/chrome/locale/nn-NO/zotero/zotero.properties
+++ b/chrome/locale/nn-NO/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=Omdøyp filer etter foreldermetadata
 pane.items.menu.duplicateAndConvert.toBookSection=Create Book Section
 pane.items.menu.duplicateAndConvert.toBook=Create Book from Book Section
 pane.items.menu.showInFeed=Show in Feed
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Show Item in Library
 
 pane.items.letter.oneParticipant=Brev til %S

--- a/chrome/locale/pl-PL/zotero/zotero.properties
+++ b/chrome/locale/pl-PL/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=Zmień nazwy plików na podstawie met
 pane.items.menu.duplicateAndConvert.toBookSection=Utwórz rozdział książki
 pane.items.menu.duplicateAndConvert.toBook=Utwórz książkę z rozdziału książki
 pane.items.menu.showInFeed=Pokaż w kanale
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Pokaż elementy w Bibliotece
 
 pane.items.letter.oneParticipant=List do %S

--- a/chrome/locale/pt-BR/zotero/zotero.properties
+++ b/chrome/locale/pt-BR/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=Renomear arquivos a partir dos metada
 pane.items.menu.duplicateAndConvert.toBookSection=Criar seção de livro
 pane.items.menu.duplicateAndConvert.toBook=Criar livro a partir de seção de livro
 pane.items.menu.showInFeed=Mostrar no Feed
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Exibir item na biblioteca
 
 pane.items.letter.oneParticipant=Carta para %S

--- a/chrome/locale/pt-PT/zotero/zotero.properties
+++ b/chrome/locale/pt-PT/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=Dar Novos Nomes aos Arquivos a partir
 pane.items.menu.duplicateAndConvert.toBookSection=Criar seção de livro
 pane.items.menu.duplicateAndConvert.toBook=Criar livro a partir de seção de livro
 pane.items.menu.showInFeed=Mostrar no Feed
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Mostrar Item na Biblioteca
 
 pane.items.letter.oneParticipant=Carta para %S

--- a/chrome/locale/ro-RO/zotero/zotero.properties
+++ b/chrome/locale/ro-RO/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=Redenumește fișiere din metadatele 
 pane.items.menu.duplicateAndConvert.toBookSection=Creează o secțiune de carte
 pane.items.menu.duplicateAndConvert.toBook=Creează o carte dintr-o secțiune de carte
 pane.items.menu.showInFeed=Afișează în flux
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Afișează înregistrarea în Bibliotecă.
 
 pane.items.letter.oneParticipant=Scrisoare către %S

--- a/chrome/locale/ru-RU/zotero/zotero.properties
+++ b/chrome/locale/ru-RU/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=Переименовать файлы
 pane.items.menu.duplicateAndConvert.toBookSection=Создать раздел книги
 pane.items.menu.duplicateAndConvert.toBook=Создать книгу из раздела книги
 pane.items.menu.showInFeed=Показать в новостной ленте
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Показать запись в библиотеке
 
 pane.items.letter.oneParticipant=Письмо %S

--- a/chrome/locale/sk-SK/zotero/zotero.properties
+++ b/chrome/locale/sk-SK/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=Premenovať súbory podľa príslušn
 pane.items.menu.duplicateAndConvert.toBookSection=Vytvoriť časť knihy
 pane.items.menu.duplicateAndConvert.toBook=Vytvoriť knihu z časti knihy
 pane.items.menu.showInFeed=Show in Feed
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Zobraziť záznam v knižnici
 
 pane.items.letter.oneParticipant=List pre %S

--- a/chrome/locale/sl-SI/zotero/zotero.properties
+++ b/chrome/locale/sl-SI/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=Preimenuj datoteke iz starševskih me
 pane.items.menu.duplicateAndConvert.toBookSection=Ustvari razdelek knjige
 pane.items.menu.duplicateAndConvert.toBook=Ustvari knjigo iz razdelka knjige
 pane.items.menu.showInFeed=Pokaži v viru
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Pokaži element v knjižnici
 
 pane.items.letter.oneParticipant=Pismo za %S

--- a/chrome/locale/sr-RS/zotero/zotero.properties
+++ b/chrome/locale/sr-RS/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=Преименуј датотеке �
 pane.items.menu.duplicateAndConvert.toBookSection=Create Book Section
 pane.items.menu.duplicateAndConvert.toBook=Create Book from Book Section
 pane.items.menu.showInFeed=Show in Feed
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Show Item in Library
 
 pane.items.letter.oneParticipant=Писмо за %S

--- a/chrome/locale/sv-SE/zotero/zotero.properties
+++ b/chrome/locale/sv-SE/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=Byt namn på filerna beroende på öv
 pane.items.menu.duplicateAndConvert.toBookSection=Create Book Section
 pane.items.menu.duplicateAndConvert.toBook=Create Book from Book Section
 pane.items.menu.showInFeed=Show in Feed
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Visa källa i bibliotek
 
 pane.items.letter.oneParticipant=Brev till %S

--- a/chrome/locale/ta/zotero/zotero.properties
+++ b/chrome/locale/ta/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=பெற்றோர் மெட்
 pane.items.menu.duplicateAndConvert.toBookSection=புத்தகப் பகுதியை உருவாக்கவும்
 pane.items.menu.duplicateAndConvert.toBook=புத்தகப் பிரிவில் இருந்து புத்தகத்தை உருவாக்கவும்
 pane.items.menu.showInFeed=ஊட்டத்தில் காட்டு
+pane.items.menu.copyAppUrl = Copy Zotero URL
 pane.items.showItemInLibrary=நூலகத்தில் உருப்படியைக் காட்டு
 
 pane.items.letter.oneParticipant=%S கடிதம்

--- a/chrome/locale/th-TH/zotero/zotero.properties
+++ b/chrome/locale/th-TH/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=เปลี่ยนชื่อแ�
 pane.items.menu.duplicateAndConvert.toBookSection=Create Book Section
 pane.items.menu.duplicateAndConvert.toBook=Create Book from Book Section
 pane.items.menu.showInFeed=Show in Feed
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Show Item in Library
 
 pane.items.letter.oneParticipant=จดหมายถึง %S

--- a/chrome/locale/tr-TR/zotero/zotero.properties
+++ b/chrome/locale/tr-TR/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=Ana Üstverilerden Dosyaları Tekrar 
 pane.items.menu.duplicateAndConvert.toBookSection=Kitap Bölümü Yarat
 pane.items.menu.duplicateAndConvert.toBook=Kitap Bölümünden Kitap Yarat
 pane.items.menu.showInFeed=Besleme içinde Göster
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Eseri Kitaplıkta Göster
 
 pane.items.letter.oneParticipant=%S'ye mektup

--- a/chrome/locale/uk-UA/zotero/zotero.properties
+++ b/chrome/locale/uk-UA/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=Перейменувати файли
 pane.items.menu.duplicateAndConvert.toBookSection=Create Book Section
 pane.items.menu.duplicateAndConvert.toBook=Create Book from Book Section
 pane.items.menu.showInFeed=Show in Feed
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Показати документ в бібліотеці
 
 pane.items.letter.oneParticipant=Лист до %S

--- a/chrome/locale/vi-VN/zotero/zotero.properties
+++ b/chrome/locale/vi-VN/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=Rename Files from Parent Metadata
 pane.items.menu.duplicateAndConvert.toBookSection=Create Book Section
 pane.items.menu.duplicateAndConvert.toBook=Create Book from Book Section
 pane.items.menu.showInFeed=Show in Feed
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=Show Item in Library
 
 pane.items.letter.oneParticipant=Thư gửi đến %S

--- a/chrome/locale/zh-CN/zotero/zotero.properties
+++ b/chrome/locale/zh-CN/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=按父级元数据重命名文件
 pane.items.menu.duplicateAndConvert.toBookSection=创建图书章节
 pane.items.menu.duplicateAndConvert.toBook=从章节创建图书
 pane.items.menu.showInFeed=在订阅中显示
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=在文献库中显示条目
 
 pane.items.letter.oneParticipant=函至 %S

--- a/chrome/locale/zh-TW/zotero/zotero.properties
+++ b/chrome/locale/zh-TW/zotero/zotero.properties
@@ -372,6 +372,7 @@ pane.items.menu.renameAttachments.multiple=以上層屬性資料重新命名
 pane.items.menu.duplicateAndConvert.toBookSection=建立圖書段落
 pane.items.menu.duplicateAndConvert.toBook=從圖書段落建立圖書
 pane.items.menu.showInFeed=在新聞來源中顯示
+pane.items.menu.copyAppUrl=Copy Zotero URL
 pane.items.showItemInLibrary=於文獻庫中顯示此項目
 
 pane.items.letter.oneParticipant=寄給 %S 的信件


### PR DESCRIPTION
This pull request adds "Copy Zotero URL" to the context menu when a single item is selected. 

Clicking on "Copy Zotero URL" will copy the Zotero app URL for the item (e.g., `zotero://select/library/items/68X5MRXD`) to the system clipboard.

Here is a screenshot of "Copy Zotero URL," as it appears in the context menu:

<img width="297" alt="Screenshot 2024-04-06 at 02 16 57" src="https://github.com/zotero/zotero/assets/42941/b9ab85ab-b2c5-436a-b8aa-027513dcf8ce">

## Rationale

I often add application URLs to various notes in Obsidian, Scrivener, Calibre, etc. This helps me link notes and research across multiple applications. So, I can be in Obsidian, for example, and click a link, which will take me to a specific paper in Zotero.

Previously, I had to take a round-about approach to construct this URL: I exported to item as a CSV file, opened that, and copied the item key, manually appending it to `zotero://select/library/items/` wherever I wanted to add the link. This was cumbersome.

Since Obsidian and other applications provide "Copy <application> URL" actions in context menus (e.g., see below), I thought it would be a good addition to add the same to Zotero.

<img width="212" alt="Screenshot 2024-04-06 at 03 10 49" src="https://github.com/zotero/zotero/assets/42941/b0087373-a247-4740-9703-285ef0f20657">

For example, clicking the "Copy Obsidian URL" item in the context menu adds a URL similar to the following to the system clipboard:

    obsidian://open?vault=My%20Notes&file=Some%20Notes%2FTest%20Note

Another example comes from Calibre. Here, if I click "Link to show book in calibre," it copies a Calibre app URL to my clipboard:

<img width="374" alt="Screenshot 2024-04-06 at 03 18 57" src="https://github.com/zotero/zotero/assets/42941/ec1f2b18-305d-41b3-9446-2358ff710b6d">

    calibre://show-book/_hex_-43616c69627265/719

Scrivener also provides this functionality, with "Copy Document Link":

<img width="266" alt="Screenshot 2024-04-06 at 03 23 30" src="https://github.com/zotero/zotero/assets/42941/f9e786f6-8f1f-475b-b1db-5b41cf1a8253">

Which produces a URL similar to this:

    x-scrivener-item:///Users/ramsey/Documents/Scrivener/My%20Project.scriv?id=FAC10365-E103-4EBF-812A-068382286037