### PR TITLE
Autofocus input in Create Parent Item dialog

### DIFF
--- a/chrome/content/zotero/components/createParent/createParent.jsx
+++ b/chrome/content/zotero/components/createParent/createParent.jsx
@@ -56,12 +56,13 @@ function CreateParent({ loading, item, toggleAccept }) {
 				<input
 					id="parent-item-identifier"
 					size="50"
-					disabled={ loading }
-					onChange={ handleInput }
+					autoFocus={true}
+					disabled={loading}
+					onChange={handleInput}
 				/>
 				<div
 					mode="undetermined"
-					className={ cx('downloadProgress', { hidden: !loading }) }
+					className={cx('downloadProgress', { hidden: !loading })}
 				>
 					<div className="progress-bar"></div>
 				</div>


### PR DESCRIPTION
And normalize some code style.

I think the focus broke because the XUL window focuses on the first focusable element on load, but async rendering causes the input field not to exist in the DOM until slightly later. Probably better to be explicit about autofocus anyway.

Fixes #4469