### PR TITLE
itembox focus edits and refactoring

### DIFF
--- a/chrome/content/zotero/elements/collapsibleSection.js
+++ b/chrome/content/zotero/elements/collapsibleSection.js
@@ -334,27 +334,6 @@
 				event.stopPropagation();
 			};
 
-			// Tab/Shift-Tab from section header through header buttons
-			if (event.key === "Tab") {
-				let nextBtn;
-				if (tgt.classList.contains("head") && event.shiftKey) {
-					return;
-				}
-				if (tgt.classList.contains("head")) {
-					nextBtn = this._head.querySelector("toolbarbutton");
-				}
-				else {
-					nextBtn = event.shiftKey ? tgt.previousElementSibling : tgt.nextElementSibling;
-				}
-				
-				if (nextBtn?.tagName == "popupset") {
-					nextBtn = this._head;
-				}
-				if (nextBtn) {
-					nextBtn.focus();
-					stopEvent();
-				}
-			}
 			if (event.target.tagName === "toolbarbutton") {
 				// No actions on right/left on header buttons
 				if (["ArrowRight", "ArrowLeft"].includes(event.key)) {

--- a/chrome/content/zotero/elements/editableText.js
+++ b/chrome/content/zotero/elements/editableText.js
@@ -333,12 +333,15 @@
 			if (event.key === 'Enter') {
 				if (this.multiline === event.shiftKey) {
 					event.preventDefault();
-					this.dispatchEvent(new CustomEvent('escape_enter'));
 					this._input.blur();
+				}
+				// Do not let out shift-enter event on multiline, since it should never do
+				// anything but add a linebreak to textarea
+				if (this.multiline && !event.shiftKey) {
+					event.stopPropagation();
 				}
 			}
 			else if (event.key === 'Escape') {
-				this.dispatchEvent(new CustomEvent('escape_enter'));
 				let initialValue = this._input.dataset.initialValue ?? '';
 				this.setAttribute('value', initialValue);
 				this._input.value = initialValue;

--- a/chrome/content/zotero/elements/editableText.js
+++ b/chrome/content/zotero/elements/editableText.js
@@ -133,9 +133,11 @@
 		set autocomplete(val) {
 			if (val) {
 				this.setAttribute('autocomplete', JSON.stringify(val));
+				this.addEventListener('keydown', this._captureAutocompleteKeydown, true);
 			}
 			else {
 				this.removeAttribute('autocomplete');
+				this.removeEventListener('keydown', this._captureAutocompleteKeydown, true);
 			}
 		}
 		
@@ -193,9 +195,6 @@
 				input.addEventListener('mousedown', this._handleMouseDown);
 				input.addEventListener('dragover', this._handleDragOver);
 				input.addEventListener('drop', this._handleDrop);
-				if (autocompleteEnabled) {
-					this.addEventListener('keydown', this._captureAutocompleteKeydown, true);
-				}
 				
 				let focused = this.focused;
 				let selectionStart = this._input?.selectionStart;

--- a/chrome/content/zotero/elements/editableText.js
+++ b/chrome/content/zotero/elements/editableText.js
@@ -133,11 +133,9 @@
 		set autocomplete(val) {
 			if (val) {
 				this.setAttribute('autocomplete', JSON.stringify(val));
-				this.addEventListener('keydown', this._captureAutocompleteKeydown, true);
 			}
 			else {
 				this.removeAttribute('autocomplete');
-				this.removeEventListener('keydown', this._captureAutocompleteKeydown, true);
 			}
 		}
 		
@@ -195,6 +193,14 @@
 				input.addEventListener('mousedown', this._handleMouseDown);
 				input.addEventListener('dragover', this._handleDragOver);
 				input.addEventListener('drop', this._handleDrop);
+				if (autocompleteEnabled) {
+					// Even through this may run multiple times on editable-text, the listener
+					// is added only once because we pass the reference to the same exact function.
+					this.addEventListener('keydown', this._captureAutocompleteKeydown, true);
+				}
+				else {
+					this.removeEventListener('keydown', this._captureAutocompleteKeydown, true);
+				}
 				
 				let focused = this.focused;
 				let selectionStart = this._input?.selectionStart;

--- a/chrome/content/zotero/elements/editableText.js
+++ b/chrome/content/zotero/elements/editableText.js
@@ -194,7 +194,7 @@
 				input.addEventListener('dragover', this._handleDragOver);
 				input.addEventListener('drop', this._handleDrop);
 				if (autocompleteEnabled) {
-					this.addEventListener('keydown', this._captureAutocompleteEnter, true);
+					this.addEventListener('keydown', this._captureAutocompleteKeydown, true);
 				}
 				
 				let focused = this.focused;
@@ -352,15 +352,20 @@
 			}
 		};
 
-		_captureAutocompleteEnter = (event) => {
-			// On Enter, mozilla stops propagation of the event which may interfere with out handling
+		_captureAutocompleteKeydown = (event) => {
+			// On Enter or Escape, mozilla stops propagation of the event which may interfere with out handling
 			// of the focus. E.g. the event should be allowed to reach itemDetails from itemBox so that focus
 			// can be moved to the itemTree or the reader.
 			// https://searchfox.org/mozilla-central/source/toolkit/content/widgets/autocomplete-input.js#564
-			// To avoid it, capture Enter keypress event and handle it without stopping its propagation.
-			if (this._input.autocomplete !== "on" || event.key !== "Enter") return;
+			// To avoid it, capture Enter and Escape keydown events and handle them without stopping propagation.
+			if (this._input.autocomplete !== "on" || !["Enter", "Escape"].includes(event.key)) return;
 			event.preventDefault();
-			this._input.handleEnter();
+			if (event.key == "Enter") {
+				this._input.handleEnter();
+			}
+			else if (event.key == "Escape") {
+				this._input.mController.handleEscape();
+			}
 		};
 		
 		_handleMouseDown = (event) => {

--- a/chrome/content/zotero/elements/editableText.js
+++ b/chrome/content/zotero/elements/editableText.js
@@ -193,6 +193,9 @@
 				input.addEventListener('mousedown', this._handleMouseDown);
 				input.addEventListener('dragover', this._handleDragOver);
 				input.addEventListener('drop', this._handleDrop);
+				if (autocompleteEnabled) {
+					this.addEventListener('keydown', this._captureAutocompleteEnter, true);
+				}
 				
 				let focused = this.focused;
 				let selectionStart = this._input?.selectionStart;
@@ -347,6 +350,17 @@
 				this._input.value = initialValue;
 				this._input.blur();
 			}
+		};
+
+		_captureAutocompleteEnter = (event) => {
+			// On Enter, mozilla stops propagation of the event which may interfere with out handling
+			// of the focus. E.g. the event should be allowed to reach itemDetails from itemBox so that focus
+			// can be moved to the itemTree or the reader.
+			// https://searchfox.org/mozilla-central/source/toolkit/content/widgets/autocomplete-input.js#564
+			// To avoid it, capture Enter keypress event and handle it without stopping its propagation.
+			if (this._input.autocomplete !== "on" || event.key !== "Enter") return;
+			event.preventDefault();
+			this._input.handleEnter();
 		};
 		
 		_handleMouseDown = (event) => {

--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -1604,7 +1604,8 @@
 				completeSelectedIndex: true,
 				ignoreBlurWhileSearching: false,
 				search: 'zotero',
-				searchParam: JSON.stringify(params)
+				searchParam: JSON.stringify(params),
+				popup: 'PopupAutoComplete'
 			};
 		}
 		

