### PR TITLE
File renaming: Match content type prefixes, add UI

### DIFF
--- a/chrome/content/zotero/elements/zoteroSearch.js
+++ b/chrome/content/zotero/elements/zoteroSearch.js
@@ -476,7 +476,7 @@
 				
 				case 'fileTypeID':
 					var rows = Zotero.FileTypes.getTypes().map(type => ({
-						name: Zotero.getString('fileTypes.' + type.name),
+						name: Zotero.getString('file-type-' + type.name),
 						value: type.id
 					}));
 					

--- a/chrome/content/zotero/preferences/preferences_general.js
+++ b/chrome/content/zotero/preferences/preferences_general.js
@@ -218,7 +218,7 @@ Zotero_Preferences.General = {
 	}),
 	
 	setAutoRenameFileTypes: function () {
-		let typesBox = document.getElementById('zotero-prefpane-file-renaming-file-types-vbox');
+		let typesBox = document.getElementById('zotero-prefpane-file-renaming-file-types-box');
 		let enabledTypes = new Set(Zotero.Prefs.get('autoRenameFiles.fileTypes').split(','));
 		for (let checkbox of typesBox.querySelectorAll('checkbox')) {
 			if (checkbox.checked) {
@@ -236,7 +236,7 @@ Zotero_Preferences.General = {
 			document.getElementById('rename-linked-files').disabled = !Zotero.Prefs.get('autoRenameFiles');
 		});
 		
-		let typesBox = document.getElementById('zotero-prefpane-file-renaming-file-types-vbox');
+		let typesBox = document.getElementById('zotero-prefpane-file-renaming-file-types-box');
 		let enabledTypes = Zotero.Prefs.get('autoRenameFiles.fileTypes').split(',');
 		for (let checkbox of typesBox.querySelectorAll('checkbox')) {
 			checkbox.checked = enabledTypes.includes(checkbox.dataset.contentType);

--- a/chrome/content/zotero/preferences/preferences_general.js
+++ b/chrome/content/zotero/preferences/preferences_general.js
@@ -217,10 +217,30 @@ Zotero_Preferences.General = {
 		}
 	}),
 	
+	setAutoRenameFileTypes: function () {
+		let typesBox = document.getElementById('zotero-prefpane-file-renaming-file-types-vbox');
+		let enabledTypes = new Set(Zotero.Prefs.get('autoRenameFiles.fileTypes').split(','));
+		for (let checkbox of typesBox.querySelectorAll('checkbox')) {
+			if (checkbox.checked) {
+				enabledTypes.add(checkbox.dataset.contentType);
+			}
+			else {
+				enabledTypes.delete(checkbox.dataset.contentType);
+			}
+		}
+		Zotero.Prefs.set('autoRenameFiles.fileTypes', [...enabledTypes].join(','));
+	},
+	
 	updateAutoRenameFilesUI: function () {
 		setTimeout(() => {
 			document.getElementById('rename-linked-files').disabled = !Zotero.Prefs.get('autoRenameFiles');
 		});
+		
+		let typesBox = document.getElementById('zotero-prefpane-file-renaming-file-types-vbox');
+		let enabledTypes = Zotero.Prefs.get('autoRenameFiles.fileTypes').split(',');
+		for (let checkbox of typesBox.querySelectorAll('checkbox')) {
+			checkbox.checked = enabledTypes.includes(checkbox.dataset.contentType);
+		}
 	},
 	
 	//

--- a/chrome/content/zotero/preferences/preferences_general.xhtml
+++ b/chrome/content/zotero/preferences/preferences_general.xhtml
@@ -116,6 +116,35 @@
 					preference="extensions.zotero.autoRenameFiles.linked"
 					oncommand="Zotero_Preferences.General.updateAutoRenameFilesUI()" native="true"
 				/>
+
+				<label data-l10n-id="preferences-file-renaming-file-types"/>
+				<vbox
+					id="zotero-prefpane-file-renaming-file-types-vbox"
+					class="indented-pref"
+					oncommand="Zotero_Preferences.General.setAutoRenameFileTypes()"
+				>
+					<checkbox
+						data-l10n-id="preferences-file-renaming-file-type-pdf"
+						data-content-type="application/pdf"
+						native="true"
+					/>
+					<checkbox
+						data-l10n-id="preferences-file-renaming-file-type-epub"
+						data-content-type="application/epub+zip"
+						native="true"
+					/>
+					<checkbox
+						data-l10n-id="preferences-file-renaming-file-type-image"
+						data-content-type="image/"
+						native="true"
+					/>
+					<checkbox
+						data-l10n-id="preferences-file-renaming-file-type-audio"
+						data-content-type="audio/"
+						native="true"
+					/>
+				</vbox>
+
 				<button id="file-renaming-button"
 					data-l10n-id="preferences-file-renaming-customize-button"
 					data-search-strings="preferences-file-renaming-format-title, preferences-file-renaming-format-template"

--- a/chrome/content/zotero/preferences/preferences_general.xhtml
+++ b/chrome/content/zotero/preferences/preferences_general.xhtml
@@ -118,8 +118,8 @@
 				/>
 
 				<label data-l10n-id="preferences-file-renaming-file-types"/>
-				<vbox
-					id="zotero-prefpane-file-renaming-file-types-vbox"
+				<hbox
+					id="zotero-prefpane-file-renaming-file-types-box"
 					class="indented-pref"
 					oncommand="Zotero_Preferences.General.setAutoRenameFileTypes()"
 				>
@@ -148,7 +148,7 @@
 						data-content-type="video/"
 						native="true"
 					/>
-				</vbox>
+				</hbox>
 
 				<button id="file-renaming-button"
 					data-l10n-id="preferences-file-renaming-customize-button"

--- a/chrome/content/zotero/preferences/preferences_general.xhtml
+++ b/chrome/content/zotero/preferences/preferences_general.xhtml
@@ -143,6 +143,11 @@
 						data-content-type="audio/"
 						native="true"
 					/>
+					<checkbox
+						data-l10n-id="preferences-file-renaming-file-type-video"
+						data-content-type="video/"
+						native="true"
+					/>
 				</vbox>
 
 				<button id="file-renaming-button"

--- a/chrome/content/zotero/xpcom/data/feed.js
+++ b/chrome/content/zotero/xpcom/data/feed.js
@@ -499,7 +499,7 @@ Zotero.Feed.prototype._updateFeed = Zotero.Promise.coroutine(function* () {
 	for (let attachment of attachmentsToAdd) {
 		if (attachment.url.indexOf('pdf') != -1 || attachment.contentType.indexOf('pdf') != -1) {
 			attachment.parentItemID = attachment.parentItem.id;
-			attachment.title = Zotero.getString('fileTypes.pdf');
+			attachment.title = Zotero.getString('file-type-pdf');
 			yield Zotero.Attachments.linkFromURL(attachment);
 		}
 	}

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -3877,6 +3877,15 @@ Zotero.Item.prototype._getDefaultTitleForAttachmentContentType = function () {
 	if (contentType === 'text/html') {
 		return Zotero.getString('file-type-webpage');
 	}
+	if (contentType.startsWith('image/')) {
+		return Zotero.getString('file-type-image');
+	}
+	if (contentType.startsWith('audio/')) {
+		return Zotero.getString('file-type-audio');
+	}
+	if (contentType.startsWith('video/')) {
+		return Zotero.getString('file-type-video');
+	}
 	return null;
 };
 

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -3864,16 +3864,20 @@ Zotero.Item.prototype.clearBestAttachmentState = function () {
 
 
 Zotero.Item.prototype._getDefaultTitleForAttachmentContentType = function () {
-	switch (this.attachmentContentType) {
-		case 'application/pdf':
-			return Zotero.getString('fileTypes.pdf');
-		case 'application/epub+zip':
-			return Zotero.getString('fileTypes.ebook');
-		case 'text/html':
-			return Zotero.getString('fileTypes.webpage');
-		default:
-			return null;
+	let contentType = this.attachmentContentType;
+	if (!contentType) {
+		return null;
 	}
+	if (contentType === 'application/pdf') {
+		return Zotero.getString('file-type-pdf');
+	}
+	if (contentType === 'application/epub+zip') {
+		return Zotero.getString('file-type-ebook');
+	}
+	if (contentType === 'text/html') {
+		return Zotero.getString('file-type-webpage');
+	}
+	return null;
 };
 
 

--- a/chrome/content/zotero/xpcom/editorInstance.js
+++ b/chrome/content/zotero/xpcom/editorInstance.js
@@ -150,7 +150,7 @@ class EditorInstance {
 			let fp = new FilePicker();
 			fp.init(this._iframeWindow, Zotero.getString('noteEditor.saveImageAs'), fp.modeSave);
 			fp.appendFilters(fp.filterImages);
-			fp.defaultString = Zotero.getString('fileTypes.image').toLowerCase() + '.' + ext;
+			fp.defaultString = Zotero.getString('file-type-image').toLowerCase() + '.' + ext;
 			let rv = await fp.show();
 			if (rv === fp.returnOK || rv === fp.returnReplace) {
 				let outputPath = fp.file;

--- a/chrome/content/zotero/xpcom/intl.js
+++ b/chrome/content/zotero/xpcom/intl.js
@@ -28,6 +28,7 @@ Zotero.Intl = new function () {
 	let intlProps;
 	let pluralFormGet;
 	let pluralFormNumForms;
+	let ftl;
 
 	// Get settings from language pack (extracted by zotero-build/locale/merge_mozilla_files)
 	this.init = function () {
@@ -88,6 +89,14 @@ Zotero.Intl = new function () {
 				this.strings[regexpResult[1]] = regexpResult[2];
 			}
 		}
+		
+		// Provide synchronous access to Fluent strings for getString()
+		ftl = new Localization([
+			'zotero.ftl',
+			// More FTL files can be hardcoded here, or added later with
+			// Zotero.ftl.addResourceIds(['...'])
+		], true);
+		Zotero.ftl = ftl;
 	};
 
 
@@ -108,11 +117,17 @@ Zotero.Intl = new function () {
 				}
 				l10n = bundle.formatStringFromName(name, params, params.length);
 			}
-			else if (this.strings[name]) {
-				return this.strings[name];
-			}
 			else {
-				l10n = bundle.GetStringFromName(name);
+				let ftlString = ftl.formatValueSync(name);
+				if (ftlString) {
+					return ftlString;
+				}
+				else if (this.strings[name]) {
+					return this.strings[name];
+				}
+				else {
+					l10n = bundle.GetStringFromName(name);
+				}
 			}
 			if (num !== undefined) {
 				let availableForms = l10n.split(/;/);

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -451,7 +451,7 @@ class ReaderInstance {
 					let fp = new FilePicker();
 					fp.init(this._iframeWindow, Zotero.getString('pdfReader.saveImageAs'), fp.modeSave);
 					fp.appendFilter("PNG", "*.png");
-					fp.defaultString = Zotero.getString('fileTypes.image').toLowerCase() + '.png';
+					fp.defaultString = Zotero.getString('file-type-image').toLowerCase() + '.png';
 					let rv = await fp.show();
 					if (rv === fp.returnOK || rv === fp.returnReplace) {
 						let outputPath = fp.file;

--- a/chrome/locale/en-US/zotero/preferences.ftl
+++ b/chrome/locale/en-US/zotero/preferences.ftl
@@ -8,6 +8,15 @@ preferences-file-renaming-title = File Renaming
 preferences-file-renaming-intro = { -app-name } automatically renames downloaded files based on the details of the parent item (title, author, etc.). You can choose to rename files added from your computer as well.
 preferences-file-renaming-auto-rename-files =
     .label = Automatically rename locally added files
+preferences-file-renaming-file-types = Rename files of these types:
+preferences-file-renaming-file-type-pdf =
+    .label = PDF
+preferences-file-renaming-file-type-epub =
+    .label = EPUB
+preferences-file-renaming-file-type-image =
+    .label = Image
+preferences-file-renaming-file-type-audio =
+    .label = Audio
 preferences-file-renaming-customize-button =
     .label = Customize Filename Format…
 

--- a/chrome/locale/en-US/zotero/preferences.ftl
+++ b/chrome/locale/en-US/zotero/preferences.ftl
@@ -17,6 +17,8 @@ preferences-file-renaming-file-type-image =
     .label = { file-type-image }
 preferences-file-renaming-file-type-audio =
     .label = { file-type-audio }
+preferences-file-renaming-file-type-video =
+    .label = { file-type-video }
 preferences-file-renaming-customize-button =
     .label = Customize Filename Format…
 

--- a/chrome/locale/en-US/zotero/preferences.ftl
+++ b/chrome/locale/en-US/zotero/preferences.ftl
@@ -10,13 +10,13 @@ preferences-file-renaming-auto-rename-files =
     .label = Automatically rename locally added files
 preferences-file-renaming-file-types = Rename files of these types:
 preferences-file-renaming-file-type-pdf =
-    .label = PDF
+    .label = { file-type-pdf }
 preferences-file-renaming-file-type-epub =
-    .label = EPUB
+    .label = { file-type-ebook }
 preferences-file-renaming-file-type-image =
-    .label = Image
+    .label = { file-type-image }
 preferences-file-renaming-file-type-audio =
-    .label = Audio
+    .label = { file-type-audio }
 preferences-file-renaming-customize-button =
     .label = Customize Filename Format…
 

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -659,3 +659,12 @@ find-pdf-files-added = { $count ->
 
 select-items-dialog =
     .buttonlabelaccept = Select
+
+file-type-webpage = Webpage
+file-type-image = Image
+file-type-pdf = PDF
+file-type-audio = Audio
+file-type-video = Video
+file-type-presentation = Presentation
+file-type-document = Document
+file-type-ebook = Ebook

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -643,15 +643,6 @@ creatorTypes.reviewedAuthor		= Reviewed Author
 creatorTypes.cosponsor			= Cosponsor
 creatorTypes.bookAuthor			= Book Author
 
-fileTypes.webpage				= Webpage
-fileTypes.image					= Image
-fileTypes.pdf					= PDF
-fileTypes.audio					= Audio
-fileTypes.video					= Video
-fileTypes.presentation			= Presentation
-fileTypes.document				= Document
-fileTypes.ebook				    = Ebook
-
 save.error.cannotMakeChangesToCollection = You cannot make changes to the currently selected collection.
 save.error.cannotAddFilesToCollection = You cannot add files to the currently selected collection.
 save.error.cannotAddToMyPublications = You cannot save items directly to My Publications. To add items, drag them from elsewhere in your library.

--- a/test/tests/attachmentsTest.js
+++ b/test/tests/attachmentsTest.js
@@ -111,7 +111,7 @@ describe("Zotero.Attachments", function() {
 				file: file,
 				parentItemID: parent.id,
 			});
-			assert.equal(attachment.getField('title'), Zotero.getString('fileTypes.pdf'));
+			assert.equal(attachment.getField('title'), Zotero.getString('file-type-pdf'));
 			await parent.eraseTx();
 		});
 	})
@@ -152,7 +152,7 @@ describe("Zotero.Attachments", function() {
 				file: file,
 				parentItemID: parent.id,
 			});
-			assert.equal(attachment.getField('title'), Zotero.getString('fileTypes.pdf'));
+			assert.equal(attachment.getField('title'), Zotero.getString('file-type-pdf'));
 			await parent.eraseTx();
 		});
 	})

--- a/test/tests/itemTreeTest.js
+++ b/test/tests/itemTreeTest.js
@@ -1573,7 +1573,7 @@ describe("Zotero.ItemTree", function() {
 			// Add a PDF attachment, which will get a default title
 			let pdfAttachment1 = Zotero.Items.get((await promise)[0]);
 			assert.equal(pdfAttachment1.parentItemID, parentItem.id);
-			assert.equal(pdfAttachment1.getField('title'), Zotero.getString('fileTypes.pdf'));
+			assert.equal(pdfAttachment1.getField('title'), Zotero.getString('file-type-pdf'));
 
 			promise = waitForItemEvent('add');
 			drop(parentRow, 0, dataTransfer);

--- a/test/tests/recognizeDocumentTest.js
+++ b/test/tests/recognizeDocumentTest.js
@@ -70,7 +70,7 @@ describe("Document Recognition", function() {
 			// The title should have changed
 			assert.equal(
 				attachment.getField('title'),
-				Zotero.getString('fileTypes.pdf')
+				Zotero.getString('file-type-pdf')
 			);
 		});
 		
@@ -103,7 +103,7 @@ describe("Document Recognition", function() {
 			// The title should have changed
 			assert.equal(
 				attachment.getField('title'),
-				Zotero.getString('fileTypes.pdf')
+				Zotero.getString('file-type-pdf')
 			);
 		});
 		
@@ -276,7 +276,7 @@ describe("Document Recognition", function() {
 			// The title should have changed
 			assert.equal(
 				attachment.getField('title'),
-				Zotero.getString('fileTypes.pdf')
+				Zotero.getString('file-type-pdf')
 			);
 		});
 		
@@ -317,7 +317,7 @@ describe("Document Recognition", function() {
 			// The title should have changed
 			assert.equal(
 				attachment.getField('title'),
-				Zotero.getString('fileTypes.pdf')
+				Zotero.getString('file-type-pdf')
 			);
 		});
 	});
@@ -370,7 +370,7 @@ describe("Document Recognition", function() {
 			// The title should have changed
 			assert.equal(
 				attachment.getField('title'),
-				Zotero.getString('fileTypes.ebook')
+				Zotero.getString('file-type-ebook')
 			);
 
 			translateStub.restore();
@@ -408,7 +408,7 @@ describe("Document Recognition", function() {
 			// The title should have changed
 			assert.equal(
 				attachment.getField('title'),
-				Zotero.getString('fileTypes.ebook')
+				Zotero.getString('file-type-ebook')
 			);
 		});
 

--- a/test/tests/translateTest.js
+++ b/test/tests/translateTest.js
@@ -2293,7 +2293,7 @@ describe("Zotero.Translate.ItemGetter", function() {
 					
 					// Set fields
 					assert.equal(attachment.itemType, 'attachment', prefix + 'itemType is correct' + suffix);
-					assert.include([Zotero.getString('fileTypes.pdf'), 'empty'], attachment.title, prefix + 'title is correct' + suffix);
+					assert.include([Zotero.getString('file-type-pdf'), 'empty'], attachment.title, prefix + 'title is correct' + suffix);
 					assert.equal(attachment.url, 'http://example.com', prefix + 'url is correct' + suffix);
 					assert.equal(attachment.note, 'note', prefix + 'note is correct' + suffix);
 					

--- a/test/tests/zoteroPaneTest.js
+++ b/test/tests/zoteroPaneTest.js
@@ -1650,7 +1650,7 @@ describe("ZoteroPane", function() {
 			file.append('test.pdf');
 			let [pdfAttachment1] = await zp.addAttachmentFromDialog(false, parentItem.id, [file.path]);
 			assert.equal(parentItem.getAttachments().length, 2);
-			assert.equal(pdfAttachment1.getField('title'), Zotero.getString('fileTypes.pdf'));
+			assert.equal(pdfAttachment1.getField('title'), Zotero.getString('file-type-pdf'));
 			
 			// Add a second, which will get a title based on its filename
 			let [pdfAttachment2] = await zp.addAttachmentFromDialog(false, parentItem.id, [file.path]);
@@ -1662,7 +1662,7 @@ describe("ZoteroPane", function() {
 			file.append('stub.epub');
 			let [epubAttachment] = await zp.addAttachmentFromDialog(false, parentItem.id, [file.path]);
 			assert.equal(parentItem.getAttachments().length, 4);
-			assert.equal(epubAttachment.getField('title'), Zotero.getString('fileTypes.ebook'));
+			assert.equal(epubAttachment.getField('title'), Zotero.getString('file-type-ebook'));
 		});
 	});
 })


### PR DESCRIPTION
Closes #4429, except I kept matching on MIME types only and just expanded it to accept prefixes. We don't always have a reliable file extension at the point where we decide whether to rename (`importFromURL()` - we just guess from the MIME type a lot of the time there).

The UI looks awful right now:

<img width="912" alt="image" src="https://github.com/user-attachments/assets/50a1e0bc-a020-476e-9653-1b9ced39f877">

Suggestions would be appreciated! (Changing the label to just "Rename:" looked worse, removing the indent looked way worse...)