### PR TITLE
redone fix of focus sticking to tab after click

### DIFF
--- a/chrome/content/zotero/components/tabBar.jsx
+++ b/chrome/content/zotero/components/tabBar.jsx
@@ -128,8 +128,6 @@ const TabBar = forwardRef(function (props, ref) {
 		}
 		props.onTabSelect(id);
 		event.stopPropagation();
-		// Prevents focus from sticking to the actual tab on windows
-		event.preventDefault();
 	}
 
 	function handleTabClick(event, id) {
@@ -162,6 +160,7 @@ const TabBar = forwardRef(function (props, ref) {
 	
 	function handleDragEnd() {
 		setDragging(false);
+		props.refocusReader();
 	}
 
 	function handleTabBarDragOver(event) {

--- a/chrome/content/zotero/elements/contextPane.js
+++ b/chrome/content/zotero/elements/contextPane.js
@@ -203,7 +203,11 @@
 					|| !document.activeElement.closest('.context-node iframe[id="editor-view"]'))) {
 				if (!Zotero_Tabs.focusOptions?.keepTabFocused) {
 					// Do not move focus to the reader during keyboard navigation
-					reader.focus();
+					setTimeout(() => {
+						// Timeout to make sure focus does not stick to the tab
+						// after click on windows
+						reader.focus();
+					});
 				}
 			}
 			

--- a/chrome/content/zotero/tabs.js
+++ b/chrome/content/zotero/tabs.js
@@ -161,6 +161,7 @@ var Zotero_Tabs = new function () {
 				onTabMove={this.move.bind(this)}
 				onTabClose={this.close.bind(this)}
 				onContextMenu={this._openMenu.bind(this)}
+				refocusReader={this.refocusReader.bind(this)}
 			/>,
 			document.getElementById('tab-bar-container'),
 			() => {
@@ -568,6 +569,18 @@ var Zotero_Tabs = new function () {
 	this.selectLast = function () {
 		this.select(this._tabs[this._tabs.length - 1].id);
 	};
+
+	/**
+	 * Return focus into the reader of the selected tab.
+	 * Required to move focus from the tab into the reader after drag.
+	 */
+	this.refocusReader = function () {
+		var reader = Zotero.Reader.getByTabID(this._selectedID);
+		if (!reader) return;
+		setTimeout(() => {
+			reader.focus();
+		}, 100);
+	}
 
 	/**
 	 * Moves focus to a tab in the specified direction.

--- a/chrome/content/zotero/tabs.js
+++ b/chrome/content/zotero/tabs.js
@@ -579,7 +579,7 @@ var Zotero_Tabs = new function () {
 		if (!reader) return;
 		setTimeout(() => {
 			reader.focus();
-		}, 100);
+		});
 	}
 
 	/**


### PR DESCRIPTION
- revert debcb9944d19862565435fe0b8768c95c3dc633f since it breaks drag-drop reordering of tabs
- when reader is being refocused by contextPane, add a small delay so that the focus settles on the tab before focusing the reader
- also explicitly refocus the reader tab after drag, since then focus also lands on the tab and finds itself outside of the reader

This should take care of focus sticking to the tab after clicking between them or drag/drop (which I assumed is not desired as well).

There are some other instances where focus may not do exactly what we want, though. Since reader is a separate browser, if any element outside of it receives focus, clicking back into the reader won't necessarily transfer focus back into it. For example, if I click on an `editable-text` in the context pane and then click on the magnifying glass in the reader, the search bar does not get focus because the reader itself does not have focus.This does not seem as big of an issue but still worth mentioning.

This tweak is in a way a repeat of the logic used to refocus the zoteroPane, but reader is refocused in `contextPane.js`, as opposed to the `tabs.js`. So it might be nice to consolidate these things into one place at some point.

Fixes #4077