### PR TITLE
vpat 66-68: fix focus within tagsBox popup

### DIFF
--- a/chrome/content/zotero/elements/collapsibleSection.js
+++ b/chrome/content/zotero/elements/collapsibleSection.js
@@ -43,7 +43,7 @@
 		set open(newOpen) {
 			newOpen = !!newOpen;
 			let oldOpen = this.open;
-			if (oldOpen === newOpen || this.empty || this.notCollapsible) return;
+			if (oldOpen === newOpen || this.empty || !this.collapsible) return;
 			this.render();
 			
 			// Force open before getting scrollHeight, so we get the right value
@@ -106,16 +106,16 @@
 			this.setAttribute('summary', val);
 		}
 		
-		get notCollapsible() {
-			return !!this.getAttribute("no-collapse");
+		get collapsible() {
+			return !this.getAttribute("no-collapse");
 		}
 
-		set notCollapsible(val) {
+		set collapsible(val) {
 			if (val) {
-				this.setAttribute('no-collapse', val);
+				this.removeAttribute('no-collapse');
 			}
 			else {
-				this.removeAttribute('no-collapse');
+				this.setAttribute('no-collapse', val);
 			}
 		}
 		

--- a/chrome/content/zotero/elements/collapsibleSection.js
+++ b/chrome/content/zotero/elements/collapsibleSection.js
@@ -43,7 +43,7 @@
 		set open(newOpen) {
 			newOpen = !!newOpen;
 			let oldOpen = this.open;
-			if (oldOpen === newOpen || this.empty) return;
+			if (oldOpen === newOpen || this.empty || this.notCollapsible) return;
 			this.render();
 			
 			// Force open before getting scrollHeight, so we get the right value
@@ -104,6 +104,19 @@
 		
 		set summary(val) {
 			this.setAttribute('summary', val);
+		}
+		
+		get notCollapsible() {
+			return !!this.getAttribute("no-collapse");
+		}
+
+		set notCollapsible(val) {
+			if (val) {
+				this.setAttribute('no-collapse', val);
+			}
+			else {
+				this.removeAttribute('no-collapse');
+			}
 		}
 		
 		static get observedAttributes() {

--- a/chrome/content/zotero/elements/itemPaneSection.js
+++ b/chrome/content/zotero/elements/itemPaneSection.js
@@ -85,12 +85,12 @@ class ItemPaneSectionElementBase extends XULElementBase {
 		}
 	}
 
-	get notCollapsible() {
-		return this._section.notCollapsible;
+	get collapsible() {
+		return this._section.collapsible;
 	}
 
-	set notCollapsible(val) {
-		this._section.notCollapsible = !!val;
+	set collapsible(val) {
+		this._section.collapsible = !!val;
 	}
 	
 	connectedCallback() {

--- a/chrome/content/zotero/elements/itemPaneSection.js
+++ b/chrome/content/zotero/elements/itemPaneSection.js
@@ -84,6 +84,14 @@ class ItemPaneSectionElementBase extends XULElementBase {
 			this._section.open = val;
 		}
 	}
+
+	get notCollapsible() {
+		return this._section.notCollapsible;
+	}
+
+	set notCollapsible(val) {
+		this._section.notCollapsible = !!val;
+	}
 	
 	connectedCallback() {
 		super.connectedCallback();

--- a/chrome/content/zotero/elements/tagsBox.js
+++ b/chrome/content/zotero/elements/tagsBox.js
@@ -30,7 +30,7 @@
 		content = MozXULElement.parseXULToFragment(`
 				<collapsible-section data-l10n-id="section-tags" data-pane="tags" extra-buttons="add">
 					<html:div class="body">
-						<html:div id="rows" class="tags-box-list" aria-label="Tags box list"/>
+						<html:div id="rows" class="tags-box-list"/>
 						<popupset>
 							<tooltip id="html-tooltip" page="true"/>
 							<menupopup id="tags-context-menu">

--- a/chrome/content/zotero/elements/tagsBox.js
+++ b/chrome/content/zotero/elements/tagsBox.js
@@ -354,6 +354,18 @@
 					focusField.focus();
 				}
 			}
+			else if (event.key == "Tab" && !event.shiftKey) {
+				// On tab from the last empty tag row, the minus icon will be focused
+				// and the row will be immediately removed in this.saveTag, so focus will be lost.
+				// To avoid that, on tab from the last tag input that is empty, focus the next
+				// element after the tag row.
+				let allTags = [...this.querySelectorAll(".row")];
+				let isLastTag = target.closest(".row") == allTags[allTags.length - 1];
+				if (isLastTag && !target.closest("editable-text").value.length) {
+					Services.focus.moveFocus(window, target.closest(".row").lastChild, Services.focus.MOVEFOCUS_FORWARD, 0);
+					event.preventDefault();
+				}
+			}
 		};
 
 		// Intercept paste, check for newlines, and convert textbox

--- a/chrome/content/zotero/elements/tagsBox.js
+++ b/chrome/content/zotero/elements/tagsBox.js
@@ -276,6 +276,8 @@
 			valueElement.setAttribute('flex', 1);
 			valueElement.setAttribute('nowrap', true);
 			valueElement.setAttribute('tight', true);
+			document.l10n.setAttributes(valueElement, "tag-field");
+			valueElement.dataset.l10nAttrs = "placeholder";
 			valueElement.className = 'zotero-box-label';
 			valueElement.readOnly = !this.editable;
 			valueElement.value = valueText;

--- a/chrome/content/zotero/elements/tagsBox.js
+++ b/chrome/content/zotero/elements/tagsBox.js
@@ -277,7 +277,6 @@
 			valueElement.setAttribute('nowrap', true);
 			valueElement.setAttribute('tight', true);
 			document.l10n.setAttributes(valueElement, "tag-field");
-			valueElement.dataset.l10nAttrs = "placeholder";
 			valueElement.className = 'zotero-box-label';
 			valueElement.readOnly = !this.editable;
 			valueElement.value = valueText;

--- a/chrome/content/zotero/elements/tagsBox.js
+++ b/chrome/content/zotero/elements/tagsBox.js
@@ -30,7 +30,7 @@
 		content = MozXULElement.parseXULToFragment(`
 				<collapsible-section data-l10n-id="section-tags" data-pane="tags" extra-buttons="add">
 					<html:div class="body">
-						<html:div id="rows" class="tags-box-list"/>
+						<html:div id="rows" class="tags-box-list" aria-label="Tags box list"/>
 						<popupset>
 							<tooltip id="html-tooltip" page="true"/>
 							<menupopup id="tags-context-menu">
@@ -301,24 +301,10 @@
 			var target = event.currentTarget;
 
 			if (event.key === 'Enter') {
-				var multiline = target.multiline;
+				// If tag's input is a multiline field, it must be right after pasting
+				// of multiple tags. Then, Enter adds a new line and shift-Enter will save
+				if (target.multiline && !event.shiftKey) return;
 				var empty = target.value == "";
-				if (event.shiftKey) {
-					if (!multiline) {
-						setTimeout(() => {
-							var val = target.value;
-							if (val !== "") {
-								val += "\n";
-							}
-							this.makeMultiline(target, val);
-						});
-						return;
-					}
-					// Submit
-				}
-				else if (multiline) {
-					return;
-				}
 
 				event.preventDefault();
 

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -887,10 +887,15 @@ class ReaderInstance {
 	}
 
 	_openTagsPopup(item, x, y) {
-		let menupopup = this._window.document.createXULElement('menupopup');
+		let menupopup = this._window.document.createXULElement('panel');
 		menupopup.addEventListener('popuphidden', function (event) {
 			if (event.target === menupopup) {
 				menupopup.remove();
+			}
+		});
+		menupopup.addEventListener('keydown', function (event) {
+			if (event.key == "Escape") {
+				menupopup.hidePopup();
 			}
 		});
 		menupopup.className = 'tags-popup';
@@ -905,12 +910,19 @@ class ReaderInstance {
 		tagsbox.editable = true;
 		tagsbox.item = item;
 		tagsbox.render();
-		menupopup.openPopup(null, 'before_start', x, y, true);
-		setTimeout(() => {
+		menupopup.shadowRoot.firstChild.style = "--panel-background: none !important;";
+		menupopup.addEventListener("popupshown", (_) => {
+			// Ensure tagsbox is open
+			tagsbox.open = true;
 			if (tagsbox.count == 0) {
 				tagsbox.newTag();
 			}
+			else {
+				tagsbox.querySelector("editable-text").focus();
+			}
+			tagsbox.notCollapsible = true;
 		});
+		menupopup.openPopup(null, 'before_start', x, y, true);
 	}
 
 	async _openContextMenu({ x, y, itemGroups }) {

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -918,7 +918,7 @@ class ReaderInstance {
 			else {
 				tagsbox.querySelector("editable-text").focus();
 			}
-			tagsbox.notCollapsible = true;
+			tagsbox.collapsible = false;
 		});
 		menupopup.openPopup(null, 'before_start', x, y, true);
 	}

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -916,7 +916,7 @@ class ReaderInstance {
 				tagsbox.newTag();
 			}
 			else {
-				tagsbox.querySelector("editable-text").focus();
+				Services.focus.setFocus(tagsbox.querySelector(".head"), Services.focus.FLAG_NOSHOWRING);
 			}
 			tagsbox.collapsible = false;
 		});

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -909,6 +909,8 @@ class ReaderInstance {
 		tagsbox.editable = true;
 		tagsbox.item = item;
 		tagsbox.render();
+		// remove unnecessary tabstop from the section header
+		tagsbox.querySelector(".head").removeAttribute("tabindex");
 		menupopup.addEventListener("popupshown", (_) => {
 			// Ensure tagsbox is open
 			tagsbox.open = true;
@@ -916,7 +918,8 @@ class ReaderInstance {
 				tagsbox.newTag();
 			}
 			else {
-				Services.focus.setFocus(tagsbox.querySelector(".head"), Services.focus.FLAG_NOSHOWRING);
+				// Focus + button
+				Services.focus.setFocus(tagsbox.querySelector("toolbarbutton"), Services.focus.FLAG_NOSHOWRING);
 			}
 			tagsbox.collapsible = false;
 		});

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -899,7 +899,6 @@ class ReaderInstance {
 			}
 		});
 		menupopup.className = 'tags-popup';
-		menupopup.setAttribute('ignorekeys', true);
 		let tagsbox = this._window.document.createXULElement('tags-box');
 		menupopup.appendChild(tagsbox);
 		tagsbox.setAttribute('flex', '1');
@@ -910,7 +909,6 @@ class ReaderInstance {
 		tagsbox.editable = true;
 		tagsbox.item = item;
 		tagsbox.render();
-		menupopup.shadowRoot.firstChild.style = "--panel-background: none !important;";
 		menupopup.addEventListener("popupshown", (_) => {
 			// Ensure tagsbox is open
 			tagsbox.open = true;

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -887,22 +887,22 @@ class ReaderInstance {
 	}
 
 	_openTagsPopup(item, x, y) {
-		let menupopup = this._window.document.createXULElement('panel');
-		menupopup.addEventListener('popuphidden', function (event) {
-			if (event.target === menupopup) {
-				menupopup.remove();
+		let tagsPopup = this._window.document.createXULElement('panel');
+		tagsPopup.addEventListener('popuphidden', function (event) {
+			if (event.target === tagsPopup) {
+				tagsPopup.remove();
 			}
 		});
-		menupopup.addEventListener('keydown', function (event) {
+		tagsPopup.addEventListener('keydown', function (event) {
 			if (event.key == "Escape") {
-				menupopup.hidePopup();
+				tagsPopup.hidePopup();
 			}
 		});
-		menupopup.className = 'tags-popup';
+		tagsPopup.className = 'tags-popup';
 		let tagsbox = this._window.document.createXULElement('tags-box');
-		menupopup.appendChild(tagsbox);
+		tagsPopup.appendChild(tagsbox);
 		tagsbox.setAttribute('flex', '1');
-		this._popupset.appendChild(menupopup);
+		this._popupset.appendChild(tagsPopup);
 		let rect = this._iframe.getBoundingClientRect();
 		x += rect.left;
 		y += rect.top;
@@ -911,7 +911,7 @@ class ReaderInstance {
 		tagsbox.render();
 		// remove unnecessary tabstop from the section header
 		tagsbox.querySelector(".head").removeAttribute("tabindex");
-		menupopup.addEventListener("popupshown", (_) => {
+		tagsPopup.addEventListener("popupshown", (_) => {
 			// Ensure tagsbox is open
 			tagsbox.open = true;
 			if (tagsbox.count == 0) {
@@ -923,7 +923,7 @@ class ReaderInstance {
 			}
 			tagsbox.collapsible = false;
 		});
-		menupopup.openPopup(null, 'before_start', x, y, true);
+		tagsPopup.openPopup(null, 'before_start', x, y, true);
 	}
 
 	async _openContextMenu({ x, y, itemGroups }) {

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -11,6 +11,7 @@ general-remind-me-later = Remind Me Later
 general-choose-file = Choose File…
 general-open-settings = Open Settings
 general-help = Help
+general-tag = Tag
 
 menu-file-show-in-finder =
     .label = Show in Finder
@@ -517,7 +518,7 @@ abstract-field =
     .placeholder = Add abstract…
 
 tag-field =
-    .aria-label = Tag
+    .aria-label = { general-tag }
 
 tagselector-search =
     .placeholder = Filter Tags

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -517,7 +517,7 @@ abstract-field =
     .placeholder = Add abstract…
 
 tag-field =
-    .placeholder = Edit tag...
+    .aria-label = Tag
 
 tagselector-search =
     .placeholder = Filter Tags

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -516,6 +516,9 @@ expand-all-sections =
 abstract-field =
     .placeholder = Add abstract…
 
+tag-field =
+    .placeholder = Edit tag...
+
 tagselector-search =
     .placeholder = Filter Tags
 

--- a/scss/components/_reader.scss
+++ b/scss/components/_reader.scss
@@ -1,13 +1,7 @@
 .tags-popup {
 	font: inherit;
 	min-width: 300px;
-	padding-inline: 8px;
-	background-color: Menu;
-
-	@media (-moz-platform: windows) {
-		& > tags-box {
-			// padding-inline does not work on Windows
-			margin-inline: 8px;
-		}
+	& > tags-box {
+		padding-inline: 8px;
 	}
 }

--- a/scss/components/_reader.scss
+++ b/scss/components/_reader.scss
@@ -1,7 +1,8 @@
-menupopup.tags-popup {
+.tags-popup {
 	font: inherit;
 	min-width: 300px;
 	padding-inline: 8px;
+	background-color: Menu;
 
 	@media (-moz-platform: windows) {
 		& > tags-box {


### PR DESCRIPTION
- focus will always enter the tagsBox popup opened from the reader
- escape from within the popup with tagsBox will close the popup (vpat 67)
- one should not be able to collapse the tagsBox. Added noCollapsible getter and setters to the collapsible panel to prevent the section from changing it's open status. This may be also used in other cases, such as to prevent itemBox from being collapsed in duplicates mode.
- patched a glitch where tab from the last empty tab input would loose focus.
- changed the `menupopup` for `panel` to display the `tagsbox` because `menupopup` has implicit `role="menu"` which is not meant to contain inputs, so voiceover completely looses cursor when inputs are focused inside of the popup. Also, tweaked spacing a bit to avoid the focus-ring getting cutoff.

Addresses: #4222
Fixes: #4230
Fixes: #4226
Addresses: #4388