### PR TITLE
Use `SelectedItemText` color on `SelectedItem` backgrounds

### DIFF
--- a/chrome/skin/default/zotero/integration.css
+++ b/chrome/skin/default/zotero/integration.css
@@ -192,7 +192,7 @@
 }
 
 .citation-dialog.editor::selection {
-	color: white;
+	color: var(--color-accent-text);
 	background: var(--color-accent);
 }
 

--- a/scss/base/_base.scss
+++ b/scss/base/_base.scss
@@ -5,6 +5,7 @@
 	line-height: 1.3333333333;
 	@media (-moz-platform: windows) {
 		--color-accent: var(--accent-blue);
+		--color-accent-text: #fff;
 		@include light-dark(--color-focus-outer-border, var(--fill-primary), var(--accent-white));
 		@include light-dark(--color-focus-border, var(--accent-white), #00000080);
 		--width-focus-outer-border: 2px;
@@ -12,11 +13,13 @@
 	}
 	@media (-moz-platform: macos) {
 		--color-accent: SelectedItem;
+		--color-accent-text: SelectedItemText;
 		--color-focus-border: color-mix(in srgb, var(--color-accent) 50%, transparent);
 		--width-focus-border: 3px;
 	}
 	@media (-moz-platform: linux) {
 		--color-accent: SelectedItem;
+		--color-accent-text: SelectedItemText;
 		--color-focus-border: var(--color-accent);
 		--width-focus-border: 2px;
 	}

--- a/scss/components/_richlistbox.scss
+++ b/scss/components/_richlistbox.scss
@@ -7,7 +7,7 @@ richlistbox.theme-listbox {
 	richlistitem {
 		--listitem-selectedBackground: var(--tag-gray);
 		--listitem-selectedFocusCurrentBackground: var(--color-accent);
-		--listitem-selectedTextColor: var(--accent-white);
+		--listitem-selectedTextColor: var(--color-accent-text);
 		--listitem-selectedBorder: transparent;
 		--listitem-selectedBottomBorder: transparent;
 		--listitem-selectedCurrentBorder: transparent;

--- a/scss/components/_virtualized-table.scss
+++ b/scss/components/_virtualized-table.scss
@@ -134,7 +134,7 @@
 
 		&.selected:not(.highlighted) {
 			background-color: var(--color-accent);
-			color: #fff;
+			color: var(--color-accent-text);
 
 			@include state(".virtualized-table:not(:focus-within)") {
 				color: var(--fill-primary);

--- a/scss/elements/_richlistCheckbox.scss
+++ b/scss/elements/_richlistCheckbox.scss
@@ -19,7 +19,7 @@ richlistcheckbox[selected="true"] {
 
 richlistbox:where(:focus) > richlistcheckbox[selected="true"] {
 	background-color: var(--color-accent);
-	color: SelectedItemText;
+	color: var(--color-accent-text);
 }
 
 richlistbox[seltype="multiple"]:focus > richlistcheckbox[current="true"],


### PR DESCRIPTION
I can't test on Linux, unfortunately, but this should fix #4349 (assuming the system color scheme's colors don't clash).