### PR TITLE
minor VPAT accessibility fixes

### DIFF
--- a/chrome/content/zotero/about.xhtml
+++ b/chrome/content/zotero/about.xhtml
@@ -27,7 +27,7 @@
 		</div>
 		<hbox>
 			<label id="version"/>
-			<label id="changelog" class="zotero-text-link" value="&zotero.whatsNew;"/>
+			<label id="changelog" class="zotero-text-link" value="&zotero.whatsNew;" role="link"/>
 		</hbox>
 		<script>
 			var version = Zotero.version;
@@ -85,6 +85,7 @@
 					// Activate text links
 					for (let span of document.getElementById('about-text').getElementsByTagName('span')) {
 						span.className = 'text-link';
+						span.setAttribute('role', 'link');
 						span.onclick = function () {
 							Zotero.launchURL(this.getAttribute('data-href'));
 						};

--- a/chrome/content/zotero/elements/attachmentBox.js
+++ b/chrome/content/zotero/elements/attachmentBox.js
@@ -343,6 +343,7 @@
 						}
 					};
 					urlField.className = 'zotero-text-link keyboard-clickable';
+					urlField.setAttribute('role', 'link');
 				}
 				else {
 					urlField.className = '';

--- a/chrome/content/zotero/elements/textLink.js
+++ b/chrome/content/zotero/elements/textLink.js
@@ -19,6 +19,7 @@
 
 		connectedCallback() {
 			this.classList.add('zotero-text-link');
+			this.setAttribute('role', 'link');
 		}
 
 		get href() {

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -3247,6 +3247,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 				// Activate text links
 				for (let span of div.getElementsByTagName('span')) {
 					if (span.classList.contains('text-link')) {
+						span.setAttribute('role', 'link');
 						if (span.hasAttribute('data-href')) {
 							span.onclick = function () {
 								doc.defaultView.ZoteroPane.loadURI(this.getAttribute('data-href'));

--- a/chrome/content/zotero/preferences/preferences_cite.xhtml
+++ b/chrome/content/zotero/preferences/preferences_cite.xhtml
@@ -34,7 +34,7 @@
 			</hbox>
 			<separator class="thin"/>
 			<hbox id="styleManager-buttons" align="center">
-				<label is="zotero-text-link"
+				<label is="zotero-text-link" role="link"
 						value="&zotero.preferences.export.getAdditionalStyles;" flex="1"
 						onclick="Zotero_Preferences.Cite.openStylesPage(); event.preventDefault()"/>
 				<button disabled="true" id="styleManager-delete" label="-"

--- a/chrome/content/zotero/preferences/preferences_file_renaming.xhtml
+++ b/chrome/content/zotero/preferences/preferences_file_renaming.xhtml
@@ -38,7 +38,7 @@
 	<separator class="thin" />
 	<label data-l10n-id="preferences-file-renaming-format-instructions-more">
 		<label
-			is="zotero-text-link"
+			is="zotero-text-link" role="link"
 			href="https://www.zotero.org/support/file_renaming"
 			data-l10n-name="file-renaming-format-help-link"
 		/>

--- a/chrome/content/zotero/preferences/preferences_sync.xhtml
+++ b/chrome/content/zotero/preferences/preferences_sync.xhtml
@@ -55,11 +55,11 @@
 
                     <vbox style="width:2em"/>
                     <vbox>
-                        <label is="zotero-text-link" value="&zotero.preferences.sync.createAccount;" href="http://zotero.org/user/register"/>
+                        <label is="zotero-text-link" role="link" value="&zotero.preferences.sync.createAccount;" href="http://zotero.org/user/register"/>
                         <separator class="thin"/>
-                        <label is="zotero-text-link" value="&zotero.preferences.sync.lostPassword;" href="http://zotero.org/user/lostpassword"/>
+                        <label is="zotero-text-link" role="link" value="&zotero.preferences.sync.lostPassword;" href="http://zotero.org/user/lostpassword"/>
                         <separator class="thin"/>
-                        <label is="zotero-text-link" value="&zotero.preferences.sync.about;" href="http://www.zotero.org/support/sync"/>
+                        <label is="zotero-text-link" role="link" value="&zotero.preferences.sync.about;" href="http://www.zotero.org/support/sync"/>
                     </vbox>
                 </hbox>
             </groupbox>
@@ -96,7 +96,7 @@
                             native="true"/>
 
                     <box/>
-                    <label is="zotero-text-link" value="&zotero.preferences.sync.about;" href="http://www.zotero.org/support/sync"/>
+                    <label is="zotero-text-link" role="link" value="&zotero.preferences.sync.about;" href="http://www.zotero.org/support/sync"/>
                 </html:div>
 
             </groupbox>
@@ -214,7 +214,7 @@
                 <vbox id="storage-terms">
                     <hbox style="margin-top: .4em; display: block" align="center">
                         <label>&zotero.preferences.sync.fileSyncing.tos1;</label>
-                        <label is="zotero-text-link" href="https://www.zotero.org/support/terms/terms_of_service" value="&zotero.preferences.sync.fileSyncing.tos2;"/>
+                        <label is="zotero-text-link" role="link" href="https://www.zotero.org/support/terms/terms_of_service" value="&zotero.preferences.sync.fileSyncing.tos2;"/>
                         <label>&zotero.preferences.period;</label>
                     </hbox>
                 </vbox>

--- a/chrome/content/zotero/preferences/preferences_sync_reset.xhtml
+++ b/chrome/content/zotero/preferences/preferences_sync_reset.xhtml
@@ -2,7 +2,7 @@
 	<html:h1>&zotero.preferences.sync.reset;</html:h1>
 
 	<!-- This doesn't wrap without an explicit width, for some reason -->
-	<description id="reset-sync-warning" width="45em">&zotero.preferences.sync.reset.warning1;<label style="margin-left: 0; margin-right: 0" is="zotero-text-link" href="http://zotero.org/support/kb/sync_reset_options">&zotero.preferences.sync.reset.warning2;</label>&zotero.preferences.sync.reset.warning3;</description>
+	<description id="reset-sync-warning" width="45em">&zotero.preferences.sync.reset.warning1;<label style="margin-left: 0; margin-right: 0" is="zotero-text-link" role="link" href="http://zotero.org/support/kb/sync_reset_options">&zotero.preferences.sync.reset.warning2;</label>&zotero.preferences.sync.reset.warning3;</description>
 	
 	<div id="sync-reset-form" xmlns="http://www.w3.org/1999/xhtml"
 			xmlns:xul="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">

--- a/chrome/content/zotero/xpcom/progressWindow.js
+++ b/chrome/content/zotero/xpcom/progressWindow.js
@@ -215,6 +215,7 @@ Zotero.ProgressWindow = function(options = {}) {
 				var elem = _progressWindow.document.createXULElement('label');
 				elem.setAttribute('value', part.text);
 				elem.setAttribute('class', 'zotero-text-link');
+				elem.setAttribute('role', 'link');
 				for (var i in part.attributes) {
 					elem.setAttribute(i, part.attributes[i]);
 				}

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -320,6 +320,20 @@ var ZoteroPane = new function()
 			ZoteroPane.hideCollectionSearch();
 			return null;
 		};
+		let focusCollectionTree = () => {
+			// Prevent Enter/Tab pressed before the filtering ran from doing anything
+			if (!ZoteroPane.collectionsView.filterEquals(collectionsSearchField.value)) {
+				return null;
+			}
+			// If the current row passes the filter, make sure it is visible and focus collectionTree
+			if (ZoteroPane.collectionsView.focusedRowMatchesFilter()) {
+				ZoteroPane.collectionsView.ensureRowIsVisible(ZoteroPane.collectionsView.selection.focused);
+				return document.getElementById('collection-tree');
+			}
+			// Otherwise, focus the first row passing the filter
+			ZoteroPane.collectionsView.focusFirstMatchingRow(false);
+			return null;
+		};
 		collectionTreeToolbar.addEventListener("keydown", (event) => {
 			let actionsMap = {
 				'zotero-tb-collection-add': {
@@ -329,22 +343,9 @@ var ZoteroPane = new function()
 					ShiftTab: () => document.getElementById('zotero-tb-sync')
 				},
 				'zotero-collections-search': {
-					Tab: () => document.getElementById('zotero-tb-add'),
+					Tab: focusCollectionTree,
 					ShiftTab: () => document.getElementById('zotero-tb-collection-add'),
-					Enter: () => {
-						// Prevent Enter pressed before the filtering ran from doing anything
-						if (!ZoteroPane.collectionsView.filterEquals(collectionsSearchField.value)) {
-							return null;
-						}
-						// If the current row passes the filter, make sure it is visible and focus collectionTree
-						if (ZoteroPane.collectionsView.focusedRowMatchesFilter()) {
-							ZoteroPane.collectionsView.ensureRowIsVisible(ZoteroPane.collectionsView.selection.focused);
-							return document.getElementById('collection-tree');
-						}
-						// Otherwise, focus the first row passing the filter
-						ZoteroPane.collectionsView.focusFirstMatchingRow(false);
-						return null;
-					},
+					Enter: focusCollectionTree,
 					Escape: clearCollectionSearch
 				},
 			};
@@ -361,8 +362,10 @@ var ZoteroPane = new function()
 						if (collectionsPane.getAttribute("collapsed")) {
 							return document.getElementById('zotero-tb-sync');
 						}
-						document.getElementById('zotero-tb-collections-search').click();
-						return null;
+						if (tagContainer.getAttribute('collapsed') == "true") {
+							return focusCollectionTree();
+						}
+						return document.querySelector("#zotero-tag-selector button");
 					}
 				},
 				'zotero-tb-lookup': {
@@ -389,7 +392,7 @@ var ZoteroPane = new function()
 					ShiftTab: () => {
 						document.getElementById("zotero-tb-search")._searchModePopup.flattenedTreeParentNode.focus();
 					},
-					Tab: () => document.getElementById("collection-tree")
+					Tab: () => document.getElementById('item-tree-main-default')
 				},
 				'zotero-tb-search-dropmarker': {
 					ArrowRight: () => null,
@@ -404,12 +407,12 @@ var ZoteroPane = new function()
 		collectionsTree.addEventListener("keydown", (event) => {
 			let actionsMap = {
 				'collection-tree': {
-					ShiftTab: () => document.getElementById("zotero-tb-search-textbox"),
+					ShiftTab: () => document.getElementById('zotero-tb-collections-search').click(),
 					Tab: () => {
 						if (tagContainer.getAttribute('collapsed') == "true") {
-							return document.getElementById('item-tree-main-default');
+							return document.getElementById('zotero-tb-add');
 						}
-						// If tag selector is collapsed, go to itemTree, otherwise
+						// If tag selector is collapsed, go to "New item" button, otherwise
 						// default to focusing on tag selector
 						return false;
 					},
@@ -422,12 +425,7 @@ var ZoteroPane = new function()
 		itemTree.addEventListener("keydown", (event) => {
 			let actionsMap = {
 				'item-tree-main-default': {
-					ShiftTab: () => {
-						if (tagContainer.getAttribute('collapsed') == "true") {
-							return document.getElementById('collection-tree');
-						}
-						return document.getElementById('zotero-tag-selector').querySelector('button');
-					}
+					ShiftTab: () => document.getElementById('zotero-tb-search-textbox')
 				}
 			};
 			moveFocus(actionsMap, event);
@@ -454,7 +452,7 @@ var ZoteroPane = new function()
 			}
 			// Special treatment for tag selector button because it has no id
 			if (e.target.tagName == "button" && e.key == "Tab" && !e.shiftKey) {
-				document.getElementById('item-tree-main-default').focus();
+				document.getElementById('zotero-tb-add').focus();
 				e.preventDefault();
 				e.stopPropagation();
 			}


### PR DESCRIPTION
This is a work in progress containing smaller VPAT accessibility fixes (such as adding aria-properties or changing the focus order).

Current issues:

- [X]  1 - added `role="link"` to labels and spans acting as links
- [X]  3 - more consistent focus order. On Tab from the end of the itemPane/Context pane, the focus will return to the tab bar so that the focus completes a full loop.
- [ ] 3-adjacent. Shift-tab from the selected tab in tab bar does not properly refocus the last element of contextPane
- [X] 4 - changed focus sequence for collections toolbar -> collections -> tags selector -> itemTree toolbar -> itemTree to better reflect page structure