### PR TITLE
Use production builds of react libraries

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -9,8 +9,6 @@
     "chrome/content/zotero/xpcom/citeproc.js",
     "chrome/content/ace/*",
     "chrome/content/scaffold/templates/*",
-    "resource/react.js",
-    "resource/react-dom.js",
     "resource/react-virtualized.js",
     "test/resource/*.js"
   ],

--- a/js-build/babel-worker.js
+++ b/js-build/babel-worker.js
@@ -30,19 +30,8 @@ async function babelWorker(ev) {
 
 	try {
 		let contents = await fs.readFile(sourcefile, 'utf8');
-		// Patch react
-		if (comparePaths(sourcefile, 'resource/react.js')) {
-			transformed = contents.replace('instanceof Error', '.constructor.name == "Error"')
-		}
-		// Patch react-dom
-		else if (comparePaths(sourcefile, 'resource/react-dom.js')) {
-			transformed = contents.replace(/ ownerDocument\.createElement\((.*?)\)/gi, 'ownerDocument.createElementNS(HTML_NAMESPACE, $1)')
-				.replace('element instanceof win.HTMLIFrameElement',
-					'typeof element != "undefined" && element.tagName.toLowerCase() == "iframe"')
-				.replace("isInputEventSupported = false", 'isInputEventSupported = true');
-		}
 		// Patch react-virtualized
-		else if (comparePaths(sourcefile, 'resource/react-virtualized.js')) {
+		if (comparePaths(sourcefile, 'resource/react-virtualized.js')) {
 			transformed = contents.replace('scrollDiv = document.createElement("div")', 'scrollDiv = document.createElementNS("http://www.w3.org/1999/xhtml", "div")')
 				.replace('document.body.appendChild(scrollDiv)', 'document.documentElement.appendChild(scrollDiv)')
 				.replace('document.body.removeChild(scrollDiv)', 'document.documentElement.removeChild(scrollDiv)');

--- a/js-build/config.js
+++ b/js-build/config.js
@@ -26,14 +26,12 @@ const copyDirs = [
 // list of files from root folder to symlink
 const symlinkFiles = [
 	'chrome.manifest',
-	// React needs to be patched by babel-worker.js, so symlink all files in resource/ except for
-	// those. Babel transpilation for React is still disabled in .babelrc.
+	// react-virtualized needs to be patched by babel-worker.js, so symlink all files in resource/ except for
+	// those. Babel transpilation is still disabled in .babelrc.
 	'resource/**/*',
-	'!resource/react.js',
-	'!resource/react-dom.js',
 	'!resource/react-virtualized.js',
 	// Only include dist directory of singleFile
-	// Also do a little bit of manipulation similar to React
+	// Also do a little bit of manipulation similar to react-virtualized
 	'!resource/SingleFile/**/*',
 	'resource/SingleFile/lib/**/*',
 	'!resource/SingleFile/lib/single-file.js',
@@ -116,9 +114,7 @@ const jsFiles = [
 	`{${dirs.join(',')}}/**/*.jsx`,
 	`!{${symlinkDirs.concat(copyDirs).join(',')}}/**/*.js`,
 	`!{${symlinkDirs.concat(copyDirs).join(',')}}/**/*.jsx`,
-	// Special handling for React -- see note above
-	'resource/react.js',
-	'resource/react-dom.js',
+	// Special handling for react-virtualized and others -- see note above
 	'resource/react-virtualized.js',
 	'resource/SingleFile/lib/single-file.js',
 	'resource/citeproc_rs_wasm.js',

--- a/resource/react-dom-server.js
+++ b/resource/react-dom-server.js
@@ -1,1 +1,1 @@
-../node_modules/react-dom/umd/react-dom-server.browser.development.js
+../node_modules/react-dom/umd/react-dom-server.browser.production.min.js

--- a/resource/react-dom.js
+++ b/resource/react-dom.js
@@ -1,1 +1,1 @@
-../node_modules/react-dom/umd/react-dom.development.js
+../node_modules/react-dom/umd/react-dom.production.min.js

--- a/resource/react-intl.js
+++ b/resource/react-intl.js
@@ -1,1 +1,1 @@
-../node_modules/react-intl/dist/react-intl.js
+../node_modules/react-intl/dist/react-intl.min.js

--- a/resource/react.js
+++ b/resource/react.js
@@ -1,1 +1,1 @@
-../node_modules/react/umd/react.development.js
+../node_modules/react/umd/react.production.min.js


### PR DESCRIPTION
Also, I removed the patching for `react` and `react-dom`, as it doesn't seem to be required anymore. These can now be linked instead of being babel-processed.

I only had a brief look, but it doesn't seem to break anything.

If we want to, we could use development versions outside of production (to include extra warning messages in that version). However, we would need to have two different processes, e.g., `npm start` for development and `npm build` for production.

Fix #4481