### PR TITLE
Focus title in itemBox after item creation

### DIFF
--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -755,13 +755,12 @@
 			
 			// Place, in order of preference, after title, after type,
 			// or at beginning
-			var titleFieldID = Zotero.ItemFields.getFieldIDFromTypeAndBase(this.item.itemTypeID, 'title');
-			var field = this._infoTable.querySelector(`[fieldname="${Zotero.ItemFields.getName(titleFieldID)}"]`);
+			var field = this.getTitleField();
 			if (!field) {
 				field = this._infoTable.querySelector('[fieldName="itemType"]');
 			}
 			if (field) {
-				this._beforeRow = field.parentNode.nextSibling;
+				this._beforeRow = field.closest(".meta-row");
 			}
 			else {
 				this._beforeRow = this._infoTable.firstChild;
@@ -2287,6 +2286,11 @@
 			let field = this.querySelector(`editable-text[fieldname="${fieldName}"]`);
 			if (!field) return false;
 			return this._focusNextField(field.getAttribute('ztabindex'));
+		}
+
+		getTitleField() {
+			var titleFieldID = Zotero.ItemFields.getFieldIDFromTypeAndBase(this.item.itemTypeID, 'title');
+			return this._infoTable.querySelector(`[fieldname="${Zotero.ItemFields.getName(titleFieldID)}"][ztabindex]`);
 		}
 
 		getFocusedTextArea() {

--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -2290,7 +2290,7 @@
 
 		getTitleField() {
 			var titleFieldID = Zotero.ItemFields.getFieldIDFromTypeAndBase(this.item.itemTypeID, 'title');
-			return this._infoTable.querySelector(`[fieldname="${Zotero.ItemFields.getName(titleFieldID)}"][ztabindex]`);
+			return this._infoTable.querySelector(`editable-text[fieldname="${Zotero.ItemFields.getName(titleFieldID)}"]`);
 		}
 
 		getFocusedTextArea() {

--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -760,7 +760,7 @@
 				field = this._infoTable.querySelector('[fieldName="itemType"]');
 			}
 			if (field) {
-				this._beforeRow = field.closest(".meta-row");
+				this._beforeRow = field.closest(".meta-row").nextSibling;
 			}
 			else {
 				this._beforeRow = this._infoTable.firstChild;

--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -2284,7 +2284,7 @@
 		}
 		
 		focusField(fieldName) {
-			let field = this.querySelector(`[fieldname="${fieldName}"][ztabindex]`);
+			let field = this.querySelector(`editable-text[fieldname="${fieldName}"]`);
 			if (!field) return false;
 			return this._focusNextField(field.getAttribute('ztabindex'));
 		}

--- a/chrome/content/zotero/elements/itemPaneSection.js
+++ b/chrome/content/zotero/elements/itemPaneSection.js
@@ -56,6 +56,12 @@ class ItemPaneSectionElementBase extends XULElementBase {
 		return this._section?.open || false;
 	}
 	
+	set open(val) {
+		if (this._section) {
+			this._section.open = val;
+		}
+	}
+	
 	connectedCallback() {
 		super.connectedCallback();
 		if (!this.render && !this.asyncRender) {

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -1304,10 +1304,10 @@ var ZoteroPane = new function()
 						var mru = Zotero.Prefs.get('newItemTypeMRU');
 						var type = mru ? mru.split(',')[0] : 'book';
 						await ZoteroPane.newItem(Zotero.ItemTypes.getID(type));
+						// If the info pane is collapsed, focus the first focusable itemPane component
 						let itemBox = document.getElementById('zotero-editpane-item-box');
-						// If the info pane is collapsed, focus the title in the header
 						if (!itemBox.open) {
-							document.querySelector("#zotero-item-pane-header editable-text").focus();
+							Services.focus.moveFocus(window, ZoteroPane.itemPane, Services.focus.MOVEFOCUS_FORWARD, 0);
 							return;
 						}
 						var menu = itemBox.itemTypeMenu;
@@ -1320,9 +1320,6 @@ var ZoteroPane = new function()
 						var removeTypeChangeHandler = function () {
 							itemBox.removeHandler('itemtypechange', handleTypeChange);
 							itemBox.itemTypeMenu.firstChild.removeEventListener('popuphiding', removeTypeChangeHandler);
-							// Focus the title field after menu closes
-							let title = document.querySelector("#zotero-item-pane-header").querySelector("editable-text");
-							title.focus();
 						};
 						itemBox.addHandler('itemtypechange', handleTypeChange);
 						itemBox.itemTypeMenu.firstChild.addEventListener('popuphiding', removeTypeChangeHandler);
@@ -1452,8 +1449,11 @@ var ZoteroPane = new function()
 		if (manual) {
 			// Update most-recently-used list for New Item menu
 			this.addItemTypeToNewItemTypeMRU(Zotero.ItemTypes.getName(typeID));
+			let itemBox = ZoteroPane.itemPane.querySelector("item-box");
+			// Make sure the item box is opened
+			itemBox.open = true;
 			// Focus the title field
-			document.getElementById('zotero-item-pane-header').querySelector("editable-text").focus();
+			itemBox.getTitleField().focus();
 		}
 		
 		return Zotero.Items.getAsync(itemID);

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -1304,12 +1304,9 @@ var ZoteroPane = new function()
 						var mru = Zotero.Prefs.get('newItemTypeMRU');
 						var type = mru ? mru.split(',')[0] : 'book';
 						await ZoteroPane.newItem(Zotero.ItemTypes.getID(type));
-						// If the info pane is collapsed, focus the first focusable itemPane component
 						let itemBox = document.getElementById('zotero-editpane-item-box');
-						if (!itemBox.open) {
-							Services.focus.moveFocus(window, ZoteroPane.itemPane, Services.focus.MOVEFOCUS_FORWARD, 0);
-							return;
-						}
+						// Ensure itemBox is opened
+						itemBox.open = true;
 						var menu = itemBox.itemTypeMenu;
 						// If the new item's type is changed immediately, update the MRU
 						var handleTypeChange = function () {

--- a/test/tests/itemPaneTest.js
+++ b/test/tests/itemPaneTest.js
@@ -143,6 +143,16 @@ describe("Item pane", function () {
 	});
 	
 	describe("Info pane", function () {
+		it("should place Title after Item Type and before creators", async function () {
+			var item = await createDataObject('item');
+			var itemPane = win.ZoteroPane.itemPane;
+			var fields = [...itemPane.querySelectorAll('.meta-label')]
+				.map(x => x.getAttribute('fieldname'));
+			assert.equal(fields[0], 'itemType');
+			assert.equal(fields[1], 'title');
+			assert.isTrue(fields[2].startsWith('creator'));
+		});
+		
 		it("should refresh on item update", function* () {
 			var item = new Zotero.Item('book');
 			var id = yield item.saveTx();

--- a/test/tests/zoteroPaneTest.js
+++ b/test/tests/zoteroPaneTest.js
@@ -18,9 +18,8 @@ describe("ZoteroPane", function() {
 	describe("#newItem", function () {
 		it("should create an item and focus the title field", function* () {
 			yield zp.newItem(Zotero.ItemTypes.getID('book'), {}, null, true);
-			let title = doc.getElementById('zotero-item-pane-header').querySelector("editable-text");
-			assert.equal(doc.activeElement.getAttribute("aria-label"), title.getAttribute("aria-label"));
-			title.blur();
+			assert.equal(doc.activeElement.closest("editable-text").id, "itembox-field-value-title");
+			doc.activeElement.blur();
 			yield Zotero.Promise.delay(1);
 		})
 		


### PR DESCRIPTION
When item is created manually, title field in itemBox will be focused instead of the title in the itemPane as before. If the itemBox is collapsed, it will be opened.

In addition, do not move the focus from the itemType menu onto the title in the header if the item is created via a keyboard shortcut and its type was immediately changed. It is generally better to avoid moving focus on behalf of the user, and now that the title is right below the itemType, it's likely no longer necessary.

Fixes: #4111


One observation: to focus the title in the itemBox on manual item creation, we have to open the itemBox if it is collapsed. If an item is created with a shortcut and the itemBox is closed, we can't always focus the title in the header of the itemPane as in #4105 because it may be in "Bibliography Entry" mode, which is not focusable. So for now, I changed it to just tab into the first focusable element of `itemPane`. That way if the title in the header is editable, it will receive focus. Otherwise, focus will land on the scrollable area. 

Focusing on the scrollable area of the itemPane is OK but it's not that useful, I think. So maybe we should just always force-open the itemBox on item creation from the shortcut too? Then, the itemType menu can always be focused and opened. The drawback is that it feels like a lot of things magically happening at the same time (section opening first and then item menu opening up) but it does seem like this would be more useful?