### PR TITLE
Select Items Dialog: restore tab order

### DIFF
--- a/chrome/content/zotero/selectItemsDialog.js
+++ b/chrome/content/zotero/selectItemsDialog.js
@@ -105,7 +105,13 @@ var doLoad = async function () {
 	document.addEventListener('dialogaccept', doAccept);
 	
 	if (isSelectItemsDialog) {
-		setTabOrder();
+		// Set proper tab order. It is only needed in selectItemsDialog - other dialogs' focus order is correct
+		document.querySelector("#zotero-tb-search").searchModePopup.parentNode.setAttribute("tabindex", 1);
+		document.querySelector("#zotero-tb-search").searchTextbox.inputField.setAttribute("tabindex", 2);
+		document.querySelector("#collection-tree").setAttribute("tabindex", 3);
+		document.querySelector("#zotero-items-tree .virtualized-table").setAttribute("tabindex", 4);
+		document.querySelector("button[dlgtype='cancel'").setAttribute("tabindex", 5);
+		document.querySelector("button[dlgtype='accept'").setAttribute("tabindex", 6);
 	}
 	
 	// Used in tests
@@ -163,13 +169,4 @@ function onItemSelected()
 
 function doAccept() {
 	io.dataOut = itemsView.getSelectedItems(true);
-}
-
-function setTabOrder() {
-	document.querySelector("#zotero-tb-search-dropmarker").shadowRoot.getElementById("zotero-tb-search-menu-button").setAttribute("tabindex", 1);
-	document.querySelector("#zotero-tb-search-textbox").shadowRoot.querySelector("input").setAttribute("tabindex", 2);
-	document.querySelector("#collection-tree").setAttribute("tabindex", 3);
-	document.querySelector("#zotero-items-tree .virtualized-table").setAttribute("tabindex", 4);
-	document.querySelector("button[dlgtype='cancel'").setAttribute("tabindex", 5);
-	document.querySelector("button[dlgtype='accept'").setAttribute("tabindex", 6);
 }

--- a/chrome/content/zotero/selectItemsDialog.js
+++ b/chrome/content/zotero/selectItemsDialog.js
@@ -105,7 +105,7 @@ var doLoad = async function () {
 	document.addEventListener('dialogaccept', doAccept);
 	
 	if (isSelectItemsDialog) {
-		// Set proper tab order. It is only needed in selectItemsDialog - other dialogs' focus order is correct
+		// Set proper tab order. It is only needed in selectItemsDialog -- other dialogs' focus order is correct
 		document.querySelector("#zotero-tb-search").searchModePopup.parentNode.setAttribute("tabindex", 1);
 		document.querySelector("#zotero-tb-search").searchTextbox.inputField.setAttribute("tabindex", 2);
 		document.querySelector("#collection-tree").setAttribute("tabindex", 3);

--- a/chrome/content/zotero/selectItemsDialog.js
+++ b/chrome/content/zotero/selectItemsDialog.js
@@ -104,6 +104,8 @@ var doLoad = async function () {
 
 	document.addEventListener('dialogaccept', doAccept);
 	
+	setTabOrder();
+	
 	// Used in tests
 	loaded = true;
 };
@@ -159,4 +161,13 @@ function onItemSelected()
 
 function doAccept() {
 	io.dataOut = itemsView.getSelectedItems(true);
+}
+
+function setTabOrder() {
+	document.querySelector("#zotero-tb-search-dropmarker").shadowRoot.getElementById("zotero-tb-search-menu-button").setAttribute("tabindex", 1);
+	document.querySelector("#zotero-tb-search-textbox").shadowRoot.querySelector("input").setAttribute("tabindex", 2);
+	document.querySelector("#collection-tree").setAttribute("tabindex", 3);
+	document.querySelector("#item-tree-related-box-select-item-dialog-default").setAttribute("tabindex", 4);
+	document.querySelector("button[dlgtype='cancel'").setAttribute("tabindex", 5);
+	document.querySelector("button[dlgtype='accept'").setAttribute("tabindex", 6);
 }

--- a/chrome/content/zotero/selectItemsDialog.js
+++ b/chrome/content/zotero/selectItemsDialog.js
@@ -110,8 +110,11 @@ var doLoad = async function () {
 		document.querySelector("#zotero-tb-search").searchTextbox.inputField.setAttribute("tabindex", 2);
 		document.querySelector("#collection-tree").setAttribute("tabindex", 3);
 		document.querySelector("#zotero-items-tree .virtualized-table").setAttribute("tabindex", 4);
-		document.querySelector("button[dlgtype='cancel'").setAttribute("tabindex", 5);
-		document.querySelector("button[dlgtype='accept'").setAttribute("tabindex", 6);
+		// On windows, buttons are in a different order than on mac, so set tabindex accordingly
+		let nextButtonTabindex = 5;
+		for (let button of [...document.querySelectorAll("button[dlgtype]:not([hidden])")]) {
+			button.setAttribute("tabindex", nextButtonTabindex++);
+		}
 	}
 	
 	// Used in tests

--- a/chrome/content/zotero/selectItemsDialog.js
+++ b/chrome/content/zotero/selectItemsDialog.js
@@ -110,7 +110,7 @@ var doLoad = async function () {
 		document.querySelector("#zotero-tb-search").searchTextbox.inputField.setAttribute("tabindex", 2);
 		document.querySelector("#collection-tree").setAttribute("tabindex", 3);
 		document.querySelector("#zotero-items-tree .virtualized-table").setAttribute("tabindex", 4);
-		// On windows, buttons are in a different order than on mac, so set tabindex accordingly
+		// On Windows, buttons are in a different order than on macOS, so set tabindex accordingly
 		let nextButtonTabindex = 5;
 		for (let button of [...document.querySelectorAll("button[dlgtype]:not([hidden])")]) {
 			button.setAttribute("tabindex", nextButtonTabindex++);

--- a/chrome/content/zotero/selectItemsDialog.js
+++ b/chrome/content/zotero/selectItemsDialog.js
@@ -104,7 +104,9 @@ var doLoad = async function () {
 
 	document.addEventListener('dialogaccept', doAccept);
 	
-	setTabOrder();
+	if (isSelectItemsDialog) {
+		setTabOrder();
+	}
 	
 	// Used in tests
 	loaded = true;
@@ -167,7 +169,7 @@ function setTabOrder() {
 	document.querySelector("#zotero-tb-search-dropmarker").shadowRoot.getElementById("zotero-tb-search-menu-button").setAttribute("tabindex", 1);
 	document.querySelector("#zotero-tb-search-textbox").shadowRoot.querySelector("input").setAttribute("tabindex", 2);
 	document.querySelector("#collection-tree").setAttribute("tabindex", 3);
-	document.querySelector("#item-tree-related-box-select-item-dialog-default").setAttribute("tabindex", 4);
+	document.querySelector("#zotero-items-tree .virtualized-table").setAttribute("tabindex", 4);
 	document.querySelector("button[dlgtype='cancel'").setAttribute("tabindex", 5);
 	document.querySelector("button[dlgtype='accept'").setAttribute("tabindex", 6);
 }


### PR DESCRIPTION
After redesign, tab order became: quickSearch -> itemTree -> cancel and accept buttons -> collectionTree.

This restores original tab sequence: quickSearch -> collectionTree -> itemsTree -> cancel and accept buttons.