### PR TITLE
File Renaming: Rearrange prefs

### DIFF
--- a/chrome/content/zotero/preferences/preferences_general.js
+++ b/chrome/content/zotero/preferences/preferences_general.js
@@ -236,15 +236,15 @@ Zotero_Preferences.General = {
 	},
 	
 	updateAutoRenameFilesUI: function () {
-		setTimeout(() => {
-			document.getElementById('rename-linked-files').disabled = !Zotero.Prefs.get('autoRenameFiles');
-		});
+		let disabled = !Zotero.Prefs.get('autoRenameFiles');
 		
 		let typesBox = document.getElementById('zotero-prefpane-file-renaming-file-types-box');
 		let enabledTypes = Zotero.Prefs.get('autoRenameFiles.fileTypes').split(',');
 		for (let checkbox of typesBox.querySelectorAll('checkbox')) {
 			checkbox.checked = enabledTypes.includes(checkbox.dataset.contentType);
+			checkbox.disabled = disabled;
 		}
+		document.getElementById('rename-linked-files').disabled = disabled;
 	},
 	
 	//

--- a/chrome/content/zotero/preferences/preferences_general.xhtml
+++ b/chrome/content/zotero/preferences/preferences_general.xhtml
@@ -109,46 +109,47 @@
 				<separator class="thin"/>
 				<checkbox data-l10n-id="preferences-file-renaming-auto-rename-files"
 					preference="extensions.zotero.autoRenameFiles"
-					oncommand="Zotero_Preferences.General.updateAutoRenameFilesUI()" native="true"
+					oncommand="setTimeout(() => Zotero_Preferences.General.updateAutoRenameFilesUI())" native="true"
 				/>
+				<vbox class="indented-pref">
+					<label data-l10n-id="preferences-file-renaming-file-types"/>
+					<hbox
+						id="zotero-prefpane-file-renaming-file-types-box"
+						class="indented-pref"
+						oncommand="Zotero_Preferences.General.setAutoRenameFileTypes()"
+					>
+						<checkbox
+							data-l10n-id="preferences-file-renaming-file-type-pdf"
+							data-content-type="application/pdf"
+							native="true"
+						/>
+						<checkbox
+							data-l10n-id="preferences-file-renaming-file-type-epub"
+							data-content-type="application/epub+zip"
+							native="true"
+						/>
+						<checkbox
+							data-l10n-id="preferences-file-renaming-file-type-image"
+							data-content-type="image/"
+							native="true"
+						/>
+						<checkbox
+							data-l10n-id="preferences-file-renaming-file-type-audio"
+							data-content-type="audio/"
+							native="true"
+						/>
+						<checkbox
+							data-l10n-id="preferences-file-renaming-file-type-video"
+							data-content-type="video/"
+							native="true"
+						/>
+					</hbox>
+				</vbox>
 				<checkbox id="rename-linked-files" class="indented-pref"
 					label="&zotero.preferences.autoRenameFiles.renameLinked;"
 					preference="extensions.zotero.autoRenameFiles.linked"
 					oncommand="Zotero_Preferences.General.updateAutoRenameFilesUI()" native="true"
 				/>
-
-				<label data-l10n-id="preferences-file-renaming-file-types"/>
-				<hbox
-					id="zotero-prefpane-file-renaming-file-types-box"
-					class="indented-pref"
-					oncommand="Zotero_Preferences.General.setAutoRenameFileTypes()"
-				>
-					<checkbox
-						data-l10n-id="preferences-file-renaming-file-type-pdf"
-						data-content-type="application/pdf"
-						native="true"
-					/>
-					<checkbox
-						data-l10n-id="preferences-file-renaming-file-type-epub"
-						data-content-type="application/epub+zip"
-						native="true"
-					/>
-					<checkbox
-						data-l10n-id="preferences-file-renaming-file-type-image"
-						data-content-type="image/"
-						native="true"
-					/>
-					<checkbox
-						data-l10n-id="preferences-file-renaming-file-type-audio"
-						data-content-type="audio/"
-						native="true"
-					/>
-					<checkbox
-						data-l10n-id="preferences-file-renaming-file-type-video"
-						data-content-type="video/"
-						native="true"
-					/>
-				</hbox>
 
 				<button id="file-renaming-button"
 					data-l10n-id="preferences-file-renaming-customize-button"


### PR DESCRIPTION
IMO this also just looks better:

<img width="586" alt="image" src="https://github.com/user-attachments/assets/b2e5fc1f-ed7c-425d-9e6b-502bc1f2a478">

(Keeping the checkboxes below "Rename linked files" looked wrong, and arguably the checkboxes controlling which file types to rename in *all* cases are more immediately relevant to the parent "Automatically rename locally added files" pref than the linked files checkbox is.)

Addresses #4485