### PR TITLE
vpat 16: context menu as a drag-drop alternative to change parent item of attachment/note

### DIFF
--- a/chrome/content/zotero/collectionTree.jsx
+++ b/chrome/content/zotero/collectionTree.jsx
@@ -2777,14 +2777,14 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 			var savedSearches = await Zotero.Searches.getAll(libraryID).filter(s => !s.deleted);
 			// Virtual collections default to showing if not explicitly hidden
 			var showDuplicates = this.props.hideSources.indexOf('duplicates') == -1
-					&& this._virtualCollectionLibraries.duplicates[libraryID] !== false;
+				&& this._virtualCollectionLibraries.duplicates[libraryID] !== false;
 			var showUnfiled = this.props.hideSources.indexOf('unfiled') == -1
-					&& this._virtualCollectionLibraries.unfiled?.[libraryID] !== false;
+				&& this._virtualCollectionLibraries.unfiled?.[libraryID] !== false;
 			var showRetracted = this.props.hideSources.indexOf('retracted') == -1
-					&& this._virtualCollectionLibraries.retracted?.[libraryID] !== false
-					&& Zotero.Retractions.libraryHasRetractedItems(libraryID);
+				&& this._virtualCollectionLibraries.retracted?.[libraryID] !== false
+				&& Zotero.Retractions.libraryHasRetractedItems(libraryID);
 			var showPublications = this.props.hideSources.indexOf('publications') == -1
-					&& libraryID == Zotero.Libraries.userLibraryID;
+				&& libraryID == Zotero.Libraries.userLibraryID;
 			var showTrash = this.props.hideSources.indexOf('trash') == -1;
 		}
 		else {

--- a/chrome/content/zotero/collectionTree.jsx
+++ b/chrome/content/zotero/collectionTree.jsx
@@ -2778,10 +2778,13 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 			// Virtual collections default to showing if not explicitly hidden
 			var showDuplicates = this.props.hideSources.indexOf('duplicates') == -1
 					&& this._virtualCollectionLibraries.duplicates[libraryID] !== false;
-			var showUnfiled = this._virtualCollectionLibraries.unfiled[libraryID] !== false;
-			var showRetracted = this._virtualCollectionLibraries.retracted[libraryID] !== false
-				&& Zotero.Retractions.libraryHasRetractedItems(libraryID);
-			var showPublications = libraryID == Zotero.Libraries.userLibraryID;
+			var showUnfiled = this.props.hideSources.indexOf('unfiled') == -1
+					&& this._virtualCollectionLibraries.unfiled?.[libraryID] !== false;
+			var showRetracted = this.props.hideSources.indexOf('retracted') == -1
+					&& this._virtualCollectionLibraries.retracted?.[libraryID] !== false
+					&& Zotero.Retractions.libraryHasRetractedItems(libraryID);
+			var showPublications = this.props.hideSources.indexOf('publications') == -1
+					&& libraryID == Zotero.Libraries.userLibraryID;
 			var showTrash = this.props.hideSources.indexOf('trash') == -1;
 		}
 		else {

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -78,6 +78,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 		onContextMenu: noop,
 		onActivate: noop,
 		emptyMessage: '',
+		multiselect: true
 	};
 
 	static propTypes = {
@@ -91,6 +92,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 		onContextMenu: PropTypes.func,
 		onActivate: PropTypes.func,
 		emptyMessage: PropTypes.string,
+		multiselect: PropTypes.bool,
 	};
 	
 	constructor(props) {
@@ -1023,7 +1025,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 					containerWidth: this.domEl.clientWidth,
 					firstColumnExtraWidth: 28, // 16px for twisty + 16px for icon - 8px column padding + 4px margin
 
-					multiSelect: true,
+					multiSelect: this.props.multiselect,
 
 					onSelectionChange: this._handleSelectionChange,
 					isSelectable: this.isSelectable,

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -78,7 +78,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 		onContextMenu: noop,
 		onActivate: noop,
 		emptyMessage: '',
-		multiselect: true
+		multiSelect: true
 	};
 
 	static propTypes = {
@@ -92,7 +92,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 		onContextMenu: PropTypes.func,
 		onActivate: PropTypes.func,
 		emptyMessage: PropTypes.string,
-		multiselect: PropTypes.bool,
+		multiSelect: PropTypes.bool,
 	};
 	
 	constructor(props) {
@@ -1025,7 +1025,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 					containerWidth: this.domEl.clientWidth,
 					firstColumnExtraWidth: 28, // 16px for twisty + 16px for icon - 8px column padding + 4px margin
 
-					multiSelect: this.props.multiselect,
+					multiSelect: this.props.multiSelect,
 
 					onSelectionChange: this._handleSelectionChange,
 					isSelectable: this.isSelectable,

--- a/chrome/content/zotero/selectItemsDialog.js
+++ b/chrome/content/zotero/selectItemsDialog.js
@@ -172,8 +172,8 @@ function onItemSelected()
 	if (io.onlyRegularItems) {
 		// Disable "accept" button if not a top level item is selected
 		let selected = itemsView.getSelectedItems();
-		let acceptBtn = document.querySelector("dialog").getButton("accept");
-		acceptBtn.disabled = (selected && !selected.every(item => item.isRegularItem()));
+		let disableAccept = (selected && !selected.every(item => item.isRegularItem()));
+		document.querySelector("dialog").setAttribute("buttondisabledaccept", disableAccept);
 	}
 }
 

