### PR TITLE
Implement Select Items dialog redesign

### DIFF
--- a/chrome/content/zotero/selectItemsDialog.js
+++ b/chrome/content/zotero/selectItemsDialog.js
@@ -30,6 +30,7 @@ var itemsView;
 var collectionsView;
 var loaded;
 var io;
+const isSelectItemsDialog = !!document.querySelector('#zotero-select-items-dialog');
 const isEditBibliographyDialog = !!document.querySelector('#zotero-edit-bibliography-dialog');
 const isAddEditItemsDialog = !!document.querySelector('#zotero-add-citation-dialog');
 
@@ -38,6 +39,18 @@ const isAddEditItemsDialog = !!document.querySelector('#zotero-add-citation-dial
  * io - used for input/output (dataOut is list of item IDs)
  */
 var doLoad = async function () {
+	// Move the dialog button box into the items pane
+	let itemsContainer = document.getElementById('zotero-items-tree-container');
+	// TEMP: Only if we're in the redesigned Select Items dialog, not the
+	// classic Add Citation dialog, or the Edit Bibliography dialog
+	// (until we redesign that too)
+	if (isSelectItemsDialog) {
+		let buttonBox = document.querySelector('dialog')
+			.shadowRoot
+			.querySelector('.dialog-button-box');
+		itemsContainer.append(buttonBox);
+	}
+	
 	// Set font size from pref
 	var sbc = document.getElementById('zotero-select-items-container');
 	Zotero.UIProperties.registerRoot(sbc);

--- a/chrome/content/zotero/selectItemsDialog.js
+++ b/chrome/content/zotero/selectItemsDialog.js
@@ -51,6 +51,9 @@ var doLoad = async function () {
 		itemsContainer.append(buttonBox);
 	}
 	
+	let searchBar = document.getElementById('zotero-tb-search');
+	searchBar.searchTextbox.select();
+
 	// Set font size from pref
 	var sbc = document.getElementById('zotero-select-items-container');
 	Zotero.UIProperties.registerRoot(sbc);

--- a/chrome/content/zotero/selectItemsDialog.xhtml
+++ b/chrome/content/zotero/selectItemsDialog.xhtml
@@ -40,6 +40,7 @@
 	onunload="doUnload();"
 	persist="screenX screenY width height"
 	class="zotero-dialog"
+	chromemargin="0,0,0,0"
 >
 <dialog
 	id="select-items-dialog"
@@ -55,16 +56,18 @@
 </script>
 
 <vbox id="zotero-select-items-container" flex="1">
-	<hbox id="search-toolbar">
-		<quick-search-textbox id="zotero-tb-search" timeout="250" oncommand="onSearch()" dir="reverse"/>
-	</hbox>
 	<hbox id="collections-items-container">
 		<vbox id="zotero-collections-tree-container" class="virtualized-table-container">
-			<html:div id="zotero-collections-tree"></html:div>
+			<html:div id="zotero-collections-tree"/>
 		</vbox>
-		<hbox id="zotero-items-pane-content" class="virtualized-table-container" flex="1">
-			<html:div id="zotero-items-tree"></html:div>
-		</hbox>
+		<vbox id="zotero-items-tree-container" flex="1">
+			<hbox id="search-toolbar">
+				<quick-search-textbox id="zotero-tb-search" timeout="250" oncommand="onSearch()" dir="reverse"/>
+			</hbox>
+			<hbox id="zotero-items-pane-content" class="virtualized-table-container">
+				<html:div id="zotero-items-tree"/>
+			</hbox>
+		</vbox>
 	</hbox>
 </vbox>
 </dialog>

--- a/scss/components/_selectItemsDialog.scss
+++ b/scss/components/_selectItemsDialog.scss
@@ -5,36 +5,65 @@
 }
 
 #select-items-dialog {
-    padding: 2em;
+    padding: 0;
+    appearance: none;
+    background: var(--material-background);
+
+    #collections-items-container {
+        flex: 1 1 auto;
+    }
 
     #zotero-select-items-container {
         display: flex;
         flex-direction: column;
-        gap: 8px;
     }
 
     #zotero-collections-tree-container {
         min-width: 200px;
 		min-height: 100%;
+        padding: 16px 8px; // Collection tree table already has 8px inline padding
+        background: var(--material-sidepane);
+        border-inline-end: var(--material-panedivider);
+    }
+
+    #zotero-collections-tree {
+        background: var(--material-sidepane);
     }
 
 	#zotero-items-pane-content {
-		min-height: 100%;
+        // Please do not become infinitely tall
+		min-height: 0;
+        flex: 1;
+        flex-basis: 0;
 	}
+
+    #search-toolbar, .dialog-button-box {
+        padding: 16px;
+    }
 
     #search-toolbar {
         display: flex;
         flex-direction: row;
         justify-content: flex-end;
-    }
-
-    #search-toolbar {
         flex: 0 0 auto;
     }
 
-    #collections-items-container {
-        flex: 1 1 auto;
-        margin-bottom: 8px;
+    #zotero-items-pane-content, .dialog-button-box {
+        border-top: var(--material-border-quarternary);
+    }
+    
+    // Draggable areas:
+    #zotero-collections-tree-container,
+    #search-toolbar,
+    .dialog-button-box {
+        -moz-window-dragging: drag;
+    }
+
+    // Non-draggable sub-areas:
+    #zotero-collections-tree-container .windowed-list,
+    #search-toolbar quick-search-textbox,
+    .dialog-button-box button {
+        -moz-window-dragging: no-drag;
     }
 }
 

--- a/scss/components/_selectItemsDialog.scss
+++ b/scss/components/_selectItemsDialog.scss
@@ -1,6 +1,6 @@
 #zotero-select-items-dialog {
     display: flex;
-    min-width: 600px;
+    min-width: 800px;
     min-height: 450px;
 }
 
@@ -21,7 +21,7 @@
     #zotero-collections-tree-container {
         min-width: 200px;
 		min-height: 100%;
-        padding: 16px 8px; // Collection tree table already has 8px inline padding
+        padding: 16px 0;
         background: var(--material-sidepane);
         border-inline-end: var(--material-panedivider);
     }
@@ -46,6 +46,14 @@
         flex-direction: row;
         justify-content: flex-end;
         flex: 0 0 auto;
+    }
+    
+    .dialog-button-box {
+        gap: 8px;
+        
+        button {
+            margin: 0;
+        }
     }
 
     #zotero-items-pane-content, .dialog-button-box {


### PR DESCRIPTION
Looks neat!

<img width="822" alt="Screenshot 2024-07-18 at 3 55 33 PM" src="https://github.com/user-attachments/assets/28c600b9-bc2e-4fc4-98a0-0e554d11ee6a">

I didn't touch the other dialogs that use the same infrastructure (classic Add Citation, Edit Bibliography). The latter, at least, could do with a touch-up, but I don't think we have a mockup for that yet.

Closes #4320

