### PR TITLE
Revised logic of trashed collections in item cache

### DIFF
--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -4261,11 +4261,21 @@ Zotero.Item.prototype.removeAllTags = function() {
 /**
  * Gets the collections the item is in
  *
+ * @param {Boolean} includeTrashed Include trashed collections
  * @return {Array<Integer>}  An array of collectionIDs for all collections the item belongs to
  */
-Zotero.Item.prototype.getCollections = function () {
+Zotero.Item.prototype.getCollections = function (includeTrashed) {
 	this._requireData('collections');
-	return this._collections.concat();
+	if (includeTrashed) return this._collections.concat();
+
+	let collections = this._collections.filter((id) => {
+		var col = Zotero.Collections.get(id);
+		if (!col) {
+			throw new Error("Collection " + id + " not found for item " + this.libraryKey);
+		}
+		return !col.deleted;
+	});
+	return collections.concat();
 };
 
 

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -4266,16 +4266,16 @@ Zotero.Item.prototype.removeAllTags = function() {
  */
 Zotero.Item.prototype.getCollections = function (includeTrashed) {
 	this._requireData('collections');
-	if (includeTrashed) return this._collections.concat();
-
-	let collections = this._collections.filter((id) => {
+	if (includeTrashed) {
+		return this._collections.concat();
+	}
+	return this._collections.filter((id) => {
 		var col = Zotero.Collections.get(id);
 		if (!col) {
 			throw new Error("Collection " + id + " not found for item " + this.libraryKey);
 		}
 		return !col.deleted;
 	});
-	return collections.concat();
 };
 
 

--- a/chrome/content/zotero/xpcom/data/items.js
+++ b/chrome/content/zotero/xpcom/data/items.js
@@ -797,8 +797,7 @@ Zotero.Items = function() {
 	this._loadCollections = Zotero.Promise.coroutine(function* (libraryID, ids, idSQL) {
 		var sql = "SELECT itemID, collectionID FROM items "
 			+ "LEFT JOIN collectionItems USING (itemID) "
-			+ "LEFT JOIN deletedCollections USING (collectionID) "
-			+ "WHERE deletedCollections.collectionID IS NULL AND libraryID=?" + idSQL;
+			+ "WHERE libraryID=?" + idSQL;
 		var params = [libraryID];
 		
 		var lastItemID;

--- a/chrome/content/zotero/xpcom/data/search.js
+++ b/chrome/content/zotero/xpcom/data/search.js
@@ -1145,8 +1145,8 @@ Zotero.Search.prototype._buildQuery = Zotero.Promise.coroutine(function* () {
 	
 	if (unfiled) {
 		sql += " AND (itemID NOT IN ("
-			// Include items that only belong to trashed collections
-			+ "SELECT itemID FROM collectionItems LEFT JOIN deletedCollections USING (collectionID) WHERE deletedCollections.collectionID IS NULL "
+			// Exclude items that belong to non-trashed collections
+			+ "SELECT itemID FROM collectionItems WHERE collectionID NOT IN (SELECT collectionID FROM deletedCollections) "
 			// Exclude children
 			+ "UNION SELECT itemID FROM itemAttachments WHERE parentItemID IS NOT NULL "
 			+ "UNION SELECT itemID FROM itemNotes WHERE parentItemID IS NOT NULL "

--- a/chrome/content/zotero/xpcom/data/search.js
+++ b/chrome/content/zotero/xpcom/data/search.js
@@ -1145,7 +1145,8 @@ Zotero.Search.prototype._buildQuery = Zotero.Promise.coroutine(function* () {
 	
 	if (unfiled) {
 		sql += " AND (itemID NOT IN ("
-			+ "SELECT itemID FROM collectionItems "
+			// Include items that only belong to trashed collections
+			+ "SELECT itemID FROM collectionItems LEFT JOIN deletedCollections USING (collectionID) WHERE deletedCollections.collectionID IS NULL "
 			// Exclude children
 			+ "UNION SELECT itemID FROM itemAttachments WHERE parentItemID IS NOT NULL "
 			+ "UNION SELECT itemID FROM itemNotes WHERE parentItemID IS NOT NULL "

--- a/test/tests/collectionTest.js
+++ b/test/tests/collectionTest.js
@@ -102,8 +102,10 @@ describe("Zotero.Collection", function() {
 			collection1.deleted = true;
 			await collection1.saveTx();
 
-			// Deleted collection is gone from item's cache
+			// Trashed collection does not count as one of item's containers
 			assert.notInclude(item1.getCollections(), collection1.id);
+			// But it should still return it if includeTrashed=true is passed
+			assert.include(item1.getCollections(true), collection1.id);
 
 			// Restore deleted collection
 			collection1.deleted = false;
@@ -114,40 +116,25 @@ describe("Zotero.Collection", function() {
 			// Collection is restored from trash
 			assert.notInclude(deleted, collection1.id);
 
-			// Collection is back in item's cache
+			// Item belongs to the restored collection
 			assert.include(item1.getCollections(), collection1.id);
 		});
 
 		it("should permanently delete collections from trash", async function () {
 			var collection1 = await createDataObject('collection');
 			var collection2 = await createDataObject('collection', { parentID: collection1.id });
-			var collection3 = await createDataObject('collection', { parentID: collection2.id });
+			var collection3 = await createDataObject('collection', { parentID: collection2.id, deleted: true });
+			var item = await createDataObject('item', { collections: [collection1.id, collection2.id, collection3.id] });
 			
 			await collection1.eraseTx();
 			
 			assert.equal(await Zotero.Collections.getAsync(collection1.id), false);
 			assert.equal(await Zotero.Collections.getAsync(collection2.id), false);
 			assert.equal(await Zotero.Collections.getAsync(collection3.id), false);
-		});
 
-		it("should not load deleted collections into item's cache on startup", async function () {
-			var collection1 = await createDataObject('collection');
-			var collection2 = await createDataObject('collection');
-			var item = await createDataObject('item', { collections: [collection1.id, collection2.id] });
-
-			collection1.deleted = true;
-			await collection1.saveTx();
-
-			// Make sure the deleted collection is gone from item's cache
-			assert.notInclude(item.getCollections(), collection1.id);
-			assert.include(item.getCollections(), collection2.id);
-
-			// Reload the item's data from DB
-			await Zotero.Items.get(item.id).reload(null, true);
-
-			// Make sure the deleted collection is not back in item's cache
-			assert.notInclude(item.getCollections(), collection1.id);
-			assert.include(item.getCollections(), collection2.id);
+			// Erased collections are fully removed as item's containers
+			assert.equal(item.getCollections().length, 0);
+			assert.equal(item.getCollections(true).length, 0);
 		});
 	})
 	

--- a/test/tests/searchTest.js
+++ b/test/tests/searchTest.js
@@ -582,6 +582,25 @@ describe("Zotero.Search", function() {
 					assert.include(matches, item1.id);
 					assert.notInclude(matches, item2.id);
 				});
+				it("should include items belonging only to trashed collections", async function () {
+					var collection = await createDataObject('collection');
+					var item = await createDataObject('item', { collections: [collection.id] });
+					
+					var s = new Zotero.Search;
+					s.libraryID = Zotero.Libraries.userLibraryID;
+					s.addCondition('unfiled', 'true');
+
+					// item belonging to a non-trashed collection is not unfiled
+					var matches = await s.search();
+					assert.notInclude(matches, item.id);
+
+					collection.deleted = true;
+					await collection.saveTx();
+
+					// item that only belongs to a trashed collection is unfiled
+					matches = await s.search();
+					assert.include(matches, item.id);
+				});
 			});
 			
 			describe("Quick search", function () {


### PR DESCRIPTION
- revert change from 2401a34031799fd7c28efe75b6c4a3036fad3987 that only loads un-trashed collections in `_loadCollections`. If an item only belongs to deleted collections, `item._loaded.collections = true` from `_loadCollections` will never run, so an exception will be thrown in `item.toJSON()` when syncing happens. Instead, to address the problem of `item.getCollections()` having stale data #4307, add 'includeTrashed' parameter to `item.getCollections()` based on which `item._collections` will be filtered. Fixes: #4346
- revert earlier, no more necessary, changes from a532cfb4759eb37bbf4952331ab20c43c65e6918 to not alter `item._collections` cache when collections are being trashed or restored. Collection is removed from `item._collections` only when it is permanently erased.
- removed unnecessary test checking for consistent `item._collections` value before and after reload, since `item._collections` is no longer modified
- fix encountered bug where a trashed child collection is not unloaded if a parent collection is erased without being trashed first.
- tweaked `Zotero.Search` sql construction to count items that only belong to trashed collections as "unfiled". Fixes: #4347