### PR TITLE
quickFormat guidance panel fixes

### DIFF
--- a/chrome/content/zotero/elements/guidancePanel.js
+++ b/chrome/content/zotero/elements/guidancePanel.js
@@ -76,7 +76,7 @@
 		 * @param {DOMElement} [options.forEl] Anchor node
 		 * @param {Boolean} [options.force] Show even if already shown
 		 */
-		show(options) {
+		async show(options) {
 			Components.utils.import("resource://gre/modules/Services.jsm");
 			if (!Zotero.Prefs.get("firstRunGuidance")) return;
 			
@@ -112,7 +112,7 @@
 			
 			if (!useLastText) {
 				if (!text) {
-					text = Zotero.getString("firstRunGuidance." + about);
+					text = await document.l10n.formatValue("first-run-guidance-" + about);
 				}
 				text = text.split("\n");
 				var descriptionNode = document.querySelector('.panel-text');

--- a/chrome/content/zotero/integration/quickFormat.js
+++ b/chrome/content/zotero/integration/quickFormat.js
@@ -85,12 +85,6 @@ var Zotero_QuickFormat = new function () {
 				document.documentElement.setAttribute("hidechrome", true);
 			}
 
-			// Include a different key combo in message on Mac
-			if(Zotero.isMac) {
-				var qf = document.querySelector('.citation-dialog.guidance');
-				qf && qf.setAttribute('about', qf.getAttribute('about') + "Mac");
-			}
-			
 			dialog = document.querySelector(".citation-dialog.entry");
 			editor = document.querySelector(".citation-dialog.editor");
 			_resizeEditor();

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -521,10 +521,10 @@ item-pane-header-more-options =
 architecture-win32-warning-message = { -app-name } is running in 32-bit mode on a 64-bit version of Windows. { -app-name } will run more efficiently in 64-bit mode.
 architecture-warning-action = Download 64-bit { -app-name }
 
-first-run-guidance-quickFormat = Type a title or author to search for a reference.
-    After you've made your selection, click the bubble to add page numbers, prefixes, or suffixes.
-    You can also do that by selecting a bubble via ← → and pressing ↓ or space.
-    You can include a page number along with your search terms (e.g. "Book title p.10") to add it directly.
-    You can edit citations directly in the word processor document.
+first-run-guidance-quickFormat = Type a title, author, and/or year to search for a reference.
+    
+    After you’ve made your selection, click the bubble or select it via the keyboard and press ↓/Space to show citation options such as page number, prefix, and suffix.
+    
+    You can also add a page number directly by including it with your search terms or typing it after the bubble and pressing { return-or-enter }.
 
-first-run-guidance-authorMenu = Zotero lets you specify editors and translators too. You can turn an author into an editor or translator by selecting from this menu.
+first-run-guidance-authorMenu = { -app-name } lets you specify editors and translators too. You can turn an author into an editor or translator by selecting from this menu.

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -520,3 +520,11 @@ item-pane-header-more-options =
 
 architecture-win32-warning-message = { -app-name } is running in 32-bit mode on a 64-bit version of Windows. { -app-name } will run more efficiently in 64-bit mode.
 architecture-warning-action = Download 64-bit { -app-name }
+
+first-run-guidance-quickFormat = Type a title or author to search for a reference.
+    After you've made your selection, click the bubble to add page numbers, prefixes, or suffixes.
+    You can also do that by selecting a bubble via ← → and pressing ↓ or space.
+    You can include a page number along with your search terms (e.g. "Book title p.10") to add it directly.
+    You can edit citations directly in the word processor document.
+
+first-run-guidance-authorMenu = Zotero lets you specify editors and translators too. You can turn an author into an editor or translator by selecting from this menu.

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -1248,7 +1248,6 @@ standalone.updateMessage			= A recommended update is available, but you do not h
 connector.name = %S Connector
 connector.error.title				= Zotero Connector Error
 
-firstRunGuidance.authorMenu		= Zotero lets you specify editors and translators, too. You can turn an author into an editor or translator by selecting from this menu.
 firstRunGuidance.quickFormat	= Type a title or author to search for a reference.\n\nAfter you've made your selection, click the bubble or press Ctrl-\u2193 to add page numbers, prefixes, or suffixes. You can also include a page number along with your search terms to add it directly.\n\nYou can edit citations directly in the word processor document.
 firstRunGuidance.quickFormatMac	= Type a title or author to search for a reference.\n\nAfter you've made your selection, click the bubble or press Cmd-\u2193 to add page numbers, prefixes, or suffixes. You can also include a page number along with your search terms to add it directly.\n\nYou can edit citations directly in the word processor document.
 firstRunGuidance.toolbarButton.new = Click the ‘Z’ button to open Zotero, or use the %S keyboard shortcut.

--- a/scss/elements/_guidancePanel.scss
+++ b/scss/elements/_guidancePanel.scss
@@ -5,6 +5,9 @@ guidance-panel {
 		align-items: center;
 		font-size: 1.1em;
 		padding: 8px 0;
+		@media (-moz-platform: linux) {
+			padding: 8px;
+		}
 	}
 	
 	#nav-buttons {


### PR DESCRIPTION
- added 8px padding around text on linux. Mac and win already have some padding around text through --panel-padding. Fixes: https://github.com/zotero/zotero/issues/4187
- guidancePanel.js fetches text from .ftl file instead of zotero.properties
- added first-run-guidance-quickFormat to zotero.ftl with updated text to better reflect current functionality. Fixes: https://github.com/zotero/zotero/issues/4191
- removed unnecessary special treatment for qf guidance panel on mac
- moved guidance panel text for itemBox creator menu into zotero.ftl