### PR TITLE
vpat 44: scaffold keyboard tab selection focus

### DIFF
--- a/chrome/content/scaffold/scaffold.js
+++ b/chrome/content/scaffold/scaffold.js
@@ -160,6 +160,10 @@ var Scaffold = new function () {
 		this.initCodeEditor();
 		this.initTestsEditor();
 
+		this.addEditorKeydownHandlers(_editors.import);
+		this.addEditorKeydownHandlers(_editors.code);
+		this.addEditorKeydownHandlers(_editors.tests);
+
 		// Set font size from general pref
 		Zotero.UIProperties.registerRoot(document.getElementById('scaffold-pane'));
 
@@ -194,29 +198,6 @@ var Scaffold = new function () {
 				}
 			});
 		}
-		// Special key handling for the editors
-		let tabbox = document.getElementById("left-tabbox");
-		// On shift-tab from the start of the first line, tab out of the editor.
-		// Use capturing listener, since Shift-Tab keydown events do not leave the editor.
-		document.addEventListener("keydown", (event) => {
-			if (!event.target.ownerDocument.URL.includes("monaco.html")) return;
-			if (event.key == "Tab" && event.shiftKey) {
-				let activeEditor = _editors[_getActiveEditorName()];
-				let position = activeEditor.getPosition();
-				if (position.column == 1 && position.lineNumber == 1) {
-					Services.focus.moveFocus(window, event.target, Services.focus.MOVEFOCUS_BACKWARD, 0);
-					event.preventDefault();
-				}
-			}
-		}, true);
-		// On Escape, focus the selected tab. Use non-capturing listener to not
-		// do anything on Escape events handled by the editor (e.g. to dismiss autocomplete popup)
-		document.addEventListener("keydown", (event) => {
-			if (!event.target.ownerDocument.URL.includes("monaco.html")) return;
-			if (event.key == "Escape") {
-				tabbox.selectedTab.focus();
-			}
-		});
 	};
 	
 	this.promptForTranslatorsDirectory = async function () {
@@ -935,6 +916,31 @@ var Scaffold = new function () {
 			openURL.setAttribute('disabled', true);
 		}
 	};
+
+	// Add special keydown handling for the editors
+	this.addEditorKeydownHandlers = function (editor) {
+		let doc = editor.getDomNode().ownerDocument;
+		let tabbox = document.getElementById("left-tabbox");
+		// On shift-tab from the start of the first line, tab out of the editor.
+		// Use capturing listener, since Shift-Tab keydown events do not propagate to the document.
+		doc.addEventListener("keydown", (event) => {
+			if (event.key == "Tab" && event.shiftKey) {
+				let position = editor.getPosition();
+				if (position.column == 1 && position.lineNumber == 1) {
+					Services.focus.moveFocus(window, event.target, Services.focus.MOVEFOCUS_BACKWARD, 0);
+					event.preventDefault();
+				}
+			}
+		}, true);
+		// On Escape, focus the selected tab. Use non-capturing listener to not
+		// do anything on Escape events handled by the editor (e.g. to dismiss autocomplete popup)
+		doc.addEventListener("keydown", (event) => {
+			if (event.key == "Escape") {
+				tabbox.selectedTab.focus();
+			}
+		});
+	};
+
 
 	this.listFieldsForItemType = function (itemType) {
 		var outputObject = {};

--- a/chrome/content/scaffold/scaffold.js
+++ b/chrome/content/scaffold/scaffold.js
@@ -195,14 +195,11 @@ var Scaffold = new function () {
 			});
 		}
 		// Special key handling for the editors
+		let tabbox = document.getElementById("left-tabbox");
+		// On shift-tab from the start of the first line, tab out of the editor.
+		// Use capturing listener, since Shift-Tab keydown events do not leave the editor.
 		document.addEventListener("keydown", (event) => {
 			if (!event.target.ownerDocument.URL.includes("monaco.html")) return;
-			let tabbox = document.getElementById("left-tabbox");
-			// On Escape, focus the selected tab
-			if (event.key == "Escape") {
-				tabbox.selectedTab.focus();
-			}
-			// On shift-tab from the start of the first line, tab out of the editor
 			if (event.key == "Tab" && event.shiftKey) {
 				let activeEditor = _editors[_getActiveEditorName()];
 				let position = activeEditor.getPosition();
@@ -212,6 +209,14 @@ var Scaffold = new function () {
 				}
 			}
 		}, true);
