### PR TITLE
post vpat 57: revert layout changes to locator

### DIFF
--- a/chrome/content/zotero/integration/addCitationDialog.xhtml
+++ b/chrome/content/zotero/integration/addCitationDialog.xhtml
@@ -111,15 +111,12 @@
 			</vbox>
 			<separator flex="4"/>
 			<vbox flex="1">
-				<hbox align="center">
-					<label data-l10n-id="quickformat-locator-type" control="label"></label>
-					<menulist onchange="Zotero_Citation_Dialog.confirmRegenerate(true)" id="label" tabindex="0" native="true">
+				<hbox align="stretch">
+					<menulist onchange="Zotero_Citation_Dialog.confirmRegenerate(true)" id="label" tabindex="0" native="true" data-l10n-id="quickformat-locator-type">
 						<menupopup id="locator-type-popup"/>
 					</menulist>
-				</hbox>
-				<hbox align="center">
-					<label data-l10n-id="quickformat-locator-value" control="locator"></label>
-					<html:input oninput="Zotero_Citation_Dialog.confirmRegenerate(false)" onchange="Zotero_Citation_Dialog.confirmRegenerate(true)" id="locator" tabindex="0"/>
+					<label id="locator_input_label" data-l10n-id="quickformat-locator-value" hidden="true"></label>
+					<html:input aria-labelledby="label locator_input_label" oninput="Zotero_Citation_Dialog.confirmRegenerate(false)"  onchange="Zotero_Citation_Dialog.confirmRegenerate(true)" id="locator" tabindex="0"/>
 				</hbox>
 				<separator style="height: 2px" flex="1"/>
 				<checkbox oncommand="Zotero_Citation_Dialog.confirmRegenerate(true)" id="suppress-author" label="&zotero.citation.suppressAuthor.label;" tabindex="0" native="true"/>

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -482,8 +482,9 @@ quickformat-aria-input = Type to search for an item to include in this citation.
 quickformat-aria-item = Press { return-or-enter } to add this item to the citation. Press Tab to go back to the search field.
 quickformat-accept = 
     .tooltiptext = Save edits to this citation
-quickformat-locator-type = Locator type:
-quickformat-locator-value = Locator value:
+quickformat-locator-type =
+    .aria-label = Locator type
+quickformat-locator-value =  Locator input
 
 insert-note-aria-input = Type to search for a note. Press Tab to navigate the list of results. Press Escape to close the dialog.
 insert-note-aria-item = Press { return-or-enter } to select this note. Press Tab to go back to the search field. Press Escape to close the dialog.


### PR DESCRIPTION
To address the immediate VPAT issues, the locator dropdown has aria-label "Locator type". The locator input is labelled by a hidden label with "Locator input" string, as well as the locator type. That way both the locator type and the "Locator input" string are announced when it is focused.

Fixes: #4039