### PR TITLE
Item box: Remove hidden buttons from flex calculations

### DIFF
--- a/scss/abstracts/_mixins.scss
+++ b/scss/abstracts/_mixins.scss
@@ -139,6 +139,7 @@
 				width: 0;
 				height: 0;
 				padding: 0;
+				position: absolute;
 			}
 		}
 		.meta-data {


### PR DESCRIPTION
Somehow, even with 0 width, height, margin (tried adding that), padding, and border, the hidden buttons were still causing the flex layout algorithm to make the row overflow horizontally. `position: absolute` removes child elements from their parents' flex calculations, and that seems to fix the issue (whatever it is) here.

@abaevbog: Could you make sure this doesn't break anything with screen readers?

Fixes #4539