### PR TITLE
Fix X button not appearing in tag selector

### DIFF
--- a/scss/components/_search.scss
+++ b/scss/components/_search.scss
@@ -29,12 +29,13 @@
 		inset-inline-end: 0;
 		width: 14px;
 		height: 14px;
-		padding-inline: 5px 8px;
-		padding-block: 5px;
-		margin-inline: 0 4px;
-		margin-block: 6px;
+		align-self: center;
+		margin-inline-end: 6px;
+		@media (-moz-platform: windows) {
+			margin-top: 2px;
+		}
 		cursor: default;
-		background: url(resource://gre-resources/searchfield-cancel.svg) no-repeat center/contain;
+		background: url(resource://content-accessible/searchfield-cancel.svg) no-repeat center/contain;
 		background-size: unset;
 	}
 }


### PR DESCRIPTION
With minor tweaks to positioning.

Fixes: #4299


Positioning tweaks added to not have the button pushed so far into the input.

Before:

<img width="305" alt="Screenshot 2024-07-01 at 5 32 35 PM" src="https://github.com/zotero/zotero/assets/36271954/a8fcb25c-d843-4557-9f11-84c2c89e8e53">

After:

<img width="297" alt="Screenshot 2024-07-01 at 5 02 29 PM" src="https://github.com/zotero/zotero/assets/36271954/2f799791-a1de-4efa-8db5-569633c83489">
