### PR TITLE
Assign ItemPane#_itemDetails default tabType

### DIFF
--- a/chrome/content/zotero/elements/itemDetails.js
+++ b/chrome/content/zotero/elements/itemDetails.js
@@ -109,11 +109,11 @@
 		}
 
 		get tabType() {
-			return this._tabType;
+			return this.getAttribute('tabType');
 		}
 
 		set tabType(tabType) {
-			this._tabType = tabType;
+			this.setAttribute('tabType', tabType);
 		}
 		
 		get collectionTreeRow() {

--- a/chrome/content/zotero/elements/itemPane.js
+++ b/chrome/content/zotero/elements/itemPane.js
@@ -30,7 +30,7 @@
 			<deck id="zotero-item-pane-content" class="zotero-item-pane-content" selectedIndex="0" flex="1">
 				<item-message-pane id="zotero-item-message" />
 				
-				<item-details id="zotero-item-details" />
+				<item-details id="zotero-item-details" tabType="library"/>
 				
 				<note-editor id="zotero-note-editor" flex="1" notitle="1"
 					previousfocus="zotero-items-tree" />


### PR DESCRIPTION
Fix pinnedPane set to ItemDetails before tabType is assigned not stored to pref
fix: #4260