### PR TITLE
vpat 57/58: classic citation editor aria fixes

### DIFF
--- a/chrome/content/zotero/integration/addCitationDialog.xhtml
+++ b/chrome/content/zotero/integration/addCitationDialog.xhtml
@@ -96,14 +96,14 @@
 		<hbox align="stretch" style="margin-top: 8px">
 			<vbox flex="1">
 				<hbox align="center">
-					<label value="&zotero.citation.prefix.label;"/>
-					<html:input type="text" class="fix" id="prefix" tabindex="3"
+					<label value="&zotero.citation.prefix.label;" control="prefix"/>
+					<html:input type="text" class="fix" id="prefix" tabindex="0"
 								oninput="Zotero_Citation_Dialog.confirmRegenerate(false)"
 								onchange="Zotero_Citation_Dialog.confirmRegenerate(true)"/>
 				</hbox>
 				<hbox align="center">
-					<label value="&zotero.citation.suffix.label;"/>
-					<html:input type="text" class="fix" id="suffix" tabindex="4"
+					<label value="&zotero.citation.suffix.label;" control="suffix"/>
+					<html:input type="text" class="fix" id="suffix" tabindex="0"
 								oninput="Zotero_Citation_Dialog.confirmRegenerate(false)"
 								onchange="Zotero_Citation_Dialog.confirmRegenerate(true)"/>
 				</hbox>
@@ -111,14 +111,18 @@
 			</vbox>
 			<separator flex="4"/>
 			<vbox flex="1">
-				<hbox align="stretch">
-					<menulist onchange="Zotero_Citation_Dialog.confirmRegenerate(true)" id="label" tabindex="5" native="true">
+				<hbox align="center">
+					<label data-l10n-id="quickformat-locator-type" control="label"></label>
+					<menulist onchange="Zotero_Citation_Dialog.confirmRegenerate(true)" id="label" tabindex="0" native="true">
 						<menupopup id="locator-type-popup"/>
 					</menulist>
-					<html:input oninput="Zotero_Citation_Dialog.confirmRegenerate(false)" onchange="Zotero_Citation_Dialog.confirmRegenerate(true)" id="locator" tabindex="2"/>
+				</hbox>
+				<hbox align="center">
+					<label data-l10n-id="quickformat-locator-value" control="locator"></label>
+					<html:input oninput="Zotero_Citation_Dialog.confirmRegenerate(false)" onchange="Zotero_Citation_Dialog.confirmRegenerate(true)" id="locator" tabindex="0"/>
 				</hbox>
 				<separator style="height: 2px" flex="1"/>
-				<checkbox oncommand="Zotero_Citation_Dialog.confirmRegenerate(true)" id="suppress-author" label="&zotero.citation.suppressAuthor.label;" tabindex="6" native="true"/>
+				<checkbox oncommand="Zotero_Citation_Dialog.confirmRegenerate(true)" id="suppress-author" label="&zotero.citation.suppressAuthor.label;" tabindex="0" native="true"/>
 			</vbox>
 		</hbox>
 

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -479,6 +479,8 @@ quickformat-aria-input = Citation item search input. Type to search for an item 
 quickformat-aria-item = Press { return-or-enter } to add this item to the citation. Press Tab to go back to the search field.
 quickformat-accept = 
     .tooltiptext = Save edits to this citation
+quickformat-locator-type = Locator type:
+quickformat-locator-value = Locator value:
 
 quicksearch-mode =
     .aria-label = Quick Search mode


### PR DESCRIPTION
- vpat 57: remove tabindex values, set `tabindex=0` on all focusable fields. It allows mozilla to determine the best focus sequence for keyboard navigation and fixes wrong order where some inputs would go before the "Ok" and "Cancel" buttons and some - after
- vpat 58: added labels to all inputs to be announced when focused. Added separate labels for locator menulist and for the locator input so that the locator type has a proper label. It is also better to have visible explicit labels when possible