--- a/chrome/content/zotero/selectItemsDialog.js
+++ b/chrome/content/zotero/selectItemsDialog.js
@@ -178,10 +178,10 @@ function onItemSelected()
 {
 	itemsView.runListeners('select');
 	if (io.onlyRegularItems) {
-		// Disable "accept" button if not a top level item is selected
+		// Disable "accept" button if a top-level item isn't selected
 		let selected = itemsView.getSelectedItems();
 		let disableAccept = (selected && !selected.every(item => item.isRegularItem()));
-		// Temp. Disable the button directly only as long as we move the button box in doLoad().
+		// TEMP: Disable the button directly only as long as we move the button box in doLoad().
 		// Then, we should set buttondisabledaccept attribute on the dialog
 		document.querySelector("dialog button[dlgtype='accept']").setAttribute("disabled", disableAccept);
 	}

--- a/chrome/content/zotero/selectItemsDialog.js
+++ b/chrome/content/zotero/selectItemsDialog.js
@@ -89,10 +89,11 @@ var doLoad = async function () {
 	itemsView.setItemsPaneMessage(Zotero.getString('pane.items.loading'));
 
 	const filterLibraryIDs = false || io.filterLibraryIDs;
+	const hideSources = io.hideCollections || ['duplicates', 'trash', 'feeds'];
 	collectionsView = await CollectionTree.init(document.getElementById('zotero-collections-tree'), {
 		onSelectionChange: Zotero.Utilities.debounce(() => onCollectionSelected(), 100),
 		filterLibraryIDs,
-		hideSources: ['duplicates', 'trash', 'feeds']
+		hideSources
 	});
 
 	await collectionsView.makeVisible();

--- a/chrome/content/zotero/selectItemsDialog.js
+++ b/chrome/content/zotero/selectItemsDialog.js
@@ -118,6 +118,13 @@ var doLoad = async function () {
 			button.setAttribute("tabindex", nextButtonTabindex++);
 		}
 	}
+	// Handle any custom button config that can be passed
+	for (let buttonConfig of io.extraButtons || []) {
+		let button = document.querySelector(`dialog button[dlgtype='${buttonConfig.type}']`);
+		button.hidden = false;
+		document.l10n.setAttributes(button, buttonConfig.l10nLabel);
+		button.addEventListener("click", event => buttonConfig.onclick(event));
+	}
 	
 	// Used in tests
 	loaded = true;

--- a/chrome/content/zotero/selectItemsDialog.js
+++ b/chrome/content/zotero/selectItemsDialog.js
@@ -84,7 +84,7 @@ var doLoad = async function () {
 		persistColumns: true,
 		columnPicker: true,
 		emptyMessage: Zotero.getString('pane.items.loading'),
-		multiselect: !io.singleSelection
+		multiSelect: !io.singleSelection
 	});
 	itemsView.setItemsPaneMessage(Zotero.getString('pane.items.loading'));
 

