### PR TITLE
Prevent duplicate main window

### DIFF
--- a/app/assets/commandLineHandler.js
+++ b/app/assets/commandLineHandler.js
@@ -1,5 +1,11 @@
 let { CommandLineOptions, TestOptions } = ChromeUtils.importESModule("chrome://zotero/content/modules/commandLineOptions.mjs");
 
+// Only allow BrowserContentHandler to open a new window if this is the initial launch,
+// meaning our CLH isn't registered yet.
+if (cmdLine.state != Ci.nsICommandLine.STATE_INITIAL_LAUNCH) {
+	cmdLine.preventDefault = true;
+}
+
 // Force debug output to window
 if (cmdLine.handleFlag("ZoteroDebug", false)) {
 	CommandLineOptions.forceDebugLog = 2;

--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -35,6 +35,7 @@ Components.classes["@mozilla.org/net/osfileconstantsservice;1"]
 const { XPCOMUtils } = ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 XPCOMUtils.defineLazyModuleGetters(globalThis, {
 	AsyncShutdown: "resource://gre/modules/AsyncShutdown.jsm",
+	AppConstants: "resource://gre/modules/AppConstants.jsm",
 });
 const { CommandLineOptions } = ChromeUtils.importESModule("chrome://zotero/content/modules/commandLineOptions.mjs");
 Services.scriptloader.loadSubScript("resource://zotero/polyfill.js");
@@ -967,7 +968,6 @@ Services.scriptloader.loadSubScript("resource://zotero/polyfill.js");
 	
 	
 	this.openMainWindow = function () {
-		const { AppConstants } = ChromeUtils.import("resource://gre/modules/AppConstants.jsm");
 		var chromeURI = AppConstants.BROWSER_CHROME_URL;
 		var flags = "chrome,all,dialog=no";
 		var ww = Components.classes['@mozilla.org/embedcomp/window-watcher;1']

--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -967,6 +967,7 @@ Services.scriptloader.loadSubScript("resource://zotero/polyfill.js");
 	
 	
 	this.openMainWindow = function () {
+		const { AppConstants } = ChromeUtils.import("resource://gre/modules/AppConstants.jsm");
 		var chromeURI = AppConstants.BROWSER_CHROME_URL;
 		var flags = "chrome,all,dialog=no";
 		var ww = Components.classes['@mozilla.org/embedcomp/window-watcher;1']


### PR DESCRIPTION
- Set `cmdLine.preventDefault` in all cases. Some internal handler is opening the main window when it's already open. I don't know where that's happening! It's not in `nsDefaultCLH`, because that checks for an existing window. In any case, `preventDefault` prevents it.
- Update `Zotero.openMainWindow()` to work on fx115: Import `AppConstants`, which is no longer available globally in ES modules

Fixes #3964