### PR TITLE
Improve Advanced Search Dialog

### DIFF
--- a/chrome/content/zotero/advancedSearch.js
+++ b/chrome/content/zotero/advancedSearch.js
@@ -58,7 +58,7 @@ var ZoteroAdvancedSearch = new function() {
 		var elem = document.getElementById('zotero-items-tree');
 		const columns = COLUMNS.map((column) => {
 			column = Object.assign({}, column);
-			column.hidden = !['title', 'firstCreator'].includes(column.dataKey);
+			column.hidden = !['title', 'firstCreator', 'year', 'hasAttachment'].includes(column.dataKey);
 			return column;
 		});
 		this.itemsView = await ItemTree.init(elem, {

--- a/chrome/content/zotero/elements/zoteroSearch.js
+++ b/chrome/content/zotero/elements/zoteroSearch.js
@@ -403,7 +403,7 @@
 				);
 			}
 			
-			this.updateSubmenuCheckboxes(conditionsMenu);
+			this.updateMenuCheckboxesRecursive(conditionsMenu, this.selectedCondition);
 			
 			// Display appropriate operators for condition
 			var selectThis;
@@ -411,7 +411,7 @@
 			{
 				var val = operatorsList.firstChild.childNodes[i].getAttribute('value');
 				var hidden = !operators[val];
-				operatorsList.firstChild.childNodes[i].toggleAttribute('hidden', hidden);
+				operatorsList.firstChild.childNodes[i].setAttribute('hidden', hidden);
 				if (!hidden && (selectThis == null || this.selectedOperator == val))
 				{
 					selectThis = i;
@@ -420,6 +420,7 @@
 			operatorsList.selectedIndex = selectThis;
 			// Setting `selected` does not change `checked`. Should explicitly set it.
 			operatorsList.selectedItem.setAttribute('checked', true);
+			this.updateMenuCheckboxesRecursive(operatorsList, operatorsList.selectedItem.getAttribute('value'));
 			
 			// Generate drop-down menu instead of textbox for certain conditions
 			switch (conditionName) {
@@ -553,6 +554,7 @@
 			if (!valueMenu.hidden) {
 				document.l10n.setAttributes(valueMenu, 'advanced-search-condition-input', { label: valueMenu.label });
 			}
+			this.updateMenuCheckboxesRecursive(operatorsList, operatorsList.selectedItem.getAttribute('value'));
 		}
 
 		createValueMenu(rows) {
@@ -690,11 +692,11 @@
 			}
 		}
 
-		updateSubmenuCheckboxes(menu) {
+		updateMenuCheckboxesRecursive(menu, value) {
 			for (let i = 0; i < menu.itemCount; i++) {
 				let item = menu.getItemAtIndex(i);
 				if (item.localName == 'menuitem') {
-					if (item.getAttribute('value') == this.selectedCondition) {
+					if (item.getAttribute('value') == value) {
 						item.setAttribute('checked', true);
 					}
 					else {
@@ -702,7 +704,7 @@
 					}
 				}
 				else {
-					this.updateSubmenuCheckboxes(item);
+					this.updateMenuCheckboxesRecursive(item, value);
 				}
 			}
 		}

--- a/scss/components/_advancedSearch.scss
+++ b/scss/components/_advancedSearch.scss
@@ -1,6 +1,6 @@
 #zotero-advanced-search-dialog {
-	min-height: 400px;
-	min-width: 500px;
+	min-height: 500px;
+	min-width: 700px;
 	
 	#zotero-search-box-container {
 		max-height: 100vh;

--- a/scss/elements/_zoteroSearch.scss
+++ b/scss/elements/_zoteroSearch.scss
@@ -41,10 +41,6 @@ zoterosearch {
 		}
 	}
 
-	#libraryMenu {
-		flex: 1;
-	}
-
 	#joinModeMenu {
 		min-width: 100px;
 	}

--- a/scss/elements/_zoteroSearch.scss
+++ b/scss/elements/_zoteroSearch.scss
@@ -42,11 +42,15 @@ zoterosearch {
 	}
 
 	#joinModeMenu {
-		min-width: 100px;
+		min-width: 60px;
+	}
+	
+	#conditionsmenu {
+		min-width: 15em;
 	}
 	
 	#operatorsmenu {
-		width: 15em;
+		min-width: 13em;
 	}
 
 	#condition-tooltips tooltip

--- a/scss/elements/_zoteroSearch.scss
+++ b/scss/elements/_zoteroSearch.scss
@@ -1,6 +1,6 @@
 zoterosearch {
 	#search-box > hbox, #search-box > groupbox {
-		margin-left: 6px;
+		margin: 0 6px;
 	}
 
 	groupbox {
@@ -39,6 +39,14 @@ zoterosearch {
 		.valuefield, .valuemenu, .value-date-age {
 			flex: 1;
 		}
+	}
+
+	#libraryMenu {
+		flex: 1;
+	}
+
+	#joinModeMenu {
+		min-width: 100px;
 	}
 	
 	#operatorsmenu {


### PR DESCRIPTION
- Set the window minimum size to 700px x 500px.
- Allow the library selector to take up all the available width of the window.
- Fix a regression where non-applicable operators remain visible.
- Fix the "✔️" appearing next to multiple operators in the operator popup menu.
- Include the "Year" and "Attachments" columns by default in the results table.

Resolve #4190