### PR TITLE
vpat 16: context menu as a drag-drop alternative to move collections

### DIFF
--- a/chrome/content/zotero/collectionTree.jsx
+++ b/chrome/content/zotero/collectionTree.jsx
@@ -1976,7 +1976,14 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 				
 				// Recursively copy subcollections
 				if (desc.children.length) {
-					await this._copyCollections({ descendents: desc.children, parentID: collectionID, addItems, targetLibraryID, targetTreeRow, copyOptions });
+					await this._copyCollections({
+						descendents: desc.children,
+						parentID: collectionID,
+						addItems,
+						targetLibraryID,
+						targetTreeRow,
+						copyOptions
+					});
 				}
 			}
 			// Items
@@ -1985,7 +1992,12 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 				let id = desc.id;
 				// Actually copy items only if moving to another library
 				if (item.libraryID !== targetLibraryID) {
-					id = await this._copyItem({ item, targetLibraryID, targetTreeRow, options: copyOptions });
+					id = await this._copyItem({
+						item,
+						targetLibraryID,
+						targetTreeRow,
+						options: copyOptions
+					});
 					// Standalone attachments might not get copied
 					if (!id) {
 						continue;
@@ -2034,7 +2046,14 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 			}];
 			
 			var addItems = new Map();
-			await this._copyCollections({ descendents: collections, parentID: targetCollectionID, addItems, targetLibraryID, targetTreeRow, copyOptions });
+			await this._copyCollections({
+				descendents: collections,
+				parentID: targetCollectionID,
+				addItems,
+				targetLibraryID,
+				targetTreeRow,
+				copyOptions
+			});
 			for (let [collectionID, items] of addItems.entries()) {
 				let collection = await Zotero.Collections.getAsync(collectionID);
 				await collection.addItems(items);
@@ -2083,7 +2102,13 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 			var droppedCollection = await Zotero.Collections.getAsync(data[0]);
 			// Collection drag between libraries
 			if (targetLibraryID != droppedCollection.libraryID) {
-				await this.executeCollectionCopy({ collection: droppedCollection, targetCollectionID, targetLibraryID, targetTreeRow, copyOptions });
+				await this.executeCollectionCopy({
+					collection: droppedCollection,
+					targetCollectionID,
+					targetLibraryID,
+					targetTreeRow,
+					copyOptions
+				});
 			}
 			// Collection drag within a library
 			else {
@@ -2163,7 +2188,12 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 					function (chunk) {
 						return Zotero.DB.executeTransaction(async () => {
 							for (let item of chunk) {
-								var id = await this._copyItem({ item, targetLibraryID, targetTreeRow, options: copyOptions })
+								var id = await this._copyItem({
+									item,
+									targetLibraryID,
+									targetTreeRow,
+									options: copyOptions
+								});
 								// Standalone attachments might not get copied
 								if (!id) {
 									continue;

--- a/chrome/content/zotero/collectionTree.jsx
+++ b/chrome/content/zotero/collectionTree.jsx
@@ -1796,7 +1796,249 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 		}
 		return true;
 	}
+
+	/**
+	 * Copy a given item into another library. Used when we need to create a copy of a collection
+	 * in another library if collection is drag-dropped into a group it is not a part of.
+	 */
+	async _copyItem({ item, targetLibraryID, targetTreeRow, options }) {
+		// Check if there's already a copy of this item in the library
+		var linkedItem = await item.getLinkedItem(targetLibraryID, true);
+		if (linkedItem) {
+			// If linked item is in the trash, undelete it and remove it from collections
+			// (since it shouldn't be restored to previous collections)
+			if (linkedItem.deleted) {
+				linkedItem.setCollections();
+				linkedItem.deleted = false;
+				await linkedItem.save({
+					skipSelect: true
+				});
+			}
+			return linkedItem.id;
+			
+			/*
+			// TODO: support tags, related, attachments, etc.
+			
+			// Overlay source item fields on unsaved clone of linked item
+			var newItem = item.clone(false, linkedItem.clone(true));
+			newItem.setField('dateAdded', item.dateAdded);
+			newItem.setField('dateModified', item.dateModified);
+			
+			var diff = newItem.diff(linkedItem, false, ["dateAdded", "dateModified"]);
+			if (!diff) {
+				// Check if creators changed
+				var creatorsChanged = false;
+				
+				var creators = item.getCreators();
+				var linkedCreators = linkedItem.getCreators();
+				if (creators.length != linkedCreators.length) {
+					Zotero.debug('Creators have changed');
+					creatorsChanged = true;
+				}
+				else {
+					for (var i=0; i<creators.length; i++) {
+						if (!creators[i].ref.equals(linkedCreators[i].ref)) {
+							Zotero.debug('changed');
+							creatorsChanged = true;
+							break;
+						}
+					}
+				}
+				if (!creatorsChanged) {
+					Zotero.debug("Linked item hasn't changed -- skipping conflict resolution");
+					continue;
+				}
+			}
+			toReconcile.push([newItem, linkedItem]);
+			continue;
+			*/
+		}
+		
+		// Standalone attachment
+		if (item.isAttachment()) {
+			var linkMode = item.attachmentLinkMode;
+			
+			// Skip linked files
+			if (linkMode == Zotero.Attachments.LINK_MODE_LINKED_FILE) {
+				Zotero.debug("Skipping standalone linked file attachment on drag");
+				return false;
+			}
+			
+			if (!targetTreeRow.filesEditable) {
+				Zotero.debug("Skipping standalone file attachment on drag");
+				return false;
+			}
+			
+			let newAttachment = await Zotero.Attachments.copyAttachmentToLibrary(item, targetLibraryID);
+			if (options.annotations) {
+				await Zotero.Items.copyChildItems(item, newAttachment);
+			}
+			
+			return newAttachment.id;
+		}
+		
+		// Create new clone item in target library
+		var newItem = item.clone(targetLibraryID, { skipTags: !options.tags });
+		
+		var newItemID = await newItem.save({
+			skipSelect: true
+		});
+		
+		// Record link
+		await newItem.addLinkedItem(item);
+		
+		if (item.isNote()) {
+			if (Zotero.Libraries.get(newItem.libraryID).filesEditable) {
+				await Zotero.Notes.copyEmbeddedImages(item, newItem);
+			}
+			return newItemID;
+		}
+		
+		// For regular items, add child items if prefs and permissions allow
+		
+		// Child notes
+		if (options.childNotes) {
+			var noteIDs = item.getNotes();
+			var notes = Zotero.Items.get(noteIDs);
+			for (let note of notes) {
+				let newNote = note.clone(targetLibraryID, { skipTags: !options.tags });
+				newNote.parentID = newItemID;
+				await newNote.save({
+					skipSelect: true
+				})
+
+				if (Zotero.Libraries.get(newNote.libraryID).filesEditable) {
+					await Zotero.Notes.copyEmbeddedImages(note, newNote);
+				}
+				await newNote.addLinkedItem(note);
+			}
+		}
+		
+		// Child attachments
+		if (options.childLinks || options.childFileAttachments) {
+			var attachmentIDs = item.getAttachments();
+			var attachments = Zotero.Items.get(attachmentIDs);
+			for (let attachment of attachments) {
+				var linkMode = attachment.attachmentLinkMode;
+				
+				// Skip linked files
+				if (linkMode == Zotero.Attachments.LINK_MODE_LINKED_FILE) {
+					Zotero.debug("Skipping child linked file attachment on drag");
+					continue;
+				}
+				
+				// Skip imported files if we don't have pref and permissions
+				if (linkMode == Zotero.Attachments.LINK_MODE_LINKED_URL) {
+					if (!options.childLinks) {
+						Zotero.debug("Skipping child link attachment on drag");
+						continue;
+					}
+				}
+				else {
+					if (!options.childFileAttachments
+							|| (!targetTreeRow.filesEditable && !targetTreeRow.isPublications())) {
+						Zotero.debug("Skipping child file attachment on drag");
+						continue;
+					}
+				}
+				let newAttachment = await Zotero.Attachments.copyAttachmentToLibrary(
+					attachment, targetLibraryID, newItemID
+				);
+				
+				if (options.annotations) {
+					await Zotero.Items.copyChildItems(attachment, newAttachment);
+				}
+			}
+		}
+		
+		return newItemID;
+	}
 	
+	/**
+	 * Helper function used by executeCollectionCopy to recursively copy collections from one library
+	 * into another.
+	 */
+	async _copyCollections({ descendents, parentID, addItems, targetLibraryID, targetTreeRow, copyOptions }) {
+		for (var desc of descendents) {
+			// Collections
+			if (desc.type == 'collection') {
+				var c = await Zotero.Collections.getAsync(desc.id);
+				let newCollection = c.clone(targetLibraryID);
+				if (parentID) {
+					newCollection.parentID = parentID;
+				}
+				var collectionID = await newCollection.save();
+				
+				// Record link
+				await newCollection.addLinkedCollection(c);
+				
+				// Recursively copy subcollections
+				if (desc.children.length) {
+					await this._copyCollections({ descendents: desc.children, parentID: collectionID, addItems, targetLibraryID, targetTreeRow, copyOptions });
+				}
+			}
+			// Items
+			else {
+				var item = await Zotero.Items.getAsync(desc.id);
+				var id = await this._copyItem({ item, targetLibraryID, targetTreeRow, options: copyOptions });
+				// Standalone attachments might not get copied
+				if (!id) {
+					continue;
+				}
+				// Mark copied item for adding to collection
+				if (parentID) {
+					let parentItems = addItems.get(parentID);
+					if (!parentItems) {
+						parentItems = [];
+						addItems.set(parentID, parentItems);
+					}
+					
+					// If source item is a top-level non-regular item (which can exist in a
+					// collection) but target item is a child item (which can't), add
+					// target item's parent to collection instead
+					if (!item.isRegularItem()) {
+						let targetItem = await Zotero.Items.getAsync(id);
+						let targetItemParentID = targetItem.parentItemID;
+						if (targetItemParentID) {
+							id = targetItemParentID;
+						}
+					}
+					
+					parentItems.push(id);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Copy a given collection into another library. Used for drag-drop of a collection onto a collection
+	 * from another group (or the group itself), as well as for "move to another collection" context menu.
+	 * @param {Zotero.Collection} collection - collection to copy
+	 * @param {String} targetCollectionID - id of the collection to copy to
+	 * @param {String} targetLibraryID - id of the library to copy to
+	 * @param {Zotero.CollectionTreeRow } targetTreeRow - tree row of the target
+	 * @param {Object} copyOptions - options how to perform the copy - see onDrop for an example
+	*/
+	async executeCollectionCopy({ collection, targetCollectionID, targetLibraryID, targetTreeRow, copyOptions }) {
+		await Zotero.DB.executeTransaction(async () => {
+			var collections = [{
+				id: collection.id,
+				children: collection.getDescendents(true),
+				type: 'collection'
+			}];
+			
+			var addItems = new Map();
+			await this._copyCollections({ descendents: collections, parentID: targetCollectionID, addItems, targetLibraryID, targetTreeRow, copyOptions });
+			for (let [collectionID, items] of addItems.entries()) {
+				let collection = await Zotero.Collections.getAsync(collectionID);
+				await collection.addItems(items);
+			}
+			
+			// TODO: add subcollections and subitems, if they don't already exist,
+			// and display a warning if any of the subcollections already exist
+		});
+	}
+
 	async onDrop(event, index) {
 		const treeRow = this.getRow(index);
 		this._dropRow = null;
@@ -1809,7 +2051,6 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 				|| !(await this.canDropCheckAsync(row, orient, dataTransfer))) {
 			return false;
 		}
-		
 		var dragData = Zotero.DragDrop.getDataFromDataTransfer(dataTransfer);
 		if (!dragData) {
 			Zotero.debug("No drag data");
@@ -1828,238 +2069,15 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 			childFileAttachments: Zotero.Prefs.get('groups.copyChildFileAttachments'),
 			annotations: Zotero.Prefs.get('groups.copyAnnotations'),
 		};
-		var copyItem = async function (item, targetLibraryID, options) {
-			var targetLibraryType = Zotero.Libraries.get(targetLibraryID).libraryType;
-			
-			// Check if there's already a copy of this item in the library
-			var linkedItem = await item.getLinkedItem(targetLibraryID, true);
-			if (linkedItem) {
-				// If linked item is in the trash, undelete it and remove it from collections
-				// (since it shouldn't be restored to previous collections)
-				if (linkedItem.deleted) {
-					linkedItem.setCollections();
-					linkedItem.deleted = false;
-					await linkedItem.save({
-						skipSelect: true
-					});
-				}
-				return linkedItem.id;
-				
-				/*
-				// TODO: support tags, related, attachments, etc.
-				
-				// Overlay source item fields on unsaved clone of linked item
-				var newItem = item.clone(false, linkedItem.clone(true));
-				newItem.setField('dateAdded', item.dateAdded);
-				newItem.setField('dateModified', item.dateModified);
-				
-				var diff = newItem.diff(linkedItem, false, ["dateAdded", "dateModified"]);
-				if (!diff) {
-					// Check if creators changed
-					var creatorsChanged = false;
-					
-					var creators = item.getCreators();
-					var linkedCreators = linkedItem.getCreators();
-					if (creators.length != linkedCreators.length) {
-						Zotero.debug('Creators have changed');
-						creatorsChanged = true;
-					}
-					else {
-						for (var i=0; i<creators.length; i++) {
-							if (!creators[i].ref.equals(linkedCreators[i].ref)) {
-								Zotero.debug('changed');
-								creatorsChanged = true;
-								break;
-							}
-						}
-					}
-					if (!creatorsChanged) {
-						Zotero.debug("Linked item hasn't changed -- skipping conflict resolution");
-						continue;
-					}
-				}
-				toReconcile.push([newItem, linkedItem]);
-				continue;
-				*/
-			}
-			
-			// Standalone attachment
-			if (item.isAttachment()) {
-				var linkMode = item.attachmentLinkMode;
-				
-				// Skip linked files
-				if (linkMode == Zotero.Attachments.LINK_MODE_LINKED_FILE) {
-					Zotero.debug("Skipping standalone linked file attachment on drag");
-					return false;
-				}
-				
-				if (!targetTreeRow.filesEditable) {
-					Zotero.debug("Skipping standalone file attachment on drag");
-					return false;
-				}
-				
-				let newAttachment = await Zotero.Attachments.copyAttachmentToLibrary(item, targetLibraryID);
-				if (options.annotations) {
-					await Zotero.Items.copyChildItems(item, newAttachment);
-				}
-				
-				return newAttachment.id;
-			}
-			
-			// Create new clone item in target library
-			var newItem = item.clone(targetLibraryID, { skipTags: !options.tags });
-			
-			var newItemID = await newItem.save({
-				skipSelect: true
-			});
-			
-			// Record link
-			await newItem.addLinkedItem(item);
-			
-			if (item.isNote()) {
-				if (Zotero.Libraries.get(newItem.libraryID).filesEditable) {
-					await Zotero.Notes.copyEmbeddedImages(item, newItem);
-				}
-				return newItemID;
-			}
-			
-			// For regular items, add child items if prefs and permissions allow
-			
-			// Child notes
-			if (options.childNotes) {
-				var noteIDs = item.getNotes();
-				var notes = Zotero.Items.get(noteIDs);
-				for (let note of notes) {
-					let newNote = note.clone(targetLibraryID, { skipTags: !options.tags });
-					newNote.parentID = newItemID;
-					await newNote.save({
-						skipSelect: true
-					})
-
-					if (Zotero.Libraries.get(newNote.libraryID).filesEditable) {
-						await Zotero.Notes.copyEmbeddedImages(note, newNote);
-					}
-					await newNote.addLinkedItem(note);
-				}
-			}
-			
-			// Child attachments
-			if (options.childLinks || options.childFileAttachments) {
-				var attachmentIDs = item.getAttachments();
-				var attachments = Zotero.Items.get(attachmentIDs);
-				for (let attachment of attachments) {
-					var linkMode = attachment.attachmentLinkMode;
-					
-					// Skip linked files
-					if (linkMode == Zotero.Attachments.LINK_MODE_LINKED_FILE) {
-						Zotero.debug("Skipping child linked file attachment on drag");
-						continue;
-					}
-					
-					// Skip imported files if we don't have pref and permissions
-					if (linkMode == Zotero.Attachments.LINK_MODE_LINKED_URL) {
-						if (!options.childLinks) {
-							Zotero.debug("Skipping child link attachment on drag");
-							continue;
-						}
-					}
-					else {
-						if (!options.childFileAttachments
-								|| (!targetTreeRow.filesEditable && !targetTreeRow.isPublications())) {
-							Zotero.debug("Skipping child file attachment on drag");
-							continue;
-						}
-					}
-					let newAttachment = await Zotero.Attachments.copyAttachmentToLibrary(
-						attachment, targetLibraryID, newItemID
-					);
-					
-					if (options.annotations) {
-						await Zotero.Items.copyChildItems(attachment, newAttachment);
-					}
-				}
-			}
-			
-			return newItemID;
-		};
 		
 		var targetLibraryID = targetTreeRow.ref.libraryID;
 		var targetCollectionID = targetTreeRow.isCollection() ? targetTreeRow.ref.id : false;
 		
 		if (dataType == 'zotero/collection') {
 			var droppedCollection = await Zotero.Collections.getAsync(data[0]);
-			
 			// Collection drag between libraries
 			if (targetLibraryID != droppedCollection.libraryID) {
-				await Zotero.DB.executeTransaction(async function () {
-					var copyCollections = async function (descendents, parentID, addItems) {
-						for (var desc of descendents) {
-							// Collections
-							if (desc.type == 'collection') {
-								var c = await Zotero.Collections.getAsync(desc.id);
-								let newCollection = c.clone(targetLibraryID);
-								if (parentID) {
-									newCollection.parentID = parentID;
-								}
-								var collectionID = await newCollection.save();
-								
-								// Record link
-								await newCollection.addLinkedCollection(c);
-								
-								// Recursively copy subcollections
-								if (desc.children.length) {
-									await copyCollections(desc.children, collectionID, addItems);
-								}
-							}
-							// Items
-							else {
-								var item = await Zotero.Items.getAsync(desc.id);
-								var id = await copyItem(item, targetLibraryID, copyOptions);
-								// Standalone attachments might not get copied
-								if (!id) {
-									continue;
-								}
-								// Mark copied item for adding to collection
-								if (parentID) {
-									let parentItems = addItems.get(parentID);
-									if (!parentItems) {
-										parentItems = [];
-										addItems.set(parentID, parentItems);
-									}
-									
-									// If source item is a top-level non-regular item (which can exist in a
-									// collection) but target item is a child item (which can't), add
-									// target item's parent to collection instead
-									if (!item.isRegularItem()) {
-										let targetItem = await Zotero.Items.getAsync(id);
-										let targetItemParentID = targetItem.parentItemID;
-										if (targetItemParentID) {
-											id = targetItemParentID;
-										}
-									}
-									
-									parentItems.push(id);
-								}
-							}
-						}
-					};
-					
-					var collections = [{
-						id: droppedCollection.id,
-						children: droppedCollection.getDescendents(true),
-						type: 'collection'
-					}];
-					
-					var addItems = new Map();
-					await copyCollections(collections, targetCollectionID, addItems);
-					for (let [collectionID, items] of addItems.entries()) {
-						let collection = await Zotero.Collections.getAsync(collectionID);
-						await collection.addItems(items);
-					}
-					
-					// TODO: add subcollections and subitems, if they don't already exist,
-					// and display a warning if any of the subcollections already exist
-				});
+				await this.executeCollectionCopy({ collection: droppedCollection, targetCollectionID, targetLibraryID, targetTreeRow, copyOptions });
 			}
 			// Collection drag within a library
 			else {
@@ -2137,9 +2155,9 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 					newItems,
 					100,
 					function (chunk) {
-						return Zotero.DB.executeTransaction(async function () {
+						return Zotero.DB.executeTransaction(async () => {
 							for (let item of chunk) {
-								var id = await copyItem(item, targetLibraryID, copyOptions)
+								var id = await this._copyItem({ item, targetLibraryID, targetTreeRow, options: copyOptions })
 								// Standalone attachments might not get copied
 								if (!id) {
 									continue;
@@ -2147,7 +2165,7 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 								newIDs.push(id);
 							}
 						});
-					}
+					}.bind(this)
 				);
 				
 				if (toReconcile.length) {

--- a/chrome/content/zotero/collectionTree.jsx
+++ b/chrome/content/zotero/collectionTree.jsx
@@ -2029,8 +2029,10 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 	}
 
 	/**
-	 * Copy a given collection into another library. Used for drag-drop of a collection onto a collection
-	 * from another group (or the group itself), as well as for "move to another collection" context menu.
+	 * Copy a given collection into another library, or duplicate it within the same library
+	 *
+	 * Used for drag-and-drop and the "Copy To" context menu option
+	 *
 	 * @param {Zotero.Collection} collection - collection to copy
 	 * @param {String} targetCollectionID - id of the collection to copy to
 	 * @param {String} targetLibraryID - id of the library to copy to

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -4112,7 +4112,7 @@ var ZoteroPane = new function()
 					let subcollection = Zotero.Collections.get(descendent.id);
 					let linkedSubcollection = await subcollection.getLinkedCollection(library.libraryID, true);
 					if (linkedSubcollection) {
-						linkedCollectionsExist[library.libraryID] = true;
+						linkedCollectionsExist[library.libraryID] = linkedSubcollection;
 					}
 				}
 			}

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -2607,7 +2607,7 @@ var ZoteroPane = new function()
 		};
 		ZoteroPane.collectionsView.executeCollectionCopy({
 			collection: selected,
-			targetCollectionID: target.id,
+			targetCollectionID: target instanceof Zotero.Collection ? target.id : null,
 			targetLibraryID: target.libraryID,
 			targetTreeRow,
 			copyOptions

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -4102,8 +4102,8 @@ var ZoteroPane = new function()
 		// and disable their menuitems. Same logic as in CollectionTree.canDropCheckAsync.
 		let linkedCollectionsExist = {};
 		(async () => {
-			for (let library of Zotero.Libraries.getAll()) {
-				if (library.libraryID == selected.libraryID || library instanceof Zotero.Feed) continue;
+			for (let library of topLevelEntries) {
+				if (library.libraryID == selected.libraryID) continue;
 				// Check which library has a collection linked to the selected collection
 				let linkedCollection = await selected.getLinkedCollection(library.libraryID, true);
 				linkedCollectionsExist[library.libraryID] = linkedCollection;
@@ -4111,13 +4111,15 @@ var ZoteroPane = new function()
 				for (let descendent of selected.getDescendents(false, 'collection')) {
 					let subcollection = Zotero.Collections.get(descendent.id);
 					let linkedSubcollection = await subcollection.getLinkedCollection(library.libraryID, true);
-					linkedCollectionsExist[library.libraryID] = linkedSubcollection || linkedCollectionsExist[library.libraryID];
+					if (linkedSubcollection) {
+						linkedCollectionsExist[library.libraryID] = true;
+					}
 				}
 			}
 			// Libraries that have linked collections have their menus disabled
 			for (let libraryMenuItem of [...popup.childNodes]) {
 				let menuItemLibID = libraryMenuItem.getAttribute("value").substring(1);
-				if (linkedCollectionsExist[parseInt(menuItemLibID)]) {
+				if (linkedCollectionsExist[menuItemLibID]) {
 					libraryMenuItem.disabled = true;
 				}
 			}
@@ -4160,8 +4162,7 @@ var ZoteroPane = new function()
 				(target) => {
 					// can't copy collection into itself or into non-editable groups
 					return selected == target
-						|| (target instanceof Zotero.Group && !target.editable)
-						|| linkedCollectionsExist[target.libraryID];
+						|| (target instanceof Zotero.Group && !target.editable);
 				}
 			);
 			popup.append(menuItem);

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -4133,8 +4133,9 @@ var ZoteroPane = new function()
 				},
 				
 				(target) => {
-					// can't copy collection into itself
-					return selected == target;
+					// can't copy collection into itself or into non-editable groups
+					return selected == target
+						|| (target instanceof Zotero.Group && !target.editable);
 				}
 			);
 			popup.append(menuItem);

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -4058,6 +4058,8 @@ var ZoteroPane = new function()
 				event.stopPropagation();
 			}
 		});
+		// Disable for already top-level collections
+		libraryMenuItem.disabled = !selected.parentID;
 		popup.appendChild(libraryMenuItem);
 		popup.appendChild(document.createXULElement("menuseparator"));
 		

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -912,6 +912,10 @@
 			<menuitem class="zotero-menuitem-show-unfiled" label="&zotero.collections.showUnfiledItems;"/>
 			<menuitem class="zotero-menuitem-show-retracted" label="&zotero.collections.showRetractedItems;"/>
 			<menuitem class="zotero-menuitem-edit-collection"/>
+			<menu class="menu-iconic zotero-menuitem-move-collection">
+				<menupopup id="zotero-move-collection-popup" onpopupshowing="ZoteroPane_Local.buildAddCollectionToCollectionMenu(event)">
+				</menupopup>
+			</menu>
 			<menuitem class="zotero-menuitem-duplicate-collection"/>
 			<menuitem class="zotero-menuitem-mark-read-feed"/>
 			<menuitem class="zotero-menuitem-edit-feed" label="&zotero.toolbar.feeds.edit;"/>
@@ -967,7 +971,7 @@
 			<menuitem class="menuitem-iconic zotero-menuitem-toggle-read-item" oncommand="ZoteroPane_Local.toggleSelectedItemsRead();"/>
 			<menuitem class="menuitem-iconic zotero-menuitem-change-top-level-item" data-l10n-id="item-menu-change-parent-item" oncommand="ZoteroPane_Local.changeParentItem();"/>
 			<menu class="menu-iconic zotero-menuitem-add-to-collection">
-				<menupopup id="zotero-add-to-collection-popup" onpopupshowing="ZoteroPane_Local.buildAddToCollectionMenu(event)">
+				<menupopup id="zotero-add-to-collection-popup" onpopupshowing="ZoteroPane_Local.buildAddItemToCollectionMenu(event)">
 					<menuitem id="zotero-add-to-new-collection" label="&zotero.toolbar.newCollection.label;" oncommand="ZoteroPane_Local.addSelectedItemsToCollection(null, true)"/>
 					<menuseparator id="zotero-add-to-collection-separator"/>
 				</menupopup>

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -913,7 +913,11 @@
 			<menuitem class="zotero-menuitem-show-retracted" label="&zotero.collections.showRetractedItems;"/>
 			<menuitem class="zotero-menuitem-edit-collection"/>
 			<menu class="menu-iconic zotero-menuitem-move-collection">
-				<menupopup id="zotero-move-collection-popup" onpopupshowing="ZoteroPane_Local.buildAddCollectionToCollectionMenu(event)">
+				<menupopup id="zotero-move-collection-popup" onpopupshowing="ZoteroPane_Local.buildMoveCollectionMenu(event)">
+				</menupopup>
+			</menu>
+			<menu class="menu-iconic zotero-menuitem-copy-collection">
+				<menupopup id="zotero-copy-collection-popup" onpopupshowing="ZoteroPane_Local.buildCopyCollectionMenu(event)">
 				</menupopup>
 			</menu>
 			<menuitem class="zotero-menuitem-duplicate-collection"/>

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -90,7 +90,7 @@ collections-menu-edit-saved-search =
 collections-menu-move-collection =
     .label = Change Parent
 collections-menu-move-collection-other-library =
-    .label = Other Collections (As Copy)
+    .label = Other Libraries (As Copy)
 
 item-creator-moveDown =
     .label = Move Down

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -88,9 +88,9 @@ collections-menu-rename-collection =
 collections-menu-edit-saved-search =
     .label = Edit Saved Search
 collections-menu-move-collection =
-    .label = Change Parent
-collections-menu-move-collection-other-library =
-    .label = Other Libraries (As Copy)
+    .label = Move to
+collections-menu-copy-collection =
+    .label = Copy to
 
 item-creator-moveDown =
     .label = Move Down

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -87,6 +87,8 @@ collections-menu-rename-collection =
     .label = Rename Collection
 collections-menu-edit-saved-search =
     .label = Edit Saved Search
+collections-menu-move-collection =
+    .label = Move to another collection
 
 item-creator-moveDown =
     .label = Move Down

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -88,7 +88,9 @@ collections-menu-rename-collection =
 collections-menu-edit-saved-search =
     .label = Edit Saved Search
 collections-menu-move-collection =
-    .label = Move to another collection
+    .label = Change Parent
+collections-menu-move-collection-other-library =
+    .label = Other Collections (As Copy)
 
 item-creator-moveDown =
     .label = Move Down

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -88,9 +88,9 @@ collections-menu-rename-collection =
 collections-menu-edit-saved-search =
     .label = Edit Saved Search
 collections-menu-move-collection =
-    .label = Move to
+    .label = Move To
 collections-menu-copy-collection =
-    .label = Copy to
+    .label = Copy To
 
 item-creator-moveDown =
     .label = Move Down

--- a/test/tests/zoteroPaneTest.js
+++ b/test/tests/zoteroPaneTest.js
@@ -1820,6 +1820,27 @@ describe("ZoteroPane", function() {
 			assert.sameMembers(items, [itemOne.id, itemTwo.id]);
 		});
 
+		it("should duplicate top-level collection", async function () {
+			let collection = await createDataObject('collection');
+			let mylibrary = Zotero.Libraries.get(collection.libraryID);
+
+			let itemOne = await createDataObject('item', { collections: [collection.id] });
+
+			await zp.collectionsView.selectByID("C" + collection.id);
+
+			await zp.copyCollection(mylibrary);
+			await waitForNotifierEvent("add", "collection");
+
+			// Find the duplicated collection and make sure it exists
+			let topLevelCollections = Zotero.Collections.getByLibrary(mylibrary.id);
+			let newCollection = topLevelCollections.find(col => col.name == collection.name && collection.id !== col.id);
+			assert.exists(newCollection);
+
+			// Newly created collection contain the same item
+			let items = newCollection.getDescendents(false, 'item').map(item => item.id);
+			assert.sameMembers(items, [itemOne.id]);
+		});
+
 		it("should copy collection between libraries", async function () {
 			let groupDestination = await createGroup();
 			let groupCollection = await createDataObject('collection', { libraryID: groupDestination.libraryID });

--- a/test/tests/zoteroPaneTest.js
+++ b/test/tests/zoteroPaneTest.js
@@ -1845,4 +1845,37 @@ describe("ZoteroPane", function() {
 			assert.sameMembers(items, [itemOne.getDisplayTitle(), itemTwo.getDisplayTitle()]);
 		});
 	});
+	describe("#moveCollection", function () {
+		it("should move collection into another collection of the same library", async function () {
+			let collection = await createDataObject('collection');
+			let collectionDestination = await createDataObject('collection');
+
+			await zp.collectionsView.selectByID("C" + collection.id);
+
+			let promise = waitForNotifierEvent("modify", "collection");
+			await zp.moveCollection(collectionDestination);
+			await promise;
+
+			// Collection was moved into destination collection
+			let collectionChildIDs = collectionDestination.getDescendents(false, 'collection').map(col => col.id);
+			assert.sameMembers(collectionChildIDs, [collection.id]);
+		});
+	});
+	describe("#moveCollection", function () {
+		it("should make collection a top-level collection", async function () {
+			let collectionParent = await createDataObject('collection');
+			let collectionChild = await createDataObject('collection', { parentID: collectionParent.id });
+			let library = Zotero.Libraries.get(collectionChild.libraryID);
+
+			await zp.collectionsView.selectByID("C" + collectionChild.id);
+
+			let promise = waitForNotifierEvent("modify", "collection");
+			await zp.moveCollection(library);
+			await promise;
+
+			// Child collection was pulled from under its parent to become a top-level collection
+			let topLevelCollections = Zotero.Collections.getByLibrary(library.id);
+			assert.includeMembers(topLevelCollections, [collectionChild]);
+		});
+	});
 })

--- a/test/tests/zoteroPaneTest.js
+++ b/test/tests/zoteroPaneTest.js
@@ -1881,8 +1881,6 @@ describe("ZoteroPane", function() {
 			let collectionChildIDs = collectionDestination.getDescendents(false, 'collection').map(col => col.id);
 			assert.sameMembers(collectionChildIDs, [collection.id]);
 		});
-	});
-	describe("#moveCollection", function () {
 		it("should make collection a top-level collection", async function () {
 			let collectionParent = await createDataObject('collection');
 			let collectionChild = await createDataObject('collection', { parentID: collectionParent.id });


### PR DESCRIPTION
- added context menu to move a collection into another collection. Since one can drag a collection into another library, the top-level entries of the contextmenu are libraries and not collections as with itemTree (shouldn't the same be true for itemTree in fact? You can drag an item to a collection in another group but I don't think it's possible to do it with the context menu).
- refactoring of collectionTree to pull out `copyCollections()` and `copyItems()` from out of the scope of `CollectionTree.onDrop`. If a collection is moved into another library, the functionality of copying over a collection needed to be exposed to ZoteroPane without the actual drag-drop happening. `copyCollection` and `copyItems` are unchanged except for the added parameters. We could avoid the refactoring by maybe faking a `drop` event from `ZoteroPane.moveToCollection` but I thought this would be cleaner and potentially useful for in the future.


<img width="1312" alt="Screenshot 2024-07-22 at 11 19 14 PM" src="https://github.com/user-attachments/assets/af16ddad-30dd-4080-aaf1-224df694a1be">

Addresses part of #3970
