### PR TITLE
vpat 43: add label to scaffold translator output

### DIFF
--- a/chrome/content/scaffold/scaffold.xhtml
+++ b/chrome/content/scaffold/scaffold.xhtml
@@ -51,6 +51,7 @@
 		<html:link rel="localization" href="browser/browserSets.ftl"/>
 		<html:link rel="localization" href="toolkit/global/textActions.ftl"/>
 		<html:link rel="localization" href="zotero.ftl" />
+		<html:link rel="localization" href="scaffold.ftl" />
 	</linkset>
 
 	<script>
@@ -536,7 +537,7 @@
 			</tabbox>
 			<splitter id="pane-splitter" resizeafter="farthest" />
 			<vbox id="right-pane">
-				<html:textarea id="output" readonly="true"/>
+				<html:textarea id="output" readonly="true" data-l10n-id="scaffold-translator-output"/>
 			</vbox>
 		</hbox>
 

--- a/chrome/locale/en-US/zotero/scaffold.ftl
+++ b/chrome/locale/en-US/zotero/scaffold.ftl
@@ -1,0 +1,2 @@
+scaffold-translator-output =
+    .aria-label = Console


### PR DESCRIPTION
In a new scaffold.ftl file.

Vpat 43 also indicates that the readonly state of the textfield does not get announced - it is a voiceover specific issue on firefox, so it is not addressed here as it should be fixed globally (preferably by mozilla - this is discussed more in #3997)