### PR TITLE
Update numeric keyboard shortcuts for keyboard layout compat

### DIFF
--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -1628,7 +1628,7 @@ var ZoteroPane = new function()
 			let sortSubmenuKeys = document.getElementById('sortSubmenuKeys');
 			for (let i = 0; i < 10; i++) {
 				let key = sortSubmenuKeys.children[i];
-				key.setAttribute('modifiers', Zotero.isMac ? 'accel alt control' : 'accel alt');
+				key.setAttribute('modifiers', Zotero.isMac ? 'accel alt control' : 'alt');
 				key.setAttribute('key', (i + 1) % 10);
 				key.addEventListener('command', () => ZoteroPane.itemsView.toggleSort(i, true));
 			}

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -64,6 +64,8 @@ var ZoteroPane = new function()
 
 	const modifierIsNotShift = ev => ev.getModifierState("Meta") || ev.getModifierState("Alt")
 	|| ev.getModifierState("Control") || ev.getModifierState("OS");
+	
+	const TAB_NUMBER_CODE_RE = /^(?:Numpad|Digit)([0-9])$/;
 
 	var self = this,
 		_loaded = false, _madeVisible = false,
@@ -984,24 +986,28 @@ var ZoteroPane = new function()
 		// Jump to tab N (or to the last tab if there are less than N tabs)
 		// CmdOrCtrl-9 is specially defined to jump to the last tab no matter how many there are.
 		if (cmdOrCtrlOnly) {
-			switch (event.key) {
-				case '1':
-				case '2':
-				case '3':
-				case '4':
-				case '5':
-				case '6':
-				case '7':
-				case '8':
-					Zotero_Tabs.jump(parseInt(event.key) - 1);
-					event.preventDefault();
-					event.stopPropagation();
-					return;
-				case '9':
-					Zotero_Tabs.selectLast();
-					event.preventDefault();
-					event.stopPropagation();
-					return;
+			let tabNumberMatch = event.code.match(TAB_NUMBER_CODE_RE);
+			if (tabNumberMatch) {
+				let tabNumber = tabNumberMatch[1];
+				switch (tabNumber) {
+					case '1':
+					case '2':
+					case '3':
+					case '4':
+					case '5':
+					case '6':
+					case '7':
+					case '8':
+						Zotero_Tabs.jump(parseInt(tabNumber) - 1);
+						event.preventDefault();
+						event.stopPropagation();
+						return;
+					case '9':
+						Zotero_Tabs.selectLast();
+						event.preventDefault();
+						event.stopPropagation();
+						return;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes item tree sorting and tab switching shortcuts so they work in the French AZERTY layout.

**Sort shortcuts:** Use Alt as the modifier on Windows. For some reason, Alt is the only modifier (besides Ctrl, which is taken) that works with the French layout. Replacing `key="[1-9]"` with `keycode="VK_[1-9]"` stops it from working at all, in any layout (I guess because that's only for unprintable keys).

**Tab shortcuts:** Use a routine similar to the one that we use in the item tree for tag shortcuts. Although `<key>` elements work with Ctrl as the modifier, key *events* report the printable value of the pressed key instead of the number (`&é"` and so on). So we compare `event.code` instead of `event.key`.

(I get stressed every time I remember that keyboard layouts are something we need to worry about, and all this is NOT HELPING)

Fixes #4080