### PR TITLE
vpat 80: focus first field in search window/dialog

### DIFF
--- a/chrome/content/zotero/advancedSearch.js
+++ b/chrome/content/zotero/advancedSearch.js
@@ -91,7 +91,7 @@ var ZoteroAdvancedSearch = new function() {
 
 		this.itemsView.changeCollectionTreeRow(collectionTreeRow);
 		// Focus the first field in the window
-		Services.focus.moveFocus(window, sbc, Services.focus.MOVEFOCUS_FORWARD, 0);
+		Services.focus.moveFocus(window, null, Services.focus.MOVEFOCUS_FORWARD, 0);
 	}
 	
 	this.onUnload = function () {

--- a/chrome/content/zotero/advancedSearch.js
+++ b/chrome/content/zotero/advancedSearch.js
@@ -90,6 +90,8 @@ var ZoteroAdvancedSearch = new function() {
 		};
 
 		this.itemsView.changeCollectionTreeRow(collectionTreeRow);
+		// Focus the first field in the window
+		Services.focus.moveFocus(window, sbc, Services.focus.MOVEFOCUS_FORWARD, 0);
 	}
 	
 	this.onUnload = function () {

--- a/chrome/content/zotero/elements/zoteroSearch.js
+++ b/chrome/content/zotero/elements/zoteroSearch.js
@@ -631,8 +631,6 @@
 			}
 			
 			this.onConditionSelected(menu.value);
-			
-			this.querySelector('#conditionsmenu').focus();
 		}
 
 		updateSearch() {

--- a/chrome/content/zotero/searchDialog.js
+++ b/chrome/content/zotero/searchDialog.js
@@ -43,6 +43,8 @@ function doLoad()
 	document.getElementById('search-name').value = io.dataIn.name;
 
 	document.addEventListener('dialogaccept', doAccept);
+	// Focus the first focusable node in the dialog
+	Services.focus.moveFocus(window, sbc, Services.focus.MOVEFOCUS_FORWARD, 0);
 }
 
 function doUnload()

--- a/chrome/content/zotero/searchDialog.js
+++ b/chrome/content/zotero/searchDialog.js
@@ -42,7 +42,7 @@ function doLoad()
 	searchBox.search = io.dataIn.search;
 	let searchName = document.getElementById('search-name');
 	searchName.value = io.dataIn.name;
-	searchName.setSelectionRange(0, searchName.value.length, "backward");
+	searchName.select();
 
 	document.addEventListener('dialogaccept', doAccept);
 }

--- a/chrome/content/zotero/searchDialog.js
+++ b/chrome/content/zotero/searchDialog.js
@@ -40,11 +40,11 @@ function doLoad()
 	var searchBox = document.getElementById('search-box');
 	searchBox.groups = io.dataIn.groups;
 	searchBox.search = io.dataIn.search;
-	document.getElementById('search-name').value = io.dataIn.name;
+	let searchName = document.getElementById('search-name');
+	searchName.value = io.dataIn.name;
+	searchName.setSelectionRange(0, searchName.value.length, "backward");
 
 	document.addEventListener('dialogaccept', doAccept);
-	// Focus the first focusable node in the dialog
-	Services.focus.moveFocus(window, sbc, Services.focus.MOVEFOCUS_FORWARD, 0);
 }
 
 function doUnload()

--- a/chrome/content/zotero/searchDialog.xhtml
+++ b/chrome/content/zotero/searchDialog.xhtml
@@ -35,7 +35,7 @@
 	
 	<vbox id="zotero-search-box-container" flex="1">
 		<hbox align="center">
-			<label value="&zotero.search.name;"/>
+			<label control="search-name" value="&zotero.search.name;"/>
 			<html:input id="search-name" type="text" width="275" maxlength="80"/>
 		</hbox>
 		<zoterosearch id="search-box" flex="1"/>


### PR DESCRIPTION
Instead of focusing the first condition, which ends up placing focus in the middle of the new window or modal. It is best to focus the first node, which is the general convention, per https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/, and what many screen reader users expect. When we focus a field in the middle of the window/dialog, it makes it seem for some users that this is the first node, which will make them miss all the fields above it.

Also, linked search name input to its label in searchDialog.xhtml.

For reference, comment from the vpat issue:

"Impact Statement: When focus is placed in the middle of a modal, verses being placed at the beginning of the content, it is likely that fields may be overlooked. Additionally, this may cause frustration as the user must backtrack to the beginning of the modal. Those who rely upon assistive technology may not see that they are placed in the middle unless exploring the search feature before hand."