### PR TITLE
Show correct context menu and itemPane header for trashed collections

### DIFF
--- a/chrome/content/zotero/elements/itemPane.js
+++ b/chrome/content/zotero/elements/itemPane.js
@@ -494,7 +494,7 @@
 				// Guess a mode from the current data
 				// No/multiple objects are selected OR selected object is a trashed collection/search
 				if (!this.data.length || this.data.length > 1
-					||this.data.every(obj => obj instanceof Zotero.Collection || obj instanceof Zotero.Search)) {
+					|| this.data[0] instanceof Zotero.Collection || this.data[0] instanceof Zotero.Search) {
 					mode = "message";
 				}
 				else if (this.data[0].isNote()) {

--- a/chrome/content/zotero/elements/itemPane.js
+++ b/chrome/content/zotero/elements/itemPane.js
@@ -492,7 +492,9 @@
 		getCurrentPane(mode = undefined) {
 			if (!mode) {
 				// Guess a mode from the current data
-				if (!this.data.length || this.data.length > 1) {
+				// No/multiple objects are selected OR selected object is a trashed collection/search
+				if (!this.data.length || this.data.length > 1
+					||this.data.every(obj => obj instanceof Zotero.Collection || obj instanceof Zotero.Search)) {
 					mode = "message";
 				}
 				else if (this.data[0].isNote()) {

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -3558,7 +3558,7 @@ var ZoteroPane = new function()
 			show.add(m.loadReport);
 		}
 		
-		var items = this.getSelectedItems();
+		var items = this.getSelectedObjects();
 		
 		if (items.length > 0) {
 			// Multiple items selected


### PR DESCRIPTION
- only have enabled "Permanently delete" and "Restore to library" options in the context menu for trashed collections and searches
- display the custom header with buttons to delete or restore in the itemPane when a trashed collection or search is selected

Fixes: #4295

https://forums.zotero.org/discussion/comment/466736/#Comment_466736

<img width="829" alt="Screenshot 2024-06-28 at 11 53 34 AM" src="https://github.com/zotero/zotero/assets/36271954/c82d174a-98fe-4f8e-a0ca-661dbc6371f5">
