### PR TITLE
vpat 3: make "remove" btn in itemPane focusable even when hidden

### DIFF
--- a/chrome/content/zotero/elements/tagsBox.js
+++ b/chrome/content/zotero/elements/tagsBox.js
@@ -189,9 +189,9 @@
 
 			if (this.editable) {
 				var remove = document.createXULElement("toolbarbutton");
-				remove.setAttribute('value', '-');
 				remove.setAttribute('class', 'zotero-clicky zotero-clicky-minus');
-				remove.setAttribute('tabindex', -1);
+				remove.setAttribute('tabindex', 0);
+				remove.setAttribute("data-l10n-id", 'section-button-remove');
 			}
 
 			var row = document.createElement("div");

--- a/scss/elements/_librariesCollectionsBox.scss
+++ b/scss/elements/_librariesCollectionsBox.scss
@@ -44,11 +44,13 @@ libraries-collections-box {
 
 			toolbarbutton {
 				margin-inline-start: auto;
-				visibility: hidden;
 				border-radius: 2px;
+				& > image {
+					visibility: hidden;
+				}
 			}
 
-			&:is(:hover, :focus-within) toolbarbutton {
+			&:is(:hover, :focus-within) toolbarbutton > image {
 				visibility: visible;
 			}
 		}

--- a/scss/elements/_notesBox.scss
+++ b/scss/elements/_notesBox.scss
@@ -34,10 +34,12 @@ notes-box, related-box {
 	
 			toolbarbutton {
 				margin-inline-start: auto;
-				visibility: hidden;
+				& > image {
+					visibility: hidden;
+				}
 			}
 	
-			&:is(:hover, :focus-within) toolbarbutton {
+			&:is(:hover, :focus-within) toolbarbutton > image{
 				visibility: visible;
 			}
 		}

--- a/scss/elements/_tagsBox.scss
+++ b/scss/elements/_tagsBox.scss
@@ -67,10 +67,12 @@ tags-box {
 
 			toolbarbutton {
 				margin-inline-start: auto;
-				visibility: hidden;
+				& > image {
+					visibility: hidden;
+				}
 			}
 
-			&:is(:hover, :focus-within) toolbarbutton {
+			&:is(:hover, :focus-within) toolbarbutton > image {
 				visibility: visible;
 			}
 		}


### PR DESCRIPTION
In itemPane, do not hide the actual "-" toolbarbutton, hide the `<image>`  inside of it. Visually, it looks the same but the button can be focused via tab without having to expicitly make it visible. It means that shift-tab from the section header will not skip the `-` button.

This does not apply to the itemBox, since there is a bit more logic in it and itemBox does not cause vpat issues.

Also, make "remove" toolbarbutton from tagsbox focusable like all others for consistency.


This is a followup to #3953. For reference, this is an example of how the `-` next to the note row gets skipped on shift-tab from "Collection and libraries" section header that this addresses.

https://github.com/zotero/zotero/assets/36271954/17a1aeed-9ab9-4a57-8323-2a09016e2143