--- a/chrome/content/zotero/selectItemsDialog.js
+++ b/chrome/content/zotero/selectItemsDialog.js
@@ -121,8 +121,8 @@ var doLoad = async function () {
 	// Handle any custom button config that can be passed
 	for (let buttonConfig of io.extraButtons || []) {
 		let button = document.querySelector(`dialog button[dlgtype='${buttonConfig.type}']`);
-		button.hidden = false;
-		document.l10n.setAttributes(button, buttonConfig.l10nLabel);
+		button.hidden = buttonConfig.isHidden(document);
+		document.l10n.setAttributes(button, buttonConfig.l10nLabel, buttonConfig.l10nArgs || {});
 		button.addEventListener("click", event => buttonConfig.onclick(event));
 	}
 	

--- a/chrome/content/zotero/selectItemsDialog.js
+++ b/chrome/content/zotero/selectItemsDialog.js
@@ -173,7 +173,9 @@ function onItemSelected()
 		// Disable "accept" button if not a top level item is selected
 		let selected = itemsView.getSelectedItems();
 		let disableAccept = (selected && !selected.every(item => item.isRegularItem()));
-		document.querySelector("dialog").setAttribute("buttondisabledaccept", disableAccept);
+		// Temp. Disable the button directly only as long as we move the button box in doLoad().
+		// Then, we should set buttondisabledaccept attribute on the dialog
+		document.querySelector("dialog button[dlgtype='accept']").setAttribute("disabled", disableAccept);
 	}
 }
 

--- a/chrome/content/zotero/selectItemsDialog.js
+++ b/chrome/content/zotero/selectItemsDialog.js
@@ -83,7 +83,8 @@ var doLoad = async function () {
 		dragAndDrop: false,
 		persistColumns: true,
 		columnPicker: true,
-		emptyMessage: Zotero.getString('pane.items.loading')
+		emptyMessage: Zotero.getString('pane.items.loading'),
+		multiselect: !io.singleSelection
 	});
 	itemsView.setItemsPaneMessage(Zotero.getString('pane.items.loading'));
 
@@ -168,6 +169,12 @@ function onSearch()
 function onItemSelected()
 {
 	itemsView.runListeners('select');
+	if (io.onlyRegularItems) {
+		// Disable "accept" button if not a top level item is selected
+		let selected = itemsView.getSelectedItems();
+		let acceptBtn = document.querySelector("dialog").getButton("accept");
+		acceptBtn.disabled = (selected && !selected.every(item => item.isRegularItem()));
+	}
 }
 
 function doAccept() {

--- a/chrome/content/zotero/selectItemsDialog.js
+++ b/chrome/content/zotero/selectItemsDialog.js
@@ -183,7 +183,13 @@ function onItemSelected()
 		let disableAccept = (selected && !selected.every(item => item.isRegularItem()));
 		// TEMP: Disable the button directly only as long as we move the button box in doLoad().
 		// Then, we should set buttondisabledaccept attribute on the dialog
-		document.querySelector("dialog button[dlgtype='accept']").setAttribute("disabled", disableAccept);
+		if (disableAccept) {
+			document.querySelector("dialog button[dlgtype='accept']").setAttribute("disabled", true);
+		}
+		else {
+			// Remove disabled attribute since the stylesheet looks at disabled attribute
+			document.querySelector("dialog button[dlgtype='accept']").removeAttribute("disabled");
+		}
 	}
 }
 

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -4994,7 +4994,7 @@ var ZoteroPane = new function()
 		};
 		// The new parent needs to be selected in the dialog
 		window.openDialog('chrome://zotero/content/selectItemsDialog.xhtml', '',
-			'chrome,dialog=no,centerscreen,resizable=yes', io);
+			'chrome,dialog=no,modal,centerscreen,resizable=yes', io);
 
 		await io.deferred.promise;
 

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -4964,9 +4964,9 @@ var ZoteroPane = new function()
 		let shouldConvertToStandaloneAttachment = false;
 		let extraButtons = [];
 		// Keep in sync with Zotero.RecognizeDocument.canRecognize()
