### PR TITLE
tabs startup loading optimization

### DIFF
--- a/chrome/content/zotero/elements/contextPane.js
+++ b/chrome/content/zotero/elements/contextPane.js
@@ -171,7 +171,7 @@
 				ZoteroContextPane.showLoadingMessage(false);
 				this._sidenav.hidden = true;
 			}
-			else if (Zotero_Tabs.selectedType == 'reader') {
+			else if (Zotero_Tabs.selectedType.includes('reader')) {
 				let reader = Zotero.Reader.getByTabID(Zotero_Tabs.selectedID);
 				this._handleReaderReady(reader);
 			
@@ -305,9 +305,8 @@
 			itemDetails.sidenav = this._sidenav;
 			if (previousPinnedPane) itemDetails.pinnedPane = previousPinnedPane;
 	
-			// `unloaded` tabs are never selected and shouldn't be rendered on creation.
-			// Use `includes` here for forward compatibility.
-			if (!tabType.includes("unloaded")) {
+			// Make sure that the context pane of the selected tab is rendered
+			if (tabID == Zotero_Tabs.selectedID) {
 				this._selectItemContext(tabID);
 			}
 		}

--- a/chrome/content/zotero/elements/contextPane.js
+++ b/chrome/content/zotero/elements/contextPane.js
@@ -195,9 +195,6 @@
 			if (!reader) {
 				return;
 			}
-			ZoteroContextPane.showLoadingMessage(true);
-			await reader._initPromise;
-			ZoteroContextPane.showLoadingMessage(false);
 			// Focus reader pages view if context pane note editor is not selected
 			if (Zotero_Tabs.selectedID == reader.tabID
 				&& !Zotero_Tabs.isTabsMenuVisible()

--- a/chrome/content/zotero/tabs.js
+++ b/chrome/content/zotero/tabs.js
@@ -452,19 +452,22 @@ var Zotero_Tabs = new function () {
 			selectedTab.lastFocusedElement = document.activeElement;
 		}
 		if (tab.type === 'reader-unloaded') {
-			// Make sure the loading message is displayed - it will be removed by reader
-			// when it is loaded
+			// Make sure the loading message is displayed first.
+			// Then, open reader and hide the loading message once it has loaded.
 			ZoteroContextPane.showLoadingMessage(true);
-			// Open reader in this unloaded tab. Once the reader instance is created,
-			// the tab's type will be changed for just "reader"
-			Zotero.Reader.open(tab.data.itemID, options && options.location, {
-				tabID: tab.id,
-				title: tab.title,
-				tabIndex,
-				allowDuplicate: true,
-				secondViewState: tab.data.secondViewState,
-				preventJumpback: true
-			});
+			let hideMessageWhenReaderLoaded = async () => {
+				let reader = await Zotero.Reader.open(tab.data.itemID, options && options.location, {
+					tabID: tab.id,
+					title: tab.title,
+					tabIndex,
+					allowDuplicate: true,
+					secondViewState: tab.data.secondViewState,
+					preventJumpback: true
+				});
+				await reader._initPromise;
+				ZoteroContextPane.showLoadingMessage(false);
+			};
+			hideMessageWhenReaderLoaded();
 		}
 		this._prevSelectedID = reopening ? this._selectedID : null;
 		this._selectedID = id;

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -519,7 +519,8 @@ class ReaderInstance {
 		}, this._iframeWindow, { cloneFunctions: true }));
 
 		this._resolveInitPromise();
-
+		// Ensure that if there was a loading message displayed, it is now hidden
+		this._window.ZoteroContextPane?.showLoadingMessage(false);
 		// Set title once again, because `ReaderWindow` isn't loaded the first time
 		this.updateTitle();
 
@@ -1016,19 +1017,28 @@ class ReaderTab extends ReaderInstance {
 		this._onToggleSidebarCallback = options.onToggleSidebar;
 		this._onChangeSidebarWidthCallback = options.onChangeSidebarWidth;
 		this._window = Services.wm.getMostRecentWindow('navigator:browser');
-		let { id, container } = this._window.Zotero_Tabs.add({
-			id: options.tabID,
-			type: 'reader',
-			title: options.title || '',
-			index: options.index,
-			data: {
-				itemID: this._item.id
-			},
-			select: !options.background,
-			preventJumpback: options.preventJumpback
-		});
-		this.tabID = id;
-		this._tabContainer = container;
+		let existingTabID = this._window.Zotero_Tabs.getTabIDByItemID(this._item.id);
+		// If an unloaded tab for this item already exists, load the reader in it.
+		// Otherwise, create a new tab
+		if (existingTabID) {
+			this.tabID = existingTabID;
+			this._tabContainer = this._window.document.getElementById(existingTabID);
+		}
+		else {
+			let { id, container } = this._window.Zotero_Tabs.add({
+				id: options.tabID,
+				type: 'reader',
+				title: options.title || '',
+				index: options.index,
+				data: {
+					itemID: this._item.id
+				},
+				select: !options.background,
+				preventJumpback: options.preventJumpback
+			});
+			this.tabID = id;
+			this._tabContainer = container;
+		}
 		
 		this._iframe = this._window.document.createXULElement('browser');
 		this._iframe.setAttribute('class', 'reader');
@@ -1736,6 +1746,9 @@ class Reader {
 	async open(itemID, location, { title, tabIndex, tabID, openInBackground, openInWindow, allowDuplicate, secondViewState, preventJumpback } = {}) {
 		let { libraryID } = Zotero.Items.getLibraryAndKeyFromID(itemID);
 		let library = Zotero.Libraries.get(libraryID);
+		let win = Zotero.getMainWindow();
+		// Change tab's type from "unloaded-reader" to "reader"
+		win.Zotero_Tabs.markAsLoaded(tabID);
 		await library.waitForDataLoad('item');
 
 		let item = Zotero.Items.get(itemID);
@@ -1746,7 +1759,6 @@ class Reader {
 		this._loadSidebarState();
 		this.triggerAnnotationsImportCheck(itemID);
 		let reader;
-		let win = Zotero.getMainWindow();
 		// If duplicating is not allowed, and no reader instance is loaded for itemID,
 		// try to find an unloaded tab and select it. Zotero.Reader.open will then be called again
 		if (!allowDuplicate && !this._readers.find(r => r.itemID === itemID)) {

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -519,8 +519,6 @@ class ReaderInstance {
 		}, this._iframeWindow, { cloneFunctions: true }));
 
 		this._resolveInitPromise();
-		// Ensure that if there was a loading message displayed, it is now hidden
-		this._window.ZoteroContextPane?.showLoadingMessage(false);
 		// Set title once again, because `ReaderWindow` isn't loaded the first time
 		this.updateTitle();
 


### PR DESCRIPTION
- if an unloaded tab is being opened, do not close the tab and have reader re-open a fresh tab. Instead, keep the tab as is, have reader use the tab as a container and just change the tab's type. It should fix a glitch on windows when if you click on a tab during initial loading, it will disappear until reader re-adds it. A few tweaks to allow unloaded tabs be generally "selectable".
Fixes: #4149
- during startup loading, select the yet-unloaded tab right away. That way, a tab is almost immediately selected, instead of being stuck on the library tab until the reader is ready.
- if the items are not loaded yet, use a placeholder icon for tabs. Fixes: #4150
- updated handling for reader loading message. When an unloaded tab is selected during initial load, the loading message needs to be displayed but, there is no loaded reader yet. So in `Zotero_Tabs.select` display the message, wait for the reader to load, resolve the `_initPromise` in an async function, and hide that message after. Removed loading message handling from contextPane to remain concise 