### PR TITLE
Move "Show File" out of Locate menu and into File menu

### DIFF
--- a/chrome/content/zotero/locateMenu.js
+++ b/chrome/content/zotero/locateMenu.js
@@ -602,15 +602,15 @@ var Zotero_LocateMenu = new function() {
 		this.className = "zotero-menuitem-show-file";
 		this.hideInToolbar = true;
 		this.l10nId = "menu-show-file";
-		this.l10nArgs = { count: 0 };
+		this.l10nArgs = { count: 1 };
 		
 		this.canHandleItem = function (item) {
 			return ZoteroPane.canShowItemInFilesystem(item);
 		};
 		
 		this.updateMenuItem = function (items) {
-			let count = items.filter(item => ZoteroPane.canShowItemInFilesystem(item))
-				.length;
+			// We only care about showing 1 or many
+			let count = Zotero.Items.numDistinctFileAttachmentsForLabel(items) > 1 ? 2 : 1;
 			this.l10nArgs = { count };
 		};
 		

--- a/chrome/content/zotero/standalone/standalone.js
+++ b/chrome/content/zotero/standalone/standalone.js
@@ -176,28 +176,25 @@ const ZoteroStandalone = new function() {
 			}
 		}
 		
+		let selectedItems = ZoteroPane.getSelectedItems();
+		
 		let showFileMenuitem = document.getElementById('menu_showFile');
