### PR TITLE
vpat 11: do not skip over disabled tags during arrow navigation

### DIFF
--- a/chrome/content/zotero/components/tagSelector/tagSelectorList.jsx
+++ b/chrome/content/zotero/components/tagSelector/tagSelectorList.jsx
@@ -316,8 +316,8 @@ class TagList extends React.PureComponent {
 			return node.previousElementSibling;
 		};
 		let nextOne = nextTag(document.activeElement);
-		// Skip disabled tags
-		while (nextOne && nextOne.classList.contains("disabled")) {
+		// Skip disabled tags, unless all tags are explicitly set to be displayed
+		while (!Zotero.Prefs.get('tagSelector.displayAllTags') && nextOne && nextOne.classList.contains("disabled")) {
 			nextOne = nextTag(nextOne);
 		}
 		if (nextOne) {

--- a/chrome/content/zotero/components/tagSelector/tagSelectorList.jsx
+++ b/chrome/content/zotero/components/tagSelector/tagSelectorList.jsx
@@ -323,10 +323,6 @@ class TagList extends React.PureComponent {
 			return node.previousElementSibling;
 		};
 		let nextOne = nextTag(document.activeElement);
-		// Skip disabled tags, unless all tags are explicitly set to be displayed
-		while (!Zotero.Prefs.get('tagSelector.displayAllTags') && nextOne && nextOne.classList.contains("disabled")) {
-			nextOne = nextTag(nextOne);
-		}
 		if (nextOne) {
 			nextOne.focus();
 		}

--- a/chrome/content/zotero/components/tagSelector/tagSelectorList.jsx
+++ b/chrome/content/zotero/components/tagSelector/tagSelectorList.jsx
@@ -229,7 +229,7 @@ class TagList extends React.PureComponent {
 	}
 
 	isEmpty() {
-		return !this.tagSelectorList().querySelector('.tag-selector-item:not(.disabled)');
+		return this.props.tags.length == 0;
 	}
 
 	clearRecordedFocusedTag() {
@@ -238,13 +238,20 @@ class TagList extends React.PureComponent {
 	}
 
 	// Focus the last focused tag from the list. If there is none, focus the first
-	// non-disabled tag.
+	// non-disabled tag. If there are no enabled tags, focus the first visible tag.
 	async focus() {
-		if (this.focusedTagIndex === null) {
-			let enabledTag = this.tagSelectorList().querySelector('.tag-selector-item:not(.disabled)');
-			if (!enabledTag) return;
-			enabledTag.focus();
+		if (this.isEmpty()) {
+			document.querySelector('.tag-selector-list').focus();
 			return;
+		}
+		if (this.focusedTagIndex === null) {
+			let enabledTagIndex = this.props.tags.findIndex(tag => !tag.disabled);
+			if (enabledTagIndex !== -1) {
+				this.focusedTagIndex = enabledTagIndex;
+			}
+			else {
+				this.focusedTagIndex = 0;
+			}
 		}
 		let tagRefocused = this.refocusTag();
 		if (tagRefocused) return;


### PR DESCRIPTION
If one explicitly selected to "Display all tags in this library", do not jump over disabled tags during arrow navigation. Followup to #3967.


Comment after initial changes this addresses:

The issue is partially resolved. The tags now have the checkbox role, which is sufficient, and they have their state announced when focused and activated. However, when all tags are set to be viewed, the disabled tags are not able to be selected on Windows. This makes it functionally no different from having 'Display All Tags in This Library' off; reasonably, one could expect the user wants to be able to see all of the tags if that option is on. It is fine for the disabled tags to not be in the focus order (navigating by Tab key), but they should still be able to be selected by screen reader cursors (navigating by arrow keys) and have a disabled state