### PR TITLE
Preferences: Replace legacy options with single `scrollTo` option

### DIFF
--- a/chrome/content/zotero/bibliography.js
+++ b/chrome/content/zotero/bibliography.js
@@ -325,7 +325,9 @@ var Zotero_File_Interface_Bibliography = new function() {
 	
 	this.manageStyles = function () {
 		document.querySelector('dialog').cancelDialog();
-		var win = Zotero.Utilities.Internal.openPreferences('zotero-prefpane-cite', { tab: 'styles-tab' });
+		var win = Zotero.Utilities.Internal.openPreferences('zotero-prefpane-cite', {
+			scrollTo: '#styles'
+		});
 		if (isDocPrefs) {
 			Zotero.Utilities.Internal.activate(win);
 		}

--- a/chrome/content/zotero/locateMenu.js
+++ b/chrome/content/zotero/locateMenu.js
@@ -652,8 +652,9 @@ var Zotero_LocateMenu = new function() {
 					null, null, null, {}
 				);
 				if (index == 0) {
-					// TODO: Scroll to Locate
-					Zotero.Utilities.Internal.openPreferences('zotero-prefpane-general');
+					Zotero.Utilities.Internal.openPreferences('zotero-prefpane-general', {
+						scrollTo: '#zotero-prefpane-locate-groupbox'
+					});
 				}
 				return;
 			}

--- a/chrome/content/zotero/preferences/preferences.js
+++ b/chrome/content/zotero/preferences/preferences.js
@@ -118,10 +118,10 @@ var Zotero_Preferences = {
 	async navigateToPane(paneID, { scrollTo } = {}) {
 		let oldPaneID = this.navigation.value;
 		this.navigation.value = paneID;
+		if (oldPaneID !== paneID) {
+			await this.waitForPaneSelect();
+		}
 		if (scrollTo) {
-			if (oldPaneID !== paneID) {
-				await this.waitForPaneSelect();
-			}
 			let elem = this.panes.get(paneID)?.container.querySelector(scrollTo);
 			if (elem) {
 				elem.scrollIntoView({ block: 'start' });

--- a/chrome/content/zotero/preferences/preferences.js
+++ b/chrome/content/zotero/preferences/preferences.js
@@ -30,6 +30,8 @@ var Zotero_Preferences = {
 	
 	_firstPaneLoadDeferred: Zotero.Promise.defer(),
 	
+	_paneSelectDeferred: Zotero.Promise.defer(),
+	
 	_observerSymbols: new Map(),
 	
 	_mutationObservers: new Map(),
@@ -66,24 +68,7 @@ var Zotero_Preferences = {
 			io = io.wrappedJSObject || io;
 
 			if (io.pane) {
-				let tabID = io.tab;
-				let tabIndex = io.tabIndex;
-				var pane = this.panes.get(io.pane);
-				this.navigation.value = io.pane;
-				// Select tab within pane by tab id
-				if (tabID !== undefined) {
-					let tab = document.getElementById(tabID);
-					if (tab) {
-						tab.control.selectedItem = tab;
-					}
-				}
-				// Select tab within pane by index
-				else if (tabIndex !== undefined) {
-					let tabBox = pane.container.querySelector('tabbox');
-					if (tabBox) {
-						tabBox.selectedIndex = tabIndex;
-					}
-				}
+				this.navigateToPane(io.pane, { scrollTo: io.scrollTo });
 			}
 		}
 		else if (document.location.hash == "#cite") {
@@ -117,14 +102,31 @@ var Zotero_Preferences = {
 		await this._firstPaneLoadDeferred.promise;
 	},
 
+	waitForPaneSelect: async function () {
+		await this._paneSelectDeferred.promise;
+	},
+
 	/**
 	 * Select a pane in the navigation sidebar, displaying its content.
 	 * Clears the current search and hides all other panes' content.
 	 *
-	 * @param {String} id
+	 * @param {String} paneID
+	 * @param {Object} [options]
+	 * @param {String} [options.scrollTo] Selector to scroll to after displaying the pane
+	 * @returns {Promise<void>}
 	 */
-	navigateToPane(id) {
-		this.navigation.value = id;
+	async navigateToPane(paneID, { scrollTo } = {}) {
+		let oldPaneID = this.navigation.value;
+		this.navigation.value = paneID;
+		if (scrollTo) {
+			if (oldPaneID !== paneID) {
+				await this.waitForPaneSelect();
+			}
+			let elem = this.panes.get(paneID)?.container.querySelector(scrollTo);
+			if (elem) {
+				elem.scrollIntoView({ block: 'start' });
+			}
+		}
 	},
 
 	openHelpLink: function () {
@@ -148,6 +150,10 @@ var Zotero_Preferences = {
 			await this._search('');
 			await this._showPane(paneID);
 			this.content.scrollTop = 0;
+
+			this._paneSelectDeferred.resolve(pane);
+			this._paneSelectDeferred = Zotero.Promise.defer();
+
 			for (let child of this.content.children) {
 				if (child !== this.helpContainer && child !== pane.container) {
 					child.hidden = true;

--- a/chrome/content/zotero/preferences/preferences_general.xhtml
+++ b/chrome/content/zotero/preferences/preferences_general.xhtml
@@ -190,7 +190,7 @@
 			</hbox>
 		</groupbox>
 		
-		<groupbox>
+		<groupbox id="zotero-prefpane-locate-groupbox">
 			<label><html:h2>&zotero.preferences.prefpane.locate;</html:h2></label>
 			
 			<label data-l10n-id="preferences-locate-library-lookup-intro"/>

--- a/chrome/content/zotero/xpcom/integration.js
+++ b/chrome/content/zotero/xpcom/integration.js
@@ -207,7 +207,9 @@ Zotero.Integration = new function() {
 		);
 
 		if (index == 0) {
-			Zotero.Utilities.Internal.openPreferences('zotero-prefpane-cite', { tab: 'wordProcessors-tab' });
+			Zotero.Utilities.Internal.openPreferences('zotero-prefpane-cite', {
+				scrollTo: '#wordProcessors'
+			});
 			return true;
 		}
 

--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -1691,55 +1691,42 @@ Zotero.Utilities.Internal = {
 	
 	openPreferences: function (paneID, options = {}) {
 		if (typeof options == 'string') {
-			Zotero.debug("openPreferences() now takes an 'options' object -- update your code", 2);
-			options = {
-				action: options
-			};
+			throw new Error("openPreferences() now takes an 'options' object -- update your code");
 		}
 		
-		var io = {
+		// If window is already open, focus it
+		var wm = Components.classes["@mozilla.org/appshell/window-mediator;1"]
+			.getService(Components.interfaces.nsIWindowMediator);
+		var enumerator = wm.getEnumerator("zotero:pref");
+		if (enumerator.hasMoreElements()) {
+			let win = enumerator.getNext();
+			win.focus();
+			if (paneID) {
+				win.Zotero_Preferences.navigateToPane(paneID, { scrollTo: options.scrollTo });
+			}
+			return win;
+		}
+
+		let io = {
 			pane: paneID,
-			tab: options.tab,
-			tabIndex: options.tabIndex,
-			action: options.action
+			scrollTo: options.scrollTo,
 		};
+		let args = [
+			'chrome://zotero/content/preferences/preferences.xhtml',
+			'zotero-prefs',
+			'chrome,titlebar,centerscreen,resizable=yes',
+			io
+		];
 		
-		var win = null;
-		// If window is already open and no special action, just focus it
-		if (!options.action) {
-			var wm = Components.classes["@mozilla.org/appshell/window-mediator;1"]
-				.getService(Components.interfaces.nsIWindowMediator);
-			var enumerator = wm.getEnumerator("zotero:pref");
-			if (enumerator.hasMoreElements()) {
-				win = enumerator.getNext();
-				win.focus();
-				if (paneID) {
-					win.Zotero_Preferences.navigation.value = paneID;
-					
-					// TODO: tab/action
-				}
-			}
+		let mainWindow = Services.wm.getMostRecentWindow("navigator:browser");
+		if (mainWindow) {
+			return mainWindow.openDialog(...args);
 		}
-		if (!win) {
-			let args = [
-				'chrome://zotero/content/preferences/preferences.xhtml',
-				'zotero-prefs',
-				'chrome,titlebar,centerscreen,resizable=yes',
-				io
-			];
-			
-			let win = Services.wm.getMostRecentWindow("navigator:browser");
-			if (win) {
-				win.openDialog(...args);
-			}
-			else {
-				// nsIWindowWatcher needs a wrappedJSObject
-				args[args.length - 1].wrappedJSObject = args[args.length - 1];
-				Services.ww.openWindow(null, ...args);
-			}
+		else {
+			// nsIWindowWatcher needs a wrappedJSObject
+			args[args.length - 1].wrappedJSObject = args[args.length - 1];
+			return Services.ww.openWindow(null, ...args);
 		}
-		
-		return win;
 	},
 	
 	

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -4002,10 +4002,10 @@ var ZoteroPane = new function()
 	}
 	
 	
-	this.openPreferences = function (paneID, action) {
+	this.openPreferences = function (paneID) {
 		Zotero.warn("ZoteroPane.openPreferences() is deprecated"
 			+ " -- use Zotero.Utilities.Internal.openPreferences() instead");
-		Zotero.Utilities.Internal.openPreferences(paneID, { action });
+		Zotero.Utilities.Internal.openPreferences(paneID);
 	}
 	
 	


### PR DESCRIPTION
And:

- Refactor `openPreferences()` for clarity
- Throw when "action" string is passed as second argument
- Use `scrollTo` option in appropriate places

Closes #4215