### PR TITLE
Tweaks to itembox unsaved creator row

### DIFF
--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -606,7 +606,7 @@
 				if ((fieldName == 'url' || fieldName == 'homepage')
 						// Only make plausible HTTP URLs clickable
 						&& Zotero.Utilities.isHTTPURL(val, true)) {
-					openLinkButton = this.createOpenLinkIcon(val);
+					openLinkButton = this.createOpenLinkIcon(val, fieldName);
 					addLinkContextMenu = true;
 				}
 				else if (fieldName == 'DOI' && val && typeof val == 'string') {
@@ -655,6 +655,7 @@
 						optionsButton.classList.add("no-display");
 					}
 					optionsButton.setAttribute('data-l10n-id', "itembox-button-options");
+					optionsButton.id = `itembox-field-${fieldName}-options`;
 					// eslint-disable-next-line no-loop-func
 					let triggerPopup = (e) => {
 						let menupopup = ZoteroPane.buildFieldTransformMenu({
@@ -682,6 +683,7 @@
 				// In field merge mode, add a button to switch field versions
 				if (this.mode == 'fieldmerge' && typeof this._fieldAlternatives[fieldName] != 'undefined') {
 					button = document.createXULElement("toolbarbutton");
+					button.id = `itembox-field-${fieldName}-merge`;
 					button.className = 'zotero-field-version-button zotero-clicky-merge';
 					let fieldLocalName = rowLabel.querySelector("label")?.textContent;
 					document.l10n.setAttributes(button, 'itembox-button-merge', { field: fieldLocalName || "" });
@@ -1400,12 +1402,13 @@
 		}
 
 		
-		createOpenLinkIcon(value) {
+		createOpenLinkIcon(value, fieldName) {
 			// In duplicates/trash mode return nothing
 			if (!(this.editable || this.item.isFeedItem)) {
 				return null;
 			}
 			let openLink = document.createXULElement("toolbarbutton");
+			openLink.id = `itembox-field-${fieldName}-link`;
 			openLink.className = "zotero-clicky zotero-clicky-open-link show-on-hover no-display";
 			openLink.addEventListener("click", event => ZoteroPane.loadURI(value, event));
 			openLink.setAttribute('data-l10n-id', "item-button-view-online");


### PR DESCRIPTION
- remove unsaved creator row on escape and on blur. The blur part is a bit tricky, since we want to remove the empty unsaved creator row on blur only sometimes. For example, the focus leaves the `editable-text` when you click on the options menu or open the creator type dropdown but the row should not be deleted. So I went with the following logic: delete unsaved creator row if the focus lands outside of the itemPane (e.g. you click on the item tree) or if the focus lands on an input outside of the row. Correct me if this sounds off.
- add switch creator mode button to unsaved creator row instead of the always disabled `+` button.
- fix unsaved creator focus glitch on save. If you add a new row, type something and then click on the creator row below it, the focus will jump to the row above it after refresh. To fix it, calculate and use `unsavedIndex` for all creator rows, not
only unsaved one, when setting `this._selectField`.
- fixed bug where focus got lost from some buttons. All focusable elements require an id so that after re-render we can find and refocus the element. Added ids to options and open link icons that were previously missing.

Fixes: #4143
Fixes: #4241