### PR TITLE
vpat 5: do not include separator in qf list count

### DIFF
--- a/chrome/content/zotero/integration/quickFormat.js
+++ b/chrome/content/zotero/integration/quickFormat.js
@@ -1007,6 +1007,8 @@ var Zotero_QuickFormat = new function () {
 		var rll = document.createXULElement("richlistitem");
 		rll.setAttribute("orient", "vertical");
 		rll.setAttribute("disabled", true);
+		// This ensures that screen readers don't include it while announcing elements' count
+		rll.setAttribute("role", "presentation");
 		rll.setAttribute("class", loading ? "citation-dialog loading" : "citation-dialog separator");
 		rll.appendChild(titleNode);
 		rll.addEventListener("mousedown", _ignoreClick, true);


### PR DESCRIPTION
Screen readers announce the index of the selected item from the list of citations in the panel. This removes the separators from the count, since they are not focusable and should be skipped.