### PR TITLE
prevent focus from sticking to tab after click

### DIFF
--- a/chrome/content/zotero/components/tabBar.jsx
+++ b/chrome/content/zotero/components/tabBar.jsx
@@ -128,6 +128,8 @@ const TabBar = forwardRef(function (props, ref) {
 		}
 		props.onTabSelect(id);
 		event.stopPropagation();
+		// Prevents focus from sticking to the actual tab on windows
+		event.preventDefault();
 	}
 
 	function handleTabClick(event, id) {


### PR DESCRIPTION
After clicking on a reader tab, the reader will get focused but the default mousedown event handler can then shift focus onto the actual tab. It looks like the focus gets "lost", and breaks reader keyboard shortcuts so we want to avoid it. Mainly happens on windows.

Fixes: #4077