### PR TITLE
Fixes for restoring of persisted attributes

### DIFF
--- a/chrome/content/zotero/elements/itemPane.js
+++ b/chrome/content/zotero/elements/itemPane.js
@@ -27,7 +27,7 @@
 {
 	class ItemPane extends XULElementBase {
 		content = MozXULElement.parseXULToFragment(`
-			<deck id="zotero-item-pane-content" class="zotero-item-pane-content" selectedIndex="0" flex="1" zotero-persist="width height" height="300">
+			<deck id="zotero-item-pane-content" class="zotero-item-pane-content" selectedIndex="0" flex="1">
 				<item-message-pane id="zotero-item-message" />
 				
 				<item-details id="zotero-item-details" />

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -6040,6 +6040,8 @@ var ZoteroPane = new function()
 				continue;
 			}
 			
+			let allowedAttributes = (el.getAttribute('zotero-persist') || '').split(/[\s,]+/);
+			
 			var elValues = serializedValues[id];
 			for (var attr in elValues) {
 				// Ignore persisted collapsed state for collection and item pane splitters, since
@@ -6048,6 +6050,11 @@ var ZoteroPane = new function()
 				if ((el.id == 'zotero-collections-splitter' || el.id == 'zotero-items-splitter')
 						&& attr == 'state'
 						&& Zotero.Prefs.get('reopenPanesOnRestart')) {
+					continue;
+				}
+				// Ignore attributes that are no longer persisted for the element
+				if (!allowedAttributes.includes(attr)) {
+					Zotero.debug(`Not restoring '${attr}' for #${id}`);
 					continue;
 				}
 				if (["width", "height"].includes(attr)) {

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -6030,7 +6030,7 @@ var ZoteroPane = new function()
 	this.unserializePersist = function () {
 		_unserialized = true;
 		var serializedValues = Zotero.Prefs.get("pane.persist");
-		if(!serializedValues) return;
+		if (!serializedValues) return;
 		serializedValues = JSON.parse(serializedValues);
 		
 		for (var id in serializedValues) {
@@ -6041,7 +6041,7 @@ var ZoteroPane = new function()
 			}
 			
 			var elValues = serializedValues[id];
-			for(var attr in elValues) {
+			for (var attr in elValues) {
 				// Ignore persisted collapsed state for collection and item pane splitters, since
 				// people close them by accident and don't know how to get them back
 				// TODO: Add a hidden pref to allow them to stay closed if people really want that?
@@ -6049,6 +6049,9 @@ var ZoteroPane = new function()
 						&& attr == 'state'
 						&& Zotero.Prefs.get('reopenPanesOnRestart')) {
 					continue;
+				}
+				if (["width", "height"].includes(attr)) {
+					el.style[attr] = `${elValues[attr]}px`;
 				}
 				el.setAttribute(attr, elValues[attr]);
 			}
@@ -6058,7 +6061,8 @@ var ZoteroPane = new function()
 			// may not yet be initialized
 			try {
 				this.itemsView.sort();
-			} catch(e) {};
+			}
+			catch (e) {}
 		}
 	};
 

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -6074,7 +6074,7 @@ var ZoteroPane = new function()
 	};
 
 	/**
-	 * Serializes zotero-persist elements to preferences
+	 * Serializes zotero-persist attributes to preferences
 	 */
 	this.serializePersist = function() {
 		if (!_unserialized) return;
@@ -6084,6 +6084,7 @@ var ZoteroPane = new function()
 		catch (e) {
 			serializedValues = {};
 		}
+		var persistedElements = new Set();
 		for (let el of document.querySelectorAll("[zotero-persist]")) {
 			if (!el.getAttribute) continue;
 			var id = el.getAttribute("id");
@@ -6092,9 +6093,16 @@ var ZoteroPane = new function()
 			for (let attr of el.getAttribute("zotero-persist").split(/[\s,]+/)) {
 				if (el.hasAttribute(attr)) {
 					elValues[attr] = el.getAttribute(attr);
+					persistedElements.add(id);
 				}
 			}
 			serializedValues[id] = elValues;
+		}
+		// Remove elements that no longer persist anything
+		for (let i in serializedValues) {
+			if (!persistedElements.has(i)) {
+				delete serializedValues[i];
+			}
 		}
 		Zotero.Prefs.set("pane.persist", JSON.stringify(serializedValues));
 	}

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -1228,7 +1228,7 @@
 											</hbox>
 											
 										</toolbar>
-										<hbox id="zotero-items-pane" class="virtualized-table-container" zotero-persist="width height" flex="1" clickthrough="never">
+										<hbox id="zotero-items-pane" class="virtualized-table-container" flex="1" clickthrough="never">
 											<html:div id="zotero-items-tree"></html:div>
 										</hbox>
 									</vbox>

--- a/scss/elements/_itemDetails.scss
+++ b/scss/elements/_itemDetails.scss
@@ -13,6 +13,7 @@
 	min-height: 0;
 	flex: 1;
 	width: auto !important;
+	height: auto !important;
 	min-width: $min-width-item-pane;
 	/* Need a min height to prevent layout issues in stacked mode */
 	min-height: 168px;

--- a/scss/elements/_itemDetails.scss
+++ b/scss/elements/_itemDetails.scss
@@ -12,8 +12,6 @@
 .zotero-item-pane-content {
 	min-height: 0;
 	flex: 1;
-	width: auto !important;
-	height: auto !important;
 	min-width: $min-width-item-pane;
 	/* Need a min height to prevent layout issues in stacked mode */
 	min-height: 168px;


### PR DESCRIPTION
Transpose `width`/`height` to CSS for fx115, and ignore persisted attributes that are no longer persisted