### PR TITLE
vpat 22: added aria-disabled to read only inputs

### DIFF
--- a/chrome/content/zotero/elements/editableText.js
+++ b/chrome/content/zotero/elements/editableText.js
@@ -218,6 +218,11 @@
 				}
 			}
 			this._input.readOnly = this.readOnly;
+			// Voiceover does not announce text as readonly. aria-readonly gets ignored as well.
+			// aria-disabled is the only found working property - it announced the text as "dimmed"
+			if (Zotero.isMac) {
+				this._input.setAttribute("aria-disabled", this.readOnly);
+			}
 			this._input.placeholder = this.placeholder;
 
 			if (this._input.tagName == "textarea") {


### PR DESCRIPTION
Read-only editable text does not get announced as "readonly" by voiceover and, per VPAT review, on JAWS and NVDA too (can't reproduce that one). Setting aria-disabled is the only found property that voiceover does not ignore (e.g. aria-readonly is not announced either), and it announces text as "dimmed"