### PR TITLE
Add `attachmentTitle` and extend file rename templating with regexp

### DIFF
--- a/chrome/content/zotero/preferences/preferences_file_renaming.js
+++ b/chrome/content/zotero/preferences/preferences_file_renaming.js
@@ -43,26 +43,27 @@ Zotero_Preferences.FileRenaming = {
 		this._itemsView.onSelect.removeListener(this._updatePreview);
 	},
 
-	getActiveTopLevelItem() {
-		const selectedItem = Zotero.getActiveZoteroPane()?.getSelectedItems()?.[0];
+	getActiveItem() {
+		let selectedItem = Zotero.getActiveZoteroPane()?.getSelectedItems()?.[0];
 		if (selectedItem) {
 			if (selectedItem.isRegularItem() && !selectedItem.parentKey) {
-				return [selectedItem, this.defaultExt];
+				return [selectedItem, this.defaultExt, ''];
 			}
-			if (selectedItem.isFileAttachment() && selectedItem.parentKey) {
-				const path = selectedItem.getFilePath();
-				const ext = Zotero.File.getExtension(Zotero.File.pathToFile(path));
-				return [Zotero.Items.getByLibraryAndKey(selectedItem.libraryID, selectedItem.parentKey), ext ?? this.defaultExt];
+			if (selectedItem.isFileAttachment()) {
+				let path = selectedItem.getFilePath();
+				let ext = Zotero.File.getExtension(Zotero.File.pathToFile(path));
+				let parentItem = Zotero.Items.getByLibraryAndKey(selectedItem.libraryID, selectedItem.parentKey);
+				return [parentItem, ext ?? this.defaultExt, selectedItem.getField('title')];
 			}
 		}
 
 		return null;
 	},
 
-	updatePreview() {
-		const [item, ext] = this.getActiveTopLevelItem() ?? [this.mockItem ?? this.makeMockItem(), this.defaultExt];
-		const tpl = document.getElementById('file-renaming-format-template').value;
-		const preview = Zotero.Attachments.getFileBaseNameFromItem(item, tpl);
+	async updatePreview() {
+		const [item, ext, attachmentTitle] = this.getActiveItem() ?? [this.mockItem ?? this.makeMockItem(), this.defaultExt, ''];
+		const formatString = document.getElementById('file-renaming-format-template').value;
+		const preview = Zotero.Attachments.getFileBaseNameFromItem(item, { formatString, attachmentTitle });
 		document.getElementById('file-renaming-format-preview').innerText = `${preview}.${ext}`;
 	},
 

--- a/chrome/content/zotero/preferences/preferences_file_renaming.xhtml
+++ b/chrome/content/zotero/preferences/preferences_file_renaming.xhtml
@@ -57,7 +57,7 @@
 			aria-labelledby="file-renaming-format-template-label"
 			id="file-renaming-format-template"
 			preference="extensions.zotero.attachmentRenameTemplate"
-			rows="3"
+			rows="8"
 		/>
 		<html:label id="file-renaming-format-preview-label">
 			<html:h2

--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -2213,7 +2213,7 @@ Zotero.Attachments = new function () {
 			throw new Error("'item' must be a Zotero.Item");
 		}
 		if (typeof options === 'string') {
-			Zotero.debug("Zotero.Attachments.getFileBaseNameFromItem(item, formatString) is deprecated -- use Zotero.Attachments(item, options)");
+			Zotero.warn("Zotero.Attachments.getFileBaseNameFromItem(item, formatString) is deprecated -- use Zotero.Attachments(item, options)");
 			options = { formatString: options };
 		}
 

--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -2253,7 +2253,7 @@ Zotero.Attachments = new function () {
 		};
 
 
-		const common = (value, { truncate = false, prefix = '', suffix = '', case: textCase = '' } = {}) => {
+		const common = (value, { truncate = false, prefix = '', suffix = '', replaceFrom = '', replaceTo = '', regexOpts = '', case: textCase = '' } = {}) => {
 			if (value === '' || value === null || typeof value === 'undefined') {
 				return '';
 			}
@@ -2283,6 +2283,9 @@ Zotero.Attachments = new function () {
 
 			let affixed = false;
 
+			if (replaceFrom) {
+				value = value.replace(new RegExp(replaceFrom, regexOpts), replaceTo);
+			}
 			if (prefix && !value.startsWith(prefix)) {
 				value = prefix + value;
 				affixed = true;

--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -2276,7 +2276,6 @@ Zotero.Attachments = new function () {
 			// match overrides all other options and returns immediately
 			if (match) {
 				try {
-					console.log(`Matching ${value} with ${match}: ${value.match(new RegExp(match, regexOpts))}`);
 					let matchResult = value.match(new RegExp(match, regexOpts));
 					return matchResult ? matchResult[0] : '';
 				}

--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -582,7 +582,7 @@ Zotero.Attachments = new function () {
 			// Rename attachment
 			if (renameIfAllowedType && !fileBaseName && this.isRenameAllowedForType(contentType)) {
 				let parentItem = Zotero.Items.get(parentItemID);
-				fileBaseName = this.getFileBaseNameFromItem(parentItem);
+				fileBaseName = this.getFileBaseNameFromItem(parentItem, { attachmentTitle: title });
 			}
 			if (fileBaseName) {
 				let ext = this._getExtensionFromURL(url, contentType);
@@ -1769,13 +1769,12 @@ Zotero.Attachments = new function () {
 	 * @return {Zotero.Item|false} - New Zotero.Item, or false if unsuccessful
 	 */
 	this.addFileFromURLs = async function (item, urlResolvers, options = {}) {
-		var fileBaseName = this.getFileBaseNameFromItem(item);
 		var tmpDir;
 		var tmpFile;
 		var attachmentItem = false;
 		try {
 			tmpDir = (await this.createTemporaryStorageDirectory()).path;
-			tmpFile = OS.Path.join(tmpDir, fileBaseName + '.tmp');
+			tmpFile = OS.Path.join(tmpDir, 'file.tmp');
 			let { title, mimeType, url, props } = await this.downloadFirstAvailableFile(
 				urlResolvers,
 				tmpFile,
@@ -1794,13 +1793,15 @@ Zotero.Attachments = new function () {
 				if (!this.FIND_AVAILABLE_FILE_TYPES.includes(mimeType)) {
 					throw new Error(`Resolved file is unsupported type ${mimeType}`);
 				}
-				let filename = fileBaseName + '.' + (Zotero.MIME.getPrimaryExtension(mimeType) || 'dat');
-				await IOUtils.move(tmpFile, PathUtils.join(tmpDir, filename));
+				title = title || _getTitleFromVersion(props.articleVersion);
+				let fileBaseName = this.getFileBaseNameFromItem(item, { attachmentTitle: title });
+				let ext = Zotero.MIME.getPrimaryExtension(mimeType) || 'dat';
+				let filename = await Zotero.File.rename(tmpFile, `${fileBaseName}.${ext}`);
 				attachmentItem = await this.createURLAttachmentFromTemporaryStorageDirectory({
 					directory: tmpDir,
 					libraryID: item.libraryID,
 					filename,
-					title: title || _getTitleFromVersion(props.articleVersion),
+					title,
 					url,
 					contentType: mimeType,
 					parentItemID: item.id
@@ -2207,10 +2208,16 @@ Zotero.Attachments = new function () {
 	 * @param {Zotero.Item} item
 	 * @param {String} formatString
 	 */
-	this.getFileBaseNameFromItem = function (item, formatString) {
+	this.getFileBaseNameFromItem = function (item, options = {}) {
 		if (!(item instanceof Zotero.Item)) {
 			throw new Error("'item' must be a Zotero.Item");
 		}
+		if (typeof options === 'string') {
+			Zotero.debug("Zotero.Attachments.getFileBaseNameFromItem(item, formatString) is deprecated -- use Zotero.Attachments(item, options)");
+			options = { formatString: options };
+		}
+
+		let { formatString = null, attachmentTitle = '' } = options;
 
 		if (!formatString) {
 			formatString = Zotero.Prefs.get('attachmentRenameTemplate');
@@ -2219,7 +2226,7 @@ Zotero.Attachments = new function () {
 		let chunks = [];
 		let protectedLiterals = new Set();
 
-		formatString = formatString.trim();
+		formatString = formatString.replace(/\r?\n|\r/g, "").trim();
 
 		const getSlicedCreatorsOfType = (creatorType, slice) => {
 			let creatorTypeIDs;
@@ -2253,7 +2260,7 @@ Zotero.Attachments = new function () {
 		};
 
 
-		const common = (value, { truncate = false, prefix = '', suffix = '', replaceFrom = '', replaceTo = '', regexOpts = '', case: textCase = '' } = {}) => {
+		const common = (value, { start = false, truncate = false, prefix = '', suffix = '', match = '', replaceFrom = '', replaceTo = '', regexOpts = 'i', case: textCase = '' } = {}) => {
 			if (value === '' || value === null || typeof value === 'undefined') {
 				return '';
 			}
@@ -2266,6 +2273,18 @@ Zotero.Attachments = new function () {
 				suffix = '';
 			}
 
+			// match overrides all other options and returns immediately
+			if (match) {
+				try {
+					console.log(`Matching ${value} with ${match}: ${value.match(new RegExp(match, regexOpts))}`);
+					let matchResult = value.match(new RegExp(match, regexOpts));
+					return matchResult ? matchResult[0] : '';
+				}
+				catch (_e) {
+					return '';
+				}
+			}
+
 			if (protectedLiterals.size > 0) {
 				// escape protected literals in the format string with \
 				value = value.replace(
@@ -2274,8 +2293,12 @@ Zotero.Attachments = new function () {
 				);
 			}
 
+			if (start) {
+				value = value.substring(start);
+			}
+
 			if (truncate) {
-				value = value.substr(0, truncate);
+				value = value.substring(0, truncate);
 			}
 
 			value = value.trim();
@@ -2284,7 +2307,12 @@ Zotero.Attachments = new function () {
 			let affixed = false;
 
 			if (replaceFrom) {
-				value = value.replace(new RegExp(replaceFrom, regexOpts), replaceTo);
+				try {
+					value = value.replace(new RegExp(replaceFrom, regexOpts), replaceTo);
+				}
+				catch (_e) {
+					// ignore
+				}
 			}
 			if (prefix && !value.startsWith(prefix)) {
 				value = prefix + value;
@@ -2313,9 +2341,11 @@ Zotero.Attachments = new function () {
 					value = Zotero.Utilities.capitalizeTitle(value, true);
 					break;
 				case 'hyphen':
+					value = value.replace(/\s+-/g, '-').replace(/-\s+/g, '-');
 					value = value.toLowerCase().replace(/\s+/g, '-');
 					break;
 				case 'snake':
+					value = value.replace(/\s+_/g, '_').replace(/_\s+/g, '_');
 					value = value.toLowerCase().replace(/\s+/g, '_');
 					break;
 				case 'camel':
@@ -2392,8 +2422,9 @@ Zotero.Attachments = new function () {
 			item.getField('firstCreator', true, true), args
 		);
 
-		const vars = { ...fields, ...creatorFields, firstCreator, itemType, year };
+		const attachmentTitleFn = args => common(attachmentTitle ?? '', args);
 
+		const vars = { ...fields, ...creatorFields, attachmentTitle: attachmentTitleFn, firstCreator, itemType, year };
 
 		// Final name is generated twice. In the first pass we collect all affixed values and determine protected literals.
 		// This is done in order to remove repeated suffixes, except if these appear in the value or the format string itself.
@@ -2480,7 +2511,7 @@ Zotero.Attachments = new function () {
 		if (!this.isRenameAllowedForType(contentType)) {
 			return false;
 		}
-		return this.getFileBaseNameFromItem(parentItem);
+		return this.getFileBaseNameFromItem(parentItem, { attachmentTitle: PathUtils.filename(file) });
 	}
 	
 	

--- a/chrome/content/zotero/xpcom/recognizeDocument.js
+++ b/chrome/content/zotero/xpcom/recognizeDocument.js
@@ -294,7 +294,7 @@ Zotero.RecognizeDocument = new function () {
 		// Rename attachment file to match new metadata
 		if (Zotero.Attachments.shouldAutoRenameFile(attachment.attachmentLinkMode == Zotero.Attachments.LINK_MODE_LINKED_FILE)) {
 			let ext = Zotero.File.getExtension(path);
-			let fileBaseName = Zotero.Attachments.getFileBaseNameFromItem(parentItem);
+			let fileBaseName = Zotero.Attachments.getFileBaseNameFromItem(parentItem, { attachmentTitle: originalTitle });
 			let newName = fileBaseName + (ext ? '.' + ext : '');
 			let result = await attachment.renameAttachmentFile(newName, false, true);
 			if (result !== true) {

--- a/chrome/content/zotero/xpcom/translation/translate_item.js
+++ b/chrome/content/zotero/xpcom/translation/translate_item.js
@@ -901,7 +901,7 @@ Zotero.Translate.ItemSaver.prototype = {
 		let fileBaseName;
 		if (parentItemID) {
 			let parentItem = yield Zotero.Items.getAsync(parentItemID);
-			fileBaseName = Zotero.Attachments.getFileBaseNameFromItem(parentItem);
+			fileBaseName = Zotero.Attachments.getFileBaseNameFromItem(parentItem, { attachmentTitle: title });
 		}
 		
 		attachment.linkMode = "imported_url";

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -5665,7 +5665,7 @@ var ZoteroPane = new function()
 			
 			let parentItemID = item.parentItemID;
 			let parentItem = await Zotero.Items.getAsync(parentItemID);
-			var newName = Zotero.Attachments.getFileBaseNameFromItem(parentItem);
+			var newName = Zotero.Attachments.getFileBaseNameFromItem(parentItem, { attachmentTitle: item.getField('title') });
 			
 			let extRE = /\.[^\.]+$/;
 			let origFilename = PathUtils.split(file).pop();

--- a/test/tests/attachmentsTest.js
+++ b/test/tests/attachmentsTest.js
@@ -1431,6 +1431,10 @@ describe("Zotero.Attachments", function() {
 				'Barius and Pixelus - 1975 - Lorem Ipsum'
 			);
 			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, '{{firstCreator suffix=" - " replaceFrom=" *and *" replaceTo="&"}}{{year suffix=" - " replaceFrom="(\\d{2})(\\d{2})" replaceTo="$2"}}{{title truncate="50" replaceFrom=".m" replaceTo="a"}} - {{title truncate="50" replaceFrom=".m" replaceTo="a" regexOpts="g"}}'),
+				'Barius&Pixelus - 75 - Lora Ipsum - Lora Ipsa'
+			);
+			assert.equal(
 				Zotero.Attachments.getFileBaseNameFromItem(item, '{{year suffix="-"}}{{firstCreator truncate="10" suffix="-"}}{{title truncate="5" }}'),
 				'1975-Barius and-Lorem'
 			);


### PR DESCRIPTION
This PR adds an option to test and use the title of the best attachment (as `attachmentTitle`) in the file renaming template. For example, the following template will conditionally use the best attachment's title or fall back to Zotero's default renaming template for items that do not have an attachment or for items where the attachment has one of the generic names ("Full Text", "Submitted Version" etc.).

````
{{ if {{ attachmentTitle match="^(full.*|submitted.*|accepted.*)$" }} }}
{{ firstCreator suffix=" - " }}{{ year suffix=" - " }}{{ title truncate="100" }}
{{ else }}
{{ if attachmentTitle }}
{{ attachmentTitle replaceFrom=".pdf|.epub" }}
{{ else }}
{{ firstCreator suffix=" - " }}{{ year suffix=" - " }}{{ title truncate="100" }}
{{ endif }}
````

This PR includes the commit from #3562. However, I've tweaked the functionality so that regex is case-insensitive by default because I expect that's what most people would prefer (also, our condition checking is already case-insensitive). This can still be configured.

Because the new `attachmentTitle` field requires a DB query to find the best attachment, `getFileBaseNameFromItem()` has become an async function. All calls throughout the codebase have been updated to reflect that. One noteworthy change is in `FileDragDataProvider` where previously `getFileBaseNameFromItem()` was used, and now the title of the attachment is used instead.

I've also introduced `start` function to enable truncating from left (should we call it `truncateLeft` instead?) and few small changes to make editing templates slightly easier and to avoid repeated hyphens/underscores when using `case="snake"` or `case="hyphen"`.

Fix #3252