### PR TITLE
Fix first row of itemTree not getting announced

### DIFF
--- a/chrome/content/zotero/components/virtualized-table.jsx
+++ b/chrome/content/zotero/components/virtualized-table.jsx
@@ -1432,7 +1432,7 @@ class VirtualizedTable extends React.Component {
 	
 	// Set aria-activedescendant on table container
 	_setAriaAciveDescendant() {
-		if (this.selection.count === 0) return;
+		if (!this.selection.count) return;
 		let selected = this._jsWindow?.getElementByIndex(this.selection.focused);
 		if (selected) {
 			selected.closest(".virtualized-table").setAttribute("aria-activedescendant", selected.id);

--- a/chrome/content/zotero/components/virtualized-table.jsx
+++ b/chrome/content/zotero/components/virtualized-table.jsx
@@ -1432,7 +1432,7 @@ class VirtualizedTable extends React.Component {
 	
 	// Set aria-activedescendant on table container
 	_setAriaAciveDescendant() {
-		if (!this.selection.focused) return;
+		if (this.selection.count === 0) return;
 		let selected = this._jsWindow?.getElementByIndex(this.selection.focused);
 		if (selected) {
 			selected.closest(".virtualized-table").setAttribute("aria-activedescendant", selected.id);


### PR DESCRIPTION
Tweak to the conditional to check if something is focused via `selection.count` (instead of `selection.focused` which defaults to 0 and fails on the very first item).

Post: 40fd5efe05bc2f0cf3abaf6b47b44408d39d0d38.

Fixes: #4444