--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -1255,20 +1255,15 @@
 				firstName.sizeToContent();
 				lastName.sizeToContent();
 				this.modifyCreator(rowIndex, fields);
-				if (this.saveOnEdit) {
-					let activeField = this.getFocusedTextArea();
-					if (activeField !== null && activeField !== firstName && activeField !== lastName) {
-						this.blurOpenField();
-					}
-					else {
-						this.item.saveTx();
-					}
-				}
-				else {
-					// If the creator is saved, autocomplete will be set in refresh()
-					// Otherwise, we'll reset it here.
+				// For empty unsaved creator rows, update their autocomplete setting so that
+				// e.g fullnames are not suggested after switch to first-last name mode.
+				// Otherwise, just save the item and appropriate autocomplete modes will be set in render()
+				if (row.querySelector("[unsaved=true]")) {
 					this.addAutocompleteToElement(firstName);
 					this.addAutocompleteToElement(lastName);
+				}
+				else {
+					this.item.saveTx();
 				}
 			}
 		}

--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -677,7 +677,8 @@
 					var button = document.createXULElement("toolbarbutton");
 					button.className = 'zotero-field-version-button zotero-clicky-merge';
 					button.setAttribute('type', 'menu');
-					button.setAttribute('data-l10n-id', 'itembox-button-merge');
+					let fieldLocalName = rowLabel.querySelector("label")?.textContent;
+					document.l10n.setAttributes(button, 'itembox-button-merge', { field: fieldLocalName || "" });
 					
 					var popup = button.appendChild(document.createXULElement("menupopup"));
 					

