### PR TITLE
Support firstCreator customization

### DIFF
--- a/chrome/content/zotero/elements/itemPaneHeader.js
+++ b/chrome/content/zotero/elements/itemPaneHeader.js
@@ -66,15 +66,18 @@
 
 		init() {
 			this._notifierID = Zotero.Notifier.registerObserver(this, ['item'], 'paneHeader');
-			this._prefsObserverIDs = [
-				Zotero.Prefs.registerObserver('itemPaneHeader', () => {
-					// TEMP?: _forceRenderAll() doesn't do anything if the section is hidden, so un-hide first
-					this.hidden = false;
-					this._forceRenderAll();
-				}),
-				Zotero.Prefs.registerObserver('itemPaneHeader.bibEntry.style', () => this._forceRenderAll()),
-				Zotero.Prefs.registerObserver('itemPaneHeader.bibEntry.locale', () => this._forceRenderAll()),
+			
+			let prefs = [
+				'itemPaneHeader',
+				'itemPaneHeader.bibEntry.style',
+				'itemPaneHeader.bibEntry.locale',
+				...Zotero.Items.FIRST_CREATOR_DISPLAY_PREFS,
 			];
+			this._prefsObserverIDs = prefs.map(pref => Zotero.Prefs.registerObserver(pref, () => {
+				// TEMP?: _forceRenderAll() doesn't do anything if the section is hidden, so un-hide first
+				this.hidden = false;
+				this._forceRenderAll();
+			}));
 			
 			this.title = this.querySelector('.title');
 			this.titleField = this.title.querySelector('editable-text');

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -108,6 +108,9 @@ var ItemTree = class ItemTree extends LibraryTree {
 			50
 		);
 		
+		this._prefsUnregisterIDs = Zotero.Items.FIRST_CREATOR_DISPLAY_PREFS
+			.map(pref => Zotero.Prefs.registerObserver(pref, this._handleFirstCreatorDisplayPrefChange));
+		
 		this._itemsPaneMessage = null;
 		
 		this._columnsId = null;
@@ -122,6 +125,9 @@ var ItemTree = class ItemTree extends LibraryTree {
 	unregister() {
 		this._uninitialized = true;
 		Zotero.Notifier.unregisterObserver(this._unregisterID);
+		for (let id of this._prefsUnregisterIDs) {
+			Zotero.Prefs.unregisterObserver(id);
+		}
 		this._writeColumnPrefsToFile(true);
 	}
 
@@ -3202,6 +3208,11 @@ var ItemTree = class ItemTree extends LibraryTree {
 		}
 		
 		return this._rowCache[itemID] = row;
+	}
+	
+	_handleFirstCreatorDisplayPrefChange = () => {
+		this._rowCache = {};
+		this.tree.invalidate();
 	}
 
 	_getColumnPrefs = () => {

--- a/chrome/content/zotero/preferences/preferences_general.xhtml
+++ b/chrome/content/zotero/preferences/preferences_general.xhtml
@@ -77,6 +77,31 @@
 					><menupopup/></menulist>
 				</hbox>
 			</vbox>
+
+			<hbox align="center">
+				<label data-l10n-id="preferences-first-creator-name-format"/>
+				<menulist id="first-creator-name-format-menulist" preference="extensions.zotero.firstCreator.nameFormat" native="true">
+					<menupopup>
+						<menuitem data-l10n-id="preferences-first-creator-name-format-last" value="last"/>
+						<menuitem data-l10n-id="preferences-first-creator-name-format-last-first" value="lastFirst"/>
+						<menuitem data-l10n-id="preferences-first-creator-name-format-first-last" value="firstLast"/>
+					</menupopup>
+				</menulist>
+			</hbox>
+
+			<hbox align="center" class="indented-pref">
+				<label control="first-creator-max-names" data-l10n-id="preferences-first-creator-max-names"/>
+				<menulist id="first-creator-max-names-menulist" preference="extensions.zotero.firstCreator.maxNames" native="true">
+					<menupopup>
+						<menuitem data-l10n-id="preferences-first-creator-max-names-option" data-l10n-args='{ "max": 0 }' value="0"/>
+						<menuitem data-l10n-id="preferences-first-creator-max-names-option" data-l10n-args='{ "max": 1 }' value="1"/>
+						<menuitem data-l10n-id="preferences-first-creator-max-names-option" data-l10n-args='{ "max": 2 }' value="2"/>
+						<menuitem data-l10n-id="preferences-first-creator-max-names-option" data-l10n-args='{ "max": 3 }' value="3"/>
+						<menuitem data-l10n-id="preferences-first-creator-max-names-option" data-l10n-args='{ "max": 4 }' value="4"/>
+						<menuitem data-l10n-id="preferences-first-creator-max-names-option" data-l10n-args='{ "max": 5 }' value="5"/>
+					</menupopup>
+				</menulist>
+			</hbox>
 		</groupbox>
 		
 		<groupbox id="zotero-prefpane-file-handling-groupbox">

--- a/chrome/locale/en-US/zotero/preferences.ftl
+++ b/chrome/locale/en-US/zotero/preferences.ftl
@@ -38,6 +38,21 @@ preferences-item-pane-header-style = Header Citation Style:
 preferences-item-pane-header-locale = Header Language:
 preferences-item-pane-header-missing-style = Missing style: <{ $shortName }>
 
+preferences-first-creator-name-format = Creator Name Format:
+preferences-first-creator-name-format-last =
+    .label = Last
+preferences-first-creator-name-format-last-first =
+    .label = Last, First
+preferences-first-creator-name-format-first-last =
+    .label = First Last
+preferences-first-creator-max-names = Switch to “et al.”:
+preferences-first-creator-max-names-option =
+    .label = { $max ->
+        [0] Never
+        [1] After { $max } creator
+        *[other] After { $max } creators
+    }
+
 preferences-advanced-language-and-region-title = Language and Region
 preferences-advanced-enable-bidi-ui =
     .label = Enable bidirectional text editing utilities

--- a/defaults/preferences/zotero.js
+++ b/defaults/preferences/zotero.js
@@ -78,6 +78,9 @@ pref("extensions.zotero.itemPaneHeader", "title");
 pref("extensions.zotero.itemPaneHeader.bibEntry.style", "http://www.zotero.org/styles/apa");
 pref("extensions.zotero.itemPaneHeader.bibEntry.locale", "");
 
+pref("extensions.zotero.firstCreator.nameFormat", "last");
+pref("extensions.zotero.firstCreator.maxNames", "2");
+
 //Tag Selector
 pref("extensions.zotero.tagSelector.showAutomatic", true);
 pref("extensions.zotero.tagSelector.displayAllTags", false);

--- a/test/tests/itemsTest.js
+++ b/test/tests/itemsTest.js
@@ -1104,6 +1104,11 @@ describe("Zotero.Items", function () {
 	})
 	
 	describe("#getFirstCreatorFromData()", function () {
+		let defaultOptions = {
+			nameFormat: 'last',
+			maxNames: 2,
+		};
+		
 		it("should handle single eligible creator", function* () {
 			for (let creatorType of ['author', 'editor', 'contributor']) {
 				assert.equal(
@@ -1116,7 +1121,8 @@ describe("Zotero.Items", function () {
 								lastName: 'B',
 								creatorTypeID: Zotero.CreatorTypes.getID(creatorType)
 							}
-						]
+						],
+						defaultOptions
 					),
 					'B',
 					creatorType
@@ -1135,7 +1141,8 @@ describe("Zotero.Items", function () {
 							lastName: 'B',
 							creatorTypeID: Zotero.CreatorTypes.getID('translator')
 						}
-					]
+					],
+					defaultOptions
 				),
 				''
 			);
@@ -1159,7 +1166,8 @@ describe("Zotero.Items", function () {
 								lastName: 'D',
 								creatorTypeID: Zotero.CreatorTypes.getID(creatorType)
 							}
-						]
+						],
+						defaultOptions
 					),
 					'D',
 					creatorType
@@ -1185,7 +1193,8 @@ describe("Zotero.Items", function () {
 								lastName: 'D',
 								creatorTypeID: Zotero.CreatorTypes.getID(creatorType)
 							}
-						]
+						],
+						defaultOptions
 					),
 					Zotero.getString(
 						'general.andJoiner',
@@ -1220,7 +1229,8 @@ describe("Zotero.Items", function () {
 								lastName: 'F',
 								creatorTypeID: Zotero.CreatorTypes.getID(creatorType)
 							}
-						]
+						],
+						defaultOptions
 					),
 					'B ' + Zotero.getString('general.etAl'),
 					creatorType
@@ -1258,7 +1268,8 @@ describe("Zotero.Items", function () {
 								lastName: 'H',
 								creatorTypeID: Zotero.CreatorTypes.getID(creatorType)
 							}
-						]
+						],
+						defaultOptions
 					),
 					Zotero.getString(
 						'general.andJoiner',


### PR DESCRIPTION
Adds two new preferences:

![image](https://github.com/zotero/zotero/assets/1770299/5825d810-f3dd-4c25-8ff0-774568153698)

Automatically decides whether to add comma/space between name parts depending on the script.

Caches on the item, invalidating when the relevant prefs change. Formatter functions are cached globally.

Left to do:

- Tests: No longer any distinction between saved and unsaved items for `firstCreator` purposes; need to test new options
- Doesn't yet affect note editor (`_formatCitationItemPreview`)

But I wanted to get some feedback on this approach first.

Closes #2831