### PR TITLE
improve JAWS in dialogs and non-main windows

### DIFF
--- a/chrome/content/zotero/integration/quickFormat.js
+++ b/chrome/content/zotero/integration/quickFormat.js
@@ -2232,9 +2232,7 @@ var Zotero_QuickFormat = new function () {
 	 */
 	this.onClassicViewCommand = function(event) {
 		_updateCitationObject();
-		var newWindow = window.newWindow = Components.classes["@mozilla.org/embedcomp/window-watcher;1"]
-			.getService(Components.interfaces.nsIWindowWatcher)
-			.openWindow(null, 'chrome://zotero/content/integration/addCitationDialog.xhtml',
+		var newWindow = window.newWindow = Zotero.openWindow(null, 'chrome://zotero/content/integration/addCitationDialog.xhtml',
 			'', 'chrome,centerscreen,resizable', io);
 		newWindow.addEventListener("focus", function() {
 			newWindow.removeEventListener("focus", arguments.callee, true);

--- a/chrome/content/zotero/xpcom/editorInstance.js
+++ b/chrome/content/zotero/xpcom/editorInstance.js
@@ -1254,9 +1254,7 @@ class EditorInstance {
 		var mode = (!Zotero.isMac && Zotero.Prefs.get('integration.keepAddCitationDialogRaised')
 			? 'popup' : 'alwaysRaised') + ',resizable=false,centerscreen';
 
-		win = that._quickFormatWindow = Components.classes['@mozilla.org/embedcomp/window-watcher;1']
-		.getService(Components.interfaces.nsIWindowWatcher)
-		.openWindow(null, 'chrome://zotero/content/integration/quickFormat.xhtml', '', mode, {
+		win = that._quickFormatWindow = Zotero.openWindow(null, 'chrome://zotero/content/integration/quickFormat.xhtml', '', mode, {
 			wrappedJSObject: io
 		});
 	}

--- a/chrome/content/zotero/xpcom/integration.js
+++ b/chrome/content/zotero/xpcom/integration.js
@@ -438,9 +438,7 @@ Zotero.Integration = new function() {
 		if(Zotero.isLinux) allOptions += ',dialog=no';
 		if(options) allOptions += ','+options;
 		
-		var window = Components.classes["@mozilla.org/embedcomp/window-watcher;1"]
-			.getService(Components.interfaces.nsIWindowWatcher)
-			.openWindow(null, url, '', allOptions, (io ? io : null));
+		var window = Zotero.openWindow(null, url, '', allOptions, (io ? io : null));
 		Zotero.Integration.currentWindow = window;
 		Zotero.Utilities.Internal.activate(window);
 		

--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -985,11 +985,16 @@ Services.scriptloader.loadSubScript("resource://zotero/polyfill.js");
 	this._setWinDialogFeatures = (features) => {
 		let paramArray = features.split(",");
 		let dialogParamIndex = paramArray.findIndex(param => param.includes("dialog"));
+		// If there already exists a dialog parameter, remove it to avoid dulicates
 		if (dialogParamIndex !== -1) {
 			paramArray.splice(dialogParamIndex, 1);
 		}
+		// If there is no dialog parameter and resizable feature is not specified,
+		// set resizable=no to make sure windows remain unresizable
+		else if (!features.includes("resizable")) {
+			paramArray.push("resizable=no");
+		}
 		paramArray.push("dialog=no");
-		paramArray.push("resizable=no");
 		return paramArray.join(",");
 	}
 	this.openDialog = (uri, name, features, args) => {
@@ -1004,6 +1009,7 @@ Services.scriptloader.loadSubScript("resource://zotero/polyfill.js");
 		if (Zotero.isWin) {
 			features = this._setWinDialogFeatures(features);
 		}
+		console.log(features);
 		return Components.classes['@mozilla.org/embedcomp/window-watcher;1']
 			.getService(Components.interfaces.nsIWindowWatcher)
 			.openWindow(parent, uri, name, features, args);

--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -973,6 +973,41 @@ Services.scriptloader.loadSubScript("resource://zotero/polyfill.js");
 			.getService(Components.interfaces.nsIWindowWatcher);
 		ww.openWindow(null, chromeURI, '_blank', flags, null);
 	}
+
+	/**
+	 * JAWS screen reader does not handle windows and dialogs that do not have
+	 * MozillaWindowClass. To worka round it, we pass dialog=no as a parameter to
+	 * all new windows or dialogs opened on Windows.
+	 * That way, they have MozillaWindowClass instead of default MozillaDialogClass.
+	 * @param {string} features - comma separated features to open window or dialog
+	 * @returns features with added dialog=no
+	 */
+	this._setWinDialogFeatures = (features) => {
+		let paramArray = features.split(",");
+		let dialogParamIndex = paramArray.findIndex(param => param.includes("dialog"));
+		if (dialogParamIndex !== -1) {
+			paramArray.splice(dialogParamIndex, 1);
+		}
+		paramArray.push("dialog=no");
+		paramArray.push("resizable=no");
+		return paramArray.join(",");
+	}
+	this.openDialog = (uri, name, features, args) => {
+		if (Zotero.isWin) {
+			features = this._setWinDialogFeatures(features);
+		}
+		let ww = this.getMainWindow();
+		ww.openDialog(uri, name, features, args);
+	}
+	
+	this.openWindow = (parent, uri, name, features, args) => {
+		if (Zotero.isWin) {
+			features = this._setWinDialogFeatures(features);
+		}
+		return Components.classes['@mozilla.org/embedcomp/window-watcher;1']
+			.getService(Components.interfaces.nsIWindowWatcher)
+			.openWindow(parent, uri, name, features, args);
+	}
 	
 	
 	this.openCheckForUpdatesWindow = function ({ modal } = {}) {

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -1504,7 +1504,7 @@ var ZoteroPane = new function()
 		);
 		
 		var io = { name, libraryID, parentCollectionID };
-		window.openDialog("chrome://zotero/content/newCollectionDialog.xhtml",
+		Zotero.openDialog("chrome://zotero/content/newCollectionDialog.xhtml",
 			"_blank", "chrome,modal,centerscreen,resizable=no", io);
 		var dataOut = io.dataOut;
 		if (!dataOut) {
@@ -1545,7 +1545,7 @@ var ZoteroPane = new function()
 	
 	this.newFeedFromURL = Zotero.Promise.coroutine(function* () {
 		let data = {};
-		window.openDialog('chrome://zotero/content/feedSettings.xhtml',
+		Zotero.openDialog('chrome://zotero/content/feedSettings.xhtml',
 			null, 'centerscreen, modal', data);
 		if (!data.cancelled) {
 			let feed = new Zotero.Feed();
@@ -1583,7 +1583,7 @@ var ZoteroPane = new function()
 		);
 		
 		var io = { dataIn: { search: s, name }, dataOut: null };
-		window.openDialog('chrome://zotero/content/searchDialog.xhtml','','chrome,modal,centerscreen',io);
+		Zotero.openDialog('chrome://zotero/content/searchDialog.xhtml','','chrome,modal,centerscreen',io);
 		if (!io.dataOut) {
 			return false;
 		}
@@ -1614,7 +1614,7 @@ var ZoteroPane = new function()
 		s.addCondition('title', 'contains', '');
 		
 		var io = {dataIn: {search: s}, dataOut: null};
-		window.openDialog('chrome://zotero/content/advancedSearch.xhtml', '', 'chrome,dialog=no,centerscreen', io);
+		Zotero.openDialog('chrome://zotero/content/advancedSearch.xhtml', '', 'chrome,dialog=no,centerscreen', io);
 	};
 
 	this.initItemsTree = async function () {
@@ -2517,7 +2517,7 @@ var ZoteroPane = new function()
 					},
 					dataOut: null
 				};
-				window.openDialog('chrome://zotero/content/searchDialog.xhtml','','chrome,modal,centerscreen',io);
+				Zotero.openDialog('chrome://zotero/content/searchDialog.xhtml','','chrome,modal,centerscreen',io);
 				if (io.dataOut) {
 					row.ref.fromJSON(io.dataOut.json);
 					yield row.ref.saveTx();
@@ -2556,7 +2556,7 @@ var ZoteroPane = new function()
 			cleanupUnreadAfter: feed.cleanupUnreadAfter
 		};
 		
-		window.openDialog('chrome://zotero/content/feedSettings.xhtml',
+		Zotero.openDialog('chrome://zotero/content/feedSettings.xhtml',
 			null, 'centerscreen, modal', data);
 		if (data.cancelled) return;
 		
@@ -4219,7 +4219,7 @@ var ZoteroPane = new function()
 		}
 		
 		var io = { itemID: itemID, collectionID: col, parentItemKey: parentKey };
-		window.openDialog('chrome://zotero/content/note.xhtml', name, 'chrome,resizable,centerscreen,dialog=false', io);
+		Zotero.openDialog('chrome://zotero/content/note.xhtml', name, 'chrome,resizable,centerscreen,dialog=false', io);
 	}
 	
 	
@@ -4243,7 +4243,7 @@ var ZoteroPane = new function()
 		}
 		
 		var io = {};
-		window.openDialog('chrome://zotero/content/attachLink.xhtml',
+		Zotero.openDialog('chrome://zotero/content/attachLink.xhtml',
 			'zotero-attach-uri-dialog', 'centerscreen, modal', io);
 		if (!io.out) return;
 		return Zotero.Attachments.linkFromURL({
@@ -5006,7 +5006,7 @@ var ZoteroPane = new function()
 			}
 		}
 		io.hasRights = allItemsHaveRights ? 'all' : (noItemsHaveRights ? 'none' : 'some');
-		window.openDialog('chrome://zotero/content/publicationsDialog.xhtml','','chrome,modal', io);
+		Zotero.openDialog('chrome://zotero/content/publicationsDialog.xhtml','','chrome,modal', io);
 		return io.keepRights !== undefined ? io : false;
 	};
 	
@@ -5260,7 +5260,7 @@ var ZoteroPane = new function()
 			}
 
 			let io = { dataIn: { item }, dataOut: null };
-			window.openDialog('chrome://zotero/content/createParentDialog.xhtml', '', 'chrome,modal,centerscreen', io);
+			Zotero.openDialog('chrome://zotero/content/createParentDialog.xhtml', '', 'chrome,modal,centerscreen', io);
 			if (!io.dataOut) {
 				return false;
 			}
@@ -6279,7 +6279,7 @@ var ZoteroPane = new function()
 	 * Opens the about dialog
 	 */
 	this.openAboutDialog = function() {
-		window.openDialog('chrome://zotero/content/about.xhtml', 'about', 'chrome,centerscreen');
+		Zotero.openDialog('chrome://zotero/content/about.xhtml', 'about', 'chrome,centerscreen');
 	}
 	
 	/**


### PR DESCRIPTION
JAWS expects a specific executable (firefox.exe) to apply dialog-specific rules, which does not match in our case. It prevents JAWS from deciding how to handle our dialogs and, for example, it does not announce inputs correctly. (E.g. input field from new collection dialog or the inputs from quickFormat window)

As a workaround, we can add `dialog=no` as a parameter to all instances of opened dialogs or windows to force the HWND window type be MozillaWindowClass which JAWS handles better.

For more details: https://github.com/zotero/zotero/issues/3930#issuecomment-2146184884.

Addresses: #3930 

----

As far as I could see, this does not cause any breakage - but I'm still marking this as a draft for now.

@dstillman @adomasven - what do you think about this general approach? Is this something we could theoretically do? 