### PR TITLE
fix attachments row not hiding at the same time as preview

### DIFF
--- a/scss/elements/_attachmentsBox.scss
+++ b/scss/elements/_attachmentsBox.scss
@@ -24,8 +24,7 @@ attachments-box {
 		}
 	}
 
-	&:not([data-use-preview]),
-	& > collapsible-section[empty] {
+	&:not([data-use-preview]) {
 		attachment-preview {
 			visibility: hidden;
 			display: none;
@@ -34,6 +33,11 @@ attachments-box {
 		.togglePreview {
 			@include svgicon-menu('preview-show', 'universal', '16');
 		}
+	}
+
+	& > collapsible-section[empty] > .body {
+		visibility: hidden;
+		display: none;
 	}
 	
 	& > collapsible-section > .body {


### PR DESCRIPTION
## Bug
In the Item Pane, Attachments section, when selected item changes from one with attachment to one without, a minor stutter is observed.This is because there is a slight delay (~20ms) between hiding the attachment preview and the attachment row. 

The attachment preview is hidden first with CSS, then the row elements are removed with JS later. There is enough delay for the browser to paint in between, resulting in a frame where the attachment rows are visible, but not the preview. The rows are removed in consequent paint, which creates visual stutter.

## Description
This PR hides the entire body (both the attachments preview and the rows) at the same time via the CSS rule that used to only hide the preview.

`.togglePreview` is currently not used anywhere (and doesn't seem to have been used at any time), so it doesn't affect anything.