### PR TITLE
HiddenBrowser: Block all downloads

### DIFF
--- a/chrome/content/zotero/actors/PageDataChild.jsm
+++ b/chrome/content/zotero/actors/PageDataChild.jsm
@@ -31,17 +31,18 @@ class PageDataChild extends JSWindowActorChild {
 			
 			case "channelInfo": {
 				let docShell = this.contentWindow.docShell;
-				let channel = (docShell.currentDocumentChannel || docShell.failedChannel)
-					?.QueryInterface(Ci.nsIHttpChannel);
-				if (channel) {
-					return {
-						responseStatus: channel.responseStatus,
-						responseStatusText: channel.responseStatusText
-					};
+				try {
+					let channel = (docShell.currentDocumentChannel || docShell.failedChannel)
+						?.QueryInterface(Ci.nsIHttpChannel);
+					if (channel) {
+						return {
+							responseStatus: channel.responseStatus,
+							responseStatusText: channel.responseStatusText
+						};
+					}
 				}
-				else {
-					return null;
-				}
+				catch (e) {}
+				return null;
 			}
 		}
 	}


### PR DESCRIPTION
The key is to set `docShell.allowContentRetargeting` to false. But that doesn't have any effect on remote loads when set in the parent process, so we do it in the `PageData` actor and actually initiate the load from there. This new approach is based on `BackgroundThumbnailsChild`, which is a little more robust than `HeadlessShell` since it runs during normal use (as opposed to only when you invoke Firefox with a special command-line option).

I wasn't able to figure out how to unit-test this, unfortunately.

Fixes #3835 (which might be happening [during indexing?](https://forums.zotero.org/discussion/comment/462257/#Comment_462257))

(Also fix `channelInfo` throwing when called on a non-HTTP channel.)