### PR TITLE
Update progress window to use SVG icons

### DIFF
--- a/chrome/content/zotero/fileInterface.js
+++ b/chrome/content/zotero/fileInterface.js
@@ -630,10 +630,10 @@ var Zotero_File_Interface = new function() {
 				closeOnClick: false
 			});
 			progressWin.changeHeadline(Zotero.getString('fileInterface.importing'));
-			let icon = 'chrome://zotero/skin/treesource-unfiled' + (Zotero.hiDPI ? "@2x" : "") + '.png';
 			progress = new progressWin.ItemProgress(
-				icon, translation.path ? PathUtils.filename(translation.path) : translators[0].label
+				null, translation.path ? PathUtils.filename(translation.path) : translators[0].label
 			);
+			progress.setItemTypeAndIcon(null, 'unfiled');
 			progressWin.show();
 			
 			translation.setHandler("itemDone",  function () {
@@ -683,15 +683,13 @@ var Zotero_File_Interface = new function() {
 		// Show popup on completion
 		if (showProgressWindow) {
 			progressWin.changeHeadline(Zotero.getString('fileInterface.importComplete'));
-			let icon;
 			if (numItems == 1) {
-				icon = translation.newItems[0].getImageSrc();
+				progress.setItemTypeAndIcon(translation.newItems[0].getItemTypeIconName());
 			}
 			else {
-				icon = 'chrome://zotero/skin/treesource-unfiled' + (Zotero.hiDPI ? "@2x" : "") + '.png';
+				progress.setItemTypeAndIcon(null, 'unfiled');
 			}
 			let text = Zotero.getString(`fileInterface.itemsWereImported`, numItems, numItems);
-			progress.setIcon(icon);
 			progress.setText(text);
 			// For synchronous translators, which don't update progress
 			progress.setProgress(100);

--- a/chrome/content/zotero/progressWindow.xhtml
+++ b/chrome/content/zotero/progressWindow.xhtml
@@ -27,6 +27,7 @@
 <?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
 <?xml-stylesheet href="chrome://global/skin/browser.css" type="text/css"?>
 <?xml-stylesheet href="chrome://zotero/skin/zotero.css" type="text/css"?>
+<?xml-stylesheet href="chrome://zotero/skin/progressWindow.css"?>
 <!DOCTYPE window SYSTEM "chrome://zotero/locale/zotero.dtd">
 
 <window id="zotero-progress"

--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -1454,17 +1454,15 @@ Zotero.Attachments = new function () {
 		
 		// If no eligible items, just show a popup saying no PDFs were found
 		if (!queue.length) {
-			let icon = 'chrome://zotero/skin/treeitem-attachment-pdf.png';
 			let progressWin = new Zotero.ProgressWindow();
 			let title = Zotero.getString('pane.items.menu.findAvailablePDF.multiple');
 			progressWin.changeHeadline(title);
 			let itemProgress = new progressWin.ItemProgress(
-				icon,
+				'attachmentPDF',
 				Zotero.getString('findPDF.noPDFsFound')
 			);
 			progressWin.show();
 			itemProgress.setProgress(100);
-			itemProgress.setIcon(icon);
 			progressWin.startCloseTimer(4000);
 			return;
 		}

--- a/chrome/content/zotero/xpcom/data/cachedTypes.js
+++ b/chrome/content/zotero/xpcom/data/cachedTypes.js
@@ -504,7 +504,7 @@ Zotero.ItemTypes = new function() {
 			case 'tvBroadcast':
 			case 'videoRecording':
 			case 'webpage':
-				itemType = itemType.replace(/([A-Z])/g, '-$1').toLowerCase();
+				itemType = itemType.replace(/(?<=^|[^A-Z])([A-Z])/g, '-$1').toLowerCase();
 				return "chrome://zotero/skin/item-type/16/" + (isDark ? 'dark' : 'light') + "/" + itemType + suffix + ".svg";
 		}
 

--- a/chrome/content/zotero/xpcom/data/feedItem.js
+++ b/chrome/content/zotero/xpcom/data/feedItem.js
@@ -245,7 +245,7 @@ Zotero.FeedItem.prototype.translate = async function (libraryID, collectionID) {
 			Zotero.debug("No translators detected for feed item " + this.id + " with URL " + this.getField('url') + 
 				' -- cloning item instead', 2);
 			let item = await this.clone(libraryID, collectionID, browser);
-			progressWindow.Translation.itemDoneHandler()(null, null, item);
+			progressWindow.Translation.itemDoneHandler()(null, item, null);
 			progressWindow.Translation.doneHandler(null, true);
 			return;
 		}
@@ -257,7 +257,7 @@ Zotero.FeedItem.prototype.translate = async function (libraryID, collectionID) {
 			}).then(items => items ? items[0] : false);
 			if (!result) {
 				let item = await this.clone(libraryID, collectionID, browser);
-				progressWindow.Translation.itemDoneHandler()(null, null, item);
+				progressWindow.Translation.itemDoneHandler()(null, item, null);
 				progressWindow.Translation.doneHandler(null, true);
 				return;
 			}

--- a/chrome/content/zotero/xpcom/data/feedItem.js
+++ b/chrome/content/zotero/xpcom/data/feedItem.js
@@ -245,7 +245,7 @@ Zotero.FeedItem.prototype.translate = async function (libraryID, collectionID) {
 			Zotero.debug("No translators detected for feed item " + this.id + " with URL " + this.getField('url') + 
 				' -- cloning item instead', 2);
 			let item = await this.clone(libraryID, collectionID, browser);
-			progressWindow.Translation.itemDoneHandler()(null, item, null);
+			progressWindow.Translation.itemDoneHandler()(null, null, item);
 			progressWindow.Translation.doneHandler(null, true);
 			return;
 		}
@@ -257,7 +257,7 @@ Zotero.FeedItem.prototype.translate = async function (libraryID, collectionID) {
 			}).then(items => items ? items[0] : false);
 			if (!result) {
 				let item = await this.clone(libraryID, collectionID, browser);
-				progressWindow.Translation.itemDoneHandler()(null, item, null);
+				progressWindow.Translation.itemDoneHandler()(null, null, item);
 				progressWindow.Translation.doneHandler(null, true);
 				return;
 			}

--- a/chrome/content/zotero/xpcom/progressWindow.js
+++ b/chrome/content/zotero/xpcom/progressWindow.js
@@ -435,7 +435,7 @@ Zotero.ProgressWindow = function(options = {}) {
 		_attachmentsMap = _attachmentsMap || new WeakMap();
 		return function(obj, dbItem, item) {
 			self.show();
-			var itemProgress = new self.ItemProgress(dbItem.getItemTypeIconName(), item.title);
+			var itemProgress = new self.ItemProgress(dbItem?.getItemTypeIconName() ?? item.itemType, item.title);
 			itemProgress.setProgress(100);
 			for(let attachment of item.attachments) {
 				// Create unsaved item to get icon

--- a/chrome/content/zotero/xpcom/progressWindow.js
+++ b/chrome/content/zotero/xpcom/progressWindow.js
@@ -282,16 +282,14 @@ Zotero.ProgressWindow = function(options = {}) {
 	 * Creates a new object representing a line in the progressWindow. This is the OO
 	 * version of addLines() above.
 	 */
-	this.ItemProgress = _deferUntilWindowLoad(function(iconSrc, text, parentItemProgress) {
+	this.ItemProgress = _deferUntilWindowLoad(function(itemType, text, parentItemProgress) {
 		this.setText(text);
 		
 		this._image = _progressWindow.document.createXULElement("hbox");
-		this._image.setAttribute("class", "zotero-progress-item-icon");
 		this._image.setAttribute("flex", 0);
-		this._image.style.width = "16px";
-		this._image.style.backgroundRepeat = "no-repeat";
-		this._image.style.backgroundSize = "auto 16px";
-		this.setIcon(iconSrc);
+		if (itemType) {
+			this.setItemTypeAndIcon(itemType);
+		}
 		
 		this._hbox = _progressWindow.document.createXULElement("hbox");
 		this._hbox.setAttribute("class", "zotero-progress-item-hbox");
@@ -327,13 +325,17 @@ Zotero.ProgressWindow = function(options = {}) {
 	this.ItemProgress.prototype.setProgress = _deferUntilWindowLoad(function(percent) {
 		if(percent != 0 && percent != 100) {
 			// Indication of partial progress, so we will use the circular indicator
-			var nArcs = 20;			
+			var nArcs = 20;
+			this._image.className = "";
+			this._image.style.width = "16px";
+			this._image.style.backgroundRepeat = "no-repeat";
+			this._image.style.backgroundSize = "auto 16px";
 			this._image.style.backgroundImage = "url('chrome://zotero/skin/progress_arcs.png')";
 			this._image.style.backgroundPosition = "-"+(Math.round(percent/100*nArcs)*16)+"px 0";
 			this._hbox.style.opacity = percent/200+.5;
 		} else if(percent == 100) {
-			this._image.style.backgroundImage = "url('"+this._iconSrc+"')";
-			this._image.style.backgroundPosition = "";
+			this._image.className = this._iconClassName;
+			this._image.style = "";
 			this._hbox.style.opacity = "1";
 			this._hbox.style.filter = "";
 		}
@@ -341,12 +343,14 @@ Zotero.ProgressWindow = function(options = {}) {
 	
 	/**
 	 * Sets the icon for this item.
-	 * @param {String} iconSrc
+	 * @param {String} [itemType]
+	 * @param {String} [cssIcon]
 	 */
-	this.ItemProgress.prototype.setIcon = _deferUntilWindowLoad(function(iconSrc) {
-		this._image.style.backgroundImage = "url('"+iconSrc+"')";
-		this._image.style.backgroundPosition = "";
-		this._iconSrc = iconSrc;
+	this.ItemProgress.prototype.setItemTypeAndIcon = _deferUntilWindowLoad(function(itemType, cssIcon = 'item-type') {
+		// No getCSSItemTypeIcon() without a window context
+		this._image.className = this._iconClassName = `icon icon-16 icon-css icon-${cssIcon}`;
+		this._image.dataset.itemType = itemType;
+		this._image.style = "";
 	});
 	
 	this.ItemProgress.prototype.setText = _deferUntilWindowLoad(function (text) {
@@ -431,30 +435,19 @@ Zotero.ProgressWindow = function(options = {}) {
 		_attachmentsMap = _attachmentsMap || new WeakMap();
 		return function(obj, dbItem, item) {
 			self.show();
-			var itemProgress = new self.ItemProgress(Zotero.ItemTypes.getImageSrc(item.itemType),
-				item.title);
+			var itemProgress = new self.ItemProgress(dbItem.getItemTypeIconName(), item.title);
 			itemProgress.setProgress(100);
-			for(var i=0; i<item.attachments.length; i++) {
-				var attachment = item.attachments[i];
+			for(let attachment of item.attachments) {
+				// Create unsaved item to get icon
+				let attachmentItem = new Zotero.Item('attachment');
+				attachmentItem.attachmentContentType = attachment.mimeType;
+				if (attachment.linkMode) {
+					attachmentItem.attachmentLinkMode = attachment.linkMode;
+				}
 				_attachmentsMap.set(attachment,
 					new self.ItemProgress(
-						Zotero.Utilities.Internal.determineAttachmentIcon(attachment),
+						attachmentItem.getItemTypeIconName(),
 						attachment.title, itemProgress));
-			}
-		}
-	};
-	
-	this.Translation.attachmentProgressHandler = function(_attachmentsMap) {
-		_attachmentsMap = _attachmentsMap || new WeakMap();
-		return function(obj, attachment, progress, error) {
-			var itemProgress = _attachmentsMap.get(attachment);
-			if(progress === false) {
-				itemProgress.setError();
-			} else {
-				itemProgress.setProgress(progress);
-				if(progress === 100) {
-					itemProgress.setIcon(Zotero.Utilities.Internal.determineAttachmentIcon(attachment));
-				}
 			}
 		}
 	};

--- a/chrome/content/zotero/xpcom/progressWindow.js
+++ b/chrome/content/zotero/xpcom/progressWindow.js
@@ -154,7 +154,7 @@ Zotero.ProgressWindow = function(options = {}) {
 	/**
 	 * Changes the "headline" shown at the top of the progress window
 	 */
-	this.changeHeadline = _deferUntilWindowLoad(function changeHeadline(text, icon, postText) {
+	this.changeHeadline = _deferUntilWindowLoad(function changeHeadline(text, cssIconKey, postText) {
 		var doc = _progressWindow.document,
 			headline = doc.getElementById("zotero-progress-text-headline");
 		while(headline.hasChildNodes()) headline.removeChild(headline.firstChild);
@@ -164,18 +164,19 @@ Zotero.ProgressWindow = function(options = {}) {
 		preNode.setAttribute("crop", "end");
 		headline.appendChild(preNode);
 		
-		if(icon) {
-			var img = doc.createXULElement("image");
-			img.width = 16;
-			img.height = 16;
-			img.setAttribute("src", icon);
-			headline.appendChild(img);
+		if(cssIconKey) {
+			// No getCSSIcon() without a window context
+			let iconEl = doc.createElement('span');
+			iconEl.classList.add('icon');
+			iconEl.classList.add('icon-16');
+			iconEl.classList.add('icon-css');
+			iconEl.classList.add(`icon-${cssIconKey}`);
+			headline.appendChild(iconEl);
 		}
 		
 		if(postText) {
 			var postNode = doc.createXULElement("label");
-			postNode.style.marginLeft = 0;
-			postNode.setAttribute("value", " "+postText);
+			postNode.setAttribute("value", postText);
 			postNode.setAttribute("crop", "end");
 			postNode.setAttribute("flex", "1");
 			headline.appendChild(postNode);
@@ -406,9 +407,11 @@ Zotero.ProgressWindow = function(options = {}) {
 			name = Zotero.getString("pane.collections.library");
 		}
 		
-		self.changeHeadline(Zotero.getString("ingester.scrapingTo"),
-			"chrome://zotero/skin/treesource-"+(collection ? "collection" : "library")+".png",
-			name+"\u2026");
+		self.changeHeadline(
+			Zotero.getString("ingester.scrapingTo"),
+			collection ? 'collection' : 'library',
+			name + "\u2026"
+		);
 	};
 	
 	this.Translation.doneHandler = function(obj, returnValue) {		

--- a/chrome/skin/default/zotero/zotero.css
+++ b/chrome/skin/default/zotero/zotero.css
@@ -38,9 +38,9 @@ label.zotero-text-link {
 
 .zotero-progress-item-hbox
 {
-	padding-left: 5px;
-	margin-top: 0;
-	margin-bottom: 0;
+	padding-inline-start: 5px;
+	padding-block: 2px;
+	margin-block: 0;
 }
 
 .zotero-progress-item-hbox[parent]
@@ -51,7 +51,8 @@ label.zotero-text-link {
 .zotero-progress-item-label
 {
 	width: 210px;
-	margin-left: 5px;
+	margin-inline: 5px 0;
+	margin-block: 0;
 }
 
 .zotero-warning {

--- a/chrome/skin/default/zotero/zotero.css
+++ b/chrome/skin/default/zotero/zotero.css
@@ -31,8 +31,7 @@ label.zotero-text-link {
 	margin-bottom: 2px;
 }
 
-.zotero-progress-item-icon
-{
+.zotero-progress-icon-headline {
 	width: 16px;
 	height: 16px;
 }

--- a/scss/progressWindow.scss
+++ b/scss/progressWindow.scss
@@ -16,6 +16,7 @@
 
 @import "components/icons";
 @import "components/collection-tree";
+@import "components/item-tree";
 
 label {
 	margin-block: 0;

--- a/scss/progressWindow.scss
+++ b/scss/progressWindow.scss
@@ -1,0 +1,22 @@
+@import "abstracts/variables";
+@import "abstracts/functions";
+@import "abstracts/mixins";
+@import "abstracts/placeholders";
+@import "abstracts/utilities";
+@import "abstracts/split-button";
+@import "abstracts/svgicon";
+
+@import "themes/light";
+@import "themes/dark";
+
+// Base
+// --------------------------------------------------
+
+@import "base/base";
+
+@import "components/icons";
+@import "components/collection-tree";
+
+label {
+	margin-block: 0;
+}


### PR DESCRIPTION
Font size has increased because we're pulling in `_base.scss`. Can override that if we don't want it.

I fixed up `getImageSrc()`, since it was returning incorrect paths for types containing multiple consecutive capital letters ("PDF"), but I also removed all remaining uses of it. Progress windows now use SVG icon names.

I also removed seemingly unused `attachmentProgressHandler`.

Before:
![image](https://github.com/zotero/zotero/assets/1770299/7d1cbca6-f3f7-4cca-93e7-3e7b37c77ec8)
![image](https://github.com/zotero/zotero/assets/1770299/c2846af3-51ca-44b0-8b2d-750bbbf8af19)

After:
![image](https://github.com/zotero/zotero/assets/1770299/d508492d-059d-4133-8a58-ba88a7646b1b)
![image](https://github.com/zotero/zotero/assets/1770299/53bbfc15-9ab7-4a10-9364-bbe1709143b5)

Fixes #4046