### PR TITLE
Remove unneeded .trim from react-virtualized patch

### DIFF
--- a/js-build/babel-worker.js
+++ b/js-build/babel-worker.js
@@ -54,7 +54,7 @@ async function babelWorker(ev) {
 				throw new Error(`"_this.state.isScrolling || isScrollingChange(!0), _this.setState({" not found in react-virtualized`);
 			}
 			transformed = transformed.replace(onScrollSetStateChunkRegex, (_, p1, p2) => {
-				return `${p1}ReactDOM.flushSync(() => ${p2.trim()})`;
+				return `${p1}ReactDOM.flushSync(() => ${p2})`;
 			});
 		}
 		// Patch single-file


### PR DESCRIPTION
Followup to #4370, per https://github.com/zotero/zotero/pull/4370#discussion_r1674336402