### PR TITLE
Don't fade right edge of a tab if text doesn't overflow + optimizations

### DIFF
--- a/chrome/content/zotero/components/tabBar.jsx
+++ b/chrome/content/zotero/components/tabBar.jsx
@@ -34,7 +34,7 @@ const SCROLL_ARROW_SCROLL_BY = 222;
 
 const Tab = memo((props) => {
 	const { icon, id, index, isBeingDragged, isItemType, onContextMenu, onDragEnd, onDragStart, onTabClick, onTabClose, onTabMouseDown, selected, title } = props;
-
+	
 	const handleTabMouseDown = useCallback(event => onTabMouseDown(event, id), [onTabMouseDown, id]);
 	const handleContextMenu = useCallback(event => onContextMenu(event, id), [onContextMenu, id]);
 	const handleTabClick = useCallback(event => onTabClick(event, id), [onTabClick, id]);
@@ -104,14 +104,18 @@ const TabBar = forwardRef(function (props, ref) {
 	useImperativeHandle(ref, () => ({ setTabs }));
 
 	useEffect(() => {
-		let handleResize = () => updateScrollArrows();
+		let handleResize = Zotero.Utilities.throttle(() => {
+			updateScrollArrows();
+			updateOverflowing();
+		}, 300, { leading: false });
 		window.addEventListener('resize', handleResize);
 		return () => {
 			window.removeEventListener('resize', handleResize);
 		};
 	}, []);
 
-	useLayoutEffect(() => updateScrollArrows());
+	useLayoutEffect(updateScrollArrows);
+	useLayoutEffect(updateOverflowing, [tabs]);
 
 	// Use offsetLeft and offsetWidth to calculate and translate tab X position
 	useLayoutEffect(() => {
@@ -164,6 +168,12 @@ const TabBar = forwardRef(function (props, ref) {
 		else {
 			tabsInnerContainerRef.current.classList.remove('scrollable');
 		}
+	}
+
+	function updateOverflowing() {
+		tabsInnerContainerRef.current.querySelectorAll('.tab-name').forEach((tabNameDOM) => {
+			tabNameDOM.classList.toggle('overflowing', tabNameDOM.scrollWidth > tabNameDOM.clientWidth);
+		});
 	}
 	
 	const handleTabMouseDown = useCallback((event, id) => {

--- a/chrome/content/zotero/tabs.js
+++ b/chrome/content/zotero/tabs.js
@@ -99,18 +99,18 @@ var Zotero_Tabs = new function () {
 				let index = ZoteroPane.collectionsView?.selection?.focused;
 				if (typeof index !== 'undefined' && ZoteroPane.collectionsView.getRow(index)) {
 					let iconName = ZoteroPane.collectionsView.getIconName(index);
-					icon = <CSSIcon name={iconName} className="tab-icon" />;
+					icon = { isItemType: false, icon: iconName };
 				}
 			}
 			else if (tab.data?.itemID) {
 				try {
 					let item = Zotero.Items.get(tab.data.itemID);
-					icon = <CSSItemTypeIcon itemType={item.getItemTypeIconName(true)} className="tab-icon" />;
+					icon = { isItemType: true, icon: item.getItemTypeIconName(true) };
 				}
 				catch (e) {
 					// item might not yet be loaded, we will get the right icon on the next update
 					// but until then use a default placeholder
-					icon = <CSSItemTypeIcon className="tab-icon" />;
+					icon = { isItemType: true, icon: null };
 				}
 			}
 
@@ -119,7 +119,7 @@ var Zotero_Tabs = new function () {
 				type: tab.type,
 				title: tab.title,
 				selected: tab.id == this._selectedID,
-				icon,
+				...icon,
 			};
 		}));
 		// Disable File > Close menuitem if multiple tabs are open

--- a/scss/components/_tabBar.scss
+++ b/scss/components/_tabBar.scss
@@ -206,12 +206,14 @@
 		text-align: start;
 		white-space: nowrap;
 
-		&:dir(ltr) {
-			mask-image: linear-gradient(to left, transparent 0px, var(--fill-primary) 20px);
-		}
+		&.overflowing {
+			&:dir(ltr) {
+				mask-image: linear-gradient(to left, transparent 0px, var(--fill-primary) 20px);
+			}
 
-		&:dir(rtl) {
-			mask-image: linear-gradient(to right, transparent 0px, var(--fill-primary) 20px);
+			&:dir(rtl) {
+				mask-image: linear-gradient(to right, transparent 0px, var(--fill-primary) 20px);
+			}
 		}
 	}
 


### PR DESCRIPTION
This update implements a check for overflowing tabs and applies the fading edge effect only when necessary. This check happens whenever tabs change as well as on window resize. I've reused the `onResize` handler and added throttling to reduce CPU burden when resizing.

Furthermore, I have optimized the tab bar to reduce the number of re-renders. Although the overflow detection introduces some overhead, the overall performance impact of this pull request should be positive.

Fix #4330