### PR TITLE
set quicksearch placeholder as fluent argument

### DIFF
--- a/chrome/content/zotero/elements/quickSearchTextbox.js
+++ b/chrome/content/zotero/elements/quickSearchTextbox.js
@@ -87,7 +87,6 @@
 			dropmarkerShadow.append(s1, s2, dropmarker);
 
 			let searchBox = document.createXULElement("search-textbox");
-			searchBox.inputField.setAttribute("data-l10n-id", "quicksearch-input");
 			searchBox.id = "zotero-tb-search-textbox";
 			this.searchTextbox = searchBox;
 			
@@ -153,9 +152,7 @@
 
 			this.searchModePopup.querySelector(`menuitem[value="${mode}"]`)
 				.setAttribute('checked', 'true');
-			this.searchTextbox.placeholder = this._searchModes[mode];
-			// Have the placeholder announced by screen readers after the label for additional context
-			this.searchTextbox.inputField.setAttribute("aria-description", this.searchTextbox.placeholder);
+			document.l10n.setAttributes(this.searchTextbox.inputField, "quicksearch-input", { placeholder: this._searchModes[mode] });
 		}
 
 		_id(id) {

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -492,3 +492,5 @@ quicksearch-mode =
     .aria-label = Quick Search mode
 quicksearch-input =
     .aria-label = Quick Search
+    .placeholder = { $placeholder }
+    .aria-description = { $placeholder }


### PR DESCRIPTION
Fluent seems to clear out label/placeholders attributes set directly (not via .ftl file). So quicksearch placeholder added directly ends up being emptied out.
This is the cleanest workaround found so far: add the placeholder as the fluent argument

Fixes: #4073