### PR TITLE
Fixes to itembox creator row bugs

### DIFF
--- a/chrome/content/zotero/elements/editableText.js
+++ b/chrome/content/zotero/elements/editableText.js
@@ -325,11 +325,11 @@
 				return;
 			}
 			this._resetStateAfterBlur();
+			this.dispatchEvent(new Event('blur'));
 		};
 		
 		_resetStateAfterBlur() {
 			this._ignoredWindowInactiveBlur = false;
-			this.dispatchEvent(new Event('blur'));
 			this.classList.remove('focused');
 			this._input.scrollLeft = 0;
 			this._input.setSelectionRange(0, 0);


### PR DESCRIPTION
- minor refactoring of blurOpenField to call blur directly on the input of `editable-text`. That is to avoid having multiple 'blur' events triggering `hideEditor` which may cause multiple re-renderings and potentially an infinite loop. It can also interfere with cases when we want to add a new creator row on shift-enter after the first refresh - second unwanted re-render would remove the newly added empty creator row.
- remove call to blurOpenField where it is not necessary and make it non-async. With `editable-text`, the fields blur and the item gets saved whenever you click outside of it, so that's no more necessary and confusing.
- on focusin of the empty unsaved creator row, use its future unsaved id that reflects its positioning instead of its real id (which technically is the very last creator row). That way, a tab from a creator row that was just filled will land to the proper component after render, as opposed to focusing the very last row.
- similar approach to removing the unsaved creator row when the focus is in it - focus the row above it, as opposed to the last row.

Fixes: #4145
Addresses part of: #4143