--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -747,10 +747,10 @@
 				field = this._infoTable.querySelector('[fieldName="itemType"]');
 			}
 			if (field) {
-				this._beforeRow = field.closest(".meta-row").nextSibling;
+				this._firstRowBeforeCreators = field.closest(".meta-row").nextSibling;
 			}
 			else {
-				this._beforeRow = this._infoTable.firstChild;
+				this._firstRowBeforeCreators = this._infoTable.firstChild;
 			}
 			
 			this._creatorCount = 0;
@@ -764,7 +764,7 @@
 				}
 				for (let i = 0; i < max; i++) {
 					let data = this.item.getCreator(i);
-					this.addCreatorRow(data, data.creatorTypeID);
+					this.addCreatorRow(data, data.creatorTypeID, false);
 				}
 				if (this._draggedCreator) {
 					this._draggedCreator = false;
@@ -800,7 +800,7 @@
 			}
 			else if (this.editable && Zotero.CreatorTypes.itemTypeHasCreators(this.item.itemTypeID)) {
 				// Add default row
-				this.addCreatorRow(false, false, true, true);
+				this.addCreatorRow(false, false, false);
 			}
 			
 			
@@ -911,8 +911,14 @@
 			
 			row.appendChild(label);
 			row.appendChild(value);
+			
+			// Special treatment for creator rows if beforeElement is not specified
+			if (!beforeElement && row.querySelector(".creator-type-value, #more-creators-label")) {
+				beforeElement = this._firstRowBeforeCreators;
+			}
+
 			if (beforeElement) {
-				this._infoTable.insertBefore(row, this._beforeRow);
+				this._infoTable.insertBefore(row, beforeElement);
 			}
 			else {
 				this._infoTable.appendChild(row);
@@ -921,7 +927,7 @@
 			return row;
 		}
 		
