### PR TITLE
save itemPane title/abstract fields on blur

### DIFF
--- a/chrome/content/zotero/elements/abstractBox.js
+++ b/chrome/content/zotero/elements/abstractBox.js
@@ -73,7 +73,7 @@
 			this.initCollapsibleSection();
 
 			this._abstractField = this.querySelector('editable-text');
-			this._abstractField.addEventListener('change', () => this.save());
+			this._abstractField.addEventListener('blur', () => this.save());
 			this._abstractField.ariaLabel = Zotero.getString('itemFields.abstractNote');
 			
 			this._feedAbstractBrowser = this.querySelector('browser');

--- a/chrome/content/zotero/elements/itemPaneHeader.js
+++ b/chrome/content/zotero/elements/itemPaneHeader.js
@@ -114,7 +114,7 @@
 			
 			this._bibEntryCache = new LRUCache();
 			
-			this.titleField.addEventListener('change', () => this.save());
+			this.titleField.addEventListener('blur', () => this.save());
 			this.titleField.ariaLabel = Zotero.getString('itemFields.title');
 			this.titleField.addEventListener('contextmenu', (event) => {
 				if (!this._item) return;


### PR DESCRIPTION
As opposed to `change` event.

Because if the field is editted and another window is focused while the cursor is in the field, the change event will be swallowed and when the field finally looses focus, it will not be saved.

This may address the reported [issue](https://forums.zotero.org/discussion/comment/468039/#Comment_468039) of edits not being saved in title and abstract fields.

Addresses: #4388