### PR TITLE
Restore autoscroll support in reader

### DIFF
--- a/chrome/content/zotero/actors/ActorManager.jsm
+++ b/chrome/content/zotero/actors/ActorManager.jsm
@@ -1,5 +1,8 @@
 var EXPORTED_SYMBOLS = [];
 
+// Register Mozilla actors
+ChromeUtils.importESModule("resource://gre/modules/ActorManagerParent.sys.mjs");
+
 ChromeUtils.registerWindowActor("PageData", {
 	child: {
 		moduleURI: "chrome://zotero/content/actors/PageDataChild.jsm"

--- a/scss/components/_mainWindow.scss
+++ b/scss/components/_mainWindow.scss
@@ -1,4 +1,4 @@
-:is(panel)::part(content) {
+:is(panel):not(#autoscroller)::part(content) {
 	--panel-background: var(--material-toolbar);
 }
 

--- a/scss/win/_menupopup.scss
+++ b/scss/win/_menupopup.scss
@@ -1,4 +1,4 @@
-menupopup, panel, #search-mode-popup {
+menupopup, panel:not(#autoscroller), #search-mode-popup {
 	--panel-border-radius: 8px;
 	--panel-background: var(--material-toolbar);
 	--menuitem-hover-background-color: var(--fill-quinary);


### PR DESCRIPTION
- Mozilla's `ActorManagerParent` was only being imported when devtools were initialized (either by opening the Error Console or by connecting via remote debugging). Import it in our `ActorManager` so Mozilla actors, including `AutoScroll`, are always registered.
   - This may have other effects! I'm assuming most of us test with the error console visible, though, so we would've had Mozilla actors, while users running without devtools wouldn't have. We definitely want those actors. (Most of them, at least.)
- Don't override autoscroller styles with our panel customizations.

Fixes #4384