### PR TITLE
zp tab focus tests pass if run on their own

### DIFF
--- a/test/tests/zoteroPaneTest.js
+++ b/test/tests/zoteroPaneTest.js
@@ -1501,6 +1501,13 @@ describe("ZoteroPane", function() {
 			await item.saveTx({
 				skipSelect: true
 			});
+			// Make sure there is more than one tab so that the tabs menu is focusable
+			if (win.Zotero_Tabs.numTabs == 1) {
+				let attachment = await importFileAttachment('test.pdf');
+				await attachment.saveTx();
+				await zp.viewAttachment(attachment.id);
+				win.Zotero_Tabs.select('zotero-pane');
+			}
 			await waitForItemsLoad(win);
 			await zp.collectionsView.selectLibrary(userLibraryID);
 		});


### PR DESCRIPTION
Make sure that more than one tab is opened before tab navigation tests are run so that the tabs menu is always focusable.

Fixes: #4180