### PR TITLE
Feeds: Refactor to move field extraction to FeedProcessor

### DIFF
--- a/test/tests/data/feedArticleMetadata.rss
+++ b/test/tests/data/feedArticleMetadata.rss
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns="http://purl.org/rss/1.0/"
+ xmlns:dc="http://purl.org/dc/elements/1.1/"
+ xmlns:dcterms="http://purl.org/dc/terms/"
+ xmlns:cc="http://web.resource.org/cc/"
+ xmlns:prism="http://prismstandard.org/namespaces/basic/2.0/"
+ xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+ xmlns:admin="http://webns.net/mvcb/"
+ xmlns:content="http://purl.org/rss/1.0/modules/content/">
+    <channel rdf:about="https://www.mdpi.com/rss/journal/fluids">
+		<title>Fluids</title>
+		<description>Latest open access articles published in Fluids at https://www.mdpi.com/journal/fluids</description>
+		<link>https://www.mdpi.com/journal/fluids</link>
+		<admin:generatorAgent rdf:resource="https://www.mdpi.com/journal/fluids"/>
+		<admin:errorReportsTo rdf:resource="mailto:support@mdpi.com"/>
+		<dc:publisher>MDPI</dc:publisher>
+		<dc:language>en</dc:language>
+		<dc:rights>Creative Commons Attribution (CC-BY)</dc:rights>
+						<prism:copyright>MDPI</prism:copyright>
+		<prism:rightsAgent>support@mdpi.com</prism:rightsAgent>
+		<image rdf:resource="https://pub.mdpi-res.com/img/design/mdpi-pub-logo.png?13cf3b5bd783e021?1716292923"/>
+				<items>
+			<rdf:Seq>
+            				<rdf:li rdf:resource="https://www.mdpi.com/2311-5521/9/6/120" />
+                    	</rdf:Seq>
+		</items>
+				<cc:license rdf:resource="http://creativecommons.org/licenses/by/3.0/" />
+	</channel>
+
+        <item rdf:about="https://www.mdpi.com/2311-5521/9/6/120">
+
+	<title>Fluids, Vol. 9, Pages 120: Environmental Hydraulics, Turbulence, and Sediment Transport, Second Edition</title>
+	<link>https://www.mdpi.com/2311-5521/9/6/120</link>
+	<description>Within river systems, the process of bed-forming is intricate, dynamic and is shaped by different factors [...]</description>
+	<pubDate>2024-05-22</pubDate>
+
+	<content:encoded><![CDATA[
+	Abstract
+	]]></content:encoded>
+
+	<dc:title>Environmental Hydraulics, Turbulence, and Sediment Transport, Second Edition</dc:title>
+			<dc:creator>Jaan H. Pu</dc:creator>
+			<dc:creator>Manish Pandey</dc:creator>
+			<dc:creator>Prashanth Reddy Hanmaiahgari</dc:creator>
+		<dc:identifier>doi: 10.3390/fluids9060120</dc:identifier>
+	<dc:source>Fluids</dc:source>
+	<dc:date>2024-05-22</dc:date>
+
+	<prism:publicationName>Fluids</prism:publicationName>
+	<prism:publicationDate>2024-05-22</prism:publicationDate>
+	<prism:volume>9</prism:volume>
+	<prism:number>6</prism:number>
+	<prism:section>Editorial</prism:section>
+	<prism:startingPage>120</prism:startingPage>
+		<prism:doi>10.3390/fluids9060120</prism:doi>
+	<prism:url>https://www.mdpi.com/2311-5521/9/6/120</prism:url>
+	
+	<cc:license rdf:resource="CC BY 4.0"/>
+</item>
+</rdf:RDF>

--- a/test/tests/feedReaderTest.js
+++ b/test/tests/feedReaderTest.js
@@ -32,6 +32,7 @@ describe("Zotero.FeedReader", function () {
 	
 	var richTextRSSFeedURL = getTestDataUrl("feedRichText.rss");
 	var cdataRSSFeedURL = getTestDataUrl("feedCDATA.rss");
+	var articleMetadataRSSFeedURL = getTestDataUrl("feedArticleMetadata.rss");
 	var atomFeedURL = getTestDataUrl("feed.atom");
 	var mediaFeedURL = getTestDataUrl("feedMedia.xml");
 	
@@ -157,6 +158,7 @@ describe("Zotero.FeedReader", function () {
 				publicationTitle: 'Publication',
 				ISSN: '0000-0000',
 				publisher: 'Publisher',
+				section: 'Article',
 				rights: '©2016 Published by Publisher',
 				language: 'en',
 				itemType: 'journalArticle',
@@ -164,6 +166,38 @@ describe("Zotero.FeedReader", function () {
 			};
 		
 			let fr = new Zotero.FeedReader(detailedRSSFeedURL);
+			yield fr.process();
+			let itemIterator = new fr.ItemIterator();
+			let item = yield itemIterator.next().value;
+			assert.deepEqual(item, expected);
+		});
+		
+		it('should parse items correctly for an RSS feed with journal article metadata', function* () {
+			let expected = {
+				guid: 'https://www.mdpi.com/2311-5521/9/6/120',
+				title: 'Environmental Hydraulics, Turbulence, and Sediment Transport, Second Edition',
+				abstractNote: 'Abstract',
+				url: 'https://www.mdpi.com/2311-5521/9/6/120',
+				creators: [
+					{ firstName: 'Jaan H.', lastName: 'Pu', creatorType: 'author' },
+					{ firstName: 'Manish', lastName: 'Pandey', creatorType: 'author' },
+					{ firstName: 'Prashanth Reddy', lastName: 'Hanmaiahgari', creatorType: 'author' }
+				],
+				date: '2024-05-22',
+				publicationTitle: 'Fluids',
+				pages: '120',
+				DOI: '10.3390/fluids9060120',
+				volume: '9',
+				issue: '6',
+				section: 'Editorial',
+				publisher: 'MDPI',
+				rights: 'MDPI',
+				language: 'en',
+				itemType: 'journalArticle',
+				enclosedItems: []
+			};
+		
+			let fr = new Zotero.FeedReader(articleMetadataRSSFeedURL);
 			yield fr.process();
 			let itemIterator = new fr.ItemIterator();
 			let item = yield itemIterator.next().value;


### PR DESCRIPTION
`FeedProcessor` has mappings between namespaced tags and metadata fields, but we were mostly ignoring them and doing the same work in `FeedReader` ([previously noted](https://github.com/zotero/zotero/commit/676ab7852b3d92525137e93ea53ff934bf22f4d9)). This moves the extraction to `FeedProcessor` and adds support for more PRISM fields (under so, so many namespaces) in the process.

Dates fields are no longer parsed in `FeedProcessor`. We didn't seem to use the parse output anyway, and it used the not-great `toUTCString()` function.

A further improvement would be to remove the distinction between maybe-HTML tags, which are stored on the Feed or Entry object as `TextConstruct` instances, and text-only tags, which are stored as plain strings, with no differentiation in property names. Right now, if a `searchLists` entry contains some tag names that are keys in the `_textConstructs` object and others that aren't, the value of that field could be stored as *either* a `TextConstruct` or a string, depending on which tag it ends up coming from. We know which fields we treat as text and which we treat as HTML, though, so everything could just be a string.

Fixes #4156