### PR TITLE
vpat 25: idea to make prefs visible to jaws cursor?

### DIFF
--- a/chrome/content/zotero/browser_wrapper.xhtml
+++ b/chrome/content/zotero/browser_wrapper.xhtml
@@ -8,32 +8,39 @@
 		width="800"
 		height="600"
 		style="display: flex;">
-	
-	<browser style="width:100%;height:100%"/>
-
 	<script>
-		let browser = document.querySelector("browser");
-		
-		browser.addEventListener("DOMContentLoaded", (e) => {
-			if (!browser.getAttribute("src")) return;
-			// When the content of browser is loaded, pass over arguments and copy its title
-			browser.contentWindow.arguments = window.arguments;
-			document.title = browser.contentDocument.title;
-			// Set the same min-width/min-height as the browser's content
-			let dialogStyle = browser.contentWindow.getComputedStyle(browser.contentDocument.querySelector("window"));
-			if (dialogStyle.getPropertyValue("min-width")) {
-				document.querySelector("window").style.minWidth = dialogStyle.getPropertyValue("min-width");
+		var init = (url, options) => {
+			let browser = document.createXULElement("browser");
+			if (!options.noType) {
+				browser.setAttribute("type", "content");
 			}
-			if (dialogStyle.getPropertyValue("min-height")) {
-				document.querySelector("window").style.minHeight = dialogStyle.getPropertyValue("min-height");
-			}
-		}, true);
-		// Without it, the window won't close if the browser contains a dialog
-		browser.addEventListener("dialogaccept", (e) => {
-			window.close();
-		});
-		browser.addEventListener("dialogcancel", (e) => {
-			window.close();
-		});
+			browser.style = "width: 100%;height: 100%";
+
+			browser.addEventListener("DOMContentLoaded", (e) => {
+				if (!browser.getAttribute("src")) return;
+				// When the content of browser is loaded, pass over arguments and copy its title
+				browser.contentWindow.arguments = window.arguments;
+				document.title = browser.contentDocument.title;
+				// Set the same min-width/min-height as the browser's content
+				let dialogStyle = browser.contentWindow.getComputedStyle(browser.contentDocument.querySelector("window"));
+				if (dialogStyle.getPropertyValue("min-width")) {
+					document.querySelector("window").style.minWidth = dialogStyle.getPropertyValue("min-width");
+				}
+				if (dialogStyle.getPropertyValue("min-height")) {
+					document.querySelector("window").style.minHeight = dialogStyle.getPropertyValue("min-height");
+				}
+			}, true);
+			// Without it, the window won't close if the browser contains a dialog
+			browser.addEventListener("dialogaccept", (e) => {
+				window.close();
+			});
+			browser.addEventListener("dialogcancel", (e) => {
+				window.close();
+			});
+
+			document.querySelector("window").append(browser);
+			browser.setAttribute("src", url);
+		}
+		window.init = init;
 	</script>
 </window>

--- a/chrome/content/zotero/browser_wrapper.xhtml
+++ b/chrome/content/zotero/browser_wrapper.xhtml
@@ -1,0 +1,39 @@
+<?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
+<?xml-stylesheet href="chrome://zotero/skin/zotero.css" type="text/css"?>
+<?xml-stylesheet href="chrome://zotero-platform/content/zotero.css" type="text/css"?>
+<window id="zotero-dialog-wrapper"
+		windowtype="zotero:wrapper"
+		xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
+		xmlns:html="http://www.w3.org/1999/xhtml"
+		width="800"
+		height="600"
+		style="display: flex;">
+	
+	<browser style="width:100%;height:100%"/>
+
+	<script>
+		let browser = document.querySelector("browser");
+		
+		browser.addEventListener("DOMContentLoaded", (e) => {
+			if (!browser.getAttribute("src")) return;
+			// When the content of browser is loaded, pass over arguments and copy its title
+			browser.contentWindow.arguments = window.arguments;
+			document.title = browser.contentDocument.title;
+			// Set the same min-width/min-height as the browser's content
+			let dialogStyle = browser.contentWindow.getComputedStyle(browser.contentDocument.querySelector("window"));
+			if (dialogStyle.getPropertyValue("min-width")) {
+				document.querySelector("window").style.minWidth = dialogStyle.getPropertyValue("min-width");
+			}
+			if (dialogStyle.getPropertyValue("min-height")) {
+				document.querySelector("window").style.minHeight = dialogStyle.getPropertyValue("min-height");
+			}
+		}, true);
+		// Without it, the window won't close if the browser contains a dialog
+		browser.addEventListener("dialogaccept", (e) => {
+			window.close();
+		});
+		browser.addEventListener("dialogcancel", (e) => {
+			window.close();
+		});
+	</script>
+</window>

--- a/chrome/content/zotero/preferences/preferences.xhtml
+++ b/chrome/content/zotero/preferences/preferences.xhtml
@@ -93,7 +93,7 @@
 					hidden="true"/>
 				<search-textbox id="prefs-search" placeholder="&zotero.lookup.button.search;" timeout="1"/>
 			</html:div>
-			<html:div id="prefs-content">
+			<html:div id="prefs-content" role="document">
 				<html:div id="prefs-help-container">
 					<button
 						oncommand="Zotero_Preferences.openHelpLink()"

--- a/chrome/content/zotero/standalone/hiddenWindow.xhtml
+++ b/chrome/content/zotero/standalone/hiddenWindow.xhtml
@@ -69,13 +69,16 @@
 				win.focus();
 			}
 			else {
-				Services.ww.openWindow(
+				let win = Services.ww.openWindow(
 					null,
-					'chrome://zotero/content/preferences/preferences.xhtml',
+					'chrome://zotero/content/browser_wrapper.xhtml',
 					'zotero-prefs',
 					'chrome,titlebar,centerscreen,resizable=yes',
 					null
 				);
+				win.addEventListener("load", (e) => {
+					win.document.querySelector("browser").setAttribute("src", 'chrome://zotero/content/preferences/preferences.xhtml');
+				});
 			}
 		}
 	</script>

