### PR TITLE
Upgrade to react 18

### DIFF
--- a/chrome/content/zotero/collectionTree.jsx
+++ b/chrome/content/zotero/collectionTree.jsx
@@ -39,11 +39,9 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 		Zotero.debug("Initializing React CollectionTree");
 		var ref;
 		opts.domEl = domEl;
-		let elem = (
-			<CollectionTree ref={c => ref = c } {...opts} />
-		);
-		await new Promise(resolve => ReactDOM.render(elem, domEl, resolve));
-
+		await new Promise(resolve => {
+			ReactDOM.createRoot(domEl).render(<CollectionTree ref={(c) => { ref = c; resolve()} } {...opts } />)
+		});
 		Zotero.debug('React CollectionTree initialized');
 		return ref;
 	}

--- a/chrome/content/zotero/components/annotation.jsx
+++ b/chrome/content/zotero/components/annotation.jsx
@@ -65,9 +65,10 @@ function AnnotationBox({ data }) {
 Zotero.AnnotationBox = memo(AnnotationBox);
 
 Zotero.AnnotationBox.render = (domEl, props) => {
-	ReactDOM.createRoot(domEl).render(<AnnotationBox { ...props } />);
+	Zotero.AnnotationBox.root = ReactDOM.createRoot(domEl);
+	Zotero.AnnotationBox.root.render(<AnnotationBox { ...props } />);
 };
 
-Zotero.AnnotationBox.destroy = (domEl) => {
-	ReactDOM.unmountComponentAtNode(domEl);
+Zotero.AnnotationBox.destroy = () => {
+	Zotero.AnnotationBox.root.unmount();
 };

--- a/chrome/content/zotero/components/annotation.jsx
+++ b/chrome/content/zotero/components/annotation.jsx
@@ -65,7 +65,7 @@ function AnnotationBox({ data }) {
 Zotero.AnnotationBox = memo(AnnotationBox);
 
 Zotero.AnnotationBox.render = (domEl, props) => {
-	ReactDOM.render(<AnnotationBox { ...props } />, domEl);
+	ReactDOM.createRoot(domEl).render(<AnnotationBox { ...props } />);
 };
 
 Zotero.AnnotationBox.destroy = (domEl) => {

--- a/chrome/content/zotero/components/createParent/createParent.jsx
+++ b/chrome/content/zotero/components/createParent/createParent.jsx
@@ -80,11 +80,12 @@ CreateParent.propTypes = {
 Zotero.CreateParent = memo(CreateParent);
 
 
-Zotero.CreateParent.destroy = (domEl) => {
-	ReactDOM.unmountComponentAtNode(domEl);
+Zotero.CreateParent.destroy = () => {
+	Zotero.CreateParent.root.unmount();
 };
 
 
 Zotero.CreateParent.render = (domEl, props) => {
-	ReactDOM.createRoot(domEl).render(<CreateParent { ...props } />);
+	Zotero.CreateParent.root = ReactDOM.createRoot(domEl);
+	Zotero.CreateParent.root.render(<CreateParent { ...props } />);
 };

--- a/chrome/content/zotero/components/createParent/createParent.jsx
+++ b/chrome/content/zotero/components/createParent/createParent.jsx
@@ -25,12 +25,17 @@
 
 'use strict';
 
-import React, { memo } from 'react';
+import React, { memo, useEffect } from 'react';
 import ReactDOM from "react-dom";
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 
 function CreateParent({ loading, item, toggleAccept }) {
+	// With React 18, this is required for the window's dialog to be properly sized
+	useEffect(() => {
+		window.sizeToContent();
+	});
+
 	// When the input has/does not have characters toggle the accept button on the dialog
 	const handleInput = (e) => {
 		if (e.target.value.trim() !== '') {
@@ -81,5 +86,5 @@ Zotero.CreateParent.destroy = (domEl) => {
 
 
 Zotero.CreateParent.render = (domEl, props) => {
-	ReactDOM.render(<CreateParent { ...props } />, domEl);
+	ReactDOM.createRoot(domEl).render(<CreateParent { ...props } />);
 };

--- a/chrome/content/zotero/components/createParent/createParent.jsx
+++ b/chrome/content/zotero/components/createParent/createParent.jsx
@@ -34,7 +34,7 @@ function CreateParent({ loading, item, toggleAccept }) {
 	// With React 18, this is required for the window's dialog to be properly sized
 	useEffect(() => {
 		window.sizeToContent();
-	});
+	}, []);
 
 	// When the input has/does not have characters toggle the accept button on the dialog
 	const handleInput = (e) => {

--- a/chrome/content/zotero/components/progressQueueTable.jsx
+++ b/chrome/content/zotero/components/progressQueueTable.jsx
@@ -24,7 +24,7 @@
 */
 import React, { memo, useCallback, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { getDOMElement } from 'components/icons';
+import { getCSSIcon } from 'components/icons';
 
 import VirtualizedTable, { renderCell } from 'components/virtualized-table';
 import { nextHTMLID, noop } from './utils';
@@ -32,13 +32,13 @@ import { nextHTMLID, noop } from './utils';
 
 function getImageByStatus(status) {
 	if (status === Zotero.ProgressQueue.ROW_PROCESSING) {
-		return getDOMElement('IconArrowRefresh');
+		return getCSSIcon('IconArrowRefresh');
 	}
 	else if (status === Zotero.ProgressQueue.ROW_FAILED) {
-		return getDOMElement('IconCross');
+		return getCSSIcon('IconCross');
 	}
 	else if (status === Zotero.ProgressQueue.ROW_SUCCEEDED) {
-		return getDOMElement('IconTick');
+		return getCSSIcon('IconTick');
 	}
 	return document.createElement('span');
 }

--- a/chrome/content/zotero/components/tabBar.jsx
+++ b/chrome/content/zotero/components/tabBar.jsx
@@ -109,6 +109,7 @@ const TabBar = forwardRef(function (props, ref) {
 			updateOverflowing();
 		}, 300, { leading: false });
 		window.addEventListener('resize', handleResize);
+		props.onLoad();
 		return () => {
 			window.removeEventListener('resize', handleResize);
 		};

--- a/chrome/content/zotero/components/virtualized-table.jsx
+++ b/chrome/content/zotero/components/virtualized-table.jsx
@@ -30,7 +30,7 @@ const PropTypes = require('prop-types');
 const cx = require('classnames');
 const WindowedList = require('./windowed-list');
 const Draggable = require('./draggable');
-const { CSSIcon, getDOMElement } = require('components/icons');
+const { CSSIcon, getCSSIcon } = require('components/icons');
 const { Zotero_Tooltip } = require('./tooltip');
 
 const TYPING_TIMEOUT = 1000;
@@ -1751,7 +1751,7 @@ function renderCheckboxCell(index, data, column, dir = null) {
 	span.setAttribute('role', 'checkbox');
 	span.setAttribute('aria-checked', data);
 	if (data) {
-		span.appendChild(getDOMElement('IconTick'));
+		span.appendChild(getCSSIcon('IconTick'));
 	}
 	return span;
 }

--- a/chrome/content/zotero/containers/tagSelectorContainer.jsx
+++ b/chrome/content/zotero/containers/tagSelectorContainer.jsx
@@ -860,7 +860,9 @@ Zotero.TagSelector = class TagSelectorContainer extends React.PureComponent {
 	static async init(domEl, opts) {
 		var ref;
 		await new Promise((resolve) => {
-			ReactDOM.createRoot(domEl).render(<TagSelectorContainer ref={(c) => {
+			let root = ReactDOM.createRoot(domEl);
+			opts.root = root;
+			root.render(<TagSelectorContainer ref={(c) => {
 				ref = c;
 				resolve();
 			} } {...opts} />);
@@ -870,7 +872,7 @@ Zotero.TagSelector = class TagSelectorContainer extends React.PureComponent {
 	
 	uninit() {
 		this._uninitialized = true;
-		ReactDOM.unmountComponentAtNode(this.domEl);
+		this.props.root.unmount();
 		Zotero.Notifier.unregisterObserver(this._notifierID);
 		Zotero.Prefs.unregisterObserver(this._prefObserverID);
 	}
@@ -878,6 +880,7 @@ Zotero.TagSelector = class TagSelectorContainer extends React.PureComponent {
 	static propTypes = {
 		container: PropTypes.string.isRequired,
 		onSelection: PropTypes.func.isRequired,
+		root: PropTypes.object,
 	};
 };
 

--- a/chrome/content/zotero/containers/tagSelectorContainer.jsx
+++ b/chrome/content/zotero/containers/tagSelectorContainer.jsx
@@ -857,13 +857,14 @@ Zotero.TagSelector = class TagSelectorContainer extends React.PureComponent {
 		return this.state.showAutomatic;
 	}
 	
-	static init(domEl, opts) {
+	static async init(domEl, opts) {
 		var ref;
-		let elem = (
-			<TagSelectorContainer ref={c => ref = c } {...opts} />
-		);
-		ReactDOM.render(elem, domEl);
-		ref.domEl = domEl;
+		await new Promise((resolve) => {
+			ReactDOM.createRoot(domEl).render(<TagSelectorContainer ref={(c) => {
+				ref = c;
+				resolve();
+			} } {...opts} />);
+		});
 		return ref;
 	}
 	

--- a/chrome/content/zotero/import/importWizard.js
+++ b/chrome/content/zotero/import/importWizard.js
@@ -169,9 +169,8 @@ const Zotero_Import_Wizard = { // eslint-disable-line no-unused-vars
 		
 		if (this.folder && !showReportErrorButton) {
 			doneQueueContainer.style.display = 'flex';
-			ReactDOM.render(
-				<ProgressQueueTable progressQueue={ Zotero.ProgressQueues.get('recognize') } />,
-				doneQueue
+			ReactDOM.createRoot(doneQueue).render(
+				<ProgressQueueTable progressQueue={ Zotero.ProgressQueues.get('recognize') } />
 			);
 		}
 		else {
@@ -381,9 +380,8 @@ const Zotero_Import_Wizard = { // eslint-disable-line no-unused-vars
 		const progressQueue = document.getElementById('progress-queue');
 		if (this.folder) {
 			progressQueueContainer.style.display = 'flex';
-			ReactDOM.render(
-				<ProgressQueueTable progressQueue={Zotero.ProgressQueues.get('recognize')} />,
-				progressQueue
+			ReactDOM.createRoot(progressQueue).render(
+				<ProgressQueueTable progressQueue={Zotero.ProgressQueues.get('recognize')} />
 			);
 		}
 		else {

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -50,10 +50,12 @@ var ItemTree = class ItemTree extends LibraryTree {
 		Zotero.debug(`Initializing React ItemTree ${opts.id}`);
 		var ref;
 		opts.domEl = domEl;
-		let elem = (
-			<ItemTree ref={c => ref = c } {...opts} />
-		);
-		await new Promise(resolve => ReactDOM.render(elem, domEl, resolve));
+		await new Promise((resolve) => {
+			ReactDOM.createRoot(domEl).render(<ItemTree ref={(c) => {
+				ref = c;
+				resolve();
+			} } {...opts} />);
+		});
 		
 		Zotero.debug(`React ItemTree ${opts.id} initialized`);
 		return ref;
@@ -2793,6 +2795,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 		let retractedAriaLabel = "";
 		if (Zotero.Retractions.isRetracted(item)) {
 			retracted = getDOMElement('IconCross');
+			console.log(retracted);
 			retracted.classList.add("retracted");
 			retractedAriaLabel = Zotero.getString('retraction.banner');
 		}

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -31,7 +31,7 @@ const LibraryTree = require('./libraryTree');
 const VirtualizedTable = require('components/virtualized-table');
 const { renderCell, formatColumnName } = VirtualizedTable;
 const Icons = require('components/icons');
-const { getDOMElement, getCSSIcon, getCSSItemTypeIcon } = Icons;
+const { getCSSIcon, getCSSItemTypeIcon } = Icons;
 const { COLUMNS } = require("zotero/itemTreeColumns");
 const { Cc, Ci, Cu, ChromeUtils } = require('chrome');
 const { OS } = ChromeUtils.importESModule("chrome://zotero/content/osfile.mjs");
@@ -2794,8 +2794,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 		let retracted = "";
 		let retractedAriaLabel = "";
 		if (Zotero.Retractions.isRetracted(item)) {
-			retracted = getDOMElement('IconCross');
-			console.log(retracted);
+			retracted = getCSSIcon("IconCross");
 			retracted.classList.add("retracted");
 			retractedAriaLabel = Zotero.getString('retraction.banner');
 		}
@@ -2915,7 +2914,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 			}
 			//else if (type == 'none') {
 			//	if (item.getField('url') || item.getField('DOI')) {
-			//		icon = getDOMElement('IconLink');
+			//		icon = getCSSIcon('IconLink');
 			//		ariaLabel = Zotero.getString('pane.item.attachments.hasLink');
 			//		icon.classList.add('cell-icon');
 			//	}

--- a/chrome/content/zotero/locateManager.jsx
+++ b/chrome/content/zotero/locateManager.jsx
@@ -39,23 +39,27 @@ const columns = [
 function init() {
 	engines = Zotero.LocateManager.getEngines();
 	const domEl = document.querySelector('#locateManager-tree');
-	let elem = (
-		<VirtualizedTable
-			getRowCount={() => engines.length}
-			id="locateManager-table"
-			ref={ref => tree = ref}
-			renderItem={VirtualizedTable.makeRowRenderer(getRowData)}
-			showHeader={true}
-			multiSelect={true}
-			columns={columns}
-			onColumnSort={null}
-			disableFontSizeScaling={true}
-			getRowString={index => getRowData(index).name}
-			onSelectionChange={handleSelectionChange}
-			onActivate={handleActivate}
-		/>
-	);
-	return new Promise(resolve => ReactDOM.render(elem, domEl, resolve));
+	return new Promise((resolve) => {
+		ReactDOM.createRoot(domEl).render(
+			<VirtualizedTable
+				getRowCount={() => engines.length}
+				id="locateManager-table"
+				ref={(ref) => {
+					tree = ref;
+					resolve();
+				}}
+				renderItem={VirtualizedTable.makeRowRenderer(getRowData)}
+				showHeader={true}
+				multiSelect={true}
+				columns={columns}
+				onColumnSort={null}
+				disableFontSizeScaling={true}
+				getRowString={index => getRowData(index).name}
+				onSelectionChange={handleSelectionChange}
+				onActivate={handleActivate}
+			/>
+		);
+	});
 }
 
 function getRowData(index) {

--- a/chrome/content/zotero/preferences/preferences_cite.jsx
+++ b/chrome/content/zotero/preferences/preferences_cite.jsx
@@ -104,25 +104,28 @@ Zotero_Preferences.Cite = {
 					return false;
 				}
 			};
-			let elem = (
-				<VirtualizedTable
-					getRowCount={() => this.styles.length}
-					id="styleManager-table"
-					ref={ref => this._tree = ref}
-					renderItem={makeRowRenderer(index => this.styles[index])}
-					showHeader={true}
-					multiSelect={true}
-					columns={columns}
-					staticColumns={true}
-					disableFontSizeScaling={true}
-					onSelectionChange={selection => document.getElementById('styleManager-delete').disabled = !selection.count}
-					onKeyDown={handleKeyDown}
-					getRowString={index => this.styles[index].title}
-				/>
-			);
 
-			let styleManager = document.getElementById("styleManager");
-			await new Promise(resolve => ReactDOM.render(elem, styleManager, resolve));
+			await new Promise((resolve) => {
+				ReactDOM.createRoot(document.getElementById("styleManager")).render(
+					<VirtualizedTable
+						getRowCount={() => this.styles.length}
+						id="styleManager-table"
+						ref={(ref) => {
+							this._tree = ref;
+							resolve();
+						}}
+						renderItem={makeRowRenderer(index => this.styles[index])}
+						showHeader={true}
+						multiSelect={true}
+						columns={columns}
+						staticColumns={true}
+						disableFontSizeScaling={true}
+						onSelectionChange={selection => document.getElementById('styleManager-delete').disabled = !selection.count}
+						onKeyDown={handleKeyDown}
+						getRowString={index => this.styles[index].title}
+					/>
+				);
+			});
 
 			// Fix style manager showing partially blank until scrolled
 			setTimeout(() => this._tree.invalidate());

--- a/chrome/content/zotero/preferences/preferences_export.jsx
+++ b/chrome/content/zotero/preferences/preferences_export.jsx
@@ -485,23 +485,27 @@ Zotero_Preferences.Export = {
 				this.updateQuickCopySiteButtons();
 			};
 			
-			let elem = (
-				<VirtualizedTable
-					getRowCount={() => this._rows.length}
-					id="quickCopy-siteSettings-table"
-					ref={ref => this._tree = ref}
-					renderItem={makeRowRenderer(index => this._rows[index])}
-					showHeader={true}
-					columns={columns}
-					staticColumns={true}
-					disableFontSizeScaling={true}
-					onSelectionChange={handleSelectionChange}
-					onKeyDown={handleKeyDown}
-					getRowString={index => this._rows[index].domain}
-					onActivate={(event, indices) => Zotero_Preferences.Export.showQuickCopySiteEditor(true)}
-				/>
-			);
-			await new Promise(resolve => ReactDOM.render(elem, document.getElementById("quickCopy-siteSettings"), resolve));
+			await new Promise((resolve) => {
+				ReactDOM.createRoot(document.getElementById("quickCopy-siteSettings")).render(
+					<VirtualizedTable
+						getRowCount={() => this._rows.length}
+						id="quickCopy-siteSettings-table"
+						ref={(ref) => {
+							this._tree = ref;
+							resolve();
+						}}
+						renderItem={makeRowRenderer(index => this._rows[index])}
+						showHeader={true}
+						columns={columns}
+						staticColumns={true}
+						disableFontSizeScaling={true}
+						onSelectionChange={handleSelectionChange}
+						onKeyDown={handleKeyDown}
+						getRowString={index => this._rows[index].domain}
+						onActivate={(event, indices) => Zotero_Preferences.Export.showQuickCopySiteEditor(true)}
+					/>
+				);
+			});
 		} else {
 			this._tree.invalidate();
 		}

--- a/chrome/content/zotero/preferences/preferences_sync.jsx
+++ b/chrome/content/zotero/preferences/preferences_sync.jsx
@@ -315,22 +315,25 @@ Zotero_Preferences.Sync = {
 				return false;
 			}
 		};
-		let elem = (
-			<VirtualizedTable
-				getRowCount={() => this._rows.length}
-				id="librariesToSync-table"
-				ref={ref => this._tree = ref}
-				renderItem={renderItem}
-				showHeader={true}
-				columns={columns}
-				staticColumns={true}
-				getRowString={index => this._rows[index].name}
-				disableFontSizeScaling={true}
-				onKeyDown={handleKeyDown}
-			/>
-		);
-		
-		ReactDOM.render(elem, document.getElementById("libraries-to-sync-tree"));
+		await new Promise((resolve) => {
+			ReactDOM.createRoot(document.getElementById("libraries-to-sync-tree")).render(
+				<VirtualizedTable
+					getRowCount={() => this._rows.length}
+					id="librariesToSync-table"
+					ref={(ref) => {
+						this._tree = ref;
+						resolve();
+					}}
+					renderItem={renderItem}
+					showHeader={true}
+					columns={columns}
+					staticColumns={true}
+					getRowString={index => this._rows[index].name}
+					disableFontSizeScaling={true}
+					onKeyDown={handleKeyDown}
+				/>
+			);
+		});
 		
 		var addRow = function (libraryName, id, checked=false, editable=true) {
 			this._rows.push({

--- a/chrome/content/zotero/preferences/preferences_sync.jsx
+++ b/chrome/content/zotero/preferences/preferences_sync.jsx
@@ -30,7 +30,6 @@ Components.utils.import("resource://zotero/config.js");
 var React = require('react');
 var ReactDOM = require('react-dom');
 var VirtualizedTable = require('components/virtualized-table');
-var { getDOMElement } = require('components/icons');
 var { renderCell } = VirtualizedTable;
 
 Zotero_Preferences.Sync = {

--- a/chrome/content/zotero/progressQueueDialog.jsx
+++ b/chrome/content/zotero/progressQueueDialog.jsx
@@ -37,13 +37,11 @@ function _init() {
 	
 	const domEl = document.querySelector('#tree');
 	
-	ReactDOM.render(
+	ReactDOM.createRoot(domEl).render(
 		<ProgressQueueTable
 			onActivate={ _handleActivate }
 			progressQueue={ _progressQueue }
-		/>,
-		domEl
-	);
+		/>);
 }
 	
 /**

--- a/chrome/content/zotero/rtfScan.js
+++ b/chrome/content/zotero/rtfScan.js
@@ -145,7 +145,7 @@ const Zotero_RTFScan = { // eslint-disable-line no-unused-vars, camelcase
 			.getElementById('choose-output-file')
 			.addEventListener('click', this.onChooseOutputFile.bind(this));
 
-		ReactDOM.render((
+		ReactDOM.createRoot(document.getElementById('tree')).render((
 			<VirtualizedTable
 				getRowCount={() => this.rows.length}
 				id="rtfScan-table"
@@ -156,7 +156,7 @@ const Zotero_RTFScan = { // eslint-disable-line no-unused-vars, camelcase
 				containerWidth={document.getElementById('tree').clientWidth}
 				disableFontSizeScaling={true}
 			/>
-		), document.getElementById('tree'));
+		));
 
 		const lastInputFile = Zotero.Prefs.get("rtfScan.lastInputFile");
 		if (lastInputFile) {

--- a/chrome/content/zotero/tabs.js
+++ b/chrome/content/zotero/tabs.js
@@ -156,7 +156,7 @@ var Zotero_Tabs = new function () {
 	};
 
 	this.init = function () {
-		ReactDOM.render(
+		ReactDOM.createRoot(document.getElementById('tab-bar-container')).render(
 			<TabBar
 				ref={this._tabBarRef}
 				onTabSelect={this.select.bind(this)}
@@ -164,11 +164,8 @@ var Zotero_Tabs = new function () {
 				onTabClose={this.close.bind(this)}
 				onContextMenu={this._openMenu.bind(this)}
 				refocusReader={this.refocusReader.bind(this)}
-			/>,
-			document.getElementById('tab-bar-container'),
-			() => {
-				this._update();
-			}
+				onLoad={this._update.bind(this)}
+			/>
 		);
 	};
 

--- a/chrome/content/zotero/tools/data_generator.jsx
+++ b/chrome/content/zotero/tools/data_generator.jsx
@@ -31,7 +31,7 @@ const ReactDOM = require('react-dom');
 
 function init() {
 	let div = document.querySelector('div');
-	ReactDOM.render(<DataGeneratorForm/>, div);
+	ReactDOM.createRoot(div).render(<DataGeneratorForm/>);
 }
 
 class DataGeneratorForm extends React.Component {
@@ -42,6 +42,10 @@ class DataGeneratorForm extends React.Component {
 			chunkSize: 50,
 			numCollections: 1000
 		};
+	}
+
+	componentDidMount() {
+		window.sizeToContent();
 	}
 
 	render() {

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -1682,11 +1682,11 @@ var ZoteroPane = new function()
 		}
 	};
 
-	this.initTagSelector = function () {
+	this.initTagSelector = async function () {
 		try {
 			var container = document.getElementById('zotero-tag-selector-container');
 			if (!container.hasAttribute('collapsed') || container.getAttribute('collapsed') == 'false') {
-				this.tagSelector = Zotero.TagSelector.init(
+				this.tagSelector = await Zotero.TagSelector.init(
 					document.getElementById('zotero-tag-selector'),
 					{
 						container: 'zotero-tag-selector-container',

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
         "classnames": "^2.2.6",
         "monaco-editor": "^0.47.0",
         "prop-types": "^15.8.0",
-        "react": "^17.0.2",
+        "react": "^18.3.1",
         "react-autosuggest": "^10.1.0",
-        "react-dom": "^17.0.2",
+        "react-dom": "^18.3.1",
         "react-intl": "^3.4.0",
         "react-select": "^3.0.8",
         "url": "^0.11.0"
@@ -5997,12 +5997,11 @@
       }
     },
     "node_modules/react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -6024,16 +6023,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
+        "scheduler": "^0.23.2"
       },
       "peerDependencies": {
-        "react": "17.0.2"
+        "react": "^18.3.1"
       }
     },
     "node_modules/react-input-autosize": {
@@ -6490,12 +6488,11 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/section-iterator": {
@@ -12420,12 +12417,11 @@
       }
     },
     "react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "react-autosuggest": {
@@ -12441,13 +12437,12 @@
       }
     },
     "react-dom": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "requires": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
+        "scheduler": "^0.23.2"
       }
     },
     "react-input-autosize": {
@@ -12811,12 +12806,11 @@
       }
     },
     "scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "section-iterator": {

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "classnames": "^2.2.6",
     "monaco-editor": "^0.47.0",
     "prop-types": "^15.8.0",
-    "react": "^17.0.2",
+    "react": "^18.3.1",
     "react-autosuggest": "^10.1.0",
-    "react-dom": "^17.0.2",
+    "react-dom": "^18.3.1",
     "react-intl": "^3.4.0",
     "react-select": "^3.0.8",
     "url": "^0.11.0"

--- a/test/tests/advancedSearchTest.js
+++ b/test/tests/advancedSearchTest.js
@@ -22,7 +22,9 @@ describe("Advanced Search", function () {
 		var promise = waitForWindow('chrome://zotero/content/advancedSearch.xhtml');
 		zp.openAdvancedSearchWindow();
 		var searchWin = yield promise;
-		
+		// After upgrading to react 18, at this point the onload listener has
+		// not finished running yet, so an extra tick needs to be skipped
+		yield Zotero.Promise.delay();
 		// Add condition
 		var searchBox = searchWin.document.getElementById('zotero-search-box');
 		

--- a/test/tests/advancedSearchTest.js
+++ b/test/tests/advancedSearchTest.js
@@ -19,12 +19,14 @@ describe("Advanced Search", function () {
 	it("should perform a search", function* () {
 		var item = yield createDataObject('item', { setTitle: true });
 		
-		var promise = waitForWindow('chrome://zotero/content/advancedSearch.xhtml');
+		var promise = waitForWindow('chrome://zotero/content/advancedSearch.xhtml', async (win) => {
+			// Wait for the itemsView to be initialized in the onload listener of the window
+			while (!win.ZoteroAdvancedSearch.itemsView) {
+				await Zotero.Promise.delay(5);
+			}
+		});
 		zp.openAdvancedSearchWindow();
 		var searchWin = yield promise;
-		// After upgrading to react 18, at this point the onload listener has
-		// not finished running yet, so an extra tick needs to be skipped
-		yield Zotero.Promise.delay();
 		// Add condition
 		var searchBox = searchWin.document.getElementById('zotero-search-box');
 		

--- a/test/tests/tagSelectorTest.js
+++ b/test/tests/tagSelectorTest.js
@@ -310,6 +310,7 @@ describe("Tag Selector", function () {
 			await Zotero.Tags.setColor(libraryID, tag2, '#BBBBBB', 2);
 			await Zotero.Tags.setColor(libraryID, tag3, '#CCCCCC', 3);
 			
+			await waitForTagSelector(win);
 			// Colored tags should appear initially as disabled
 			elems = getColoredTagElements();
 			assert.lengthOf(elems, 3);
@@ -402,10 +403,9 @@ describe("Tag Selector", function () {
 			var promise, tagSelector;
 			
 			// Add collection
-			promise = waitForTagSelector(win);
 			var collection = yield createDataObject('collection');
 			yield select(win, collection);
-			yield promise;
+			yield waitForTagSelector(win);
 			
 			// Tag selector should be empty in new collection
 			assert.equal(getRegularTags().length, 0);
@@ -435,9 +435,8 @@ describe("Tag Selector", function () {
 			var tagElems = tagSelectorElem.querySelectorAll('.tag-selector-item');
 			var count = tagElems.length;
 
-			var promise = waitForTagSelector(win);
 			yield Zotero.Tags.setColor(libraryID, "Top", '#AAAAAA');
-			yield promise;
+			yield waitForTagSelector(win);
 
 			tagElems = tagSelectorElem.querySelectorAll('.tag-selector-item');
 			assert.equal(tagElems.length, count + 1);
@@ -707,14 +706,13 @@ describe("Tag Selector", function () {
 			yield Zotero.Tags.setColor(libraryID, oldTag, "#F3F3F3");
 			yield promise;
 			
-			promise = waitForTagSelector(win);
 			waitForDialog(function (dialogWindow, dialog) {
 				dialogWindow.document.getElementById('loginTextbox').value = newTag;
 				dialog.acceptDialog();
 			});
 			tagSelector.contextTag = {name: oldTag};
 			yield tagSelector.openRenamePrompt();
-			yield promise;
+			yield waitForTagSelector(win);;
 			
 			var tags = getColoredTags();
 			assert.notInclude(tags, oldTag);


### PR DESCRIPTION
Upgrading to react 18 to not have incorrect `aria-description`-related warnings in the console. 

Changes:
- `ReactDOM.render()` -> `ReactDOM.createrRoot().render`
   - await for promise that is resolved in ref attribute of `root.render()` as an alternative for removed callback from `ReactDOM.render`
   - await-ing for promise every time when ref needs to be used after render (e.g. tag selector container), otherwise ref will be undefined
   - additional `window.sizeToContent` calls to properly size dialogs with react-rendered content (e.g. create parent), otherwise the window can cut off some of the content.
- `Icons.getCSSIcon` instead of `getDOMElement`
   - `getDOMElement` relied on `React.renderToStaticMarkup`, which is react 18 was moved to a different file than the
one exposed with `react-dom-server`. To not add another file just for that one function, replace `getDOMElement` with `getCSSIcon`.
   -  `getDOMElement` was mainly used for a few remaining png icons that were not replaced with svg. For those few icons, just record which background-url should be set when the module loads and add it in `getCSSIcon` if applicable. Alternatively, `background-image` for those pngs could be moved into a stylesheet?
   - a few hardcoded twisty svgs in icons.jsx are not used anywhere (they would be fetched via IconTwisty), so those are removed
- `ReactDOM.unmountComponentAtNode` => `root.unmount()`
   - unmountComponentAtNode is deprecated, so save or pass the root as a prop and call root.unmount when the component is destroyed


There are still a few warnings related to `ReactDOM.render` being deprecated but those come from the reader or note-editor, which should be updated as well.

Fixes: #4310 