### PR TITLE
post vpat-57: qf locator string tweak

### DIFF
--- a/chrome/content/zotero/integration/addCitationDialog.xhtml
+++ b/chrome/content/zotero/integration/addCitationDialog.xhtml
@@ -115,8 +115,8 @@
 					<menulist onchange="Zotero_Citation_Dialog.confirmRegenerate(true)" id="label" tabindex="0" native="true" data-l10n-id="quickformat-locator-type">
 						<menupopup id="locator-type-popup"/>
 					</menulist>
-					<label id="locator_input_label" data-l10n-id="quickformat-locator-value" hidden="true"></label>
-					<html:input aria-labelledby="label locator_input_label" oninput="Zotero_Citation_Dialog.confirmRegenerate(false)"  onchange="Zotero_Citation_Dialog.confirmRegenerate(true)" id="locator" tabindex="0"/>
+					<label id="locator-input-label" data-l10n-id="quickformat-locator-value" hidden="true"></label>
+					<html:input aria-labelledby="label locator-input-label" oninput="Zotero_Citation_Dialog.confirmRegenerate(false)"  onchange="Zotero_Citation_Dialog.confirmRegenerate(true)" id="locator" tabindex="0"/>
 				</hbox>
 				<separator style="height: 2px" flex="1"/>
 				<checkbox oncommand="Zotero_Citation_Dialog.confirmRegenerate(true)" id="suppress-author" label="&zotero.citation.suppressAuthor.label;" tabindex="0" native="true"/>

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -484,7 +484,7 @@ quickformat-accept =
     .tooltiptext = Save edits to this citation
 quickformat-locator-type =
     .aria-label = Locator type
-quickformat-locator-value =  Locator input
+quickformat-locator-value =  Locator
 
 insert-note-aria-input = Type to search for a note. Press Tab to navigate the list of results. Press Escape to close the dialog.
 insert-note-aria-item = Press { return-or-enter } to select this note. Press Tab to go back to the search field. Press Escape to close the dialog.


### PR DESCRIPTION
"Locator input" -> "Locator"

Fixes: #4066

Per comment from https://github.com/zotero/zotero/commit/0077c3f07a2f0fa1fb0e2568f25aa8b598b9074a:
> "input" strikes me as a fairly technical term.
Doesn't the screen reader already tell you that it's a text box? So "input" seems a bit redundant anyway. Seems like it could just be "Locator"?

Yeah, "input" is fairly technical... Screen readers do announce that it's an input field in this way or another (e.g. voiceover will say "edit text"). With `aria-labelledBy` pointing at the locator type dropdown and the input's label, screen readers announce both (e.g. "Locator type page. Locator input 6"). So the only reason why I added "input" initially is to make a clearer distinction from "Locator type" which indeed might not be helpful. I suppose we can go with "Locator" and if the VPAT review indicates there's some confusion, we can revisit the exact phrasing?

Alternatively, we could try "Locator value"? This might indicate that the locator has essentially 2 pieces - "type" from the dropdown and the value that you have to type in. It would then be announced as something "Locator type page. Locator value" when the empty input field for the locator is focused.