### PR TITLE
vpat 27: rtfscan - link labels to inputs

### DIFF
--- a/chrome/content/zotero/rtfScan.js
+++ b/chrome/content/zotero/rtfScan.js
@@ -645,10 +645,11 @@ const Zotero_RTFScan = { // eslint-disable-line no-unused-vars, camelcase
 		this.wizard.canAdvance = newCanAdvance;
 	},
 
-	updatePath() {
+	async updatePath() {
 		this.wizard.canAdvance = this.inputFile && this.outputFile;
-		document.getElementById('input-path').value = this.inputFile ? this.inputFile.path : '';
-		document.getElementById('output-path').value = this.outputFile ? this.outputFile.path : '';
+		let noFileSelectedLabel = await document.l10n.formatValue("rtfScan-no-file-selected");
+		document.getElementById('input-path').value = this.inputFile ? this.inputFile.path : noFileSelectedLabel;
+		document.getElementById('output-path').value = this.outputFile ? this.outputFile.path : noFileSelectedLabel;
 	},
 
 	insertRows(newRows, beforeRow) {

--- a/chrome/content/zotero/rtfScan.xhtml
+++ b/chrome/content/zotero/rtfScan.xhtml
@@ -37,15 +37,15 @@
 			<div>
 				<label control="input-path" class="file-input-label" data-l10n-id="rtfScan-input-file" />
 				<div class="file-input-container">
-					<html:input type="text" data-l10n-id="zotero-file-none-selected" id="input-path" readonly="true"/>
-					<button id="choose-input-file" data-l10n-id="rtfScan-file-choose-input" />
+					<html:input type="text" id="input-path" readonly="true"/>
+					<button id="choose-input-file" data-l10n-id="rtfScan-choose-input-file" />
 				</div>
 			</div>
 			<div>
 				<label control="output-path" class="file-input-label" data-l10n-id="rtfScan-output-file" />
 				<div class="file-input-container">
-					<html:input type="text" data-l10n-id="zotero-file-none-selected" id="output-path" readonly="true"/>
-					<button id="choose-output-file" data-l10n-id="rtfScan-file-choose-output" />
+					<html:input type="text" id="output-path" readonly="true"/>
+					<button id="choose-output-file" data-l10n-id="rtfScan-choose-output-file" />
 				</div>
 			</div>
 		</wizardpage>

--- a/chrome/content/zotero/rtfScan.xhtml
+++ b/chrome/content/zotero/rtfScan.xhtml
@@ -35,17 +35,17 @@
 				<span class="page-start-2" data-l10n-id="rtfScan-introPage-description2" />
 			</div>
 			<div>
-				<label for="choose-input-file" class="file-input-label" data-l10n-id="rtfScan-input-file" />
+				<label control="input-path" class="file-input-label" data-l10n-id="rtfScan-input-file" />
 				<div class="file-input-container">
-					<html:input type="text" data-l10n-id="zotero-file-none-selected" id="input-path" readonly="true" />
-					<button id="choose-input-file" data-l10n-id="zotero-file-choose" />
+					<html:input type="text" data-l10n-id="zotero-file-none-selected" id="input-path" readonly="true"/>
+					<button id="choose-input-file" data-l10n-id="rtfScan-file-choose-input" />
 				</div>
 			</div>
 			<div>
-				<label for="choose-output-file" class="file-input-label" data-l10n-id="rtfScan-output-file" />
+				<label control="output-path" class="file-input-label" data-l10n-id="rtfScan-output-file" />
 				<div class="file-input-container">
-					<html:input type="text" data-l10n-id="zotero-file-none-selected" id="output-path" readonly="true" />
-					<button id="choose-output-file" data-l10n-id="zotero-file-choose" />
+					<html:input type="text" data-l10n-id="zotero-file-none-selected" id="output-path" readonly="true"/>
+					<button id="choose-output-file" data-l10n-id="rtfScan-file-choose-output" />
 				</div>
 			</div>
 		</wizardpage>

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -8,6 +8,7 @@ return-or-enter =
 general-remove = Remove
 general-add = Add
 general-remind-me-later = Remind Me Later
+general-choose-file =  Choose File…
 
 menu-file-show-in-finder =
     .label = Show in Finder
@@ -221,10 +222,10 @@ rtfScan-output-file = Output File
 
 rtfScan-no-file-selected = No file selected
 rtfScan-choose-input-file =
-    .label = Choose File…
+    .label = { general-choose-file }
     .aria-label = Choose Input File
 rtfScan-choose-output-file =
-    .label = Choose File…
+    .label = { general-choose-file }
     .aria-label = Choose Output File
 
 rtfScan-intro-page = 

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -221,9 +221,11 @@ rtfScan-output-file = Output File
 
 rtfScan-no-file-selected = No file selected
 rtfScan-choose-input-file =
-    .label = Choose Input File...
+    .label = Choose File…
+    .aria-label = Choose Input File
 rtfScan-choose-output-file =
-    .label = Choose Output File...
+    .label = Choose File…
+    .aria-label = Choose Output File
 
 rtfScan-intro-page = 
     .label = Introduction

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -8,7 +8,7 @@ return-or-enter =
 general-remove = Remove
 general-add = Add
 general-remind-me-later = Remind Me Later
-general-choose-file =  Choose File…
+general-choose-file = Choose File…
 
 menu-file-show-in-finder =
     .label = Show in Finder

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -222,8 +222,10 @@ rtfScan-output-file = Output File
 zotero-file-none-selected =
     .value = No file selected
 
-zotero-file-choose =
-    .label = Choose File…
+rtfScan-file-choose-input =
+    .label = Choose input file
+rtfScan-file-choose-output =
+    .label = Choose output file
 
 rtfScan-intro-page = 
     .label = Introduction

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -219,13 +219,11 @@ rtfScan-introPage-description2 = To get started, select an RTF input file and an
 rtfScan-input-file = Input File
 rtfScan-output-file = Output File
 
-zotero-file-none-selected =
-    .value = No file selected
-
-rtfScan-file-choose-input =
-    .label = Choose input file
-rtfScan-file-choose-output =
-    .label = Choose output file
+rtfScan-no-file-selected = No file selected
+rtfScan-choose-input-file =
+    .label = Choose Input File...
+rtfScan-choose-output-file =
+    .label = Choose Output File...
 
 rtfScan-intro-page = 
     .label = Introduction


### PR DESCRIPTION
- linked input/output file labels to the input fields so they have a descriptive name
- "Choose file" for both buttons is not context specific. Added separate .ftl entries to have "Choose input file" and "Choose output file" labels.

Note: there are readonly fields that voiceover does not announce as "readonly" - it seems to be a general firefox issue, so this is not addressed here. This is discussed in more details here: #3997