### PR TITLE
Prevent empty item type menu from appearing after Cmd-Shift-N when info section is collapsed

### DIFF
--- a/chrome/content/zotero/elements/itemPaneSection.js
+++ b/chrome/content/zotero/elements/itemPaneSection.js
@@ -52,7 +52,7 @@ class ItemPaneSectionElementBase extends XULElementBase {
 		this.setAttribute('tabType', tabType);
 	}
 	
-	get isSectionOpen() {
+	get open() {
 		return this._section?.open || false;
 	}
 	

--- a/chrome/content/zotero/elements/itemPaneSection.js
+++ b/chrome/content/zotero/elements/itemPaneSection.js
@@ -52,6 +52,10 @@ class ItemPaneSectionElementBase extends XULElementBase {
 		this.setAttribute('tabType', tabType);
 	}
 	
+	get isSectionOpen() {
+		return this._section?.open || false;
+	}
+	
 	connectedCallback() {
 		super.connectedCallback();
 		if (!this.render && !this.asyncRender) {

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -1305,6 +1305,11 @@ var ZoteroPane = new function()
 						var type = mru ? mru.split(',')[0] : 'book';
 						await ZoteroPane.newItem(Zotero.ItemTypes.getID(type));
 						let itemBox = document.getElementById('zotero-editpane-item-box');
+						// If the info pane is collapsed, focus the title in the header
+						if (!itemBox._section.open) {
+							document.querySelector("#zotero-item-pane-header editable-text").focus();
+							return;
+						}
 						var menu = itemBox.itemTypeMenu;
 						// If the new item's type is changed immediately, update the MRU
 						var handleTypeChange = function () {

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -1306,7 +1306,7 @@ var ZoteroPane = new function()
 						await ZoteroPane.newItem(Zotero.ItemTypes.getID(type));
 						let itemBox = document.getElementById('zotero-editpane-item-box');
 						// If the info pane is collapsed, focus the title in the header
-						if (!itemBox._section.open) {
+						if (!itemBox.isSectionOpen) {
 							document.querySelector("#zotero-item-pane-header editable-text").focus();
 							return;
 						}

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -1306,7 +1306,7 @@ var ZoteroPane = new function()
 						await ZoteroPane.newItem(Zotero.ItemTypes.getID(type));
 						let itemBox = document.getElementById('zotero-editpane-item-box');
 						// If the info pane is collapsed, focus the title in the header
-						if (!itemBox.isSectionOpen) {
+						if (!itemBox.open) {
 							document.querySelector("#zotero-item-pane-header editable-text").focus();
 							return;
 						}


### PR DESCRIPTION
If the info section is collapsed, do not try to focus and open the itemType menu after item creation via Cmd-Shift-N as it can lead to an empty dropdown. Just focus the header title in that case.

<img width="1424" alt="Screenshot 2024-05-09 at 5 37 32 PM" src="https://github.com/zotero/zotero/assets/36271954/feef19af-a6fb-4db7-ad6a-49ca390d76fc">
