### PR TITLE
Fix focus not moving from reader into contextPane if the header is in bibliography entry mode

### DIFF
--- a/chrome/content/zotero/elements/contextPane.js
+++ b/chrome/content/zotero/elements/contextPane.js
@@ -317,8 +317,9 @@
 	
 			if (splitter.getAttribute('state') != 'collapsed') {
 				if (this.mode == "item") {
-					let header = this._itemPaneDeck.selectedPanel.querySelector("item-pane-header editable-text");
-					header.focus();
+					let header = this._itemPaneDeck.selectedPanel.querySelector("item-pane-header");
+					// Focus the first focusable node after header
+					Services.focus.moveFocus(window, header, Services.focus.MOVEFOCUS_FORWARD, 0);
 					return true;
 				}
 				else {


### PR DESCRIPTION
Instead of trying to focus `editable-text` of the header (which may not be possible), just focus the next node after the header.