### PR TITLE
Setting - Feeds fix misaligned unread/read cleanup option

### DIFF
--- a/chrome/content/zotero/preferences/preferences_advanced.xhtml
+++ b/chrome/content/zotero/preferences/preferences_advanced.xhtml
@@ -198,7 +198,7 @@
 			<hbox>
 				<hbox align="center">
 					<label id="zotero-prefpane-feeds-readAfter-label1" value="&zotero.feedSettings.cleanupReadAfter.label1;"/>
-					<html:input class="html-input" type="number" min="1" step="1" size="2" data-preference="feeds.defaultCleanupUnreadAfter"
+					<html:input class="html-input" type="number" min="1" step="1" size="2" data-preference="feeds.defaultCleanupReadAfter"
 						aria-labelledby="zotero-prefpane-feeds-readAfter-label1 zotero-prefpane-feeds-readAfter-label2"/>
 					<label id="zotero-prefpane-feeds-readAfter-label2" value="&zotero.feedSettings.cleanupReadAfter.label2;"/>
 				</hbox>
@@ -206,7 +206,7 @@
 			<hbox>
 				<hbox align="center">
 					<label id="zotero-prefpane-feeds-unreadAfter-label1" value="&zotero.feedSettings.cleanupUnreadAfter.label1;"/>
-					<html:input class="html-input" type="number" min="1" step="1" size="2" data-preference="feeds.defaultCleanupReadAfter"
+					<html:input class="html-input" type="number" min="1" step="1" size="2" data-preference="feeds.defaultCleanupUnreadAfter"
 						aria-labelledby="zotero-prefpane-feeds-unreadAfter-label1 zotero-prefpane-feeds-unreadAfter-label2"/>
 					<label id="zotero-prefpane-feeds-unreadAfter-label2" value="&zotero.feedSettings.cleanupUnreadAfter.label2;"/>
 				</hbox>


### PR DESCRIPTION
The settings was writing to the wrong preference key, code tested on macOS