### PR TITLE
Fix itembox merge button remaining visible

### DIFF
--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -2269,10 +2269,12 @@
 			event.preventDefault();
 			event.stopPropagation();
 			
+			let target = event.target;
 			let isRightClick = event.type == 'contextmenu';
-			if (!isRightClick) {
-				event.target.classList.add("show-without-hover");
-				event.target.classList.remove("show-on-hover");
+			// Force button to show regardless of its hover status if applicable
+			if (!isRightClick && target.classList.contains("show-on-hover")) {
+				target.classList.add("show-without-hover");
+				target.classList.remove("show-on-hover");
 			}
 			// On click, we have x/y coordinates so use that
 			// On keyboard click, open it next to the target

--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -151,10 +151,16 @@
 			});
 
 			// Ensure no button is forced to stay visible once the menu is closed
-			this.addEventListener('popuphidden', (_) => {
+			this.addEventListener('popuphidden', (event) => {
 				for (let node of this.querySelectorAll('.show-without-hover')) {
 					node.classList.remove('show-without-hover');
 					node.classList.add("show-on-hover");
+				}
+				// Some toolbarbuttons get stuck with open=true if popup is
+				// opened via keyboard (e.g. select version btn in merge mode)
+				let popupParent = event.target.parentElement;
+				if (popupParent?.getAttribute("open") == "true") {
+					popupParent.removeAttribute("open");
 				}
 			});
 

--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -150,12 +150,11 @@
 				this._id('creator-transform-switch').setAttribute("label", creatorNameBox.getAttribute("switch-mode-label"));
 			});
 
-			// Ensure no button is forced to stay visible once the menu is cloed
-			this.querySelector('#zotero-creator-transform-menu').addEventListener('popuphidden', (_) => {
-				let row = document.popupNode.closest('.meta-row');
-				for (let node of row.querySelectorAll('toolbarbutton.show-on-hover')) {
-					node.style.removeProperty('visibility');
-					node.style.removeProperty('display');
+			// Ensure no button is forced to stay visible once the menu is closed
+			this.addEventListener('popuphidden', (_) => {
+				for (let node of this.querySelectorAll('.show-without-hover')) {
+					node.classList.remove('show-without-hover');
+					node.classList.add("show-on-hover");
 				}
 			});
 
@@ -657,7 +656,6 @@
 						this.querySelector('popupset').append(menupopup);
 						menupopup.addEventListener('popuphidden', () => {
 							menupopup.remove();
-							optionsButton.style.visibility = '';
 						});
 						this.handlePopupOpening(e, menupopup);
 					};
@@ -2273,8 +2271,8 @@
 			
 			let isRightClick = event.type == 'contextmenu';
 			if (!isRightClick) {
-				event.target.style.visibility = "visible";
-				event.target.style.display = "revert";
+				event.target.classList.add("show-without-hover");
+				event.target.classList.remove("show-on-hover");
 			}
 			// On click, we have x/y coordinates so use that
 			// On keyboard click, open it next to the target

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -1054,7 +1054,7 @@ var ZoteroPane = new function()
 			event.target.click();
 			// Some menus have a history of not opening on programmatic click
 			// If event.target.click above worked, this will be a noop.
-			if (event.target.querySelector("menupopup")) {
+			if (event.target.menupopup) {
 				event.target.open = true;
 			}
 			event.preventDefault();

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -1052,7 +1052,7 @@ var ZoteroPane = new function()
 			&& (["button", "toolbarbutton"].includes(tgt.tagName)
 				|| tgt.classList.contains("keyboard-clickable"))) {
 			event.target.click();
-			// Some menus have a history of not opening on programic click
+			// Some menus have a history of not opening on programmatic click
 			// If event.target.click above worked, this will be a noop.
 			if (event.target.querySelector("menupopup")) {
 				event.target.open = true;

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -1051,11 +1051,11 @@ var ZoteroPane = new function()
 		if ([" ", "Enter"].includes(event.key)
 			&& (["button", "toolbarbutton"].includes(tgt.tagName)
 				|| tgt.classList.contains("keyboard-clickable"))) {
+			event.target.click();
+			// Some menus have a history of not opening on programic click
+			// If event.target.click above worked, this will be a noop.
 			if (event.target.querySelector("menupopup")) {
 				event.target.open = true;
-			}
-			else {
-				event.target.click();
 			}
 			event.preventDefault();
 			event.stopPropagation();


### PR DESCRIPTION
Even after the merge mode is no longer active.

Fixes: #4240

---

The issue was arising from `document.popupNode` not being set when the popup was being opened in `handlePopupOpening`, so `popuphidden` listener wasn't clearing `display` and `visibility` style properties. I thought it might be best to not use the inline css at all and just remove/add classes in a more general `popuphidden ` listener that doesn't require  `document.popupNode` to work. 