### PR TITLE
do not save edits on Escape in reader tags popup

### DIFF
--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -911,7 +911,7 @@ class ReaderInstance {
 		let tagsPopup = this._window.document.createXULElement('panel');
 		// <panel> completely takes over Escape keydown event, by attaching a capturing keydown
 		// listener to document which just closes the popup. It leads to unwanted edits being saved.
-		// Attach our own listener to this._window.document to properly handle Escape on editted tags
+		// Attach our own listener to this._window.document to properly handle Escape on edited tags
 		let handleKeyDown = (event) => {
 			if (event.key !== "Escape") return;
 			let focusedTag = tagsPopup.querySelector("editable-text.focused");
@@ -925,7 +925,7 @@ class ReaderInstance {
 					focusedTag.value = focusedTag.initialValue;
 				}
 			}
-			// now that all tags values are set, close the popup
+			// now that all tags values are reset, close the popup
 			tagsPopup.hidePopup();
 		};
 		tagsPopup.addEventListener('popuphidden', (event) => {


### PR DESCRIPTION
`<panel>` takes over Escape handling by just closing the popup via what looks like a capturing listener on `document`, since Escape keydown events never even reach the popup itself. When the popup is just closed like that, tagsBox is blurred so all unwanted edits get saved.

To properly handle Escape, attach our own capturing listener that will reset all edits before the popup is closed.

Followup to https://github.com/zotero/zotero/commit/a73035c848668d2c03a7e81a7897e2a67e5b7b2d
Fixes: #4398