### PR TITLE
vpat 46 followup: more aria for preferences inputs

### DIFF
--- a/chrome/content/zotero/preferences/preferences_advanced.xhtml
+++ b/chrome/content/zotero/preferences/preferences_advanced.xhtml
@@ -61,15 +61,17 @@
 			</vbox>
 			
 			<hbox align="center">
-				<label value="&zotero.preferences.attachmentBaseDir.basePath;"/>
+				<label id="baseAttachmentPathLabel" value="&zotero.preferences.attachmentBaseDir.basePath;"/>
 				<html:input type="text" id="baseAttachmentPath"
 					preference="extensions.zotero.baseAttachmentPath"
 					readonly="true"
 					flex="1"
-					tabindex="-1"/>
+					tabindex="0"
+					aria-labelledby="baseAttachmentPathLabel"/>
 				<button id="baseAttachmentPathButton"
 					label="&zotero.preferences.attachmentBaseDir.selectBasePath;"
-					oncommand="Zotero_Preferences.Attachment_Base_Directory.choosePath()"/>
+					oncommand="Zotero_Preferences.Attachment_Base_Directory.choosePath()"
+					aria-describedby="baseAttachmentPathLabel"/>
 			</hbox>
 			
 			<hbox>

--- a/chrome/content/zotero/preferences/preferences_cite.xhtml
+++ b/chrome/content/zotero/preferences/preferences_cite.xhtml
@@ -27,7 +27,7 @@
 	<vbox class="main-section" id="styles">
 		<groupbox flex="1">
 			<!-- HTML needs to be wrapped in an hbox to isolate from XUL box layout -->
-			<hbox><label><html:h2>&zotero.preferences.cite.styles.styleManager;</html:h2></label></hbox>
+			<hbox><label control="styleManager-table"><html:h2>&zotero.preferences.cite.styles.styleManager;</html:h2></label></hbox>
 			
 			<hbox class="virtualized-table-container" flex="1">
 				<html:div id="styleManager"/>

--- a/chrome/content/zotero/preferences/preferences_export.xhtml
+++ b/chrome/content/zotero/preferences/preferences_export.xhtml
@@ -56,22 +56,22 @@
 		<box id="noteQuickCopy-wrapper">
 			<vbox id="noteQuickCopy-format-options" hidden="true" align="center">
 				<hbox id="noteQuickCopy-markdown-options" align="center">
-					<label control="noteQuickCopy-markdown-includeAppLinks"></label>
+					<label id="noteQuickCopy-markdown-includeAppLinks-label"></label>
 					<checkbox id="noteQuickCopy-markdown-includeAppLinks"
 						oncommand="Zotero_Preferences.Export.onUpdateNoteExportOptions()"
-						native="true"/>
+						native="true" aria-describedby="noteQuickCopy-markdown-includeAppLinks-label"/>
 				</hbox>
 				<hbox id="noteQuickCopy-html-options" align="center">
-					<label control="noteQuickCopy-html-includeAppLinks"></label>
+					<label id="noteQuickCopy-html-includeAppLinks-label"></label>
 					<checkbox id="noteQuickCopy-html-includeAppLinks"
 						oncommand="Zotero_Preferences.Export.onUpdateNoteExportOptions()"
-						native="true"/>
+						native="true" aria-describedby="noteQuickCopy-html-includeAppLinks-label"/>
 				</hbox>
 			</vbox>
 		</box>
 		<separator/>
 		
-		<label value="&zotero.preferences.quickCopy.siteEditor.setings;" control="quickCopy-siteSettings"/>
+		<label value="&zotero.preferences.quickCopy.siteEditor.setings;" control="quickCopy-siteSettings-table"/>
 		<hbox class="virtualized-table-container" flex="1">
 			<html:div id="quickCopy-siteSettings"/>
 		</hbox>

--- a/chrome/content/zotero/preferences/preferences_general.xhtml
+++ b/chrome/content/zotero/preferences/preferences_general.xhtml
@@ -28,11 +28,12 @@
 			<label><html:h2>&zotero.preferences.interface;</html:h2></label>
 		
 			<hbox align="center">
-				<label data-l10n-id="preferences-color-scheme"/>
+				<label id="color-scheme-label" data-l10n-id="preferences-color-scheme"/>
+				<!-- aria-describedby set on individual radio buttons because voiceover won't announce it if set on radiogroup-->
 				<radiogroup orient="horizontal" id="color-scheme" preference="browser.theme.toolbar-theme">
-					<radio data-l10n-id="preferences-color-scheme-auto" value="2"/>
-					<radio data-l10n-id="preferences-color-scheme-light" value="1"/>
-					<radio data-l10n-id="preferences-color-scheme-dark" value="0"/>
+					<radio data-l10n-id="preferences-color-scheme-auto" value="2" aria-describedby="color-scheme-label"/>
+					<radio data-l10n-id="preferences-color-scheme-light" value="1" aria-describedby="color-scheme-label"/>
+					<radio data-l10n-id="preferences-color-scheme-dark" value="0" aria-describedby="color-scheme-label"/>
 				</radiogroup>
 			</hbox>
 		
@@ -46,7 +47,7 @@
 			</hbox>
 
 			<hbox align="center">
-				<label data-l10n-id="preferences-item-pane-header"/>
+				<label data-l10n-id="preferences-item-pane-header" control="item-pane-header-menulist"/>
 				<menulist id="item-pane-header-menulist" preference="extensions.zotero.itemPaneHeader" native="true">
 					<menupopup>
 						<menuitem data-l10n-id="item-pane-header-none" value="none"/>

--- a/chrome/locale/en-US/zotero/preferences.ftl
+++ b/chrome/locale/en-US/zotero/preferences.ftl
@@ -43,7 +43,7 @@ preferences-locate-resolver = Resolver:
 preferences-locate-base-url = Base URL:
 
 preferences-quickCopy-minus =
-    .aria-label = { general-minus }
+    .aria-label = { general-remove }
     .label = { $label }
 preferences-quickCopy-plus =
     .aria-label = { general-add }


### PR DESCRIPTION
Hopefully, this is the last of aria edits for the preferences window. 

- linked color scheme radio buttons to their label. Using aria-describedby on individual radio buttons instead of linking color scheme label to radiogroup because voiceover does not announce the label in that case.
- linked item pane header dropdown to its label
- linked markdown and richtext note format checkboxes to their labels.
- added aria description to linked attachments base directory so the input and "choose" button
- linked virtualized tables to their labels

Data directory location setting needs some more labeling as well but it's mechanics should be generally reworked per vpat 50 and it should be all addressed in #4048 

For reference, the latest VPAT feedback:

---

Still affected on Mac and windows (meaning these elements or the elements in their section are not properly associated with their label): 
General: Color Scheme, Item Pane Header
Export: Markdown, Rich Text/HTML, Site-specific Settings table
Cite: Style Manager table, the buttons after "get additional styles…"
Advanced: "Choose…" button after Base Directory, the whole Data Directory Location section