--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -1714,21 +1714,26 @@ Zotero.Utilities.Internal = {
 			scrollTo: options.scrollTo,
 		};
 		let args = [
-			'chrome://zotero/content/preferences/preferences.xhtml',
+			'chrome://zotero/content/browser_wrapper.xhtml',
 			'zotero-prefs',
 			'chrome,titlebar,centerscreen,resizable=yes',
 			io
 		];
 		
 		let mainWindow = Services.wm.getMostRecentWindow("navigator:browser");
+		let openedWin;
 		if (mainWindow) {
-			return mainWindow.openDialog(...args);
+			openedWin = mainWindow.openDialog(...args);
 		}
 		else {
 			// nsIWindowWatcher needs a wrappedJSObject
 			args[args.length - 1].wrappedJSObject = args[args.length - 1];
-			return Services.ww.openWindow(null, ...args);
+			openedWin = Services.ww.openWindow(null, ...args);
 		}
+		openedWin.addEventListener("load", (_) => {
+			openedWin.document.querySelector("browser").setAttribute("src", 'chrome://zotero/content/preferences/preferences.xhtml');
+		});
+		return openedWin;
 	},
 	
 	

--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -1714,26 +1714,12 @@ Zotero.Utilities.Internal = {
 			scrollTo: options.scrollTo,
 		};
 		let args = [
-			'chrome://zotero/content/browser_wrapper.xhtml',
+			'chrome://zotero/content/preferences/preferences.xhtml',
 			'zotero-prefs',
 			'chrome,titlebar,centerscreen,resizable=yes',
 			io
 		];
-		
-		let mainWindow = Services.wm.getMostRecentWindow("navigator:browser");
-		let openedWin;
-		if (mainWindow) {
-			openedWin = mainWindow.openDialog(...args);
-		}
-		else {
-			// nsIWindowWatcher needs a wrappedJSObject
-			args[args.length - 1].wrappedJSObject = args[args.length - 1];
-			openedWin = Services.ww.openWindow(null, ...args);
-		}
-		openedWin.addEventListener("load", (_) => {
-			openedWin.document.querySelector("browser").setAttribute("src", 'chrome://zotero/content/preferences/preferences.xhtml');
-		});
-		return openedWin;
+		return Zotero.openWindowInBrowserWrapper(...args);
 	},
 	
 	

--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -973,6 +973,21 @@ Services.scriptloader.loadSubScript("resource://zotero/polyfill.js");
 			.getService(Components.interfaces.nsIWindowWatcher);
 		ww.openWindow(null, chromeURI, '_blank', flags, null);
 	}
