### PR TITLE
tag selector focus edits, fix windowing breakage

### DIFF
--- a/chrome/content/zotero/components/tagSelector/tagSelectorList.jsx
+++ b/chrome/content/zotero/components/tagSelector/tagSelectorList.jsx
@@ -293,17 +293,16 @@ class TagList extends React.PureComponent {
 		}
 	};
 
-	handleKeyDown(e) {
+	async handleKeyDown(e) {
 		if (!["ArrowRight", "ArrowLeft"].includes(e.key)) return;
 		// If the windowing kicks in, the node of the initially-focused tag may not
 		// exist, so first we may need to scroll to it.
 		if (!document.activeElement.classList.contains("tag-selector-item")) {
-			this.setState({ scrollToCell: this.focusedTagIndex }, async () => {
-				// Even though the state was updated, the tags are not rendered yet.
-				// So we have to wait for handleSectionRendered to run before proceeding.
-				await this.waitForSectionRender();
-				this.shiftFocus(e);
-			});
+			this.setState({ scrollToCell: this.focusedTagIndex });
+			// Even after the <Collection> re-renders, the new tag nodes may not be rendered yet.
+			// So we have to wait for handleSectionRendered to run before proceeding.
+			await this.waitForSectionRender();
+			this.shiftFocus(e);
 			return;
 		}
 		this.shiftFocus(e);

--- a/chrome/content/zotero/components/tagSelector/tagSelectorList.jsx
+++ b/chrome/content/zotero/components/tagSelector/tagSelectorList.jsx
@@ -47,6 +47,7 @@ class TagList extends React.PureComponent {
 		this.scrollToTopOnNextUpdate = false;
 		this.prevTagCount = 0;
 		this.focusedTagIndex = null;
+		this.lastFocusedTagIndex = null;
 		this.keypressToHandleOnNextUpdate = null;
 		this.state = {
 			scrollToCell: null
@@ -186,6 +187,7 @@ class TagList extends React.PureComponent {
 			onDragExit,
 			onDrop,
 			onFocus: (_) => {
+				this.lastFocusedTagIndex = this.focusedTagIndex;
 				this.focusedTagIndex = index;
 			}
 		};
@@ -245,8 +247,13 @@ class TagList extends React.PureComponent {
 		// <Collection> sets role="grid" which is not semantically correct
 		tagsList.setAttribute("role", "group");
 
-		this.setState({ scrollToCell: undefined });
 		if (this.focusedTagIndex === null) return;
+		// If the focused tag does not changed, the scrollToCell won't change
+		// either, so the <Collection> won't scroll to the desired tag if we don't reset it.
+		// E.g. second arrowLeft keypress when first tag is focused won't scroll to it.
+		if (this.lastFocusedTagIndex === this.focusedTagIndex) {
+			this.setState({ scrollToCell: null });
+		}
 		// Check if the tag that is supposed to be focused is within the rendered tags range.
 		// If it is, make sure it is focused. If it is not - focus the tags list.
 		if (indices.includes(this.focusedTagIndex)) {
@@ -271,6 +278,7 @@ class TagList extends React.PureComponent {
 		let tagsList = document.querySelector('.tag-selector-list');
 		if (!tagsList.contains(event.relatedTarget)) {
 			this.focusedTagIndex = null;
+			this.lastFocusedTagIndex = null;
 		}
 	};
 

--- a/chrome/content/zotero/components/tagSelector/tagSelectorList.jsx
+++ b/chrome/content/zotero/components/tagSelector/tagSelectorList.jsx
@@ -224,24 +224,6 @@ class TagList extends React.PureComponent {
 		);
 	};
 
-	shiftFocus(e) {
-		if (!document.activeElement.classList.contains("tag-selector-item")) return;
-		if (!["ArrowRight", "ArrowLeft"].includes(e.key)) return;
-		// Handle arrow navigation
-		let nextTag = (node) => {
-			if (e.key == "ArrowRight") return node.nextElementSibling;
-			return node.previousElementSibling;
-		};
-		let nextOne = nextTag(document.activeElement);
-		// Skip disabled tags
-		while (nextOne && nextOne.classList.contains("disabled")) {
-			nextOne = nextTag(nextOne);
-		}
-		if (nextOne) {
-			nextOne.focus();
-		}
-	}
-
 	// Try to refocus a focused tag that was removed due to windowing
 	refocusTag() {
 		let tagsList = document.querySelector('.tag-selector-list');
@@ -302,10 +284,22 @@ class TagList extends React.PureComponent {
 			// Even after the <Collection> re-renders, the new tag nodes may not be rendered yet.
 			// So we have to wait for handleSectionRendered to run before proceeding.
 			await this.waitForSectionRender();
-			this.shiftFocus(e);
-			return;
 		}
-		this.shiftFocus(e);
+		// Sanity check to make sure that now a tag node is focused
+		if (!document.activeElement.classList.contains("tag-selector-item")) return;
+		// Handle arrow navigation
+		let nextTag = (node) => {
+			if (e.key == "ArrowRight") return node.nextElementSibling;
+			return node.previousElementSibling;
+		};
+		let nextOne = nextTag(document.activeElement);
+		// Skip disabled tags
+		while (nextOne && nextOne.classList.contains("disabled")) {
+			nextOne = nextTag(nextOne);
+		}
+		if (nextOne) {
+			nextOne.focus();
+		}
 	}
 	
 	render() {

--- a/chrome/content/zotero/containers/tagSelectorContainer.jsx
+++ b/chrome/content/zotero/containers/tagSelectorContainer.jsx
@@ -580,34 +580,6 @@ Zotero.TagSelector = class TagSelectorContainer extends React.PureComponent {
 		}
 	}
 
-	handleKeyDown = (e) => {
-		if (["ArrowRight", "ArrowLeft"].includes(e.key)) {
-			let nextTag = (node) => {
-				if (e.key == "ArrowRight") return node.nextElementSibling;
-				return node.previousElementSibling;
-			};
-			let nextOne = nextTag(e.target);
-			// Skip disabled tags
-			while (nextOne && nextOne.classList.contains("disabled")) {
-				nextOne = nextTag(nextOne);
-			}
-			if (nextOne) {
-				nextOne.focus();
-			}
-		}
-		else if (e.key == "Tab" && !e.shiftKey) {
-			this.focusTextbox();
-			e.preventDefault();
-		}
-		else if (e.key == "Tab" && e.shiftKey) {
-			document.querySelector('.tag-selector-list').focus();
-			e.preventDefault();
-		}
-		if ([" ", "Enter"].includes(e.key)) {
-			e.target.click();
-		}
-	}
-
 	handleSearch = (searchString) => {
 		this.setState({searchString});
 	}

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -412,9 +412,12 @@ var ZoteroPane = new function()
 						if (tagContainer.getAttribute('collapsed') == "true") {
 							return document.getElementById('zotero-tb-add');
 						}
-						// If tag selector is collapsed, go to "New item" button, otherwise
-						// default to focusing on tag selector
-						return tagContainer.querySelector(".tag-selector-list");
+						// If tag selector is collapsed, go to "New item" button, otherwise focus tag selector
+						let firstNonDisabledTag = tagSelector.querySelector('.tag-selector-item:not(.disabled)');
+						if (firstNonDisabledTag) {
+							return firstNonDisabledTag;
+						}
+						return tagSelector.querySelector(".search-input");
 					},
 					Escape: clearCollectionSearch
 				}
@@ -445,20 +448,14 @@ var ZoteroPane = new function()
 				},
 				'tag-selector-item': {
 					Tab: () => tagSelector.querySelector(".search-input"),
-					ShiftTab: () => tagSelector.querySelector(".tag-selector-list"),
+					ShiftTab: () => document.getElementById("collection-tree"),
 				},
 				'tag-selector-actions': {
 					Tab: () => document.getElementById('zotero-tb-add'),
 					ShiftTab: () => tagSelector.querySelector(".search-input")
 				},
 				'tag-selector-list': {
-					Tab: () => {
-						let firstNonDisabledTag = tagSelector.querySelector('.tag-selector-item:not(.disabled)');
-						if (firstNonDisabledTag) {
-							return firstNonDisabledTag;
-						}
-						return tagSelector.querySelector(".search-input");
-					},
+					Tab: () => tagSelector.querySelector(".search-input"),
 					ShiftTab: () => document.getElementById("collection-tree"),
 				}
 			};

--- a/test/tests/zoteroPaneTest.js
+++ b/test/tests/zoteroPaneTest.js
@@ -1534,7 +1534,6 @@ describe("ZoteroPane", function() {
 			"tag-selector-actions",
 			"search-input",
 			"tag-selector-item",
-			"tag-selector-list",
 			"collection-tree",
 			"zotero-collections-search",
 			"zotero-tb-collection-add",


### PR DESCRIPTION
- no tabstop on the tag selector scrollable area
- change tag selector's role from default "grid" to "group". "grid" is not quite correct semantically and leads to voiceover suggesting irrelevant commands.
- move all keyboard handling logic to tagSelectorList.jsx. Tabbing through tag selector is now handled in ZoteroPane, so the only logic left there is arrow navigation
between tags, and there's no reason to not have it together with the tags list.
- a workaround to deal with focused tags when windowing kicks in. When a tag is focused, record its index. Each time tags are re-rendered, if the saved index is not among rendered tags, refocus it, otherwise, move focus to the tags list. So if the tag is focused, you scroll away and then back, the tag will get re-focused and it will look like it never left. In arrowUp/Down handler, if the desired tag does not exist, keep scrolling
until the tag is found and focused before handling the navigation

Fixes: #3974
Also fixes the windowing breakage brought up in https://github.com/zotero/zotero/pull/3977#issuecomment-2053562097