### PR TITLE
basicViewer: Open links externally

### DIFF
--- a/chrome/content/zotero/actors/ActorManager.jsm
+++ b/chrome/content/zotero/actors/ActorManager.jsm
@@ -29,7 +29,6 @@ ChromeUtils.registerWindowActor("FeedAbstract", {
 		moduleURI: "chrome://zotero/content/actors/FeedAbstractChild.jsm",
 		events: {
 			DOMDocElementInserted: {},
-			click: {},
 		}
 	},
 	messageManagerGroups: ["feedAbstract"]
@@ -45,5 +44,18 @@ ChromeUtils.registerWindowActor("ZoteroPrint", {
 			pageshow: {}
 		}
 	}
+});
+
+ChromeUtils.registerWindowActor("ExternalLinkHandler", {
+	parent: {
+		moduleURI: "chrome://zotero/content/actors/ExternalLinkHandlerParent.jsm",
+	},
+	child: {
+		moduleURI: "chrome://zotero/content/actors/ExternalLinkHandlerChild.jsm",
+		events: {
+			click: {},
+		}
+	},
+	messageManagerGroups: ["feedAbstract", "basicViewer"]
 });
 

--- a/chrome/content/zotero/actors/ExternalLinkHandlerChild.jsm
+++ b/chrome/content/zotero/actors/ExternalLinkHandlerChild.jsm
@@ -1,0 +1,26 @@
+var EXPORTED_SYMBOLS = ["ExternalLinkHandlerChild"];
+
+
+class ExternalLinkHandlerChild extends JSWindowActorChild {
+	async handleEvent(event) {
+		switch (event.type) {
+			case "click": {
+				let { button, target } = event;
+				if (button !== 0) {
+					break;
+				}
+				if ((target.localName === 'a' || target.localName === 'area') && target.href
+						|| target.localName === 'label' && target.classList.contains('text-link')) {
+					event.stopPropagation();
+					event.preventDefault();
+					await this._sendLaunchURL(target.href || target.getAttribute('href'));
+				}
+				break;
+			}
+		}
+	}
+	
+	async _sendLaunchURL(url) {
+		await this.sendAsyncMessage("launchURL", url);
+	}
+}

--- a/chrome/content/zotero/actors/ExternalLinkHandlerParent.jsm
+++ b/chrome/content/zotero/actors/ExternalLinkHandlerParent.jsm
@@ -1,0 +1,16 @@
+var EXPORTED_SYMBOLS = ["ExternalLinkHandlerParent"];
+
+ChromeUtils.defineESModuleGetters(this, {
+	Zotero: "chrome://zotero/content/zotero.mjs"
+});
+
+class ExternalLinkHandlerParent extends JSWindowActorParent {
+	async receiveMessage({ name, data }) {
+		switch (name) {
+			case "launchURL": {
+				Zotero.launchURL(data);
+				return;
+			}
+		}
+	}
+}

--- a/chrome/content/zotero/preferences/preferences_cite.jsx
+++ b/chrome/content/zotero/preferences/preferences_cite.jsx
@@ -144,21 +144,7 @@ Zotero_Preferences.Cite = {
 	
 	
 	openStylesPage: function () {
-		Zotero.openInViewer("https://www.zotero.org/styles/", {
-			onLoad(doc) {
-				// Hide header, intro paragraph, Link, and Source
-				//
-				// (The first two aren't sent to the client normally, but hide anyway in case they are.)
-				var style = doc.createElement('style');
-				style.type = 'text/css';
-				style.innerHTML = 'h1, #intro, .style-individual-link, .style-view-source { display: none !important; }'
-					// TEMP: Default UA styles that aren't being included in Firefox 60 for some reason
-					+ 'html { background: #fff; }'
-					+ 'a { color: rgb(0, 0, 238) !important; text-decoration: underline; }'
-					+ 'a:active { color: rgb(238, 0, 0) !important; }';
-				doc.getElementsByTagName('head')[0].appendChild(style);
-			}
-		});
+		Zotero.openInViewer("https://www.zotero.org/styles/");
 	},
 	
 	

--- a/chrome/content/zotero/standalone/basicViewer.js
+++ b/chrome/content/zotero/standalone/basicViewer.js
@@ -68,14 +68,6 @@ window.addEventListener("keypress", function (event) {
 	}
 });
 
-// Handle <label class="text-link />
-window.addEventListener("click", function (event) {
-	if (event.originalTarget.localName == 'label'
-			&& event.originalTarget.classList.contains('text-link')) {
-		Zotero.launchURL(event.originalTarget.getAttribute('href'));
-	}
-});
-
 window.addEventListener('dragover', (e) => {
 	// Prevent default to allow drop (e.g. to allow dropping an XPI on the Add-ons window)
 	e.preventDefault();

--- a/chrome/content/zotero/standalone/basicViewer.xhtml
+++ b/chrome/content/zotero/standalone/basicViewer.xhtml
@@ -221,7 +221,8 @@
 					remote="false"
 					disableglobalhistory="true"
 					maychangeremoteness="true"
-					context="contentAreaContextMenu"/>
+					context="contentAreaContextMenu"
+					messagemanagergroup="basicViewer"/>
 		</vbox>
 	</hbox>
 </window>


### PR DESCRIPTION
Generalizes some code from the `FeedAbstract` actor to apply to viewers as well.

Also:
- Remove nonfunctional code that tries to modify CSS on https://www.zotero.org/styles/ - no longer works because the browser is remote (and was no longer necessary anyway).

Fixes #4197