### PR TITLE
Fix color picker (and other) button styles

### DIFF
--- a/scss/elements/_colorPicker.scss
+++ b/scss/elements/_colorPicker.scss
@@ -29,6 +29,7 @@ color-picker {
 		appearance: none;
 		height: auto;
 		border: 0;
+		border-radius: 0;
 		margin: 0;
 		padding: 0;
 	}

--- a/scss/elements/_colorPicker.scss
+++ b/scss/elements/_colorPicker.scss
@@ -27,7 +27,10 @@ color-picker {
 
 	.grid-tile, .grid-tile:hover {
 		appearance: none;
+		height: auto;
 		border: 0;
+		margin: 0;
+		padding: 0;
 	}
 
 	.grid-tile[selected="true"] {

--- a/scss/win/components/_button.scss
+++ b/scss/win/components/_button.scss
@@ -1,6 +1,10 @@
-// skip React Button element
-button:not(.btn, [type=checkbox], [type=radio]),
-input:is([type=button], [type=submit]) {
+// Use :where to reset specificity to 0
+// https://css-tricks.com/using-the-specificity-of-where-as-a-css-reset/
+:where(
+	// skip React Button element
+	button:not(.btn, [type=checkbox], [type=radio]),
+	input:is([type=button], [type=submit])
+) {
 	@include windows-form-element;
 
 	padding: 4px 11px 6px 11px;


### PR DESCRIPTION
- Prevent Windows button defaults from overriding other styles by setting specificity to 0
- Fix color picker swatch appearing too small and grid buttons overlapping/overflowing

Fixes #4079