### PR TITLE
always open duplicatesPane itembox

### DIFF
--- a/chrome/content/zotero/elements/duplicatesMergePane.js
+++ b/chrome/content/zotero/elements/duplicatesMergePane.js
@@ -139,6 +139,8 @@
 			button.label = Zotero.getString('pane.item.duplicates.mergeItems', (otherItems.length + 1));
 			versionSelect.hidden = fieldSelect.hidden = !alternatives;
 			itembox.hiddenFields = alternatives ? [] : ['dateAdded', 'dateModified'];
+			// Since the header of the collapsible section is hidden, the section has to be opened
+			itembox.open = true;
 			
 			this.setMaster(0);
 			


### PR DESCRIPTION
Since the header of the collapsible section is not visible, there is no way to expand the itemBox if it was collapsed before dulicate items are selected. With this, itembox is always opened when a new set of duplicate items is selected.

Fixes: #4318