### PR TITLE
Z6: Fix DOI field context menu items acting on *all* DOIs

### DIFF
--- a/chrome/content/zotero/bindings/itembox.xml
+++ b/chrome/content/zotero/bindings/itembox.xml
@@ -442,10 +442,10 @@
 								label.setAttribute("tooltiptext", Zotero.getString('pane.item.viewOnline.tooltip'));
 								
 								var openURLMenuItem = this._id('zotero-doi-menu-view-online');
-								openURLMenuItem.oncommand = event => ZoteroPane_Local.loadURI(doi, event);
+								openURLMenuItem.setAttribute("oncommand", "ZoteroPane_Local.loadURI('" + doi + "', event)");
 								
 								var copyMenuItem = this._id('zotero-doi-menu-copy');
-								copyMenuItem.oncommand = () => Zotero.Utilities.Internal.copyTextToClipboard(doi);
+								copyMenuItem.setAttribute("oncommand", "Zotero.Utilities.Internal.copyTextToClipboard('" + doi + "')");
 							}
 						}
 						else if (fieldName == 'abstractNote') {

--- a/chrome/content/zotero/bindings/itembox.xml
+++ b/chrome/content/zotero/bindings/itembox.xml
@@ -442,10 +442,10 @@
 								label.setAttribute("tooltiptext", Zotero.getString('pane.item.viewOnline.tooltip'));
 								
 								var openURLMenuItem = this._id('zotero-doi-menu-view-online');
-								openURLMenuItem.addEventListener('command', event => ZoteroPane_Local.loadURI(doi, event));
+								openURLMenuItem.oncommand = event => ZoteroPane_Local.loadURI(doi, event);
 								
 								var copyMenuItem = this._id('zotero-doi-menu-copy');
-								copyMenuItem.addEventListener('command', () => Zotero.Utilities.Internal.copyTextToClipboard(doi));
+								copyMenuItem.oncommand = () => Zotero.Utilities.Internal.copyTextToClipboard(doi);
 							}
 						}
 						else if (fieldName == 'abstractNote') {


### PR DESCRIPTION
Fixes #4099; amends f006995676fc2bc160cc6a05e3d46f8666b33c22 to use event listener properties for listeners that need to be overwritten. (I don't have a Z6 build environment set up to test, but I don't see why this wouldn't work.)