### PR TITLE
Feed & feed abstract fixes

### DIFF
--- a/chrome/content/zotero/actors/FeedAbstractChild.jsm
+++ b/chrome/content/zotero/actors/FeedAbstractChild.jsm
@@ -10,10 +10,13 @@ class FeedAbstractChild extends JSWindowActorChild {
 		this._stylesheetPromise = this.sendQuery('getStylesheet');
 	}
 	
-	async receiveMessage({ name, data }) {
+	async receiveMessage({ name, data: { url, html } }) {
 		switch (name) {
 			case "setContent": {
-				this.document.documentElement.innerHTML = data;
+				let base = this.document.createElement("base");
+				base.href = url;
+				this.document.head.replaceChildren(base);
+				this.document.body.innerHTML = html;
 				break;
 			}
 		}

--- a/chrome/content/zotero/elements/abstractBox.js
+++ b/chrome/content/zotero/elements/abstractBox.js
@@ -126,13 +126,14 @@
 		}
 		
 		async _renderFeedItem() {
-			let abstract = this.item.getField('abstractNote');
+			let url = this.item.library.url;
+			let html = this.item.getField('abstractNote');
 			this._abstractField.hidden = true;
 			this._feedAbstractBrowser.hidden = false;
-			this._section.summary = Zotero.Utilities.cleanTags(abstract);
+			this._section.summary = Zotero.Utilities.cleanTags(html);
 			
 			let actor = this._feedAbstractBrowser.browsingContext.currentWindowGlobal.getActor('FeedAbstract');
-			await actor.sendQuery('setContent', abstract);
+			await actor.sendQuery('setContent', { url, html });
 		}
 		
 		_renderRegularItem() {

--- a/chrome/content/zotero/xpcom/feedReader.js
+++ b/chrome/content/zotero/xpcom/feedReader.js
@@ -416,23 +416,23 @@ Zotero.FeedReader._getFeedItem = function (feedEntry, feedInfo) {
 			
 	if (feedEntry.title) item.title = Zotero.FeedReader._getRichText(feedEntry.title, 'title');
 	
-	if (feedEntry.summary) {
-		let summaryFragment = feedEntry.summary.createDocumentFragment();
-		if (summaryFragment.querySelectorAll('body').length === 1) {
-			summaryFragment.replaceChildren(...summaryFragment.querySelector('body').childNodes);
+	if (feedEntry.content || feedEntry.summary) {
+		let abstractFragment = (feedEntry.content || feedEntry.summary).createDocumentFragment();
+		if (abstractFragment.querySelectorAll('body').length === 1) {
+			abstractFragment.replaceChildren(...abstractFragment.querySelector('body').childNodes);
 		}
-		item.abstractNote = new XMLSerializer().serializeToString(summaryFragment);
-		
-		if (!item.title) {
-			// We will probably have to trim this, so let's use plain text to
-			// avoid splitting inside some markup
-			let title = Zotero.Utilities.trimInternal(feedEntry.summary.plainText());
-			let splitAt = title.lastIndexOf(' ', 50);
-			if (splitAt == -1) splitAt = 50;
-			
-			item.title = title.substr(0, splitAt);
-			if (splitAt <= title.length) item.title += '...';
-		}
+		item.abstractNote = new XMLSerializer().serializeToString(abstractFragment);
+	}
+
+	if (feedEntry.summary && !item.title) {
+		// We will probably have to trim this, so let's use plain text to
+		// avoid splitting inside some markup
+		let title = Zotero.Utilities.trimInternal(feedEntry.summary.plainText());
+		let splitAt = title.lastIndexOf(' ', 50);
+		if (splitAt == -1) splitAt = 50;
+
+		item.title = title.substr(0, splitAt);
+		if (splitAt <= title.length) item.title += '...';
 	}
 	
 	if (feedEntry.link) item.url = feedEntry.link.href;

--- a/scss/feedAbstract.scss
+++ b/scss/feedAbstract.scss
@@ -11,6 +11,10 @@
 
 @import "base/base";
 
+html {
+	color-scheme: light dark;
+}
+
 html, body {
 	background: var(--material-sidepane);
 	overflow: clip;

--- a/test/tests/data/feedRichText.rss
+++ b/test/tests/data/feedRichText.rss
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!-- Lifted from http://cyber.law.harvard.edu/rss/examples/rss2sample.xml -->
-<rss version="2.0">
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
    <channel>
       <title>Liftoff News</title>
       <link>http://liftoff.msfc.nasa.gov/</link>
@@ -25,6 +25,14 @@
          <description>The proposed &lt;b&gt;VASIMR&lt;/b&gt; engine would do that.</description>
          <pubDate>Tue, 27 May 2003 08:37:32 GMT</pubDate>
          <guid>http://liftoff.msfc.nasa.gov/2003/05/27.html#item571</guid>
+      </item>
+      <item>
+         <title>This item has content</title>
+         <link>https://onlinelibrary.wiley.com/journal/27314375?af=R</link>
+         <description>This description has no tags in it.</description>
+         <content:encoded>This content has &lt;blink&gt;tags&lt;/blink&gt; in it.</content:encoded>
+         <pubDate>Tue, 23 Apr 2024 00:38:38 -0700</pubDate>
+         <guid>10.1002/dro2.121</guid>
       </item>
    </channel>
 </rss>

--- a/test/tests/feedReaderTest.js
+++ b/test/tests/feedReaderTest.js
@@ -217,6 +217,18 @@ describe("Zotero.FeedReader", function () {
 			assert.equal(item.title, "Embedded <b>tags</b>");
 		});
 
+		it('should use content as abstractNote when available', async () => {
+			const fr = new Zotero.FeedReader(richTextRSSFeedURL);
+			await fr.process();
+			const itemIterator = new fr.ItemIterator();
+			let item;
+			for (let i = 0; i < 3; i++) {
+				item = await itemIterator.next().value;
+			}
+
+			assert.include(item.abstractNote, '<blink');
+		});
+
 		it('should parse HTML fields', async () => {
 			const fr = new Zotero.FeedReader(richTextRSSFeedURL);
 			await fr.process();
@@ -227,7 +239,6 @@ describe("Zotero.FeedReader", function () {
 				item = await itemIterator.next().value;
 			}
 
-			// The entry description is XHTML, so tags are removed there.
 			assert.equal(item.abstractNote, 'The proposed <b xmlns="http://www.w3.org/1999/xhtml">VASIMR</b> engine would do that.');
 		});
 


### PR DESCRIPTION
Fixes all issues reported [here](https://forums.zotero.org/discussion/113989/zotero-7-beta-graphical-abstract-in-rss-feeds):

- Black on black text
- Broken relative/protocol-relative images
- Reader ignoring rich-text content in favor of plain-text summary