### PR TITLE
vpat 15: more detailed labels for itemPane

### DIFF
--- a/chrome/content/zotero/elements/collapsibleSection.js
+++ b/chrome/content/zotero/elements/collapsibleSection.js
@@ -157,6 +157,8 @@
 			let twisty = document.createXULElement('toolbarbutton');
 			twisty.className = 'twisty';
 			twisty.setAttribute("tabindex", "0");
+			twisty.setAttribute("tooltip", "dynamic-tooltip");
+			twisty.setAttribute("data-l10n-attrs", "dynamic-tooltiptext");
 			this._head.append(twisty);
 			
 			this._buildExtraButtons();
@@ -173,6 +175,12 @@
 			if (this.hasAttribute('data-l10n-id') && !this.hasAttribute('data-l10n-args')) {
 				this.setAttribute('data-l10n-args', JSON.stringify({ count: 0 }));
 			}
+			// Fetch the localized value of the current pane which is used to set aria-properties
+			document.l10n.formatValue(`pane-${this.dataset.pane}`)
+				.then((res) => {
+					this._paneName = res;
+				})
+				.catch((_) => {}); // sanity check as it should never happen
 		}
 		
 		_buildContextMenu() {
@@ -409,8 +417,9 @@
 			this._head.setAttribute("aria-label", this.label);
 			this._title.textContent = this.label;
 			this._summary.textContent = this.summary;
-			this._head.querySelector('.twisty').hidden = this._disableCollapsing;
-			this._head.querySelector('.twisty').setAttribute('data-l10n-id', `section-button-${this.open ? "collapse" : "expand"}`);
+			let twisty = this._head.querySelector('.twisty');
+			twisty.hidden = this._disableCollapsing;
+			document.l10n.setAttributes(twisty, `section-button-${this.open ? "collapse" : "expand"}`, { section: this._paneName || "" });
 		}
 	}
 	customElements.define("collapsible-section", CollapsibleSection);

--- a/chrome/content/zotero/elements/collapsibleSection.js
+++ b/chrome/content/zotero/elements/collapsibleSection.js
@@ -179,8 +179,7 @@
 			document.l10n.formatValue(`pane-${this.dataset.pane}`)
 				.then((res) => {
 					this._paneName = res;
-				})
-				.catch((_) => {}); // sanity check as it should never happen
+				});
 		}
 		
 		_buildContextMenu() {

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -58,7 +58,6 @@ var ZoteroPane = new function()
 	this.clearItemsPaneMessage = clearItemsPaneMessage;
 	this.viewSelectedAttachment = viewSelectedAttachment;
 	this.reportErrors = reportErrors;
-	this.setDynamicTooltip = setDynamicTooltip;
 	
 	this.document = document;
 
@@ -495,18 +494,6 @@ var ZoteroPane = new function()
 				node.classList.remove("hidden-focus");
 			}
 		});
-	}
-
-	// Set the label of the dynamic tooltip. Can be used when we cannot set .tooltiptext
-	// property, e.g. if we don't want the tooltip to be announced by screenreaders.
-	function setDynamicTooltip(e) {
-		let tooltip = e.target;
-		let triggerNode = tooltip.triggerNode;
-		if (!triggerNode || !triggerNode.getAttribute("dynamic-tooltiptext")) {
-			e.preventDefault();
-			return;
-		}
-		tooltip.setAttribute("label", triggerNode.getAttribute("dynamic-tooltiptext"));
 	}
 
 	/**
@@ -6335,6 +6322,17 @@ var ZoteroPane = new function()
 		}
 	};
 	
+	// Set the label of the dynamic tooltip. Can be used when we cannot set .tooltiptext
+	// property, e.g. if we don't want the tooltip to be announced by screenreaders.
+	this.setDynamicTooltip = function (event) {
+		let tooltip = event.target;
+		let triggerNode = tooltip.triggerNode;
+		if (!triggerNode || !triggerNode.getAttribute("dynamic-tooltiptext")) {
+			event.preventDefault();
+			return;
+		}
+		tooltip.setAttribute("label", triggerNode.getAttribute("dynamic-tooltiptext"));
+	};
 	/**
 	 * Opens the about dialog
 	 */

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -6333,6 +6333,7 @@ var ZoteroPane = new function()
 		}
 		tooltip.setAttribute("label", triggerNode.getAttribute("dynamic-tooltiptext"));
 	};
+
 	/**
 	 * Opens the about dialog
 	 */

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -58,6 +58,7 @@ var ZoteroPane = new function()
 	this.clearItemsPaneMessage = clearItemsPaneMessage;
 	this.viewSelectedAttachment = viewSelectedAttachment;
 	this.reportErrors = reportErrors;
+	this.setDynamicTooltip = setDynamicTooltip;
 	
 	this.document = document;
 
@@ -494,6 +495,18 @@ var ZoteroPane = new function()
 				node.classList.remove("hidden-focus");
 			}
 		});
+	}
+
+	// Set the label of the dynamic tooltip. Can be used when we cannot set .tooltiptext
+	// property, e.g. if we don't want the tooltip to be announced by screenreaders.
+	function setDynamicTooltip(e) {
+		let tooltip = e.target;
+		let triggerNode = tooltip.triggerNode;
+		if (!triggerNode || !triggerNode.getAttribute("dynamic-tooltiptext")) {
+			e.preventDefault();
+			return;
+		}
+		tooltip.setAttribute("label", triggerNode.getAttribute("dynamic-tooltiptext"));
 	}
 
 	/**

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -889,6 +889,7 @@
 		</hbox>
 	</hbox>
 	
+	<tooltip id="dynamic-tooltip" onpopupshowing="ZoteroPane.setDynamicTooltip(event)"></tooltip>
 	<!-- Global popupset for all context menus -->
 	<popupset>
 		<!-- Library -->

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -459,9 +459,11 @@ section-button-remove =
 section-button-add =
     .tooltiptext = { general-add }
 section-button-expand =
-    .tooltiptext = Expand section
+    .dynamic-tooltiptext = Expand section
+    .label = Expand { $section } section
 section-button-collapse =
-    .tooltiptext = Collapse section
+    .dynamic-tooltiptext = Collapse section
+    .label = Collapse { $section } section
 annotations-count =
     { $count ->
         [one] { $count } Annotation


### PR DESCRIPTION
- added role=button to the itemPane header
- twisty button's tooltip will include the section's name, e.g. "Expand info section".

Post: #3957 (vpat 15 and vpat 6 are duplicates)
Vpat comment after the initial edits this should address:

The issue is partially resolved. The various sections of the 'Item Pane' now have names. They are missing button roles, however; they can be activated to expand/collapse the section. The dedicated expand/collapse buttons should include the section in their names. Right now, they are all 'Expand section'/'Collapse section.

Initial issue description:

There is a pane of items with what seem to be "related", "tags", Libraries and collection", "notes", and possibly more. These buttons may expand or collapse more sections, and all of these buttons, and mentioned items, are not named or described properly.