+		// On Escape, focus the selected tab. Use non-capturing listener to not
+		// do anything on Escape events handled by the editor (e.g. to dismiss autocomplete popup)
+		document.addEventListener("keydown", (event) => {
+			if (!event.target.ownerDocument.URL.includes("monaco.html")) return;
+			if (event.key == "Escape") {
+				tabbox.selectedTab.focus();
+			}
+		});
 	};
 	
 	this.promptForTranslatorsDirectory = async function () {

--- a/chrome/content/scaffold/scaffold.js
+++ b/chrome/content/scaffold/scaffold.js
@@ -202,13 +202,11 @@ var Scaffold = new function () {
 			if (event.key == "Escape") {
 				tabbox.selectedTab.focus();
 			}
-			// On shift-tab from the start of the line, tab out of the editor
+			// On shift-tab from the start of the first line, tab out of the editor
 			if (event.key == "Tab" && event.shiftKey) {
-				let editorDoc = event.target.ownerDocument;
-				let margin = editorDoc.querySelector(".margin");
-				let cursor = editorDoc.querySelector("textarea.monaco-mouse-cursor-text");
-				// check if cursor is at the same position as the left margin
-				if (margin.style.width == cursor.style.left) {
+				let activeEditor = _editors[_getActiveEditorName()];
+				let position = activeEditor.getPosition();
+				if (position.column == 1 && position.lineNumber == 1) {
 					Services.focus.moveFocus(window, event.target, Services.focus.MOVEFOCUS_BACKWARD, 0);
 					event.preventDefault();
 				}

--- a/chrome/content/scaffold/scaffold.xhtml
+++ b/chrome/content/scaffold/scaffold.xhtml
@@ -464,7 +464,7 @@
 					</tabpanel>
 					<tabpanel flex="1" id="tabpanel-code">
 						<vbox flex="1">
-							<iframe src="monaco/monaco.html" id="editor-code" flex="1" onmousedown="this.focus()"/>
+							<iframe src="monaco/monaco.html" id="editor-code" focus-on-tab-select="true" flex="1" onmousedown="this.focus()"/>
 						</vbox>
 					</tabpanel>
 					<tabpanel flex="1" id="tabpanel-tests">
@@ -486,6 +486,7 @@
 									seltype="multiple"
 									onselect="Scaffold.handleTestSelect(event)"
 									context="testing-context-menu"
+									focus-on-tab-select="true"
 								/>
 							</vbox>
 							<hbox id="testing-buttons">
@@ -529,7 +530,7 @@
 								<button observes="validate-tests" label="&scaffold.testing.create.import;" tooltiptext="Create a new test from the current import data" oncommand="Scaffold.saveTestFromCurrent('import')" />
 								<button observes="validate-tests" label="&scaffold.testing.create.search;" tooltiptext="Create a new test from the current search data" oncommand="Scaffold.saveTestFromCurrent('search')" />
 							</hbox>
-							<iframe src="monaco/monaco.html" id="editor-import" flex="1" onmousedown="this.focus()"/>
+							<iframe src="monaco/monaco.html" id="editor-import" flex="1" focus-on-tab-select="true" onmousedown="this.focus()"/>
 						</vbox>
 					</tabpanel>
 				</tabpanels>

--- a/scss/scaffold.scss
+++ b/scss/scaffold.scss
@@ -82,7 +82,8 @@ browser,
 #left-tabbox {
 	flex: 1;
 	min-width: 500px;
-	margin: 5px;
+	margin: 0 5px 5px 5px;
+	padding-top: 5px; // padding at the top for focus-ring of tabs to not cutoff tabs focusring
 	overflow: clip;
 	
 	tabpanel {
@@ -210,4 +211,10 @@ browser,
 			margin: 0;
 		}
 	}
+}
+
+// show focusring only during keyboard navigation
+#tabs:not([clicked]) tab:focus-visible {
+	outline: none;
+	box-shadow: 0 0 0 var(--width-focus-border) var(--color-focus-border);
 }


### PR DESCRIPTION
Do not move focus from the tab onto the editor/input, during keyboard navigation to not change context per https://www.w3.org/WAI/WCAG21/Understanding/on-input. 

Based on the success criteria above, it seems like it is desired to avoid context (specifically focus in our case) changes during tab navigation in general. Avoiding it completely would be detrimental to overall functionality, since it's way better for the input to be focused after you click on a tab. So I thought this could be a reasonable compromise that's also somewhat close to what firefox does: if you switch tabs via clicking, the focus will move into the selected tab panel but if you select a tab with keyboard, focus remains on it?

---

VPAT 44 description for reference:

In the Zotero desktop app's 'Translator'/'Scaffold' modal, there is a tab panel with tabs for different sections. The 'Code,' Tests,' and 'Test Input' tabs have code inputs in them. When one of these tabs is selected, the code input is automatically focused. Focus should remain on the tab panel. This occurs wiht or without a screen reader active.

Impact Statement: Operable elements have certain predictable behaviors. Whenever something breaks those expectations, the user should be informed ahead of time. If they are not it can be disorienting for all users, but especially those with visual or cognitive impairments.

Expected Result: Changing the setting of an element does not cause an unexpected change of context.