### PR TITLE
No focus ring and background in CR readonly fields

### DIFF
--- a/scss/merge.scss
+++ b/scss/merge.scss
@@ -55,6 +55,12 @@ merge-group {
 	#right-pane groupbox:focus:not([selected=true]) h2 {
 		text-decoration: underline;
 	}
+
+	editable-text .input:read-only {
+		--width-focus-border: 0px !important;
+		--width-focus-outer-border: 0px !important;
+		background: transparent !important;
+	}
 }
 
 #resolve-all {


### PR DESCRIPTION
fix: #4138

Before: https://github.com/zotero/zotero/pull/4130#issuecomment-2117465957

Current:
<img width="830" alt="image" src="https://github.com/user-attachments/assets/9902a7e9-0d98-4dfa-aae6-5719f90ae6ff">
