### PR TITLE
fix to focus test breakage in zoteroPaneTest

### DIFF
--- a/chrome/content/zotero/components/search.jsx
+++ b/chrome/content/zotero/components/search.jsx
@@ -92,6 +92,7 @@ class Search extends React.PureComponent {
 					onChange={this.handleChange}
 					onKeyDown={this.handleKeyDown}
 					value={this.state.immediateValue}
+					className="search-input"
 					{...pick(this.props, p => p.startsWith('data-') || p.startsWith('aria-'))}
 				/>
 				{this.state.immediateValue !== ''

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -414,7 +414,7 @@ var ZoteroPane = new function()
 						}
 						// If tag selector is collapsed, go to "New item" button, otherwise
 						// default to focusing on tag selector
-						return false;
+						return tagContainer.querySelector(".tag-selector-list");
 					},
 					Escape: clearCollectionSearch
 				}
@@ -432,30 +432,37 @@ var ZoteroPane = new function()
 		});
 
 		tagSelector.addEventListener("keydown", (e) => {
-			// Tab from the scrollable tag list or Shift-Tab from the input field focuses the first
-			// non-disabled tag. If there are none, the tags are skipped
-			if ((e.target.classList.contains("tag-selector-list") && e.key == "Tab" && !e.shiftKey)
-				|| e.target.tagName == "input" && e.key == "Tab" && e.shiftKey) {
-				let firstNonDisabledTag = document.querySelector('.tag-selector-item:not(.disabled)');
-				if (firstNonDisabledTag) {
-					firstNonDisabledTag.focus();
+			let actionsMap = {
+				'search-input': {
+					Tab: () => tagSelector.querySelector('.tag-selector-actions'),
+					ShiftTab: () => {
+						let firstNonDisabledTag = tagSelector.querySelector('.tag-selector-item:not(.disabled)');
+						if (firstNonDisabledTag) {
+							return firstNonDisabledTag;
+						}
+						return document.getElementById("collection-tree");
+					},
+				},
+				'tag-selector-item': {
+					Tab: () => tagSelector.querySelector(".search-input"),
+					ShiftTab: () => tagSelector.querySelector(".tag-selector-list"),
+				},
+				'tag-selector-actions': {
+					Tab: () => document.getElementById('zotero-tb-add'),
+					ShiftTab: () => tagSelector.querySelector(".search-input")
+				},
+				'tag-selector-list': {
+					Tab: () => {
+						let firstNonDisabledTag = tagSelector.querySelector('.tag-selector-item:not(.disabled)');
+						if (firstNonDisabledTag) {
+							return firstNonDisabledTag;
+						}
+						return tagSelector.querySelector(".search-input");
+					},
+					ShiftTab: () => document.getElementById("collection-tree"),
 				}
-				else if (e.target.classList.contains("tag-selector-list")) {
-					tagSelector.querySelector("input").focus();
-				}
-				else {
-					tagSelector.querySelector(".tag-selector-list").focus();
-				}
-				
-				e.preventDefault();
-				e.stopPropagation();
-			}
-			// Special treatment for tag selector button because it has no id
-			if (e.target.tagName == "button" && e.key == "Tab" && !e.shiftKey) {
-				document.getElementById('zotero-tb-add').focus();
-				e.preventDefault();
-				e.stopPropagation();
-			}
+			};
+			moveFocus(actionsMap, e);
 		});
 	}
 


### PR DESCRIPTION
- edits to zoteroPaneTest.js focus tests to expect the updated focus sequence: selected tab -> tabs menu -> sync button -> collectionTree toolbar -> collectionTree -> tags selector -> itemTree toolbar
- updated tags selector keydown handling to explicitly handle all tab/shift-tab events using moveFocus. It is more readable and explicit focus handling for all components is required for programmic tab/shiftTab events dispatched in tests to actually move focus

Fixes: https://github.com/zotero/zotero/issues/3975