### PR TITLE
Remove form element rule !important suffix on Windows

### DIFF
--- a/scss/win/abstracts/_mixins.scss
+++ b/scss/win/abstracts/_mixins.scss
@@ -1,13 +1,12 @@
 @mixin windows-form-element-base {
 	appearance: none;
 	padding: 0;
-	border: 1px solid transparent !important;
+	border: 1px solid transparent;
 	border-radius: 4px;
 
 	background-origin: border-box;
 	background-clip: padding-box, padding-box, border-box;
-	// Overwrite default background color
-	background-color: unset !important;
+	background-color: unset;
 	// Simulate linear-gradient border with border-radius using background-image
 
 	@include light-dark(--color-form-element-background, var(--color-background70), var(--fill-quinary));


### PR DESCRIPTION
Fix tab bar button hover effect on Windows
A follow up fix of #4518