### PR TITLE
remove unnecessarry scrollbar in tabs menu on mac

### DIFF
--- a/scss/components/_tabsMenu.scss
+++ b/scss/components/_tabsMenu.scss
@@ -30,7 +30,6 @@
 	appearance: none;
 	margin: 0;
 	overflow-x: hidden;
-	overflow-y: scroll;
 	scrollbar-width: thin;
 	padding: 5px 0;
 


### PR DESCRIPTION
Make sure the vertical scrollbar does not occupy space on mac when the menu is not scrollable even if the "Show scroll bar" setting is "Always"

Fixes: #4121