### PR TITLE
fix focusring not appearing on linux

### DIFF
--- a/scss/base/_base.scss
+++ b/scss/base/_base.scss
@@ -17,7 +17,7 @@
 	}
 	@media (-moz-platform: linux) {
 		--color-accent: SelectedItem;
-		--color-focus-border: -moz-accent-color;
+		--color-focus-border: var(--color-accent);
 		--width-focus-border: 2px;
 	}
 	// Only used on Windows


### PR DESCRIPTION
`-moz-accent-color` variable doesn't seem to exist on linux. Use `--color-accent` as the focus border, same as what is already done in the reader.

Fixes: #4340