### PR TITLE
Fix tab duplication breakage

### DIFF
--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -1016,7 +1016,7 @@ class ReaderTab extends ReaderInstance {
 		this._onToggleSidebarCallback = options.onToggleSidebar;
 		this._onChangeSidebarWidthCallback = options.onChangeSidebarWidth;
 		this._window = Services.wm.getMostRecentWindow('navigator:browser');
-		let existingTabID = this._window.Zotero_Tabs.getTabIDByItemID(this._item.id);
+		let existingTabID = options.tabID;
 		// If an unloaded tab for this item already exists, load the reader in it.
 		// Otherwise, create a new tab
 		if (existingTabID) {


### PR DESCRIPTION
Fix to breakage after 3f45def that would not open a duplicate tab but instead create another reader instance in the same tab. Instead of finding a tab for a specific item, use tabID that is passed when reader should be loaded in an unloaded tab. That allows us to know if the tab is being duplicated or not.

Fixes: #4272

https://github.com/zotero/zotero/assets/36271954/63fbc4dc-852e-49ea-8b3c-841577226cdd

