### PR TITLE
Bidi improvements and fixes

### DIFF
--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -1506,7 +1506,9 @@
 			if (lazy.BIDI_BROWSER_UI) {
 				// Attempt to guess text direction automatically
 				let language = this.item.getField('language');
-				valueElement.dir = Zotero.ItemFields.getDirection(fieldName, language);
+				valueElement.dir = Zotero.ItemFields.getDirection(
+					this.item.itemTypeID, fieldName, language
+				);
 			}
 			
 			// Regardless, align the text in unfocused fields consistently, following the locale's direction

--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -26,6 +26,16 @@
 "use strict";
 
 {
+	const { XPCOMUtils } = ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+
+	const lazy = {};
+	XPCOMUtils.defineLazyPreferenceGetter(
+		lazy,
+		"BIDI_BROWSER_UI",
+		"bidi.browser.ui",
+		false
+	);
+
 	class ItemBox extends ItemPaneSectionElementBase {
 		constructor() {
 			super();
@@ -1493,17 +1503,13 @@
 			
 			valueElement.value = valueText;
 
-			// Attempt to make bidi things work automatically:
-			// If we have text to work off of, let the layout engine try to guess the text direction
-			if (valueText) {
-				valueElement.dir = 'auto';
-			}
-			// If not, assume it follows the locale's direction
-			else {
-				valueElement.dir = Zotero.dir;
+			if (lazy.BIDI_BROWSER_UI) {
+				// Attempt to guess text direction automatically
+				let language = this.item.getField('language');
+				valueElement.dir = Zotero.ItemFields.getDirection(fieldName, language);
 			}
 			
-			// Regardless, align the text in the label consistently, following the locale's direction
+			// Regardless, align the text in unfocused fields consistently, following the locale's direction
 			if (Zotero.rtl) {
 				valueElement.style.textAlign = 'right';
 			}

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -2861,7 +2861,9 @@ var ItemTree = class ItemTree extends LibraryTree {
 		let textSpanAriaLabel = [textWithFullStop, itemTypeAriaLabel, tagAriaLabel, retractedAriaLabel].join(' ');
 		textSpan.className = "cell-text";
 		if (lazy.BIDI_BROWSER_UI) {
-			textSpan.dir = Zotero.ItemFields.getDirection(column.dataKey, item.getField('language'));
+			textSpan.dir = Zotero.ItemFields.getDirection(
+				item.itemTypeID, column.dataKey, item.getField('language')
+			);
 		}
 		textSpan.setAttribute('aria-label', textSpanAriaLabel);
 

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -35,6 +35,15 @@ const { getCSSIcon, getCSSItemTypeIcon } = Icons;
 const { COLUMNS } = require("zotero/itemTreeColumns");
 const { Cc, Ci, Cu, ChromeUtils } = require('chrome');
 const { OS } = ChromeUtils.importESModule("chrome://zotero/content/osfile.mjs");
+const { XPCOMUtils } = ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+
+const lazy = {};
+XPCOMUtils.defineLazyPreferenceGetter(
+	lazy,
+	"BIDI_BROWSER_UI",
+	"bidi.browser.ui",
+	false
+);
 
 /**
  * @typedef {import("./itemTreeColumns.jsx").ItemTreeColumnOptions} ItemTreeColumnOptions
@@ -2851,7 +2860,9 @@ var ItemTree = class ItemTree extends LibraryTree {
 		}
 		let textSpanAriaLabel = [textWithFullStop, itemTypeAriaLabel, tagAriaLabel, retractedAriaLabel].join(' ');
 		textSpan.className = "cell-text";
-		textSpan.dir = 'auto';
+		if (lazy.BIDI_BROWSER_UI) {
+			textSpan.dir = Zotero.ItemFields.getDirection(column.dataKey, item.getField('language'));
+		}
 		textSpan.setAttribute('aria-label', textSpanAriaLabel);
 
 		if (Zotero.Prefs.get('ui.tagsAfterTitle')) {

--- a/chrome/content/zotero/xpcom/data/itemFields.js
+++ b/chrome/content/zotero/xpcom/data/itemFields.js
@@ -421,12 +421,13 @@ Zotero.ItemFields = new function() {
 	/**
 	 * Guess the text direction of a field, using the item's language field if available.
 	 *
+	 * @param {number} itemTypeID
 	 * @param {string | number} field
 	 * @param {string} [itemLanguage]
 	 * @returns {'auto' | 'ltr' | 'rtl'}
 	 */
-	this.getDirection = function (field, itemLanguage) {
-		field = this.getName(field) || field;
+	this.getDirection = function (itemTypeID, field, itemLanguage) {
+		field = this.getName(this.getBaseIDFromTypeAndField(itemTypeID, field) || field);
 		switch (field) {
 			// Certain fields containing IDs, numbers, and data: always LTR
 			case 'ISBN':
@@ -438,24 +439,15 @@ Zotero.ItemFields = new function() {
 			case 'numberOfVolumes':
 			case 'issue':
 			case 'runningTime':
-			case 'billNumber':
 			case 'number':
 			case 'versionNumber':
-			case 'documentNumber':
-			case 'patentNumber':
 			case 'applicationNumber':
 			case 'priorityNumbers':
-			case 'episodeNumber':
-			case 'reportNumber':
 			case 'codeNumber':
-			case 'publicLawNumber':
-			case 'archiveID':
-			case 'codePages':
 			case 'pages':
 			case 'numPages':
 			case 'seriesNumber':
 			case 'edition':
-			case 'identifier':
 			case 'citationKey':
 			case 'language':
 			case 'extra':

--- a/chrome/content/zotero/xpcom/data/itemFields.js
+++ b/chrome/content/zotero/xpcom/data/itemFields.js
@@ -471,6 +471,7 @@ Zotero.ItemFields = new function() {
 						}
 					}
 					catch (e) {
+						Zotero.logError(e);
 					}
 					return 'ltr';
 				}

--- a/chrome/content/zotero/xpcom/data/itemFields.js
+++ b/chrome/content/zotero/xpcom/data/itemFields.js
@@ -419,6 +419,75 @@ Zotero.ItemFields = new function() {
 	
 	
 	/**
+	 * Guess the text direction of a field, using the item's language field if available.
+	 *
+	 * @param {string | number} field
+	 * @param {string} [itemLanguage]
+	 * @returns {'auto' | 'ltr' | 'rtl'}
+	 */
+	this.getDirection = function (field, itemLanguage) {
+		field = this.getName(field) || field;
+		switch (field) {
+			// Certain fields containing IDs, numbers, and data: always LTR
+			case 'ISBN':
+			case 'ISSN':
+			case 'DOI':
+			case 'url':
+			case 'callNumber':
+			case 'volume':
+			case 'numberOfVolumes':
+			case 'issue':
+			case 'runningTime':
+			case 'billNumber':
+			case 'number':
+			case 'versionNumber':
+			case 'documentNumber':
+			case 'patentNumber':
+			case 'applicationNumber':
+			case 'priorityNumbers':
+			case 'episodeNumber':
+			case 'reportNumber':
+			case 'codeNumber':
+			case 'publicLawNumber':
+			case 'archiveID':
+			case 'codePages':
+			case 'pages':
+			case 'numPages':
+			case 'seriesNumber':
+			case 'edition':
+			case 'identifier':
+			case 'citationKey':
+			case 'language':
+			case 'extra':
+				return 'ltr';
+			// Primary fields: follow app locale
+			case 'dateAdded':
+			case 'dateModified':
+			case 'accessDate':
+				return Zotero.dir;
+			// Everything else: guess based on the language if we have one; otherwise auto
+			default:
+				if (itemLanguage) {
+					let languageCode = Zotero.Utilities.Item.languageToISO6391(itemLanguage);
+					try {
+						let locale = new Intl.Locale(languageCode).maximize();
+						// https://www.w3.org/International/questions/qa-scripts#directions
+						// TODO: Remove this once Fx supports Intl.Locale#getTextInfo()
+						if (['Adlm', 'Arab', 'Aran', 'Rohg', 'Hebr', 'Mand', 'Mend', 'Nkoo', 'Hung', 'Samr', 'Syrc', 'Thaa', 'Yezi']
+								.includes(locale.script)) {
+							return 'rtl';
+						}
+					}
+					catch (e) {
+					}
+					return 'ltr';
+				}
+				return 'auto';
+		}
+	};
+
+
+	/**
 	* Check whether a field is valid, throwing an exception if not
 	* (since it should never actually happen)
 	**/

--- a/scss/elements/_editableText.scss
+++ b/scss/elements/_editableText.scss
@@ -93,6 +93,7 @@ editable-text {
 		&:read-only, &:not(:focus) {
 			appearance: none;
 			background: transparent;
+			text-align: inherit;
 		}
 		
 		&:hover:not(:read-only, :focus) {


### PR DESCRIPTION
- Guess item field direction based on the field itself, the item's language field, and the app locale
- Fix `editable-text` `dir` attribute and `text-align` style (apparently these haven't actually done anything since the redesign - oops)
- Slightly improve `editable-text` mouse selection behavior when value or alignment changes on focus
- Don't bother calculating anything if bidi utilities aren't enabled

Fixes #4517