### PR TITLE
vpat 59: make quickFormat reference box separator text darker

### DIFF
--- a/chrome/content/zotero/integration/quickFormat.js
+++ b/chrome/content/zotero/integration/quickFormat.js
@@ -1438,6 +1438,9 @@ var Zotero_QuickFormat = new function () {
 		// Try to make the panel appear right in the center on windows
 		let leftMargin = Zotero.isWin ? 5 : 15;
 		referencePanel.openPopup(dialog, "after_start", leftMargin, 0, false, false, null);
+		// Initially, panel has an opacity of 0.9 to not display the shadow behind it but we override
+		// it upon the first opening for the panel to not look transparent on windows
+		referencePanel.style.opacity = "1";
 	}
 	
 	/**

--- a/chrome/content/zotero/integration/quickFormat.js
+++ b/chrome/content/zotero/integration/quickFormat.js
@@ -1438,8 +1438,8 @@ var Zotero_QuickFormat = new function () {
 		// Try to make the panel appear right in the center on windows
 		let leftMargin = Zotero.isWin ? 5 : 15;
 		referencePanel.openPopup(dialog, "after_start", leftMargin, 0, false, false, null);
-		// Initially, panel has an opacity of 0.9 to not display the shadow behind it but we override
-		// it upon the first opening for the panel to not look transparent on windows
+		// Initially, panel has an opacity of 0.9 to prevent a shadow from appearing behind the
+		// panel on Windows, but we override it upon the first opening of the panel
 		referencePanel.style.opacity = "1";
 	}
 	

--- a/chrome/skin/default/zotero/integration.css
+++ b/chrome/skin/default/zotero/integration.css
@@ -241,7 +241,7 @@
 	font-size: 12px;
 	font: -moz-field;
 	-moz-user-focus: ignore;
-	color: rgb(87, 87, 87);
+	color: var(--fill-secondary);
 }
 
 richlistitem[selected="true"] {

--- a/chrome/skin/default/zotero/integration.css
+++ b/chrome/skin/default/zotero/integration.css
@@ -241,7 +241,7 @@
 	font-size: 12px;
 	font: -moz-field;
 	-moz-user-focus: ignore;
-	color: gray;
+	color: rgb(87, 87, 87);
 }
 
 richlistitem[selected="true"] {

--- a/scss/themes/_light.scss
+++ b/scss/themes/_light.scss
@@ -15,7 +15,7 @@ $-colors: (
     accent-yellow: #faa700,
     accent-highlight: #ffea0080,
     fill-primary: #000000d9,
-    fill-secondary: #00000080,
+    fill-secondary: #0000008c,
     fill-tertiary: #00000040,
     fill-quarternary: #0000001a,
     fill-quinary: #0000000d,


### PR DESCRIPTION
So that on windows, the separator text on white background has a high enough contrast ratio for accessibility.

Old `gray` color (`rgb(128, 128, 128)` or `#808080`) for separator text has a contrast ratio with the white background of reference box of ~3.94, which is below all minimum requirements.

This makes separator text a bit darker `rgb(87, 87, 87)` or `#575757` to make sure there is more contrast.

Tested via: https://webaim.org/resources/contrastchecker/

Before:

<img width="801" alt="Screenshot 2024-07-16 at 5 41 13 PM" src="https://github.com/user-attachments/assets/7ef9e9b1-8c59-4403-b3cc-f65f692c8dbd">

After:

<img width="817" alt="Screenshot 2024-07-16 at 5 40 20 PM" src="https://github.com/user-attachments/assets/cb0b8aec-2ef3-4893-807b-3b995b113be0">
