### PR TITLE
Retrieve Metadata & Create Parent: Use `autoRenameFiles.fileTypes`

### DIFF
--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -2503,6 +2503,12 @@ Zotero.Attachments = new function () {
 	};
 	
 	
+	this.shouldAutoRenameAttachment = function (attachment) {
+		return Zotero.Attachments.shouldAutoRenameFile(attachment.attachmentLinkMode == Zotero.Attachments.LINK_MODE_LINKED_FILE)
+			&& Zotero.Attachments.isRenameAllowedForType(attachment.attachmentContentType);
+	};
+	
+	
 	this.getRenamedFileBaseNameIfAllowedType = async function (parentItem, file) {
 		var contentType = file.endsWith('.pdf')
 			// Don't bother reading file if there's a .pdf extension

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -3907,9 +3907,7 @@ Zotero.Item.prototype.setAutoAttachmentTitle = function ({ ignoreAutoRenamePrefs
 	// file is being renamed, give it a default title ("PDF", "Webpage", etc.)
 	let isFirstOfType = this.parentItemID
 		&& this.parentItem.numFileAttachmentsWithContentType(this.attachmentContentType) <= 1;
-	let isBeingRenamed = ignoreAutoRenamePrefs
-		|| (Zotero.Attachments.shouldAutoRenameFile(this.isLinkedFileAttachment())
-			&& Zotero.Attachments.isRenameAllowedForType(this.attachmentContentType));
+	let isBeingRenamed = ignoreAutoRenamePrefs || Zotero.Attachments.shouldAutoRenameAttachment(this);
 	if (isFirstOfType && isBeingRenamed) {
 		let defaultTitle = this._getDefaultTitleForAttachmentContentType();
 		if (defaultTitle !== null) {

--- a/chrome/content/zotero/xpcom/recognizeDocument.js
+++ b/chrome/content/zotero/xpcom/recognizeDocument.js
@@ -292,7 +292,7 @@ Zotero.RecognizeDocument = new function () {
 		var originalFilename = PathUtils.filename(path);
 		
 		// Rename attachment file to match new metadata
-		if (Zotero.Attachments.shouldAutoRenameFile(attachment.attachmentLinkMode == Zotero.Attachments.LINK_MODE_LINKED_FILE)) {
+		if (Zotero.Attachments.shouldAutoRenameAttachment(attachment)) {
 			let ext = Zotero.File.getExtension(path);
 			let fileBaseName = Zotero.Attachments.getFileBaseNameFromItem(parentItem, { attachmentTitle: originalTitle });
 			let newName = fileBaseName + (ext ? '.' + ext : '');
@@ -300,11 +300,9 @@ Zotero.RecognizeDocument = new function () {
 			if (result !== true) {
 				throw new Error("Error renaming " + path);
 			}
+			attachment.setAutoAttachmentTitle({ ignoreAutoRenamePrefs: true });
+			await attachment.saveTx();
 		}
-		
-		// Rename attachment title
-		attachment.setAutoAttachmentTitle();
-		await attachment.saveTx();
 
 		try {
 			let win = Zotero.getMainWindow();

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -5343,7 +5343,7 @@ var ZoteroPane = new function()
 		}
 
 		for (let item of items) {
-			if (Zotero.Attachments.shouldAutoRenameFile(item.attachmentLinkMode == Zotero.Attachments.LINK_MODE_LINKED_FILE)) {
+			if (Zotero.Attachments.shouldAutoRenameAttachment(item)) {
 				let path = item.getFilePath();
 				if (!path) {
 					Zotero.debug('No path for attachment ' + item.key);

--- a/test/tests/zoteroPaneTest.js
+++ b/test/tests/zoteroPaneTest.js
@@ -1698,7 +1698,26 @@ describe("ZoteroPane", function() {
 			assert.equal(attachment.getField('title'), Zotero.getString('file-type-pdf'));
 		});
 
-		it("should not rename a linked attachment or set an automatic title when linked file renaming disabled", async function () {
+		it("shouldn't rename or change the title of an attachment with a disabled type", async function () {
+			Zotero.Prefs.set('autoRenameFiles.fileTypes', 'x-nonexistent/type');
+
+			let file = getTestDataDirectory();
+			file.append('test.pdf');
+			let attachment = await Zotero.Attachments.linkFromFile({
+				file,
+				title: 'Attachment title'
+			});
+			assert.equal(attachment.attachmentFilename, 'test.pdf');
+
+			let parent = await createParent();
+			assert.equal(attachment.parentItem, parent);
+			assert.equal(attachment.attachmentFilename, 'test.pdf');
+			assert.equal(attachment.getField('title'), 'Attachment title');
+
+			Zotero.Prefs.clear('autoRenameFiles.fileTypes');
+		});
+
+		it("shouldn't rename a linked attachment or set an automatic title when linked file renaming disabled", async function () {
 			Zotero.Prefs.set('autoRenameFiles.linked', false);
 			
 			let file = getTestDataDirectory();


### PR DESCRIPTION
Don't change the filename or title unless auto-renaming is enabled for the attachment link mode and content type.

Closes #4484