### PR TITLE
CookieSandbox: Fix attachToInterfaceRequestor() for XHRs

### DIFF
--- a/chrome/content/zotero/xpcom/cookieSandbox.js
+++ b/chrome/content/zotero/xpcom/cookieSandbox.js
@@ -170,7 +170,10 @@ Zotero.CookieSandbox.prototype = {
 	 * @param {nsIInterfaceRequestor} ir
 	 */
 	"attachToInterfaceRequestor": function(ir) {
-		Zotero.CookieSandbox.Observer.trackedInterfaceRequestors.set(ir.QueryInterface(Components.interfaces.nsIInterfaceRequestor), this);
+		if (typeof ir.QueryInterface === 'function') {
+			ir = ir.QueryInterface(Components.interfaces.nsIInterfaceRequestor);
+		}
+		Zotero.CookieSandbox.Observer.trackedInterfaceRequestors.set(ir, this);
 	},
 	
 	/**


### PR DESCRIPTION
XHRs still [implement](https://searchfox.org/mozilla-central/rev/1f5e1875cbfd5d4b1bfa27ca54832f62dd19589e/dom/webidl/XMLHttpRequest.webidl#131-132) `getInterface()`, but they no longer support `QueryInterface`.

Fixes #4042