### PR TITLE
 Fix to stale or incorrect trashed collections data appearing in librariesCollectionsBox

### DIFF
--- a/chrome/content/zotero/elements/librariesCollectionsBox.js
+++ b/chrome/content/zotero/elements/librariesCollectionsBox.js
@@ -65,7 +65,7 @@ import { getCSSIcon } from 'components/icons';
 		}
 
 		init() {
-			this._notifierID = Zotero.Notifier.registerObserver(this, ['item'], 'librariesCollectionsBox');
+			this._notifierID = Zotero.Notifier.registerObserver(this, ['item', 'collection'], 'librariesCollectionsBox');
 			this._body = this.querySelector('.body');
 			this.initCollapsibleSection();
 			this._section.addEventListener('add', this._handleAdd);
@@ -77,10 +77,18 @@ import { getCSSIcon } from 'components/icons';
 		}
 
 		notify(action, type, ids) {
+			if (!this._item) return;
 			if (action == 'modify'
-					&& this._item
+					&& type == "item"
 					&& (ids.includes(this._item.id) || this._linkedItems.some(item => ids.includes(item.id)))) {
 				this._forceRenderAll();
+			}
+			
+			if (["modify", "trash"].includes(action) && type == "collection") {
+				let isRelevantCollection = ids.findIndex(id => Zotero.Collections.get(id).hasItem(this._item)) !== -1;
+				if (isRelevantCollection) {
+					this._forceRenderAll();
+				}
 			}
 		}
 		

