### PR TITLE
fx115: Fix Scaffold richlistboxes and load dialog sizing

### DIFF
--- a/chrome/content/scaffold/load.js
+++ b/chrome/content/scaffold/load.js
@@ -84,10 +84,6 @@ var Scaffold_Load = new function () {
 				listcell.setAttribute('flex', '1');
 				listcell.append(translator.label);
 				listitem.appendChild(listcell);
-				listcell = document.createXULElement("hbox");
-				listcell.setAttribute('width', '130');
-				listcell.append(translator.creator);
-				listitem.appendChild(listcell);
 
 				listbox.appendChild(listitem);
 			}

--- a/chrome/content/scaffold/load.xhtml
+++ b/chrome/content/scaffold/load.xhtml
@@ -24,24 +24,20 @@
     ***** END LICENSE BLOCK *****
 -->
 <?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
-<?xml-stylesheet href="chrome://scaffold/skin/scaffold.css" type="text/css"?>
+<?xml-stylesheet href="chrome://zotero/skin/scaffold.css" type="text/css"?>
 <?xml-stylesheet href="chrome://zotero/skin/zotero.css" type="text/css"?>
 <?xml-stylesheet href="chrome://zotero-platform/content/zotero.css"?>
 
 <!DOCTYPE window SYSTEM "chrome://scaffold/locale/scaffold.dtd">
 <window
 	xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
-	title="&scaffold.load.title;" width="400" height="330"
+	title="&scaffold.load.title;"
 	onload="Scaffold_Load.onLoad()"
-	class="zotero-dialog">
+	class="zotero-dialog"
+	style="min-width: 500px;">
 <dialog buttons="cancel,accept"
 	id="scaffold-load">
 	<script src="load.js"/>
-	
-	<listheader>
-		<treecol flex="1" label="&scaffold.load.label.label;"/>
-		<treecol width="130" label="&scaffold.load.creator.label;"/>
-	</listheader>
-	<richlistbox id="listbox" class="theme-listbox" flex="1"/>
+	<richlistbox id="listbox" class="theme-listbox"/>
 </dialog>
 </window>

--- a/chrome/content/scaffold/scaffold.js
+++ b/chrome/content/scaffold/scaffold.js
@@ -650,7 +650,7 @@ var Scaffold = new function () {
 			io.translatorProvider = _translatorProvider;
 			io.url = io.rootUrl = _browser.currentURI.spec;
 			window.openDialog("chrome://scaffold/content/load.xhtml",
-				"_blank", "chrome,modal", io);
+				"_blank", "chrome,modal,resizable=no", io);
 			translator = io.dataOut;
 		}
 		else {
@@ -1759,7 +1759,7 @@ var Scaffold = new function () {
 			let hbox = document.createXULElement('hbox');
 			hbox.append(elem);
 			if (flex !== undefined) hbox.setAttribute('flex', flex);
-			if (width !== undefined) hbox.setAttribute('width', width);
+			if (width !== undefined) hbox.style.width = width + 'px';
 			return hbox;
 		}
 
@@ -1783,7 +1783,7 @@ var Scaffold = new function () {
 		let oldStatuses = {};
 		for (let i = 0; i < count; i++) {
 			let item = listBox.getItemAtIndex(i);
-			let [, statusCell] = item.firstElementChild.children;
+			let [, statusCell] = item.children;
 			oldStatuses[item.dataset.testString] = statusCell.getAttribute('value');
 		}
 
@@ -1798,24 +1798,18 @@ var Scaffold = new function () {
 
 			item.innerHTML = ''; // clear children/content if reusing
 
-			let hbox = document.createXULElement('hbox');
-			hbox.setAttribute('flex', 1);
-			hbox.setAttribute('align', 'center');
-
 			let input = document.createXULElement('label');
-			input.value = getTestLabel(test);
-			hbox.appendChild(wrapWithHBox(input, { flex: 1 }));
+			input.append(getTestLabel(test));
+			item.appendChild(wrapWithHBox(input, { flex: 1 }));
 
 			let status = document.createXULElement('label');
-			status.value = oldStatuses[testString] || 'Not run';
-			hbox.appendChild(wrapWithHBox(status, { width: 150 }));
+			status.append(oldStatuses[testString] || 'Not run');
+			item.appendChild(wrapWithHBox(status, { width: 150 }));
 
 			let defer = document.createXULElement('checkbox');
 			defer.checked = test.defer;
 			defer.disabled = true;
-			hbox.appendChild(wrapWithHBox(defer, { width: 30 }));
-
-			item.appendChild(hbox);
+			item.appendChild(wrapWithHBox(defer, { width: 30 }));
 
 			item.dataset.testString = testString;
 			item.dataset.testType = test.type;

--- a/chrome/locale/en-US/scaffold/scaffold.dtd
+++ b/chrome/locale/en-US/scaffold/scaffold.dtd
@@ -61,8 +61,6 @@
 <!ENTITY scaffold.metadata.priority.default				"100">
 
 <!ENTITY scaffold.load.title							"Open Translator">
-<!ENTITY scaffold.load.label.label						"Label">
-<!ENTITY scaffold.load.creator.label					"Creator">
 
 <!ENTITY scaffold.editor.external.label					"Use external editor">
 

--- a/scss/scaffold.scss
+++ b/scss/scaffold.scss
@@ -101,7 +101,15 @@ tab {
 }
 
 richlistbox {
-	min-width:200px;
+	min-width: 200px;
+
+	richlistitem {
+		align-items: center;
+
+		> hbox {
+			display: block;
+		}
+	}
 }
 
 #zotero-toolbar toolbarseparator {
@@ -156,5 +164,11 @@ vbox > splitter {
 		background: var(--material-background);
 		outline: none;
 		border: 0;
+	}
+}
+
+#scaffold-load {
+	#listbox {
+		height: 300px;
 	}
 }


### PR DESCRIPTION
And remove Creator column from the load dialog - it was of questionable value when opening a translator, caused weird fx115 layout issues, and takes up space that's better used for displaying translator labels.

https://forums.zotero.org/discussion/113602/zotero-7b72-translator-editor-scaffold-broken