### PR TITLE
Fix duplicate attachment row from attachments-box `notify()`

### DIFF
--- a/chrome/content/zotero/elements/attachmentsBox.js
+++ b/chrome/content/zotero/elements/attachmentsBox.js
@@ -112,14 +112,13 @@
 			this._updateAttachmentIDs().then(() => {
 				this.updatePreview();
 
-				let attachments = Zotero.Items.get((this._attachmentIDs).filter(id => ids.includes(id)));
-				if (attachments.length === 0 && action !== "delete") {
-					return;
-				}
-				for (let attachment of attachments) {
-					this.querySelector(`attachment-row[attachment-id="${attachment.id}"]`)
+				for (let id of ids) {
+					this.querySelector(`attachment-row[attachment-id="${id}"]`)
 						?.remove();
-					if (action !== 'delete') {
+				}
+				if (action !== 'delete') {
+					let attachments = Zotero.Items.get(this._attachmentIDs.filter(id => ids.includes(id)));
+					for (let attachment of attachments) {
 						this.addRow(attachment);
 					}
 				}

--- a/chrome/content/zotero/elements/attachmentsBox.js
+++ b/chrome/content/zotero/elements/attachmentsBox.js
@@ -113,31 +113,13 @@
 				if (attachments.length === 0 && action !== "delete") {
 					return;
 				}
-				if (action == 'add') {
-					for (let attachment of attachments) {
+				for (let attachment of attachments) {
+					this.querySelector(`attachment-row[attachment-id="${attachment.id}"]`)
+						?.remove();
+					if (action !== 'delete') {
 						this.addRow(attachment);
 					}
 				}
-				// When annotation added to attachment, action=modify
-				// When annotation deleted from attachment, action=refresh
-				else if (action == 'modify' || action == 'refresh') {
-					for (let attachment of attachments) {
-						let row = this.querySelector(`attachment-row[attachment-id="${attachment.id}"]`);
-						if (row) {
-							row.remove();
-						}
-						this.addRow(attachment);
-					}
-				}
-				else if (action == 'delete') {
-					for (let id of ids) {
-						let row = this.querySelector(`attachment-row[attachment-id="${id}"]`);
-						if (row) {
-							row.remove();
-						}
-					}
-				}
-				
 				this.updateCount();
 			});
 		}

--- a/chrome/content/zotero/elements/attachmentsBox.js
+++ b/chrome/content/zotero/elements/attachmentsBox.js
@@ -104,6 +104,9 @@
 		}
 
 		notify(action, type, ids) {
+			if (!(action === 'add' || action === 'modify' || action === 'refresh' || action === 'delete')) {
+				return;
+			}
 			if (!this._item?.isRegularItem()) return;
 
 			this._updateAttachmentIDs().then(() => {

--- a/test/tests/itemPaneTest.js
+++ b/test/tests/itemPaneTest.js
@@ -597,6 +597,9 @@ describe("Item pane", function () {
 			assert.equal(preview.previewType, "pdf");
 			// 2 rows
 			assert.equal(attachmentsBox.querySelectorAll("attachment-row").length, 2);
+			// Simulate an extra 'add' event on the attachment - still 2 rows
+			attachmentsBox.notify('add', 'item', [attachment2.id]);
+			assert.equal(attachmentsBox.querySelectorAll("attachment-row").length, 2);
 
 			// Created annotations should be update in preview and attachment row
 			let annotation = await createAnnotation('highlight', attachment2);


### PR DESCRIPTION
`refresh` event comes before `add` when an attachment is added to an item (not sure why), so we end up with a duplicate row. Fix by always removing any existing row before adding a new one.

Fixes #4249