### PR TITLE
fix tagsbox enter glitch

### DIFF
--- a/chrome/content/zotero/elements/editableText.js
+++ b/chrome/content/zotero/elements/editableText.js
@@ -324,8 +324,8 @@
 				this._ignoredWindowInactiveBlur = true;
 				return;
 			}
-			this._resetStateAfterBlur();
 			this.dispatchEvent(new Event('blur'));
+			this._resetStateAfterBlur();
 		};
 		
 		_resetStateAfterBlur() {

--- a/test/tests/tagsboxTest.js
+++ b/test/tests/tagsboxTest.js
@@ -16,7 +16,7 @@ describe("Item Tags Box", function () {
 	
 	
 	describe("Tag Editing", function () {
-		it.skip("should update tag when pressing Enter in textbox", async function () {
+		it("should update tag when pressing Enter in textbox", async function () {
 			if (!doc.hasFocus()) {
 				// editable-text behavior relies on focus, so we first need to bring the window to the front.
 				// Not required on all platforms. In some cases (e.g. Linux), the window is at the front from the start.


### PR DESCRIPTION
The 'blur' event needs to be dispatched by editable-text before its state is reset (not after) because tagsbox uses .initialValue in the 'blur' handler.

followup to 101e6d55d507723c4d59e79dc304bdba03721953

Fixes: #3575