### PR TITLE
Retrive webdav props via PROPFIND only.

### DIFF
--- a/chrome/content/zotero/xpcom/storage/webdav.js
+++ b/chrome/content/zotero/xpcom/storage/webdav.js
@@ -618,32 +618,6 @@ Zotero.Sync.Storage.Mode.WebDAV.prototype = {
 			}
 		}
 		
-		// Test whether URL is WebDAV-enabled
-		var req = yield Zotero.HTTP.request(
-			"OPTIONS",
-			uri,
-			{
-				successCodes: [200, 204, 404],
-				requestObserver: function (req) {
-					if (req.channel) {
-						channel = req.channel;
-					}
-					if (options.onRequest) {
-						options.onRequest(req);
-					}
-				},
-				errorDelayMax: 0,
-				debug: true
-			}
-		);
-		
-		Zotero.debug(req.getAllResponseHeaders());
-		
-		var dav = req.getResponseHeader("DAV");
-		if (dav == null) {
-			throw new this.VerificationError("NOT_DAV", uri);
-		}
-		
 		var headers = { Depth: 0 };
 		var contentTypeXML = { "Content-Type": "text/xml; charset=utf-8" };
 		
@@ -663,6 +637,13 @@ Zotero.Sync.Storage.Mode.WebDAV.prototype = {
 			errorDelayMax: 0,
 			debug: true
 		});
+		
+		Zotero.debug(req.getAllResponseHeaders());
+		
+		var dav = req.getResponseHeader("DAV");
+		if (dav == null) {
+			throw new this.VerificationError("NOT_DAV", uri);
+		}
 		
 		if (req.status == 207) {
 			// Test if missing files return 404s


### PR DESCRIPTION
HTTP OPTIONS has been used to [CORS preflight](https://maddevs.io/blog/web-security-an-overview-of-sop-cors-and-csrf/#preflight-requests) frequently, so the response header only include ACL related fields, no DAV field.

According to [webdav protocal](https://en.wikipedia.org/wiki/WebDAV#/media/File:WebDAV_collaborative_authoring.png) seems use PROPFIND to get DAV properties is enough.

For example, when i have a webdav server behind nginx-ingress and have `cors` enabled, the `nginx.conf` will contains such settings:
```
                        if ($request_method = 'OPTIONS') {
                                set $cors ${cors}options;
                        }
                        
                        if ($cors = "true") {
                                more_set_headers 'Access-Control-Allow-Origin: $http_origin';
                                more_set_headers 'Access-Control-Allow-Credentials: true'; 
                                more_set_headers 'Access-Control-Allow-Methods: GET, PUT, POST, DELETE, PATCH, OPTIONS';
                                more_set_headers 'Access-Control-Allow-Headers: X-Forwarded-For';
                                
                                more_set_headers 'Access-Control-Max-Age: 1728000';
                        }
                        
                        if ($cors = "trueoptions") {
                                more_set_headers 'Access-Control-Allow-Origin: $http_origin';
                                more_set_headers 'Access-Control-Allow-Credentials: true'; 
                                more_set_headers 'Access-Control-Allow-Methods: GET, PUT, POST, DELETE, PATCH, OPTIONS';
                                more_set_headers 'Access-Control-Allow-Headers: X-Forwarded-For';
                                
                                more_set_headers 'Access-Control-Max-Age: 1728000';
                                more_set_headers 'Content-Type: text/plain charset=UTF-8';
                                more_set_headers 'Content-Length: 0';
                                return 204;
                        }
```
So http options will be captured and always response with only ACL headers.