### PR TITLE
Fix column-sorting shortcuts on Windows

### DIFF
--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -1627,12 +1627,10 @@ var ZoteroPane = new function()
 
 			let sortSubmenuKeys = document.getElementById('sortSubmenuKeys');
 			for (let i = 0; i < 10; i++) {
-				let key = document.createElement('key');
-				key.id = 'key_sortCol' + i;
+				let key = sortSubmenuKeys.children[i];
 				key.setAttribute('modifiers', Zotero.isMac ? 'accel alt control' : 'accel alt');
 				key.setAttribute('key', (i + 1) % 10);
 				key.addEventListener('command', () => ZoteroPane.itemsView.toggleSort(i, true));
-				sortSubmenuKeys.append(key);
 			}
 		}
 		catch (e) {

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -191,7 +191,20 @@
 		<key id="key_findPrevious2" keycode="&findAgainCmd.key2;" modifiers="shift" command="cmd_findPrevious"/>
 	</keyset>
 	
-	<keyset id="sortSubmenuKeys"/>
+	<keyset id="sortSubmenuKeys">
+		<!-- Attributes are set in initItemsTree(), but these don't work on Windows if they're
+		     created in JS -->
+		<key id="key_sortCol0"/>
+		<key id="key_sortCol1"/>
+		<key id="key_sortCol2"/>
+		<key id="key_sortCol3"/>
+		<key id="key_sortCol4"/>
+		<key id="key_sortCol5"/>
+		<key id="key_sortCol6"/>
+		<key id="key_sortCol7"/>
+		<key id="key_sortCol8"/>
+		<key id="key_sortCol9"/>
+	</keyset>
 	
 	<vbox id="titlebar">
 		<hbox class="titlebar-icon-container">


### PR DESCRIPTION
They don't work when created in JS for some reason.

(The use of `createElement` instead of `createXULElement` wasn't the issue, although that was a mistake.)

Fixes #4056