### PR TITLE
Fix progress queue dialog overflow

### DIFF
--- a/chrome/content/zotero/progressQueueDialog.xhtml
+++ b/chrome/content/zotero/progressQueueDialog.xhtml
@@ -1,6 +1,7 @@
 <?xml version="1.0" ?>
 <?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
 <?xml-stylesheet href="chrome://zotero-platform/content/zotero.css"?>
+<?xml-stylesheet href="chrome://zotero/skin/progressQueueDialog.css"?>
 <!DOCTYPE window SYSTEM "chrome://zotero/locale/zotero.dtd">
 
 <window xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
@@ -11,15 +12,15 @@
 	style="display: flex;">
 	<script src="include.js"></script>
 	<script src="progressQueueDialog.js"/>
-	<vbox id="zotero-progress-box" style="padding:10px" flex="1">
+	<vbox id="progress-queue-root" flex="1">
 		<label id="label" control="progress-indicator" value=""/>
 		<hbox align="center">
-			<html:progress id="progress-indicator" max="100" style="flex: 1;"/>
+			<html:progress id="progress-indicator" max="100"/>
 			<button id="cancel-button" label="&zotero.general.cancel;"/>
 			<button id="minimize-button" label="&zotero.general.minimize;"/>
 			<button id="close-button" label="&zotero.general.close;"/>
 		</hbox>
-		<hbox class="virtualized-table-container" flex="1" height="200px">
+		<hbox class="virtualized-table-container" flex="1">
 			<html:div id="tree"/>
 		</hbox>
 	</vbox>

--- a/chrome/content/zotero/xpcom/progressQueueDialog.js
+++ b/chrome/content/zotero/xpcom/progressQueueDialog.js
@@ -83,7 +83,7 @@ Zotero.ProgressQueueDialog = function (progressQueue) {
 	};
 	
 	function _onWindowLoaded() {
-		var rootElement = _progressWindow.document.getElementById('zotero-progress-box');
+		var rootElement = _progressWindow.document.getElementById('progress-queue-root');
 		Zotero.UIProperties.registerRoot(rootElement);
 		
 		_progressIndicator = _progressWindow.document.getElementById('progress-indicator');

--- a/chrome/skin/default/zotero/zotero.css
+++ b/chrome/skin/default/zotero/zotero.css
@@ -1,20 +1,3 @@
-/* Font sizes */
-*[zoteroFontSize=medium] treechildren::-moz-tree-row
-{
-	height: 1.5em;
-}
-
-*[zoteroFontSize=large] treechildren::-moz-tree-row, *[zoteroFontSize=x-large] treechildren::-moz-tree-row
-{
-	height: 1.5em;
-}
-
-*[zoteroFontSize=large] .treecol-text, *[zoteroFontSize=x-large] .treecol-text
-{
-	margin:0;
-	padding:0;
-}
-
 groupbox > label > h2, groupbox > * > label > h2 {
 	font-size: 14px;
 	margin-top: 1em;
@@ -48,11 +31,6 @@ label.zotero-text-link {
 	margin-bottom: 2px;
 }
 
-.zotero-progress-icon-headline {
-	width: 16px;
-	height: 16px;
-}
-
 .zotero-progress-item-icon
 {
 	width: 16px;
@@ -77,30 +55,10 @@ label.zotero-text-link {
 	margin-left: 5px;
 }
 
-.zotero-scrape-popup-library
-{
-	list-style-image: url('chrome://zotero/skin/treesource-library.png');
-}
-
-.zotero-scrape-popup-collection
-{
-	list-style-image: url('chrome://zotero/skin/treesource-collection.png');
-}
-
 .zotero-warning {
   font-weight: 600;
   font-size: 1.25em;
   margin-bottom: 1em;
-}
-
-.zotero-small-progress-indicator {
-	list-style-image: url(chrome://global/skin/icons/notloading_16.png);
-	margin-left: -2px;
-	margin-right: -2px;
-}
-
-.zotero-small-progress-indicator[status=animate] {
-	list-style-image: url(chrome://global/skin/icons/loading_16.png);
 }
 
 #zotero-note-window {
@@ -168,11 +126,4 @@ zoterosearch .menulist-icon {
 .form-grid {
 	display: grid;
 	grid-template-columns: max-content 1fr;
-}
-
-
-/* BEGIN 2X BLOCK -- DO NOT EDIT MANUALLY -- USE 2XIZE */
-@media (min-resolution: 1.25dppx) {
-	.zotero-scrape-popup-library { list-style-image: url('chrome://zotero/skin/treesource-library@2x.png'); }
-	.zotero-scrape-popup-collection { list-style-image: url('chrome://zotero/skin/treesource-collection@2x.png'); }
 }

--- a/chrome/skin/default/zotero/zotero.css
+++ b/chrome/skin/default/zotero/zotero.css
@@ -42,15 +42,6 @@ label.zotero-text-link {
 	font-weight: 600;
 }
 
-#zotero-progress-box
-{
-	border: 2px solid #7a0000;
-	margin: 0;
-	min-height: 50px;
-	width: 250px;
-	padding: 3px 0 3px 0;
-}
-
 #zotero-progress-text-headline
 {
 	font-weight: 600;
@@ -84,16 +75,6 @@ label.zotero-text-link {
 {
 	width: 210px;
 	margin-left: 5px;
-}
-
-#zotero-progress-box description
-{
-	width: 220px;
-}
-
-#zotero-progress-box description label
-{
-	margin: 0;
 }
 
 .zotero-scrape-popup-library

--- a/scss/progressQueueDialog.scss
+++ b/scss/progressQueueDialog.scss
@@ -1,0 +1,12 @@
+#progress-queue-root {
+	min-height: 0;
+	padding: 10px;
+}
+
+#progress-indicator {
+	flex: 1;
+}
+
+.virtualized-table-container {
+	height: 200px;
+}


### PR DESCRIPTION
- Change root element ID - `#zotero-progress-box` corresponded to some outdated and unused styles in `zotero.css` that we don't want to apply here
	- Remove those unused styles
- Add `progressQueueDialog.scss` and move styles there

Fixes #4026