### PR TITLE
prefs: fix text-link not clicking on space/enter

### DIFF
--- a/chrome/content/zotero/elements/textLink.js
+++ b/chrome/content/zotero/elements/textLink.js
@@ -9,11 +9,16 @@
 					this.open(event);
 				}
 			}, true);
+			this.addEventListener('keypress', (event) => {
+				if (event.key == 'Enter' || event.key == ' ') {
+					event.preventDefault();
+					this.click();
+				}
+			});
 		}
 
 		connectedCallback() {
 			this.classList.add('zotero-text-link');
-			this.classList.add('keyboard-clickable');
 			this.setAttribute('role', 'link');
 		}
 

--- a/scss/components/_textLink.scss
+++ b/scss/components/_textLink.scss
@@ -4,4 +4,5 @@
 	text-decoration: underline;
 	border: var(--material-border-transparent);
 	cursor: pointer;
+	@include focus-ring;
 }


### PR DESCRIPTION
Fix regression after 117197e11d1e92e9d5eea5c4a3369c61fd5e65cc where space or enter would not trigger a click on a link outside of the main window.

`.keyboard-clickable` is handled by listener in `ZoteroPane`, so links outside of it (e.g. in preferences) are not affected by it. For now, just explicitly handle `keypress` event by the zotero-text-link component.

Also, added a focus-ring around the link so it is visible when it is focused.

Fixes: #4521