### PR TITLE
BlockingObserver: Don't block when browserId is 0

### DIFF
--- a/chrome/content/zotero/BlockingObserver.jsm
+++ b/chrome/content/zotero/BlockingObserver.jsm
@@ -51,7 +51,7 @@ class BlockingObserver {
 	}
 
 	register(browser) {
-		let id = Zotero.platformMajorVersion > 102 ? browser.browserId : browser.browsingContext.top.id;
+		let id = browser.browserId;
 		if (id === 0) {
 			throw new Error('BlockingObserver: Browser is not initialized');
 		}
@@ -64,7 +64,7 @@ class BlockingObserver {
 	}
 
 	unregister(browser) {
-		let id = Zotero.platformMajorVersion > 102 ? browser.browserId : browser.browsingContext.top.id;
+		let id = browser.browserId;
 		if (id === 0) {
 			throw new Error('BlockingObserver: Browser is not initialized');
 		}
@@ -87,7 +87,7 @@ class BlockingObserver {
 
 	observe(subject) {
 		let channel = subject.QueryInterface(Ci.nsIHttpChannel);
-		let id = Zotero.platformMajorVersion > 102 ? channel.browserId : channel.topBrowsingContextId;
+		let id = channel.browserId;
 		if (id === 0) {
 			return;
 		}

--- a/chrome/content/zotero/BlockingObserver.jsm
+++ b/chrome/content/zotero/BlockingObserver.jsm
@@ -41,12 +41,6 @@ class BlockingObserver {
 	 * @param {(uri: nsIURI) => boolean} shouldBlock
 	 */
 	constructor({ shouldBlock }) {
-		// TEMP: Disable in CI for now to avoid HTTP request failures
-		// https://github.com/zotero/zotero/issues/3962
-		if (Zotero.automatedTest) {
-			this.shouldBlock = () => false;
-			return;
-		}
 		this.shouldBlock = shouldBlock;
 	}
 

--- a/test/tests/HiddenBrowserTest.js
+++ b/test/tests/HiddenBrowserTest.js
@@ -43,10 +43,6 @@ describe("HiddenBrowser", function() {
 		});
 		
 		it("should prevent a remote request with blockRemoteResources", async function () {
-			// TEMP: Disable in CI for now to avoid HTTP request failures
-			// https://github.com/zotero/zotero/issues/3962
-			if (Zotero.automatedTest) this.skip();
-			
 			let path = OS.Path.join(getTestDataDirectory().path, 'test-hidden.html');
 			let browser = new HiddenBrowser({ blockRemoteResources: true });
 			await browser.load(path);


### PR DESCRIPTION
When a browser isn't initialized (added to the DOM), its `browserId` is 0. When a channel isn't associated with a browser, its `browserId` is also zero. So passing an un-initialized browser to `register()` would block all requests that didn't come from a browser! Now `register()` will throw and `observe()` will ignore `browserId` 0.

(I don't know what conditions were causing an un-initialized browser to be passed to `BlockingObserver`, if that was even the issue at all, but this should help us figure that out.)

Fixes #3962, I hope - will see once CI runs