### PR TITLE
Fix unwanted empty creator row in itemBox

### DIFF
--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -51,6 +51,7 @@
 			this._draggedCreator = false;
 			this._selectField = null;
 			this._selectFieldSelection = null;
+			this._addCreatorRow = false;
 		}
 
 		get content() {


### PR DESCRIPTION
`this._addCreatorRow` needs to be properly initialized to `false` (as opposed to being undefined) because `false` is the value we check against to decide if an empty row should be added and focused after rendering.

Fixes: #4268

"More creator rows" click would always add an empty row. If there are not enough creators, the empty row would sometimes appear, I believe, depending on if itemBox is rendered only once or not.

https://github.com/zotero/zotero/assets/36271954/0002b6f6-0187-4225-b800-915c3f71ed1f