-		let numFiles = ZoteroPane.getSelectedItems()
-			.filter(item => ZoteroPane.canShowItemInFilesystem(item))
-			.length;
+		let numFiles = Zotero.Items.numDistinctFileAttachmentsForLabel(selectedItems);
 		showFileMenuitem.disabled = !numFiles;
 		document.l10n.setArgs(showFileMenuitem, {
-			count: numFiles
+			// We only care about showing 1 or many
+			count: numFiles > 1 ? 2 : 1
 		});
 
 		// TEMP: Quick implementation
 		try {
 			let menuitem = document.getElementById('menu_export_files');
+			// Library tab
 			if (!reader) {
-				let numFiles = ZoteroPane.getSelectedItems().reduce((num, item) => {
-					if (item.isPDFAttachment()) {
-						return num + 1;
-					}
-					if (item.isRegularItem()) {
-						return num + item.numPDFAttachments();
-					}
-					return num;
-				}, 0);
+				let numFiles = Zotero.Items.numDistinctFileAttachmentsForLabel(
+					selectedItems,
+					item => item.isPDFAttachment()
+				);
 				if (numFiles) {
 					menuitem.hidden = false;
 					menuitem.label = Zotero.getString(
@@ -208,6 +205,7 @@ const ZoteroStandalone = new function() {
 					menuitem.hidden = true;
 				}
 			}
+			// Reader tab
 			else {
 				menuitem.hidden = true;
 			}

--- a/chrome/content/zotero/standalone/standalone.js
+++ b/chrome/content/zotero/standalone/standalone.js
@@ -157,8 +157,9 @@ const ZoteroStandalone = new function() {
 	};
 
 	this.onFileMenuOpen = function () {
-		// PDF annotation transfer ("Import Annotation"/"Store Annotations in File")
 		let reader = Zotero.Reader.getByTabID(Zotero_Tabs.selectedID);
+		
+		// PDF annotation transfer ("Import Annotation"/"Store Annotations in File")
 		if (reader) {
 			let item = Zotero.Items.get(reader.itemID);
 			let library = Zotero.Libraries.get(item.libraryID);
@@ -175,14 +176,20 @@ const ZoteroStandalone = new function() {
 			}
 		}
 		
+		let showFileMenuitem = document.getElementById('menu_showFile');
+		let numFiles = ZoteroPane.getSelectedItems()
+			.filter(item => ZoteroPane.canShowItemInFilesystem(item))
+			.length;
+		showFileMenuitem.disabled = !numFiles;
+		document.l10n.setArgs(showFileMenuitem, {
+			count: numFiles
+		});
+
 		// TEMP: Quick implementation
 		try {
 			let menuitem = document.getElementById('menu_export_files');
-			let sep = menuitem.nextSibling;
-			
-			let zp = Zotero.getActiveZoteroPane();
-			if (zp && !reader) {
-				let numFiles = zp.getSelectedItems().reduce((num, item) => {
+			if (!reader) {
+				let numFiles = ZoteroPane.getSelectedItems().reduce((num, item) => {
 					if (item.isPDFAttachment()) {
 						return num + 1;
 					}
@@ -193,19 +200,16 @@ const ZoteroStandalone = new function() {
 				}, 0);
 				if (numFiles) {
 					menuitem.hidden = false;
-					sep.hidden = false;
 					menuitem.label = Zotero.getString(
 						'pane.items.menu.exportPDF' + (numFiles == 1 ? '' : '.multiple')
 					);
 				}
 				else {
 					menuitem.hidden = true;
-					sep.hidden = true;
 				}
 			}
 			else {
 				menuitem.hidden = true;
-				sep.hidden = true;
 			}
 		}
 		catch (e) {

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -2461,6 +2461,20 @@ Zotero.Item.prototype.numAttachments = function (includeTrashed) {
 }
 
 
+/**
+ * Returns the number of file attachments of an item
+ *
+ * @return <Integer>
+ */
+Zotero.Item.prototype.numFileAttachments = function () {
+	this._requireData('childItems');
+	return this.getAttachments()
+		.map(itemID => Zotero.Items.get(itemID))
+		.filter(item => item.isFileAttachment())
+		.length;
+};
+
+
 Zotero.Item.prototype.numNonHTMLFileAttachments = function () {
 	this._requireData('childItems');
 	return this.getAttachments()

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -4901,6 +4901,32 @@ var ZoteroPane = new function()
 	}
 	
 	
+	this.canShowItemInFilesystem = function (item) {
+		return item.isRegularItem() && item.numAttachments()
+			|| item.isAttachment() && item.attachmentLinkMode !== Zotero.Attachments.LINK_MODE_LINKED_URL;
+	};
+	
+	
+	this.showItemsInFilesystem = async function (items = this.getSelectedItems()) {
+		let attachments = (await Promise.all(
+			items.map((item) => {
+				if (item.isRegularItem()) {
+					return item.getBestAttachment();
+				}
+				else if (item.isAttachment() && item.attachmentLinkMode !== Zotero.Attachments.LINK_MODE_LINKED_URL) {
+					return item;
+				}
+				else {
+					return null;
+				}
+			})
+		)).filter(Boolean);
+		for (let attachment of attachments) {
+			await this.showAttachmentInFilesystem(attachment.id);
+		}
+	};
+	
+	
 	this.showAttachmentInFilesystem = async function (itemID, noLocateOnMissing) {
 		var attachment = await Zotero.Items.getAsync(itemID)
 		if (attachment.attachmentLinkMode == Zotero.Attachments.LINK_MODE_LINKED_URL) return;

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -4902,8 +4902,7 @@ var ZoteroPane = new function()
 	
 	
 	this.canShowItemInFilesystem = function (item) {
-		return item.isRegularItem() && item.numAttachments()
-			|| item.isAttachment() && item.attachmentLinkMode !== Zotero.Attachments.LINK_MODE_LINKED_URL;
+		return (item.isRegularItem() && item.numFileAttachments()) || item.isFileAttachment();
 	};
 	
 	
@@ -4913,7 +4912,7 @@ var ZoteroPane = new function()
 				if (item.isRegularItem()) {
 					return item.getBestAttachment();
 				}
-				else if (item.isAttachment() && item.attachmentLinkMode !== Zotero.Attachments.LINK_MODE_LINKED_URL) {
+				else if (item.isFileAttachment()) {
 					return item;
 				}
 				else {

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -319,10 +319,13 @@
 							<menuitem id="menu_close_tab" class="menu-type-reader" label="&closeCmd.label;" key="key_close"
 									accesskey="&closeCmd.accesskey;" oncommand="Zotero_Tabs.close()"/>
 							<menuseparator class="menu-type-library"/>
+							<menuitem data-l10n-id="menu-show-file" id="menu_showFile"
+									class="menu-type-library"
+									oncommand="ZoteroPane.showItemsInFilesystem()"/>
 							<menuitem id="menu_export_files" class="menu-type-library"
 									oncommand="ZoteroPane.exportSelectedFiles()"
 									hidden="true"/>
-							<menuseparator class="menu-type-library" hidden="true"/>
+							<menuseparator class="menu-type-library"/>
 							<menuitem id="menu_import" class="menu-type-library" label="&importCmd.label;"
 									command="cmd_zotero_import" key="key_import"/>
 							<menuitem id="menu_importFromClipboard" class="menu-type-library" label="&importFromClipboardCmd.label;"

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -10,6 +10,15 @@ general-add = Add
 
 menu-print =
     .label = { general-print }
+menu-show-file =
+    .label = { PLATFORM() ->
+        [macos] Show in Finder
+        *[other] { $count ->
+            [0] Show File
+            [one] Show File
+            *[other] Show Files
+        }
+    }
 
 menu-density =
     .label = Density

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -14,7 +14,6 @@ menu-show-file =
     .label = { PLATFORM() ->
         [macos] Show in Finder
         *[other] { $count ->
-            [0] Show File
             [one] Show File
             *[other] Show Files
         }

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -1231,7 +1231,6 @@ locate.snapshot.label				= View Snapshot
 locate.file.label					= View File
 locate.externalViewer.label			= Open in External Viewer
 locate.internalViewer.label			= Open in Internal Viewer
-locate.showFile.label				= Show File
 locate.libraryLookup.label			= Library Lookup
 locate.libraryLookup.noResolver.title = No OpenURL Resolver
 locate.libraryLookup.noResolver.text = You must choose an OpenURL resolver from the Advanced pane of the %S preferences.

--- a/scss/components/_menu.scss
+++ b/scss/components/_menu.scss
@@ -22,7 +22,7 @@ $menu-icons: (
 	attach: "attachment",
 	attachments-web-link: "link",
 	view-online: "globe",
-	view-file: "folder-open",
+	show-file: "folder-open",
 	view-external: "page",
 	library-lookup: "library-lookup",
 	new-feed: "feed",


### PR DESCRIPTION
And improve `locateMenu.js` Fluent handling:

- `l10nKey` -> `l10nId`
- Only get `l10nArgs` once, since `ViewAttachment` calculates it with a fairly complex getter routine
- Don't make option objects stringify their l10n args themselves

Fixes #4118 (and includes "Show File" -> "Show in Finder" on macOS - will revert if we don't want that)