+	// In works - one function to open a dialog inside of a window's <browser>
+	this.openWindowInWrapper = function (_, name, link, params, io) {
+		let args = [...arguments];
+		let wrapperUrl = 'chrome://zotero/content/browser_wrapper.xhtml';
+		
+		let url = args[1];
+		args[1] = wrapperUrl;
+		args[args.length - 1].wrappedJSObject = args[args.length - 1];
+		let win = Services.ww.openWindow(...args);
+		
+		win.addEventListener("load", (e) => {
+			win.document.querySelector("browser").setAttribute("src", url);
+		});
+		return win;
+	};
 	
 	
 	this.openCheckForUpdatesWindow = function ({ modal } = {}) {

--- a/test/tests/bibliographyTest.js
+++ b/test/tests/bibliographyTest.js
@@ -19,14 +19,15 @@ describe("Create Bibliography Dialog", function () {
 		var deferred = Zotero.Promise.defer();
 		var called = false;
 		waitForWindow("chrome://zotero/content/bibliography.xhtml", function (dialog) {
-			waitForWindow("chrome://zotero/content/preferences/preferences.xhtml", function (window) {
+			waitForWindow("chrome://zotero/content/browser_wrapper.xhtml", function (window) {
+				let browser = window.document.querySelector("browser");
 				// Wait for switch to Cite pane
 				(async function () {
 					do {
 						Zotero.debug("Checking for pane");
 						await Zotero.Promise.delay(5);
 					}
-					while (!window.document.querySelector('[value=zotero-prefpane-cite]').selected);
+					while (!browser.getAttribute("src") && !browser.contentDocument.querySelector('[value=zotero-prefpane-cite]')?.selected);
 					called = true;
 					window.close();
 					deferred.resolve();


### PR DESCRIPTION
VPAT 25 issue boils down to important text in the preferences (e.g. Export > > QuickCopy notes at the top) not being visible for some screen readers' (mainly nvda/jaws) cursors, which means they are not currently readable. Similarly, we have vpat 46 which mentions that sections do not get announced by JAWS.

The issue is solved easily for NVDA by adding `role="document"` to the container of preferences content, after which it can switch between browse and focus mode to, if needed, read the text. This is an [example](https://www.dropbox.com/scl/fi/ed7n4otsndlacacm9u8fr/1_nvda_working.mov?rlkey=kinyohqb6bd8b71hdisbounsq&st=jzfh0npk&dl=0).

Unfortunately, it does not help JAWS (this is JAWS with the first commit only with unchanged behavior: [recording](https://www.dropbox.com/scl/fi/2ieqepljdnmo67x9jhmmq/1_jaws_not_working.mov?rlkey=frum5dsxsvmti894n5som9cdt&st=9j5b9i1l&dl=0)). Because in some cases JAWS is configured to not use the virtual cursor, I am guessing the root of the issue is similar to what we had with the window class in #3930, where we have to fit into what JAWS is set up to do. This issue only applies to XUL windows - JAWS has no problems, for instance, in reader tabs loaded into `<browser>`. So as a workaround for this (and potentially other issues) I thought what if we load the preferences.xhtml into a browser of a new window, similar to what we do with reader tabs? I believe this is what firefox and thunderbird do as well.

This is just a draft in which JAWS works ([recording](https://www.dropbox.com/scl/fi/u1941qhyuqogtbp1gqy48/2_jaws_working.mov?rlkey=jii35f5ahstquiuy6o5hl04go&st=umaf0909&dl=0)) as expected thought there obviously is some breakage with how the window looks

Before continuing down this road, I wanted to check if there is any reason to not do this that I may not know? Is there anything specific to keep in mind before going further?

There are alternative workarounds to getting JAWS to read the text in the settings (as well as other places where this issue may be relevant) but none of the ones I thought of seem as good. We could link all text nodes as `aria-describedby` to some of the focusable nodes but there may not be a great candidate to link the text to (e.g. quick format instructions). For section headers, we could make the entire section focusable and add them as `aria-labelledby` to the actual section (which would add a bunch of extra  tab stops).

@dstillman what do you think about all this? It could be that I am really overthinking it and a adding a few extra tabstops by making each section focusable, adding section headers as `aria-label`s (for jaws), and linking text to relevant nodes (or section if no checkboxes or inputs apply) with `aria-describedby` is not as bad as it seemed to me at first and we should do just that (edit: though this does leave it up to JAWS to read all `aria-describedby` which, as I just tried, is not very reliable). But I was also thinking that since JAWS still struggles with inputs particularly in dialogs (#4205) maybe loading window content through the `<browser>` is not a bad idea to explore (again, since firefox and thunderbird do it almost everywhere) in case we want to apply it elsewhere.
