### PR TITLE
vpat 48: announce selection for default virtualized table

### DIFF
--- a/chrome/content/zotero/collectionTree.jsx
+++ b/chrome/content/zotero/collectionTree.jsx
@@ -220,8 +220,6 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 				}
 			}
 		}
-		// Update aria-activedescendant on the tree
-		this.forceUpdate();
 		if (shouldDebounce) {
 			this._onSelectionChangeDebounced();
 		}

--- a/chrome/content/zotero/components/virtualized-table.jsx
+++ b/chrome/content/zotero/components/virtualized-table.jsx
@@ -256,6 +256,7 @@ class TreeSelection {
 	_updateTree(shouldDebounce) {
 		if (!this.selectEventsSuppressed && this._tree.props.onSelectionChange) {
 			this._tree.props.onSelectionChange(this, shouldDebounce);
+			this._tree._setAriaAciveDescendant();
 		}
 	}
 
@@ -811,11 +812,6 @@ class VirtualizedTable extends React.Component {
 		else {
 			return;
 		}
-		// Set aria-activedescendant on table container in case if render() is not called after selection change
-		let selected = this._jsWindow?.getElementByIndex(this.selection.focused);
-		if (selected) {
-			selected.closest(".virtualized-table").setAttribute("aria-activedescendant", selected.id);
-		}
 
 		this.scrollToRow(index);
 	}
@@ -1286,12 +1282,6 @@ class VirtualizedTable extends React.Component {
 		if (this.props.role == 'treegrid') {
 			props['aria-readonly'] = true;
 		}
-		if (this.selection.count > 0) {
-			const elem = this._jsWindow && this._jsWindow.getElementByIndex(this.selection.focused);
-			if (elem) {
-				props['aria-activedescendant'] = elem.id;
-			}
-		}
 		let jsWindowProps = {
 			id: this._jsWindowID,
 			className: "virtualized-table-body",
@@ -1438,6 +1428,15 @@ class VirtualizedTable extends React.Component {
 		this.invalidate();
 		this._columns = new Columns(this);
 		await new Promise((resolve) => {this.forceUpdate(resolve)});
+	}
+	
+	// Set aria-activedescendant on table container
+	_setAriaAciveDescendant() {
+		if (!this.selection.focused) return;
+		let selected = this._jsWindow?.getElementByIndex(this.selection.focused);
+		if (selected) {
+			selected.closest(".virtualized-table").setAttribute("aria-activedescendant", selected.id);
+		}
 	}
 }
 

--- a/chrome/content/zotero/components/virtualized-table.jsx
+++ b/chrome/content/zotero/components/virtualized-table.jsx
@@ -811,6 +811,11 @@ class VirtualizedTable extends React.Component {
 		else {
 			return;
 		}
+		// Set aria-activedescendant on table container in case if render() is not called after selection change
+		let selected = this._jsWindow?.getElementByIndex(this.selection.focused);
+		if (selected) {
+			selected.closest(".virtualized-table").setAttribute("aria-activedescendant", selected.id);
+		}
 
 		this.scrollToRow(index);
 	}
@@ -1771,6 +1776,7 @@ function makeRowRenderer(getRowData) {
 		div.classList.toggle('selected', selection.isSelected(index));
 		div.classList.toggle('focused', selection.focused == index);
 		const rowData = getRowData(index);
+		let ariaLabel = "";
 		
 		if (columns.length) {
 			for (let column of columns) {
@@ -1782,12 +1788,18 @@ function makeRowRenderer(getRowData) {
 				else {
 					div.appendChild(renderCell(index, rowData[column.dataKey], column));
 				}
+				let columnName = column.label;
+				if (column.label in Zotero.Intl.strings) {
+					columnName = Zotero.getString(column.label);
+				}
+				ariaLabel += `${columnName}: ${rowData[column.dataKey]} `;
 			}
 		}
 		else {
 			div.appendChild(renderCell(index, rowData));
 		}
 
+		div.setAttribute("aria-label", ariaLabel);
 		return div;
 	};
 }

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -3121,8 +3121,6 @@ var ItemTree = class ItemTree extends LibraryTree {
 				this.tree.invalidateRow(this._rowMap[id]);
 			}
 		}
-		// Update aria-activedescendant on the tree
-		this.forceUpdate();
 		this.duplicateMouseSelection = false;
 		if (shouldDebounce) {
 			this._onSelectionChangeDebounced();


### PR DESCRIPTION
- set `aria-activedescendant` in `_onSelection` handler of virtualized table. For simpler virtualized tables (e.g. style manager in Zotero_Preferences.Cite), the table does not get re-rendered when selection changes, so `aria-activedescendant` does not get updated in `render()`, which means the screen reader is just quiet.
- construct and set aria-label for rows build via `makeRowRenderer` of VirtualizedTable so that is is announced when the row is selected