### PR TITLE
Fix RTF Scan never marks citations as unmapped

### DIFF
--- a/chrome/content/zotero/rtfScan.js
+++ b/chrome/content/zotero/rtfScan.js
@@ -474,7 +474,7 @@ const Zotero_RTFScan = { // eslint-disable-line no-unused-vars, camelcase
 			Zotero.debug("Mapped to " + ids);
 			this.citationItemIDs[citationString] = ids;
 
-			if (!ids) {	// no mapping found
+			if (!ids.length) {	// no mapping found
 				let row = _generateItem(citationString, "");
 				row.parent = unmappedRow;
 				this.insertRows(row, this.rowMap.ambiguous);


### PR DESCRIPTION
When porting RTF Scan, I've kept the logic unchanged. However, I've now noticed that unmapped citations are always classified as ambiguous due to an invalid check (`Zotero.Search` returns an empty array if no results are found, and that is truthy, so we need to check for length instead).

I've tracked this back to the [original code](https://github.com/zotero/zotero/blame/f274323478bbc0fb26aa876a832197add76891d8/chrome/content/zotero/rtfScan.js#L233), so perhaps `Zotero.Search` has changed in the meantime or maybe it has never worked - or maybe I'm missing something?