-		let canBeMovedOutOfparent = !selectedItems.some(item => item.isWebAttachment() && !item.isPDFAttachment() && !item.isEPUBAttachment());
+		let canBeMovedOutOfParent = !selectedItems.some(item => item.isWebAttachment() && !item.isPDFAttachment() && !item.isEPUBAttachment());
 		// Add a button to the dialog to make attachments standalone, if applicable
-		if (canBeMovedOutOfparent) {
+		if (canBeMovedOutOfParent) {
 			extraButtons = [{
 				type: "extra1",
 				l10nLabel: "select-items-convertToStandaloneAttachment",
@@ -5018,7 +5018,7 @@ var ZoteroPane = new function()
 		}
 		if (!io.dataOut?.length) return;
 
-		let newParentItem = await Zotero.Items.getAsync(io.dataOut);
+		let newParentItem = Zotero.Items.get(io.dataOut);
 		
 		if (!newParentItem.length) return;
 

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -4974,6 +4974,8 @@ var ZoteroPane = new function()
 				onclick: function (event) {
 					shouldConvertToStandaloneAttachment = true;
 					let doc = event.target.ownerDocument;
+					// if accept button is disabled, dialog cannot be accepted
+					doc.querySelector("dialog button[dlgtype='accept']").removeAttribute("disabled");
 					doc.querySelector("dialog").acceptDialog();
 				},
 				isHidden: function () {

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -3942,7 +3942,7 @@ var ZoteroPane = new function()
 		}
 		
 		// Update parent item of notes/attachments
-		if (items.every(item => !item.isRegularItem())) {
+		if (items.every(item => item.isNote() || item.isAttachment())) {
 			show.add(m.changeParentItem);
 		}
 
@@ -4981,12 +4981,12 @@ var ZoteroPane = new function()
 		
 		if (!newParentItem.length) return;
 
-		for (let [index, item] of selectedItems.entries()) {
-			item.parentID = newParentItem[0].id;
-			let isLast = index == selectedItems.length - 1;
-			// Skip all notifiers until the last item to avoid refreshing itemTree multiple times
-			await item.saveTx({ skipSelect: true, skipNotifier: !isLast });
-		}
+		await Zotero.DB.executeTransaction(async () => {
+			for (let item of selectedItems) {
+				item.parentID = newParentItem[0].id;
+				await item.save({ skipSelect: true });
+			}
+		});
 	};
 	/**
 	 * @deprecated

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -4968,7 +4968,8 @@ var ZoteroPane = new function()
 			itemTreeID: 'change-parent-item-select-item-dialog',
 			filterLibraryIDs: [libraryID],
 			singleSelection: true,
-			onlyRegularItems: true
+			onlyRegularItems: true,
+			hideCollections: ['duplicates', 'trash', 'feeds', 'unfiled', 'retracted', 'publications']
 		};
 		// The new parent needs to be selected in the dialog
 		window.openDialog('chrome://zotero/content/selectItemsDialog.xhtml', '',

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -4984,7 +4984,6 @@ var ZoteroPane = new function()
 		let io = {
 			dataIn: null,
 			dataOut: null,
-			deferred: Zotero.Promise.defer(),
 			itemTreeID: 'change-parent-item-select-item-dialog',
 			filterLibraryIDs: [libraryID],
 			singleSelection: true,
@@ -4995,8 +4994,6 @@ var ZoteroPane = new function()
 		// The new parent needs to be selected in the dialog
 		window.openDialog('chrome://zotero/content/selectItemsDialog.xhtml', '',
 			'chrome,dialog=no,modal,centerscreen,resizable=yes', io);
-
-		await io.deferred.promise;
 
 		// If "Convert to Standalone Attachment" is selected, make all attachments top-level items
 		if (shouldConvertToStandaloneAttachment) {

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -4951,9 +4951,9 @@ var ZoteroPane = new function()
 	
 	
 	/**
-	 * Update the parent of the selected items.
-	 * Essentially an alternative to drag-droping a child item between top level items in itemTree
-	 * that is mainly needed for accessibility.
+	 * Update the parent of the selected items
+	 *
+	 * An accessible alternative to dragging/dropping a child item between top-level items
 	*/
 	this.changeParentItem = async function () {
 		let selectedItems = this.getSelectedItems();

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -4970,11 +4970,15 @@ var ZoteroPane = new function()
 			extraButtons = [{
 				type: "extra1",
 				l10nLabel: "select-items-convertToStandaloneAttachment",
+				l10nArgs: { count: selectedItems.length },
 				onclick: function (event) {
 					shouldConvertToStandaloneAttachment = true;
 					let doc = event.target.ownerDocument;
 					doc.querySelector("dialog").acceptDialog();
 				},
+				isHidden: function () {
+					return selectedItems.every(item => !item.parentID);
+				}
 			}];
 		}
 		let io = {

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -4961,7 +4961,7 @@ var ZoteroPane = new function()
 		if (selectedItems.some(item => item.isRegularItem())) return;
 
 		let libraryID = this.getSelectedLibraryID();
-		let shouldMoveToStandaloneAttachment = false;
+		let shouldConvertToStandaloneAttachment = false;
 		let extraButtons = [];
 		// Keep in sync with Zotero.RecognizeDocument.canRecognize()
 		let canBeMovedOutOfparent = !selectedItems.some(item => item.isWebAttachment() && !item.isPDFAttachment() && !item.isEPUBAttachment());
@@ -4969,9 +4969,9 @@ var ZoteroPane = new function()
 		if (canBeMovedOutOfparent) {
 			extraButtons = [{
 				type: "extra1",
-				l10nLabel: "select-items-moveToStandaloneAttachment",
+				l10nLabel: "select-items-convertToStandaloneAttachment",
 				onclick: function (event) {
-					shouldMoveToStandaloneAttachment = true;
+					shouldConvertToStandaloneAttachment = true;
 					let doc = event.target.ownerDocument;
 					doc.querySelector("dialog").acceptDialog();
 				},
@@ -4994,8 +4994,8 @@ var ZoteroPane = new function()
 
 		await io.deferred.promise;
 
-		// If "Move to standalong attachment" is selected, make all attachments top-level items
-		if (shouldMoveToStandaloneAttachment) {
+		// If "Convert to Standalone Attachment" is selected, make all attachments top-level items
+		if (shouldConvertToStandaloneAttachment) {
 			await Zotero.DB.executeTransaction(async () => {
 				for (let item of selectedItems) {
 					let parent = Zotero.Items.get(item.parentID);

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -961,6 +961,7 @@
 			<menuitem class="menuitem-iconic zotero-menuitem-find-pdf" oncommand="ZoteroPane.findFilesForSelectedItems()"/>
 			<menuseparator/>
 			<menuitem class="menuitem-iconic zotero-menuitem-toggle-read-item" oncommand="ZoteroPane_Local.toggleSelectedItemsRead();"/>
+			<menuitem class="menuitem-iconic zotero-menuitem-change-top-level-item" data-l10n-id="item-menu-change-parent-item" oncommand="ZoteroPane_Local.changeParentItem();"/>
 			<menu class="menu-iconic zotero-menuitem-add-to-collection">
 				<menupopup id="zotero-add-to-collection-popup" onpopupshowing="ZoteroPane_Local.buildAddToCollectionMenu(event)">
 					<menuitem id="zotero-add-to-new-collection" label="&zotero.toolbar.newCollection.label;" oncommand="ZoteroPane_Local.addSelectedItemsToCollection(null, true)"/>

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -665,8 +665,8 @@ find-pdf-files-added = { $count ->
 
 select-items-dialog =
     .buttonlabelaccept = Select
-select-items-moveToStandaloneAttachment =
-    .label = Move to Standalone Attachment
+select-items-convertToStandaloneAttachment =
+    .label = Convert to Standalone Attachment
 
 file-type-webpage = Webpage
 file-type-image = Image

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -665,6 +665,8 @@ find-pdf-files-added = { $count ->
 
 select-items-dialog =
     .buttonlabelaccept = Select
+select-items-moveToStandaloneAttachment =
+    .label = Move to Standalone Attachment
 
 file-type-webpage = Webpage
 file-type-image = Image

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -119,6 +119,8 @@ item-menu-add-linked-file =
      .label = Linked File
 item-menu-add-url =
      .label = Web Link
+item-menu-change-parent-item =
+     .label = Change Parent Item
 
 view-online = View Online
 item-menu-option-view-online =

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -120,7 +120,7 @@ item-menu-add-linked-file =
 item-menu-add-url =
      .label = Web Link
 item-menu-change-parent-item =
-     .label = Change Parent Item
+     .label = Move to Parent
 
 view-online = View Online
 item-menu-option-view-online =

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -666,7 +666,10 @@ find-pdf-files-added = { $count ->
 select-items-dialog =
     .buttonlabelaccept = Select
 select-items-convertToStandaloneAttachment =
-    .label = Convert to Standalone Attachment
+    .label = { $count ->
+        [one] Convert to Standalone Attachment
+        *[other] Convert to Standalone Attachments
+}
 
 file-type-webpage = Webpage
 file-type-image = Image

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -120,7 +120,7 @@ item-menu-add-linked-file =
 item-menu-add-url =
      .label = Web Link
 item-menu-change-parent-item =
-     .label = Move to Parent Item…
+     .label = Change Parent Item…
 
 view-online = View Online
 item-menu-option-view-online =

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -120,7 +120,7 @@ item-menu-add-linked-file =
 item-menu-add-url =
      .label = Web Link
 item-menu-change-parent-item =
-     .label = Move to Parent
+     .label = Move to Parent Item…
 
 view-online = View Online
 item-menu-option-view-online =

--- a/scss/components/_selectItemsDialog.scss
+++ b/scss/components/_selectItemsDialog.scss
@@ -73,6 +73,18 @@
     .dialog-button-box button {
         -moz-window-dragging: no-drag;
     }
+
+	// Move padding into rows so that draggable collection container
+	// does not expand all the way past the scrollbar and cause draggin scrollbar
+	// to drag the entire window.
+	#zotero-collections-tree-container {
+		.virtualized-table-body {
+			padding-inline-end: 0;
+			.row {
+				padding-inline-end: 8px;
+			}
+		}
+	}
 }
 
 // richlistbox elements are crazy and will expand beyond the window size

--- a/scss/components/_selectItemsDialog.scss
+++ b/scss/components/_selectItemsDialog.scss
@@ -82,6 +82,7 @@
 			padding-inline-end: 0;
 			.row {
 				padding-inline-end: 8px;
+				width: 183px;
 			}
 		}
 	}

--- a/scss/components/_selectItemsDialog.scss
+++ b/scss/components/_selectItemsDialog.scss
@@ -74,9 +74,9 @@
         -moz-window-dragging: no-drag;
     }
 
-	// Move padding into rows so that draggable collection container
-	// does not expand all the way past the scrollbar and cause draggin scrollbar
-	// to drag the entire window.
+	// Move padding into rows so that draggable collection container does not
+	// expand all the way past the scrollbar and cause dragging the scrollbar
+	// to drag the entire window
 	#zotero-collections-tree-container {
 		.virtualized-table-body {
 			padding-inline-end: 0;

--- a/test/tests/zoteroPaneTest.js
+++ b/test/tests/zoteroPaneTest.js
@@ -1768,7 +1768,7 @@ describe("ZoteroPane", function() {
 			assert.notInclude(oldParent.getAttachments(), attachment.id);
 		});
 
-		it("should allow to move attachments to standalone when applicable", async function() {
+		it("should allow converting attachments to standalone when applicable", async function() {
 			let collection = await createDataObject('collection');
 			let parent = await createDataObject('item', { collections: [collection.id] });
 			var attachment = await importPDFAttachment(parent);


### PR DESCRIPTION
- added "Change Parent Item" context menu option to itemTree as a non-drag-drop alternative to changing the parent of attachments or notes
- context menu option appears only when all selected items are non-regular items
- upon activation, a dialog to select the new parent will appear. Added a tweak to the dialog to disable the "accept" button if a selected item is not top level
- minor edit to itemTree to set the multiselect property based on a prop, since we do not want to have multiselect enabled in this instance
- when the new top-level item is picked, set that new item as a parent of the selected items

Addresses part of https://github.com/zotero/zotero/issues/3970