-		addCreatorRow(creatorData, creatorTypeIDOrName, unsaved, defaultRow) {
+		addCreatorRow(creatorData, creatorTypeIDOrName, unsaved, before) {
 			// getCreatorFields(), switchCreatorMode() and handleCreatorAutoCompleteSelect()
 			// may need need to be adjusted if this DOM structure changes
 
@@ -975,8 +981,8 @@
 			labelWrapper.setAttribute('aria-describedby', 'creator-type-label-inner');
 			labelWrapper.setAttribute('id', `creator-${rowIndex}-label`);
 
-			// If not editable or only 1 creator row, hide grippy
-			if (!this.editable || this.item.numCreators() < 2) {
+			// If not editable or only 1 creator row or a row is unsaved, hide grippy
+			if (!this.editable || this.item.numCreators() < 2 || unsaved) {
 				grippy.classList.add("single-creator-grippy");
 				grippy.setAttribute('disabled', true);
 			}
@@ -1031,7 +1037,11 @@
 			addButton.setAttribute("class", "zotero-clicky zotero-clicky-plus show-on-hover no-display");
 			addButton.setAttribute('id', `creator-${rowIndex}-add`);
 			addButton.setAttribute('tooltiptext', Zotero.getString('general.create'));
-			addButton.addEventListener("command", () => this.addCreatorRow(null, typeID, true));
+			addButton.addEventListener("command", (e) => {
+				// + button adds a creator row after the row that was clicked
+				let nextRow = e.target.closest(".meta-row").nextElementSibling;
+				this.addCreatorRow(null, typeID, true, nextRow);
+			});
 			rowData.appendChild(addButton);
 
 			// Options button that opens creator transform menu
@@ -1060,10 +1070,14 @@
 			
 			this._creatorCount++;
 			
-			
-			let row = this.addDynamicRow(rowLabel, rowData, true);
+			// Delete existing unsaved creator row if any
+			let unsavedCreatorData = this._infoTable.querySelector(".creator-type-value[unsaved=true]");
+			if (unsavedCreatorData) {
+				unsavedCreatorData.closest(".meta-row").remove();
+			}
 
-			this._updateCreatorButtonsStatus();
+			let row = this.addDynamicRow(rowLabel, rowData, before);
+
 			this._ensureButtonsFocusable();
 			
 			/**
@@ -1133,10 +1147,14 @@
 
 			row.addEventListener("keydown", e => this.handleCreatorRowKeyDown(e));
 			lastNameElem.addEventListener("paste", e => this.handleCreatorPaste(e));
-			// Focus new rows
-			if (unsaved && !defaultRow) {
+			// Focus unsaved empty creator row
+			if (unsaved) {
+				rowData.setAttribute("unsaved", true);
 				lastNameElem.focus();
 			}
+			// Refresh creator buttons status, e.g. to disable + button of a row that just added
+			// a new creator
+			this._updateCreatorButtonsStatus();
 		}
 		
 		addMoreCreatorsRow(num) {
@@ -1159,7 +1177,7 @@
 			});
 			rowData.textContent = Zotero.getString('general.numMore', num);
 			
-			this.addDynamicRow(rowLabel, rowData, true);
+			this.addDynamicRow(rowLabel, rowData);
 		}
 		
 		addDateRow(field, value) {
@@ -1199,7 +1217,6 @@
 			var lastName = creatorNameBox.firstChild;
 			var firstName = creatorNameBox.lastChild;
 
-			let tab;
 			// Switch to single-field mode
 			if (fieldMode == 1) {
 				creatorNameBox.setAttribute('switch-mode-label', Zotero.getString('pane.item.switchFieldMode.two'));
@@ -1719,7 +1736,6 @@
 				// Do nothing from the last empty row
 				if (creatorFields.lastName == "" && creatorFields.firstName == "") return;
 				this.addCreatorRow(false, creatorFields.creatorTypeID, true);
-				this._selectField = `itembox-field-value-creator-${this._creatorCount - 1}-lastName`;
 			}
 		}
 
@@ -1944,7 +1960,7 @@
 				row = creatorValue.closest(".meta-row");
 				let { lastName, firstName } = this.getCreatorFields(row);
 				let isEmpty = lastName == "" && firstName == "";
-				let isNextRowCreator = row.nextSibling.querySelector(".creator-type-value");
+				let isNextRowUnsavedCreator = row.nextSibling?.querySelector(".creator-type-value[unsaved=true]");
 				let isDefaultEmptyRow = isEmpty && creatorValues.length == 1;
 		
 				if (!this.editable) {
@@ -1954,7 +1970,7 @@
 					return;
 				}
 
-				row.querySelector(".zotero-clicky-plus").disabled = isEmpty || isNextRowCreator;
+				row.querySelector(".zotero-clicky-plus").disabled = isEmpty || isNextRowUnsavedCreator;
 				row.querySelector(".zotero-clicky-minus").disabled = isDefaultEmptyRow;
 			}
 		}
@@ -1963,11 +1979,22 @@
 			var typeID = row.querySelector('[typeid]').getAttribute('typeid');
 			var [label1, label2] = row.querySelectorAll('editable-text');
 			var fieldMode = row.querySelector('[fieldMode]')?.getAttribute('fieldMode');
+			var unsavedIndex = null;
+			// Fetch positioning of a newly added unsaved row. It will be the index of
+			// this creator after the item is saved
+			if (row.querySelector("[unsaved=true]")) {
+				let previousRow = row.previousSibling;
+				unsavedIndex = 0;
+				if (previousRow.querySelector(".creator-type-value")) {
+					unsavedIndex = 1 + parseInt(previousRow.querySelector(".creator-type-label").id.split('-')[1]);
+				}
+			}
 			var fields = {
 				lastName: label1.value,
 				firstName: label2.value,
 				fieldMode: fieldMode ? parseInt(fieldMode) : 0,
 				creatorTypeID: parseInt(typeID),
+				unsavedIndex: unsavedIndex,
 			};
 			
 			return fields;
@@ -1985,6 +2012,12 @@
 					return false;
 				}
 				return this.item.removeCreator(index);
+			}
+			// If this is a newly added row and there is an unsaved index,
+			// shift all creators and update all indices.
+			if (fields.unsavedIndex) {
+				// Skip saving in this call to avoid extra re-rendering
+				this.moveCreator(index, null, fields.unsavedIndex, true);
 			}
 
 			return this.item.setCreator(index, fields);
@@ -2107,7 +2140,7 @@
 		/**
 		 * @return {Promise}
 		 */
-		moveCreator(index, dir, newIndex) {
+		moveCreator(index, dir, newIndex, skipSave) {
 			return Zotero.spawn(function* () {
 				yield this.blurOpenField();
 				if (index == 0 && dir == 'up') {
@@ -2153,7 +2186,7 @@
 					}
 					this.item.setCreator(i, creators[i]);
 				}
-				if (this.saveOnEdit) {
+				if (this.saveOnEdit && !skipSave) {
 					this.item.saveTx();
 				}
 			}, this);

--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -234,7 +234,7 @@
 			// If the focus leaves the itemBox, clear the last focused element
 			this._infoTable.addEventListener("focusout", (e) => {
 				let destination = e.relatedTarget;
-				if (destination && !this._infoTable.contains(destination)) {
+				if (!(destination && this._infoTable.contains(destination))) {
 					this._selectField = null;
 				}
 			});
@@ -1593,11 +1593,11 @@
 				// https://searchfox.org/mozilla-central/rev/2d678a843ceab81e43f7ffb83212197dc10e944a/toolkit/content/widgets/autocomplete-input.js#372
 				// https://searchfox.org/mozilla-central/rev/2d678a843ceab81e43f7ffb83212197dc10e944a/browser/components/search/content/searchbar.js#791
 				elem.onTextEntered = () => {
-					this.handleCreatorAutoCompleteSelect(elem, true);
+					this.handleCreatorAutoCompleteSelect(elem);
 				};
 				// Tab/Shift-Tab
 				elem.addEventListener('change', () => {
-					this.handleCreatorAutoCompleteSelect(elem, true);
+					this.handleCreatorAutoCompleteSelect(elem);
 				});
 			}
 			elem.autocomplete = {
@@ -1605,7 +1605,7 @@
 				ignoreBlurWhileSearching: false,
 				search: 'zotero',
 				searchParam: JSON.stringify(params),
-				popup: 'PopupAutoComplete'
+				popup: 'PopupAutoComplete',
 			};
 		}
 		
@@ -1614,7 +1614,7 @@
 		 * Save a multiple-field selection for the creator autocomplete
 		 * (e.g. "Shakespeare, William")
 		 */
-		handleCreatorAutoCompleteSelect(textbox, stayFocused) {
+		handleCreatorAutoCompleteSelect(textbox) {
 			let inputField = textbox.querySelector("input");
 			if (!inputField) {
 				return;
@@ -1634,7 +1634,7 @@
 			if (!id) {
 				return;
 			}
-			
+
 			var [creatorID, numFields] = id.split('-');
 			
 			// If result uses two fields, save both

--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -948,7 +948,7 @@
 			let labelWrapper = document.createElement('div');
 			let grippy = document.createXULElement('toolbarbutton');
 			
-			labelWrapper.className = 'creator-type-label';
+			labelWrapper.className = 'creator-type-label keyboard-clickable';
 			labelWrapper.setAttribute("tabindex", 0);
 			grippy.className = "zotero-clicky zotero-clicky-grippy show-on-hover";
 			grippy.setAttribute('tabindex', -1);

--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -500,7 +500,6 @@
 			// Item type menu
 			this.addItemTypeMenu();
 			this.updateItemTypeMenuSelection();
-			this.itemTypeMenu.disabled = !this.showTypeMenu;
 			var fieldNames = [];
 			
 			// Manual field order
@@ -882,11 +881,20 @@
 				menulist.addEventListener('focus', () => {
 					this.ensureElementIsVisible(menulist);
 				});
+				// This is instead of setting disabled=true so that the menu is not excluded
+				// from tab navigation. For <input>s, we just set readonly=true but it is not
+				// a valid property for menulist.
+				menulist.addEventListener("popupshowing", (e) => {
+					if (!this._editable) {
+						e.preventDefault();
+						e.stopPropagation();
+					}
+				});
 				menulist.setAttribute("aria-labelledby", "itembox-field-itemType-label");
 				this.itemTypeMenu = menulist;
 				rowData.appendChild(menulist);
 			}
-			this.itemTypeMenu.disabled = !this.showTypeMenu;
+			this.itemTypeMenu.setAttribute("aria-disabled", !this._editable);
 			row.appendChild(labelWrapper);
 			row.appendChild(rowData);
 			this._infoTable.appendChild(row);

--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -1130,7 +1130,7 @@
 			this.addAutocompleteToElement(lastNameElem);
 			this.addAutocompleteToElement(firstNameElem);
 
-			row.addEventListener("keydown", e => this.handleCreatorRowKeyPresses(e));
+			row.addEventListener("keydown", e => this.handleCreatorRowKeyDown(e));
 			lastNameElem.addEventListener("paste", e => this.handleCreatorPaste(e));
 			// Focus new rows
 			if (unsaved && !defaultRow) {
@@ -1691,7 +1691,7 @@
 		}
 		
 		// Handle Shift-Enter on creator input field
-		handleCreatorRowKeyPresses(event) {
+		handleCreatorRowKeyDown(event) {
 			let target = event.target.closest("editable-text");
 			if (!target) return;
 

--- a/chrome/content/zotero/elements/itemDetails.js
+++ b/chrome/content/zotero/elements/itemDetails.js
@@ -199,7 +199,7 @@
 			this._header = this.querySelector('#zotero-item-pane-header');
 			this._paneParent = this.querySelector('#zotero-view-item');
 
-			this._container.addEventListener("keydown", this._handleKeypress);
+			this._container.addEventListener("keydown", this._handleKeydown);
 			this._paneParent.addEventListener('scroll', this._handleContainerScroll);
 
 			this._paneHiddenOb = new MutationObserver(this._handlePaneStatus);
@@ -225,7 +225,7 @@
 		}
 
 		destroy() {
-			this._container.removeEventListener("keypress", this._handleKeypress);
+			this._container.removeEventListener("keydown", this._handleKeydown);
 			this._paneParent.removeEventListener('scroll', this._handleContainerScroll);
 
 			this._paneHiddenOb.disconnect();
@@ -535,7 +535,7 @@
 		};
 
 		// Keyboard navigation within the itemPane. Also handles contextPane keyboard nav
-		_handleKeypress = (event) => {
+		_handleKeydown = (event) => {
 			let stopEvent = () => {
 				event.preventDefault();
 				event.stopPropagation();
@@ -553,7 +553,7 @@
 				return;
 			}
 			// On Escape/Enter on editable-text, return focus to the item tree or reader
-			if (event.key == "Escape" || (event.key == "Enter" && event.target.closest('editable-text'))) {
+			if (event.key == "Escape" || (event.key == "Enter" && event.target.classList.contains('input'))) {
 				if (isLibraryTab) {
 					document.getElementById('item-tree-main-default').focus();
 				}

--- a/chrome/content/zotero/elements/itemDetails.js
+++ b/chrome/content/zotero/elements/itemDetails.js
@@ -199,7 +199,7 @@
 			this._header = this.querySelector('#zotero-item-pane-header');
 			this._paneParent = this.querySelector('#zotero-view-item');
 
-			this._container.addEventListener("keypress", this._handleKeypress);
+			this._container.addEventListener("keydown", this._handleKeypress);
 			this._paneParent.addEventListener('scroll', this._handleContainerScroll);
 
 			this._paneHiddenOb = new MutationObserver(this._handlePaneStatus);
@@ -552,21 +552,16 @@
 				stopEvent();
 				return;
 			}
-			// Tab tavigation between entries and buttons within library, related and notes boxes
-			if (event.key == "Tab" && event.target.closest(".box")) {
-				let next = null;
-				if (event.key == "Tab" && !event.shiftKey) {
-					next = event.target.nextElementSibling;
+			// On Escape/Enter on editable-text, return focus to the item tree or reader
+			if (event.key == "Escape" || (event.key == "Enter" && event.target.closest('editable-text'))) {
+				if (isLibraryTab) {
+					document.getElementById('item-tree-main-default').focus();
 				}
-				if (event.key == "Tab" && event.shiftKey) {
-					next = event.target.parentNode.previousElementSibling?.lastChild;
-				}
-				// Force the element to be visible before focusing
-				if (next) {
-					next.style.visibility = "visible";
-					next.focus();
-					next.style.removeProperty("visibility");
-					stopEvent();
+				else {
+					let reader = Zotero.Reader.getByTabID(Zotero_Tabs.selectedID);
+					if (reader) {
+						reader.focus();
+					}
 				}
 			}
 		};

--- a/chrome/content/zotero/elements/tagsBox.js
+++ b/chrome/content/zotero/elements/tagsBox.js
@@ -327,6 +327,11 @@
 				if (!row.parentElement) {
 					return;
 				}
+				// Do not propagate event to itemDetails that would send focus to itemTree or reader
+				// because a new empty row will be created and focused in saveTag
+				if (row.getAttribute("isNew")) {
+					event.stopPropagation();
+				}
 				let blurOnly = false;
 				let focusField = false;
 
@@ -347,13 +352,6 @@
 				}
 				if (focusField) {
 					focusField.focus();
-				}
-				// Return focus to items pane
-				else {
-					var tree = document.getElementById('zotero-items-tree');
-					if (tree) {
-						tree.focus();
-					}
 				}
 			}
 		};

--- a/chrome/content/zotero/tabs.js
+++ b/chrome/content/zotero/tabs.js
@@ -768,31 +768,7 @@ var Zotero_Tabs = new function () {
 				Services.focus.MOVEFOCUS_BACKWARD, 0);
 			return;
 		}
-		// If no item is selected, focus items list.
-		if (ZoteroPane.itemPane.mode == "message") {
-			document.getElementById("item-tree-main-default").focus();
-			return;
-		}
-		let selected = ZoteroPane.getSelectedItems();
-		// If the selected collection row is duplicates, just focus on the
-		// itemTree until the merge pane is keyboard accessible
-		// If multiple items selected, focus on itemTree as well.
-		let collectionRow = ZoteroPane.collectionsView.selectedTreeRow;
-		if (collectionRow.isDuplicates() || selected.length !== 1) {
-			document.getElementById("item-tree-main-default").focus();
-			return;
-		}
-		// Special treatment for notes and attachments in itemPane
-		selected = selected[0];
-		if (selected.isNote()) {
-			document.getElementById("zotero-note-editor").focus();
-			return;
-		}
-		if (selected.isAttachment()) {
-			document.getElementById("attachment-note-editor").focus();
-			return;
-		}
-		// For regular items, focus the last field
+		// Focus the last field of itemPane
 		// We do that by moving focus backwards from the element following the pane, because Services.focus doesn't
 		// support MOVEFOCUS_LAST on subtrees
 		Services.focus.moveFocus(window, document.getElementById("zotero-context-splitter"),

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -2147,7 +2147,7 @@ var ZoteroPane = new function()
 		await original.saveTx({ skipDateModifiedUpdate: true });
 		await duplicate.saveTx();
 		
-		document.getElementById('zotero-editpane-item-box').focusField('title');
+		ZoteroPane.itemPane.querySelector("item-box").getTitleField().focus();
 		return duplicate;
 	};
 	

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -121,7 +121,7 @@ item-button-view-online =
 itembox-button-options =
     .tooltiptext = Open Context Menu
 itembox-button-merge =
-    .aria-label = Select Version
+    .aria-label = Select { $field } Version
 
 reader-use-dark-mode-for-content =
     .label = Use Dark Mode for Content

--- a/scss/abstracts/_mixins.scss
+++ b/scss/abstracts/_mixins.scss
@@ -123,13 +123,6 @@
 	row-gap: 2px;
 	width: inherit;
 
-	.show-on-hover {
-		visibility: hidden;
-		&.no-display {
-			display: none;
-		}
-	}
-
 	.meta-row {
 		display: grid;
 		grid-template-columns: subgrid;
@@ -139,14 +132,15 @@
 			display: none;
 		}	
 
-		// On hover of the meta-row, reveal all hidden icons
-		// unless there's .noHover class which keeps everything hidden
-		&:not(.noHover):hover .show-on-hover,
-		&:focus-within .show-on-hover {
-			visibility: visible;
-			display: revert;
+		&:not(:hover):not(:focus-within) .show-on-hover,
+		&.noHover .show-on-hover {
+			clip-path: inset(50%);
+			&.no-display {
+				width: 0;
+				height: 0;
+				padding: 0;
+			}
 		}
-	
 		.meta-data {
 			width: 0;
 			min-width: 100%;


### PR DESCRIPTION
- removed ztabindex logic from itemBox. It is no longer needed, adds unnecessary complexity and is likely at the root of multiple glitches if a plugin inserts an arbitrary row that does not have ztabindex set.
- if a creator row is deleted when the focus is inside of the row, focus another creator row to not loose the focus.
- more centralized button handling in `_ensureButtonsFocusable` and `_updateCreatorButtonsStatus`
- refactoring of hidden toolbarbuttons css so that the icons are still hidden and don't occupy space (if desired) but are still visible for screen readers, so they are focusable without JS changing their visibility (this with ztabindex removal fixes vpat 24)
- removed `escape_enter` event from `editable-text`. It was a workaround to know when itemBox should move focus back to itemTree. Unhandled Enter on an input or Escape should focus itemTree (or reader) from anywhere in the itemPane/contextPane (not just itemBox), so that logic is moved to itemDetails.js. To avoid conflicts with Shift-Enter, do not propagate that event outside of multiline editable-text. Fixes: #3896
- removed not necessary keyboard nav handling from itemDetails.js. It was only needed for mac, and is redundant if "Keyboard navigation" setting is on
- using `keydown` instead of `keypress` for itemDetails keyboard nav handling because `Enter` `keypress` does not seem to get out of `editable-text` but `keydown` does.
- old handleKeyPress from itemBox is no longer relevant for most elements, so it is removed and substituted with a dedicated handler just for creator row.
- moved the creator's paste handler into it's own dedicated function from the autocomplete handler (which was confusing)
- special handling for `enter` and `escape` events on `editable-text` with autocomplete to not stop event propagation, so that the events  can bubble and be handled in `itemDetails`. It avoids some cases of the focus being lost and returned to the `window`. It was unnecessary earlier due to `escape_enter` workaround but only within itemBox and only within itemPane. [Example of focus being lost](https://www.dropbox.com/scl/fi/4qe7q8q8ix2d0j5q7z1ob/focus_lost_example.mov?rlkey=j35cn683tk1cbtgsoppn6s3nt&st=k0qbqvre&dl=0)
- removed explicit tab navigation handling from `collapsible-section` header. Currently, it may get stuck when buttons are hidden (e.g. in the trash mode). It was only added to enable keyboard navigation on mac before special "Keyboard navigation" setting was discovered (it was never an issue on windows), so now it's easier to just let mozilla handle it.
- always use `getTitleField` to find and focus the proper title field in itemBox
- on shift-tab from the focused tab, just move focus to the first focusable element before the splitter without any special handling for attachments, notes and duplicates pane as before. It ensures a more consistent and predictable keyboard navigation, especially now that itemPane is fairly keyboard accessible.

Fixes: #4076
