### PR TITLE
Set automatic title on first child attachment of each type

### DIFF
--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -2496,6 +2496,13 @@ var ItemTree = class ItemTree extends LibraryTree {
 					}
 
 					if (item) {
+						try {
+							item.setFirstAttachmentTitle();
+							await item.saveTx();
+						}
+						catch (e) {
+							Zotero.logError(e);
+						}
 						addedItems.push(item);
 					}
 				}

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -2496,13 +2496,8 @@ var ItemTree = class ItemTree extends LibraryTree {
 					}
 
 					if (item) {
-						try {
-							item.setFirstAttachmentTitle();
-							await item.saveTx();
-						}
-						catch (e) {
-							Zotero.logError(e);
-						}
+						item.setFirstAttachmentTitle();
+						await item.saveTx();
 						addedItems.push(item);
 					}
 				}

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -3866,11 +3866,11 @@ Zotero.Item.prototype.clearBestAttachmentState = function () {
 Zotero.Item.prototype._getDefaultTitleForAttachmentContentType = function () {
 	switch (this.attachmentContentType) {
 		case 'application/pdf':
-			return 'PDF';
+			return Zotero.getString('fileTypes.pdf');
 		case 'application/epub+zip':
-			return 'EPUB';
+			return Zotero.getString('fileTypes.ebook');
 		case 'text/html':
-			return 'HTML';
+			return Zotero.getString('fileTypes.webpage');
 		default:
 			return null;
 	}

--- a/chrome/content/zotero/xpcom/recognizeDocument.js
+++ b/chrome/content/zotero/xpcom/recognizeDocument.js
@@ -200,11 +200,9 @@ Zotero.RecognizeDocument = new function () {
 		try {
 			let currentFilename = attachment.attachmentFilename;
 			if (currentFilename != originalFilename) {
-				let renamed = await attachment.renameAttachmentFile(originalFilename);
-				if (renamed) {
-					attachment.setField('title', originalTitle);
-				}
+				await attachment.renameAttachmentFile(originalFilename);
 			}
+			attachment.setField('title', originalTitle);
 		}
 		catch (e) {
 			Zotero.logError(e);
@@ -302,11 +300,12 @@ Zotero.RecognizeDocument = new function () {
 			if (result !== true) {
 				throw new Error("Error renaming " + path);
 			}
-			// Rename attachment title
-			attachment.setField('title', newName);
-			await attachment.saveTx();
 		}
 		
+		// Rename attachment title
+		attachment.setFirstAttachmentTitle();
+		await attachment.saveTx();
+
 		try {
 			let win = Zotero.getMainWindow();
 			if (selectParent && win && win.Zotero_Tabs.selectedID == 'zotero-pane') {

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -652,7 +652,7 @@ creatorTypes.reviewedAuthor		= Reviewed Author
 creatorTypes.cosponsor			= Cosponsor
 creatorTypes.bookAuthor			= Book Author
 
-fileTypes.webpage				= Web Page
+fileTypes.webpage				= Webpage
 fileTypes.image					= Image
 fileTypes.pdf					= PDF
 fileTypes.audio					= Audio

--- a/test/tests/itemTreeTest.js
+++ b/test/tests/itemTreeTest.js
@@ -1331,9 +1331,7 @@ describe("Zotero.ItemTree", function() {
 			var itemIDs = await promise;
 			var item = Zotero.Items.get(itemIDs[0]);
 			assert.equal(item.parentItemID, parentItem.id);
-			var title = item.getField('title');
 			var path = await item.getFilePathAsync();
-			assert.equal(title, parentTitle + '.pdf');
 			assert.equal(OS.Path.basename(path), parentTitle + '.pdf');
 		});
 		
@@ -1378,9 +1376,7 @@ describe("Zotero.ItemTree", function() {
 			var itemIDs = await promise;
 			var item = Zotero.Items.get(itemIDs[0]);
 			assert.equal(item.parentItemID, parentItem.id);
-			var title = item.getField('title');
 			var path = await item.getFilePathAsync();
-			assert.equal(title, parentTitle + '.pdf');
 			assert.equal(OS.Path.basename(path), parentTitle + '.pdf');
 		});
 		
@@ -1425,9 +1421,7 @@ describe("Zotero.ItemTree", function() {
 			var itemIDs = await promise;
 			var item = Zotero.Items.get(itemIDs[0]);
 			assert.equal(item.parentItemID, parentItem.id);
-			var title = item.getField('title');
 			var path = await item.getFilePathAsync();
-			assert.equal(title, 'empty.pdf');
 			assert.equal(OS.Path.basename(path), 'empty.pdf');
 		});
 		
@@ -1464,10 +1458,8 @@ describe("Zotero.ItemTree", function() {
 			var itemIDs = await promise;
 			var item = Zotero.Items.get(itemIDs[0]);
 			assert.equal(item.parentItemID, parentItem.id);
-			var title = item.getField('title');
 			var path = await item.getFilePathAsync();
 			// Should match original filename, not parent title
-			assert.equal(title, originalFileName);
 			assert.equal(OS.Path.basename(path), originalFileName);
 		});
 		
@@ -1506,9 +1498,7 @@ describe("Zotero.ItemTree", function() {
 			var itemIDs = await promise;
 			var item = Zotero.Items.get(itemIDs[0]);
 			assert.equal(item.parentItemID, parentItem.id);
-			var title = item.getField('title');
 			var path = await item.getFilePathAsync();
-			assert.equal(title, originalFileName);
 			assert.equal(OS.Path.basename(path), originalFileName);
 		});
 		
@@ -1543,9 +1533,7 @@ describe("Zotero.ItemTree", function() {
 			var itemIDs = await promise;
 			var item = Zotero.Items.get(itemIDs[0]);
 			assert.equal(item.parentItemID, parentItem.id);
-			var title = item.getField('title');
 			var path = await item.getFilePathAsync();
-			assert.equal(title, originalFileName);
 			assert.equal(OS.Path.basename(path), originalFileName);
 		});
 
@@ -1585,7 +1573,7 @@ describe("Zotero.ItemTree", function() {
 			// Add a PDF attachment, which will be renamed
 			let pdfAttachment1 = Zotero.Items.get((await promise)[0]);
 			assert.equal(pdfAttachment1.parentItemID, parentItem.id);
-			assert.equal(pdfAttachment1.getField('title'), 'PDF');
+			assert.equal(pdfAttachment1.getField('title'), Zotero.getString('fileTypes.pdf'));
 
 			promise = waitForItemEvent('add');
 			drop(parentRow, 0, dataTransfer);

--- a/test/tests/recognizeDocumentTest.js
+++ b/test/tests/recognizeDocumentTest.js
@@ -70,7 +70,7 @@ describe("Document Recognition", function() {
 			// The title should have changed
 			assert.equal(
 				attachment.getField('title'),
-				'PDF'
+				Zotero.getString('fileTypes.pdf')
 			);
 		});
 		
@@ -103,7 +103,7 @@ describe("Document Recognition", function() {
 			// The title should have changed
 			assert.equal(
 				attachment.getField('title'),
-				'PDF'
+				Zotero.getString('fileTypes.pdf')
 			);
 		});
 		
@@ -276,7 +276,7 @@ describe("Document Recognition", function() {
 			// The title should have changed
 			assert.equal(
 				attachment.getField('title'),
-				'PDF'
+				Zotero.getString('fileTypes.pdf')
 			);
 		});
 		
@@ -317,7 +317,7 @@ describe("Document Recognition", function() {
 			// The title should have changed
 			assert.equal(
 				attachment.getField('title'),
-				'PDF'
+				Zotero.getString('fileTypes.pdf')
 			);
 		});
 	});
@@ -370,7 +370,7 @@ describe("Document Recognition", function() {
 			// The title should have changed
 			assert.equal(
 				attachment.getField('title'),
-				'EPUB'
+				Zotero.getString('fileTypes.ebook')
 			);
 
 			translateStub.restore();
@@ -408,7 +408,7 @@ describe("Document Recognition", function() {
 			// The title should have changed
 			assert.equal(
 				attachment.getField('title'),
-				'EPUB'
+				Zotero.getString('fileTypes.ebook')
 			);
 		});
 

--- a/test/tests/recognizeDocumentTest.js
+++ b/test/tests/recognizeDocumentTest.js
@@ -66,6 +66,12 @@ describe("Document Recognition", function() {
 				attachment.attachmentFilename,
 				Zotero.Attachments.getFileBaseNameFromItem(item) + '.pdf'
 			);
+			
+			// The title should have changed
+			assert.equal(
+				attachment.getField('title'),
+				'PDF'
+			);
 		});
 		
 		it("should recognize a PDF by arXiv ID", async function () {
@@ -93,6 +99,12 @@ describe("Document Recognition", function() {
 			while (progressWindow.document.getElementById("label").value != completeStr) {
 				await Zotero.Promise.delay(20);
 			}
+
+			// The title should have changed
+			assert.equal(
+				attachment.getField('title'),
+				'PDF'
+			);
 		});
 		
 		it("should put new item in same collection", async function () {
@@ -260,6 +272,12 @@ describe("Document Recognition", function() {
 				attachment.attachmentFilename,
 				Zotero.Attachments.getFileBaseNameFromItem(item) + '.pdf'
 			);
+
+			// The title should have changed
+			assert.equal(
+				attachment.getField('title'),
+				'PDF'
+			);
 		});
 		
 		it("shouldn't rename a linked file attachment using parent metadata if pref disabled", async function () {
@@ -295,6 +313,12 @@ describe("Document Recognition", function() {
 			
 			// The file should not have been renamed
 			assert.equal(attachment.attachmentFilename, 'test.pdf');
+
+			// The title should have changed
+			assert.equal(
+				attachment.getField('title'),
+				'PDF'
+			);
 		});
 	});
 
@@ -343,6 +367,12 @@ describe("Document Recognition", function() {
 				Zotero.Attachments.getFileBaseNameFromItem(item) + '.epub'
 			);
 
+			// The title should have changed
+			assert.equal(
+				attachment.getField('title'),
+				'EPUB'
+			);
+
 			translateStub.restore();
 		});
 
@@ -373,6 +403,12 @@ describe("Document Recognition", function() {
 			assert.equal(
 				attachment.attachmentFilename,
 				Zotero.Attachments.getFileBaseNameFromItem(item) + '.epub'
+			);
+
+			// The title should have changed
+			assert.equal(
+				attachment.getField('title'),
+				'EPUB'
 			);
 		});
 

--- a/test/tests/zoteroPaneTest.js
+++ b/test/tests/zoteroPaneTest.js
@@ -1649,4 +1649,35 @@ describe("ZoteroPane", function() {
 			assert.equal(doc.activeElement.id, "zotero-tb-add");
 		});
 	});
+	
+	describe("#addAttachmentFromDialog()", function () {
+		it("should set an automatic title on the first file attachment of each supported type", async function () {
+			let parentItem = await createDataObject('item');
+			
+			// Add a link attachment, which won't affect renaming
+			await Zotero.Attachments.linkFromURL({
+				url: 'https://example.com/',
+				parentItemID: parentItem.id,
+			});
+			
+			// Add a PDF attachment, which will be renamed
+			let file = getTestDataDirectory();
+			file.append('test.pdf');
+			let [pdfAttachment1] = await zp.addAttachmentFromDialog(false, parentItem.id, [file.path]);
+			assert.equal(parentItem.getAttachments().length, 2);
+			assert.equal(pdfAttachment1.getField('title'), 'PDF');
+			
+			// Add a second, which won't
+			let [pdfAttachment2] = await zp.addAttachmentFromDialog(false, parentItem.id, [file.path]);
+			assert.equal(parentItem.getAttachments().length, 3);
+			assert.equal(pdfAttachment2.getField('title'), 'test.pdf');
+			
+			// Add an EPUB attachment, which will be renamed
+			file = getTestDataDirectory();
+			file.append('stub.epub');
+			let [epubAttachment] = await zp.addAttachmentFromDialog(false, parentItem.id, [file.path]);
+			assert.equal(parentItem.getAttachments().length, 4);
+			assert.equal(epubAttachment.getField('title'), 'EPUB');
+		});
+	});
 })

--- a/test/tests/zoteroPaneTest.js
+++ b/test/tests/zoteroPaneTest.js
@@ -1665,7 +1665,7 @@ describe("ZoteroPane", function() {
 			file.append('test.pdf');
 			let [pdfAttachment1] = await zp.addAttachmentFromDialog(false, parentItem.id, [file.path]);
 			assert.equal(parentItem.getAttachments().length, 2);
-			assert.equal(pdfAttachment1.getField('title'), 'PDF');
+			assert.equal(pdfAttachment1.getField('title'), Zotero.getString('fileTypes.pdf'));
 			
 			// Add a second, which won't
 			let [pdfAttachment2] = await zp.addAttachmentFromDialog(false, parentItem.id, [file.path]);
@@ -1677,7 +1677,7 @@ describe("ZoteroPane", function() {
 			file.append('stub.epub');
 			let [epubAttachment] = await zp.addAttachmentFromDialog(false, parentItem.id, [file.path]);
 			assert.equal(parentItem.getAttachments().length, 4);
-			assert.equal(epubAttachment.getField('title'), 'EPUB');
+			assert.equal(epubAttachment.getField('title'), Zotero.getString('fileTypes.ebook'));
 		});
 	});
 })


### PR DESCRIPTION
And tweak `addAttachmentFromDialog()`:

- Accept a `files` argument for tests (`FilePicker#show()` can't be mocked)
- Return the added attachments

`setFirstAttachmentTitle()` is a kind of awkward method, but it encapsulates logic that we need in a few different places. The alternative would be to expose `_getDefaultTitleForAttachmentContentType()`, pass whatever it returns into `setField()`, and only run the `isFirstOfType` check in places where there could actually be other attachments (manually adding attachments to existing items, basically). Not sure that's that much better.

Needs #3860 (though I think any conflicts with that would be pretty minor; current conflict with `main` is from there). Addresses #4211 for Create Parent Item, Retrieve Metadata, and manually added attachments.