### PR TITLE
Rename subsequent attachments, don't change title when renaming from parent metadata

### DIFF
--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -2496,7 +2496,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 					}
 
 					if (item) {
-						item.setFirstAttachmentTitle();
+						item.setAutoAttachmentTitle();
 						await item.saveTx();
 						addedItems.push(item);
 					}

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -3877,23 +3877,34 @@ Zotero.Item.prototype._getDefaultTitleForAttachmentContentType = function () {
 };
 
 
-Zotero.Item.prototype.setFirstAttachmentTitle = function () {
+Zotero.Item.prototype.setAutoAttachmentTitle = function () {
 	if (!this.isAttachment()) {
-		throw new Error("setFirstAttachmentTitle() can only be called on attachment items");
+		throw new Error("setAutoAttachmentTitle() can only be called on attachment items");
 	}
 	if (!this.isFileAttachment() || !this.parentItemID) {
 		return;
 	}
+	
+	// If this is the only attachment of its type on the parent item, give it
+	// a default title ("PDF", "Webpage", etc.)
 	let isFirstOfType = this.parentItem.numFileAttachmentsWithContentType(this.attachmentContentType) <= 1;
-	if (!isFirstOfType) {
-		return;
+	if (isFirstOfType) {
+		let defaultTitle = this._getDefaultTitleForAttachmentContentType();
+		if (defaultTitle !== null) {
+			this.setField('title', defaultTitle);
+			return;
+		}
 	}
-	let defaultTitle = this._getDefaultTitleForAttachmentContentType();
-	if (defaultTitle === null) {
-		// Keep existing title
-		return;
+	
+	// If this isn't the only attachment of its type or we don't have a default
+	// title for this type, name it after its filename, minus the extension
+	let filename = this.attachmentFilename;
+	if (filename) {
+		let title = filename.replace(/\.[^.]+$/, '');
+		if (title) {
+			this.setField('title', title);
+		}
 	}
-	this.setField('title', defaultTitle);
 };
 
 

--- a/chrome/content/zotero/xpcom/recognizeDocument.js
+++ b/chrome/content/zotero/xpcom/recognizeDocument.js
@@ -303,7 +303,7 @@ Zotero.RecognizeDocument = new function () {
 		}
 		
 		// Rename attachment title
-		attachment.setFirstAttachmentTitle();
+		attachment.setAutoAttachmentTitle();
 		await attachment.saveTx();
 
 		try {

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -4411,7 +4411,7 @@ var ZoteroPane = new function()
 			}
 			
 			try {
-				item.setFirstAttachmentTitle();
+				item.setAutoAttachmentTitle();
 				await item.saveTx();
 			}
 			catch (e) {
@@ -5343,7 +5343,7 @@ var ZoteroPane = new function()
 
 		await Zotero.DB.executeTransaction(async () => {
 			for (let item of items) {
-				item.setFirstAttachmentTitle();
+				item.setAutoAttachmentTitle();
 				await item.save();
 			}
 		});

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -5666,19 +5666,11 @@ var ZoteroPane = new function()
 			if (ext) {
 				newName = newName + ext[0];
 			}
-			let origFilenameNoExt = origFilename.replace(extRE, '')
 			
 			var renamed = await item.renameAttachmentFile(newName, false, true);
 			if (renamed !== true) {
 				Zotero.debug("Could not rename file (" + renamed + ")");
 				continue;
-			}
-			
-			// If the attachment title matched the filename, change it now
-			let origTitle = item.getField('title');
-			if (origTitle == origFilename || origTitle == origFilenameNoExt) {
-				item.setField('title', newName);
-				await item.saveTx();
 			}
 			
 			let str = await document.l10n.formatValue('file-renaming-file-renamed-to', { filename: newName });

--- a/test/tests/itemTreeTest.js
+++ b/test/tests/itemTreeTest.js
@@ -1570,7 +1570,7 @@ describe("Zotero.ItemTree", function() {
 			let promise = waitForItemEvent('add');
 			drop(parentRow, 0, dataTransfer);
 
-			// Add a PDF attachment, which will be renamed
+			// Add a PDF attachment, which will get a default title
 			let pdfAttachment1 = Zotero.Items.get((await promise)[0]);
 			assert.equal(pdfAttachment1.parentItemID, parentItem.id);
 			assert.equal(pdfAttachment1.getField('title'), Zotero.getString('fileTypes.pdf'));
@@ -1578,10 +1578,10 @@ describe("Zotero.ItemTree", function() {
 			promise = waitForItemEvent('add');
 			drop(parentRow, 0, dataTransfer);
 
-			// Add a second, which won't
+			// Add a second, which will get a title based on its filename
 			let pdfAttachment2 = Zotero.Items.get((await promise)[0]);
 			assert.equal(pdfAttachment2.parentItemID, parentItem.id);
-			assert.equal(pdfAttachment2.getField('title'), 'test.pdf');
+			assert.equal(pdfAttachment2.getField('title'), 'test');
 		});
 	});
 	

--- a/test/tests/zoteroPaneTest.js
+++ b/test/tests/zoteroPaneTest.js
@@ -685,21 +685,6 @@ describe("ZoteroPane", function() {
 			assert.equal(attachment.attachmentFilename, 'Title.png');
 			assert.equal(attachment.getField('title'), 'test.png')
 		});
-		
-		it("should change attachment title even if the same as filename without extension", async function () {
-			var item = createUnsavedDataObject('item');
-			item.setField('title', 'Title');
-			await item.saveTx();
-			
-			var attachment = await importFileAttachment('test.png', { parentItemID: item.id });
-			attachment.setField('title', 'test');
-			await attachment.saveTx();
-			await zp.selectItem(attachment.id);
-			
-			await zp.renameSelectedAttachmentsFromParents();
-			assert.equal(attachment.attachmentFilename, 'Title.png');
-			assert.equal(attachment.getField('title'), 'test')
-		});
 	});
 	
 	

--- a/test/tests/zoteroPaneTest.js
+++ b/test/tests/zoteroPaneTest.js
@@ -1660,19 +1660,19 @@ describe("ZoteroPane", function() {
 				parentItemID: parentItem.id,
 			});
 			
-			// Add a PDF attachment, which will be renamed
+			// Add a PDF attachment, which will get a default title
 			let file = getTestDataDirectory();
 			file.append('test.pdf');
 			let [pdfAttachment1] = await zp.addAttachmentFromDialog(false, parentItem.id, [file.path]);
 			assert.equal(parentItem.getAttachments().length, 2);
 			assert.equal(pdfAttachment1.getField('title'), Zotero.getString('fileTypes.pdf'));
 			
-			// Add a second, which won't
+			// Add a second, which will get a title based on its filename
 			let [pdfAttachment2] = await zp.addAttachmentFromDialog(false, parentItem.id, [file.path]);
 			assert.equal(parentItem.getAttachments().length, 3);
-			assert.equal(pdfAttachment2.getField('title'), 'test.pdf');
+			assert.equal(pdfAttachment2.getField('title'), 'test');
 			
-			// Add an EPUB attachment, which will be renamed
+			// Add an EPUB attachment, which will get a default title
 			file = getTestDataDirectory();
 			file.append('stub.epub');
 			let [epubAttachment] = await zp.addAttachmentFromDialog(false, parentItem.id, [file.path]);

--- a/test/tests/zoteroPaneTest.js
+++ b/test/tests/zoteroPaneTest.js
@@ -671,7 +671,7 @@ describe("ZoteroPane", function() {
 			assert.equal(attachment.getField('title'), 'Image')
 		});
 		
-		it("should change attachment title if the same as filename", async function () {
+		it("should not change attachment title even if the same as filename", async function () {
 			var item = createUnsavedDataObject('item');
 			item.setField('title', 'Title');
 			await item.saveTx();
@@ -683,10 +683,10 @@ describe("ZoteroPane", function() {
 			
 			await zp.renameSelectedAttachmentsFromParents();
 			assert.equal(attachment.attachmentFilename, 'Title.png');
-			assert.equal(attachment.getField('title'), 'Title.png')
+			assert.equal(attachment.getField('title'), 'test.png')
 		});
 		
-		it("should change attachment title if the same as filename without extension", async function () {
+		it("should change attachment title even if the same as filename without extension", async function () {
 			var item = createUnsavedDataObject('item');
 			item.setField('title', 'Title');
 			await item.saveTx();
@@ -698,7 +698,7 @@ describe("ZoteroPane", function() {
 			
 			await zp.renameSelectedAttachmentsFromParents();
 			assert.equal(attachment.attachmentFilename, 'Title.png');
-			assert.equal(attachment.getField('title'), 'Title.png')
+			assert.equal(attachment.getField('title'), 'test')
 		});
 	});
 	


### PR DESCRIPTION
Addresses https://github.com/zotero/zotero/issues/4211#issuecomment-2217514461