### PR TITLE
Fix missing icons in menulists on Windows

### DIFF
--- a/scss/win/_menupopup.scss
+++ b/scss/win/_menupopup.scss
@@ -55,12 +55,12 @@ menupopup {
 			menu:not([icon], .menu-iconic),
 			menuitem:not([checked="true"], [icon], .menuitem-iconic) {
 				padding-inline-start: 36px;
-			}
-			menuitem {
+
 				.menu-iconic-icon {
 					display: none;
 				}
 			}
+
 			menuitem[selected="true"] {
 				padding-inline-start: 12px !important;
 		


### PR DESCRIPTION
Only set display: none on the icon element when we actually don't have an icon to show.

Fixes #4273