### PR TITLE
vpat 7,14: popups count and cursor fixes

### DIFF
--- a/chrome/content/zotero/customElements.js
+++ b/chrome/content/zotero/customElements.js
@@ -176,22 +176,15 @@ Services.scriptloader.loadSubScript('chrome://zotero/content/elements/itemPaneSe
 				this.addEventListener("popupshowing", clearSeparatorAriaSemantics);
 
 				// If a menu closes with voiceover cursor in it, the cursor gets stuck in no-longer-visible
-				// menu and voiceover will be quiet until it is restarted. As a workaround, remove the menu
-				// from DOM to force voiceover to move its cursor and insert it back after a small delay;
+				// menu and voiceover will be quiet until it is restarted. Marking the menu
+				// as aria-hidden for a moment forces voiceover to shift its cursor.
 				this.addEventListener("popuphidden", (e) => {
 					if (this !== e.target || this.parentNode?.closest("menupopup")) {
 						return;
 					}
-					let parent = this.parentNode;
-					let sibling = this.nextSibling;
-					this.remove();
+					this.setAttribute("aria-hidden", true);
 					setTimeout(() => {
-						if (sibling) {
-							parent.insertBefore(this, sibling);
-						}
-						else {
-							parent.appendChild(this);
-						}
+						this.removeAttribute("aria-hidden");
 					});
 				});
 

--- a/chrome/content/zotero/customElements.js
+++ b/chrome/content/zotero/customElements.js
@@ -98,6 +98,15 @@ Services.scriptloader.loadSubScript('chrome://zotero/content/elements/itemPaneSe
 		});
 	}
 
+	// Clear whatever aria semantics the separator has so it is not counted when
+	// screen readers list how many menuitems a menu has.
+	document.addEventListener("popupshowing", (event) => {
+		if (event.originalTarget.tagName !== "menupopup") return;
+		for (let separator of [...event.originalTarget.querySelectorAll("menuseparator")]) {
+			separator.setAttribute("role", "presentation");
+		}
+	});
+
 	// Add MacOS menupopup fade animation to menupopups
 	if (Zotero.isMac) {
 		let MozMenuPopupPrototype = customElements.get("menupopup").prototype;
@@ -113,15 +122,6 @@ Services.scriptloader.loadSubScript('chrome://zotero/content/elements/itemPaneSe
 					":scope > menuitem:not([hidden]):is([type=checkbox],[type=radio])"
 				);
 				this.toggleAttribute("needsgutter", haveCheckableChild);
-
-				// Clear whatever aria semantics the separator has so it is not counted when
-				// voiceover lists how many menuitems a menu has.
-				let clearSeparatorAriaSemantics = () => {
-					for (let separator of [...this.querySelectorAll("menuseparator")]) {
-						separator.setAttribute("role", "presentation");
-					}
-				};
-				clearSeparatorAriaSemantics();
 
 				/**
 				 * Add fade animation to the popup
@@ -172,8 +172,6 @@ Services.scriptloader.loadSubScript('chrome://zotero/content/elements/itemPaneSe
 						this.hidePopup();
 					}, 200);
 				});
-
-				this.addEventListener("popupshowing", clearSeparatorAriaSemantics);
 
 				// If a menu closes with voiceover cursor in it, the cursor gets stuck in no-longer-visible
 				// menu and voiceover will be quiet until it is restarted. Marking the menu


### PR DESCRIPTION
- vpat_7: when a popup is showing, mark menuseparators with role="presentation" to clear whatever semantics a separator has. It prevents the screen readers from counting it as an interactable element while announcing the index of a menuitem within the popup. It also makes the screen readers count items across all sections, instead of stopping at the first separator.
- vpat_14: when the popup is hiding, delete the popup and immediately re-insert it into the DOM. It forces voiceover to move cursor back to the focused element. Otherwise, it is not aware that the popup went away, the cursor gets stuck on the invisible element, and if it happens, no elements will be announced until the screen readers is reloaded.