### PR TITLE
Try to prevent ConcurrentCaller from failing CI

### DIFF
--- a/test/tests/concurrentCallerTest.js
+++ b/test/tests/concurrentCallerTest.js
@@ -115,7 +115,7 @@ describe("ConcurrentCaller", function () {
 			var finished = 0;
 			var failed = false;
 			
-			var ids1 = {"1": 100, "2": 45, "3": 80};
+			var ids1 = {"1": 100, "2": 45, "3": 200};
 			var ids2 = {"4": 1, "5": 1};
 			var makeFunc = function (id, delay) {
 				return Zotero.Promise.coroutine(function* () {


### PR DESCRIPTION
As far as I can tell, what's happening here is that random event loop lag sometimes causes the delay between `caller.start(funcs1)` and `caller.start(funcs2)` to be long enough that function 3 actually _has_ finished before 4 and 5 do. This change makes 3 take longer. Maybe that'll help!