### PR TITLE
Fix keyboard focus not landing on feeds itemTree

### DIFF
--- a/chrome/content/zotero/elements/itemDetails.js
+++ b/chrome/content/zotero/elements/itemDetails.js
@@ -568,7 +568,7 @@
 			// On Escape/Enter on editable-text, return focus to the item tree or reader
 			if (event.key == "Escape" || (event.key == "Enter" && event.target.classList.contains('input'))) {
 				if (isLibraryTab) {
-					document.getElementById('item-tree-main-default').focus();
+					document.querySelector('#zotero-items-tree .virtualized-table').focus();
 				}
 				else {
 					let reader = Zotero.Reader.getByTabID(Zotero_Tabs.selectedID);

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -407,7 +407,7 @@ var ZoteroPane = new function()
 					ShiftTab: () => {
 						document.getElementById("zotero-tb-search")._searchModePopup.flattenedTreeParentNode.focus();
 					},
-					Tab: () => document.getElementById('item-tree-main-default')
+					Tab: () => itemTree.querySelector(".virtualized-table")
 				},
 				'zotero-tb-search-dropmarker': {
 					ArrowNext: () => null,


### PR DESCRIPTION
Do not use specific `#item-tree-main-default` selector to find the itemTree node to focus since a different id can be set for the table, e.g for the list of feeds.

Use a more general `#zotero-items-tree .virtualized-table` selector to focus the itemTree on tab from quickSearch and on Escape keypress from an `editable-text` of itemPane.

Fixes: #4494