### PR TITLE
Item box: Save text selection along with focus

### DIFF
--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -2233,8 +2233,7 @@
 				}
 			}
 			
-			this._selectField = null;
-			this._selectFieldSelection = null;
+			this._clearSavedFieldFocus();
 		}
 
 		getTitleField() {


### PR DESCRIPTION
@abaevbog: Let me know if this looks alright!

I didn't touch them in this PR, but some of the other places where `this._selectField` is set don't seem to be doing anything / the right thing:

- Tabbing out of an empty unsaved creator row brings me to the button bar on the next field, not [the last name](https://github.com/AbeJellinek/zotero/blob/fcaed18d0d6555e5a5e5be7fbed5071e7d508e16/chrome/content/zotero/elements/itemBox.js#L1530)
- Shift-Enter from the last creator before "More creators..." adds a new row at the end, not [in the middle](https://github.com/AbeJellinek/zotero/blob/fcaed18d0d6555e5a5e5be7fbed5071e7d508e16/chrome/content/zotero/elements/itemBox.js#L1760)
- Pasting a tab-separated creator string selects a new empty creator, not [the last name of the last new creator](https://github.com/AbeJellinek/zotero/blob/fcaed18d0d6555e5a5e5be7fbed5071e7d508e16/chrome/content/zotero/elements/itemBox.js#L1827)

Fixes #4164