### PR TITLE
Feed settings: Make disclosure triangle focusable, extract SCSS

### DIFF
--- a/chrome/content/zotero/feedSettings.xhtml
+++ b/chrome/content/zotero/feedSettings.xhtml
@@ -36,12 +36,12 @@
 		<html:input id="feed-title" style="max-width: 30em;" />
 	</html:div>
 	<vbox id="advanced-options" class="zotero-advanced-options">
-		<hbox onclick="Zotero_Feed_Settings.toggleAdvancedOptions()"  class="zotero-advanced-options-label">
-			<toolbarbutton class="toolbarbutton-menu-dropmarker"/>
+		<button oncommand="Zotero_Feed_Settings.toggleAdvancedOptions()" class="zotero-advanced-options-label">
+			<dropmarker type="menu" class="toolbarbutton-menu-dropmarker"/>
 			<hbox align="center">
 				<label value="&zotero.general.advancedOptions.label;"/>
 			</hbox>
-		</hbox>
+		</button>
 		<vbox id="advanced-options-togglable">
 			<hbox align="center">
 				<label value="&zotero.feedSettings.refresh.label1;" control="feed-ttl"/>

--- a/chrome/skin/default/zotero/zotero.css
+++ b/chrome/skin/default/zotero/zotero.css
@@ -97,28 +97,6 @@ zoterosearch .menulist-icon {
 	max-width: 29.5em;
 }
 
-.zotero-advanced-options > .zotero-advanced-options-label > .toolbarbutton-menu-dropmarker {
-	transform: rotate(270deg);
-}
-
-.zotero-advanced-options[state=open] > .zotero-advanced-options-label > .toolbarbutton-menu-dropmarker {
-	transform: none;
-}
-
-#zotero-feed-settings grid hbox:first-child {
-	-moz-box-pack: end;
-}
-
-#zotero-feed-settings .html-input {
-	width: 50px;
-	text-align: right;
-}
-
-#zotero-feed-settings #advanced-options-togglable hbox {
-	display: flex;
-	align-items: center;
-}
-
 #zotero-edit-bibliography-dialog #item-list .listcell-icon {
 	max-width: 16px;
 }

--- a/scss/_zotero.scss
+++ b/scss/_zotero.scss
@@ -34,6 +34,7 @@
 @import "components/editable";
 @import "components/editBibliographyDialog";
 @import "components/exportOptions";
+@import "components/feedSettings";
 @import "components/icons";
 @import "components/import-wizard";
 @import "components/item-tree";

--- a/scss/components/_feedSettings.scss
+++ b/scss/components/_feedSettings.scss
@@ -1,0 +1,29 @@
+#zotero-feed-settings {
+	.zotero-advanced-options > .zotero-advanced-options-label {
+		@include focus-ring;
+		
+		appearance: none;
+		border: none;
+		outline: none;
+		background: transparent;
+		padding: 0;
+	}
+
+	.zotero-advanced-options > .zotero-advanced-options-label > .toolbarbutton-menu-dropmarker {
+		transform: rotate(270deg);
+	}
+
+	.zotero-advanced-options[state=open] > .zotero-advanced-options-label > .toolbarbutton-menu-dropmarker {
+		transform: none;
+	}
+
+	.html-input {
+		width: 50px;
+		text-align: right;
+	}
+
+	#advanced-options-togglable hbox {
+		display: flex;
+		align-items: center;
+	}
+}


### PR DESCRIPTION
- `<hbox>` -> `<button>`, `<toolbarbutton>` -> `<dropmarker>`
- Extract styles to SCSS and use `focus-ring` mixin

Needs [this fix](https://github.com/zotero/zotero/pull/4466/files#r1705740392) in order to have correct padding on Windows.

Fixes #4512