### PR TITLE
fixes to saved search dialog layout

### DIFF
--- a/chrome/content/zotero/searchDialog.xhtml
+++ b/chrome/content/zotero/searchDialog.xhtml
@@ -13,8 +13,7 @@
 	onunload="doUnload();"
 	drawintitlebar-platforms="mac"
 	xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
-	xmlns:html="http://www.w3.org/1999/xhtml"
-	style="padding:2em">
+	xmlns:html="http://www.w3.org/1999/xhtml">
 <dialog
 	id="zotero-search-dialog"
 	buttons="cancel,accept">

--- a/scss/elements/_zoteroSearch.scss
+++ b/scss/elements/_zoteroSearch.scss
@@ -46,11 +46,11 @@ zoterosearch {
 	}
 	
 	#conditionsmenu {
-		min-width: 15em;
+		width: 15em;
 	}
 	
-	#operatorsmenu {
-		min-width: 13em;
+	#operatorsmenu, #valuemenu, #valuefield, .search-in-the-last {
+		width: 12em;
 	}
 
 	#condition-tooltips tooltip


### PR DESCRIPTION
- remove padding between the `<dialog>` and the window edges
- explicit width for all zoterosearch fields because otherwise a menulist with a long content (e.g. longer collection name) name can push the + and - buttons outside of the window

Fixes: #4374

Before:

<img width="724" alt="Screenshot 2024-07-11 at 11 09 07 AM" src="https://github.com/zotero/zotero/assets/36271954/e056e3a2-b964-4cd7-a5c5-053b5e4b4007">

After:

<img width="623" alt="Screenshot 2024-07-11 at 10 58 20 AM" src="https://github.com/zotero/zotero/assets/36271954/126cc1ea-0d23-404d-8080-c2b88a2c7a53">
