### PR TITLE
vpat 19: aria labels to tags and collection filter

### DIFF
--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -1170,6 +1170,7 @@ var ZoteroPane = new function()
 	this.initCollectionTreeSearch = function () {
 		let collectionSearchField = document.getElementById("zotero-collections-search");
 		let collectionSearchButton = document.getElementById("zotero-tb-collections-search");
+		collectionSearchField.inputField.setAttribute("aria-label", collectionSearchField.placeholder);
 		collectionSearchField.style.visibility = 'hidden';
 		collectionSearchField.addEventListener("blur", ZoteroPane.hideCollectionSearch);
 		collectionSearchButton.addEventListener("click", (_) => {

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -57,6 +57,7 @@ zotero-collections-search-btn =
     .tooltiptext = { filter-collections }
 zotero-tabs-menu-filter =
     .placeholder = Search Tabs
+    .aria-label = Search Tabs
 zotero-tabs-menu-close-button =
     .title = Close Tab
 
@@ -433,9 +434,11 @@ abstract-field =
 
 tagselector-search =
     .placeholder = Filter Tags
+    .aria-label = Filter Tags
 
 context-notes-search =
     .placeholder = Search Notes
+    .aria-label = Search Notes
 
 new-collection-dialog =
     .title = New Collection


### PR DESCRIPTION
The filters only have a placeholder, so once there is some text, it goes away and nothing else gets announced, so we need a label. However, the note from the VPAT review indicates that the label needs to be VISIBLE per 3.3.2 success criteria: https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.

This is something worth discussing, since 3.3.2 seems mainly concerned with inputs for form fields, while these are search fields which is somewhat different. So I am not sure if the visibility requirement necessarily applies here. After all, https://www.w3.org/WAI/ that lists the accessibility criteria has a search field with the label not being visible ...