--- a/chrome/content/zotero/elements/librariesCollectionsBox.js
+++ b/chrome/content/zotero/elements/librariesCollectionsBox.js
@@ -85,7 +85,7 @@ import { getCSSIcon } from 'components/icons';
 			}
 			
 			if (["modify", "trash"].includes(action) && type == "collection") {
-				let isRelevantCollection = ids.findIndex(id => Zotero.Collections.get(id).hasItem(this._item)) !== -1;
+				let isRelevantCollection = ids.some(id => Zotero.Collections.get(id).hasItem(this._item));
 				if (isRelevantCollection) {
 					this._forceRenderAll();
 				}

--- a/chrome/content/zotero/xpcom/data/collection.js
+++ b/chrome/content/zotero/xpcom/data/collection.js
@@ -357,8 +357,8 @@ Zotero.Collection.prototype._saveData = Zotero.Promise.coroutine(function* (env)
 
 			// Add restored collection back into item's _collections cache
 			this.getChildItems(false, true).forEach((item) => {
-				const collectionNotCached = item._collections.filter(c => c != this.id).length == 0;
-				if (collectionNotCached) {
+				let collectionCached = item._collections.includes(this.id);
+				if (!collectionCached) {
 					item._collections.push(this.id);
 				}
 			});

--- a/chrome/content/zotero/xpcom/data/items.js
+++ b/chrome/content/zotero/xpcom/data/items.js
@@ -797,7 +797,8 @@ Zotero.Items = function() {
 	this._loadCollections = Zotero.Promise.coroutine(function* (libraryID, ids, idSQL) {
 		var sql = "SELECT itemID, collectionID FROM items "
 			+ "LEFT JOIN collectionItems USING (itemID) "
-			+ "WHERE libraryID=?" + idSQL;
+			+ "LEFT JOIN deletedCollections USING (collectionID) "
+			+ "WHERE deletedCollections.collectionID IS NULL AND libraryID=?" + idSQL;
 		var params = [libraryID];
 		
 		var lastItemID;

--- a/test/tests/itemPaneTest.js
+++ b/test/tests/itemPaneTest.js
@@ -446,20 +446,6 @@ describe("Item pane", function () {
 			rowIDs = [...section.querySelectorAll(".row")].map(node => node.dataset.id);
 			assert.deepEqual(rowIDs, [`L${item.libraryID}`, `C${collectionParent.id}`, `C${collectionChild.id}`]);
 		});
-
-		it("should not display trashed collections after reload", async function () {
-			collectionChild.deleted = true;
-			collectionChild.saveTx();
-
-			await waitForNotifierEvent('trash', 'collection');
-
-			// Reload the item's data from DB and re-render the section to simulate loading on startup
-			await Zotero.Items.get(item.id).reload(null, true);
-			section._forceRenderAll();
-
-			let rowIDs = [...section.querySelectorAll(".row")].map(node => node.dataset.id);
-			assert.deepEqual(rowIDs, [`L${item.libraryID}`, `C${collectionParent.id}`]);
-		});
 	});
 
 	describe("Attachments pane", function () {

--- a/test/tests/itemPaneTest.js
+++ b/test/tests/itemPaneTest.js
@@ -394,6 +394,74 @@ describe("Item pane", function () {
 		});
 	});
 
+	describe("Libraries and collections pane", function () {
+		var item, collectionParent, collectionChild, section;
+
+		// Fresh setup of an item belonging to 2 collections - parent and child - for each test
+		beforeEach(async function () {
+			collectionParent = await createDataObject('collection');
+			collectionChild = await createDataObject('collection', { parentID: collectionParent.id });
+			item = await createDataObject('item', { collections: [collectionParent.id, collectionChild.id] });
+			await ZoteroPane.selectItem(item.id);
+			section = ZoteroPane.itemPane._itemDetails.getPane("libraries-collections");
+		});
+		
+		it("should update collection's name after rename", async function () {
+			collectionChild.name = "Updated collection name";
+			collectionChild.saveTx();
+
+			await waitForNotifierEvent('modify', 'collection');
+
+			let collectionRow = section.querySelector(`.row[data-id="C${collectionChild.id}"]`);
+			assert.equal(collectionRow.innerText, collectionChild.name);
+		});
+
+		it("should remove collection that has been trashed", async function () {
+			collectionChild.deleted = true;
+			collectionChild.saveTx();
+
+			await waitForNotifierEvent('trash', 'collection');
+
+			let rowIDs = [...section.querySelectorAll(".row")].map(node => node.dataset.id);
+			assert.deepEqual(rowIDs, [`L${item.libraryID}`, `C${collectionParent.id}`]);
+		});
+
+		it("should bring back collection restored from trash", async function () {
+			collectionChild.deleted = true;
+			collectionChild.saveTx();
+
+			await waitForNotifierEvent('trash', 'collection');
+
+			// Make sure the collection is actually gone
+			let rowIDs = [...section.querySelectorAll(".row")].map(node => node.dataset.id);
+			assert.deepEqual(rowIDs, [`L${item.libraryID}`, `C${collectionParent.id}`]);
+
+			// Restore the collection from trash
+			collectionChild.deleted = false;
+			collectionChild.saveTx();
+
+			await waitForNotifierEvent('modify', 'collection');
+
+			// The collection row should appear again
+			rowIDs = [...section.querySelectorAll(".row")].map(node => node.dataset.id);
+			assert.deepEqual(rowIDs, [`L${item.libraryID}`, `C${collectionParent.id}`, `C${collectionChild.id}`]);
+		});
+
+		it("should not display trashed collections after reload", async function () {
+			collectionChild.deleted = true;
+			collectionChild.saveTx();
+
+			await waitForNotifierEvent('trash', 'collection');
+
+			// Reload the item's data from DB and re-render the section to simulate loading on startup
+			await Zotero.Items.get(item.id).reload(null, true);
+			section._forceRenderAll();
+
+			let rowIDs = [...section.querySelectorAll(".row")].map(node => node.dataset.id);
+			assert.deepEqual(rowIDs, [`L${item.libraryID}`, `C${collectionParent.id}`]);
+		});
+	});
+
 	describe("Attachments pane", function () {
 		let paneID = "attachments";
 


### PR DESCRIPTION
 - listen to `collection` notifier events and re-render  the section if a relevant collection is trashed or modified. That way, a trashed collection will be removed, restored collection will be added back and renaming a collection will update the name in the librariesCollectionsBox.
  - fixed a bug where a restored collection would not be added into `item._collections` cache. Fixed false-positive test for it.
  - do not add trashed collections into `item. _collections` cache in `Zotero.Items._loadCollections`. Otherwise, trashed collections will appear in librariesCollectionsBox after the app is restarted.

  Fixes: #4307