### PR TITLE
 Create Bibliography: Use HiddenBrowser to fix printing 

### DIFF
--- a/chrome/content/zotero/actors/ActorManager.jsm
+++ b/chrome/content/zotero/actors/ActorManager.jsm
@@ -34,3 +34,16 @@ ChromeUtils.registerWindowActor("FeedAbstract", {
 	},
 	messageManagerGroups: ["feedAbstract"]
 });
+
+ChromeUtils.registerWindowActor("ZoteroPrint", {
+	parent: {
+		moduleURI: "chrome://zotero/content/actors/ZoteroPrintParent.jsm"
+	},
+	child: {
+		moduleURI: "chrome://zotero/content/actors/ZoteroPrintChild.jsm",
+		events: {
+			pageshow: {}
+		}
+	}
+});
+

--- a/chrome/content/zotero/actors/ZoteroPrintChild.jsm
+++ b/chrome/content/zotero/actors/ZoteroPrintChild.jsm
@@ -1,0 +1,26 @@
+var EXPORTED_SYMBOLS = ["ZoteroPrintChild"];
+
+
+class ZoteroPrintChild extends JSWindowActorChild {
+	actorCreated() {
+		Cu.exportFunction(
+			() => new this.contentWindow.Promise(
+				(resolve, reject) => this._sendZoteroPrint().then(resolve, reject)
+			),
+			this.contentWindow,
+			{ defineAs: "zoteroPrint" }
+		);
+	}
+
+	async handleEvent(event) {
+		switch (event.type) {
+			case "pageshow": {
+				// We just need this to trigger actor creation
+			}
+		}
+	}
+
+	async _sendZoteroPrint() {
+		await this.sendQuery("zoteroPrint");
+	}
+}

--- a/chrome/content/zotero/actors/ZoteroPrintParent.jsm
+++ b/chrome/content/zotero/actors/ZoteroPrintParent.jsm
@@ -1,0 +1,51 @@
+var EXPORTED_SYMBOLS = ["ZoteroPrintParent"];
+
+const { XPCOMUtils } = ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+
+XPCOMUtils.defineLazyModuleGetters(this, {
+	Services: "resource://gre/modules/Services.jsm",
+});
+
+ChromeUtils.defineESModuleGetters(this, {
+	Zotero: "chrome://zotero/content/zotero.mjs",
+});
+
+class ZoteroPrintParent extends JSWindowActorParent {
+	async receiveMessage({ name, data }) {
+		switch (name) {
+			case "zoteroPrint": {
+				await this.zoteroPrint(data || {});
+			}
+		}
+	}
+
+	/**
+	 * A custom print function to work around Zotero 7 printing issues
+	 * @param {Object} [options]
+	 * @param {Object} [options.overrideSettings] PrintUtils.getPrintSettings() settings to override
+	 * @returns {Promise<void>}
+	 */
+	async zoteroPrint(options = {}) {
+		let win = Zotero.getMainWindow();
+		if (win) {
+			let { PrintUtils } = win;
+			let settings = PrintUtils.getPrintSettings("", false);
+			Object.assign(settings, options.overrideSettings || {});
+			let doPrint = await PrintUtils.handleSystemPrintDialog(
+				this.browsingContext.topChromeWindow, false, settings
+			);
+			if (doPrint) {
+				let printPromise = this.browsingContext.print(settings);
+				// An ugly hack to close the browser window that has a static clone
+				// of the content that is being printed. Without this, the window
+				// will be open while transferring the content into system print queue,
+				// which can take time for large PDF files
+				let win = Services.wm.getMostRecentWindow("navigator:browser");
+				if (win?.document?.getElementById('statuspanel')) {
+					win.close();
+				}
+				await printPromise;
+			}
+		}
+	}
+}

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -162,29 +162,6 @@ class ReaderInstance {
 
 		await this._waitForReader();
 
-		// A custom print function to work around Zotero 7 printing issues
-		this._iframeWindow.wrappedJSObject.zoteroPrint = async () => {
-			let win = Zotero.getMainWindow();
-			if (win) {
-				let { PrintUtils } = win;
-				let settings = PrintUtils.getPrintSettings("", false);
-				let doPrint = await PrintUtils.handleSystemPrintDialog(
-					this._iframeWindow.browsingContext.topChromeWindow, false, settings
-				);
-				if (doPrint) {
-					this._iframeWindow.browsingContext.print(settings);
-					// An ugly hack to close the browser window that has a static clone
-					// of the content that is being printed. Without this, the window
-					// will be open while transferring the content into system print queue,
-					// which can take time for large PDF files
-					let win = Services.wm.getMostRecentWindow("navigator:browser");
-					if (win?.document?.getElementById('statuspanel')) {
-						win.close();
-					}
-				}
-			}
-		};
-
 		this._iframeWindow.addEventListener('customEvent', (event) => {
 			let data = event.detail.wrappedJSObject;
 			let append = data.append;


### PR DESCRIPTION
And extract the reader's `zoteroPrint()` function and use it in HiddenBrowser.

Printing doesn't work on any browser that's within a `HiddenFrame`, the `hiddenDOMWindow`, etc. It needs to be under an actual visible chrome window. There's no error message, just a silent failure, so I'm not sure what the issue is. In any case, added a new `useHiddenFrame` option to `HiddenBrowser`. When set to false, we use the main window instead of a `HiddenFrame`.

Reader will need zotero/reader#123 after this.

Fixes #3190 