### PR TITLE
vpat 23: better aria label for itembox merge button

### DIFF
--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -670,7 +670,8 @@
 					var button = document.createXULElement("toolbarbutton");
 					button.className = 'zotero-field-version-button zotero-clicky-merge';
 					button.setAttribute('type', 'menu');
-					button.setAttribute('data-l10n-id', 'itembox-button-merge');
+					let fieldLocalName = rowLabel.querySelector("label")?.textContent;
+					document.l10n.setAttributes(button, 'itembox-button-merge', { field: fieldLocalName || "" });
 					
 					var popup = button.appendChild(document.createXULElement("menupopup"));
 					

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -121,7 +121,7 @@ item-button-view-online =
 itembox-button-options =
     .tooltiptext = Open Context Menu
 itembox-button-merge =
-    .aria-label = Select Version
+    .aria-label = Select version of { $field } field
 
 reader-use-dark-mode-for-content =
     .label = Use Dark Mode for Content


### PR DESCRIPTION
Added the field name for the label to be more descriptive. The new announced label is e.g. "Select version of title field".

Followup to https://github.com/zotero/zotero/pull/4096#issuecomment-2121894422