### PR TITLE
Fix to test breakage

### DIFF
--- a/test/content/support.js
+++ b/test/content/support.js
@@ -1007,9 +1007,7 @@ function importFileAttachment(filename, options = {}) {
 	Object.assign(importOptions, options);
 	// Override default behavior - don't set title based on type,
 	// just use extension-less leafName
-	if (!('title' in importOptions)) {
-		importOptions.title = file.leafName.replace(/\.[^.]+$/, '');
-	}
+	importOptions.title ??= file.leafName.replace(/\.[^.]+$/, '');
 	return Zotero.Attachments.importFromFile(importOptions);
 }
 

--- a/test/tests/recognizeDocumentTest.js
+++ b/test/tests/recognizeDocumentTest.js
@@ -314,10 +314,10 @@ describe("Document Recognition", function() {
 			// The file should not have been renamed
 			assert.equal(attachment.attachmentFilename, 'test.pdf');
 
-			// The title should have changed
+			// The title should not have changed
 			assert.equal(
 				attachment.getField('title'),
-				Zotero.getString('file-type-pdf')
+				"test"
 			);
 		});
 	});


### PR DESCRIPTION
- fix annotation test breakage. `importOptions` always has a title field, set in `importPDFAttachment`,
so the title was never getting set.
- fix document recognition test. if `autoRenameFiles.linked` pref is false, the file's title should not change