### PR TITLE
vpat 31 and 33 - aria tweaks for Tools > Plugins

### DIFF
--- a/chrome/content/zotero/standalone/standalone.js
+++ b/chrome/content/zotero/standalone/standalone.js
@@ -724,7 +724,8 @@ const ZoteroStandalone = new function() {
 		}, true);
 
 		// A11y: after a click, check if the panel with plugin details appeared.
-		// If so, delete a misleading role=tabpanel
+		// If so, delete a misleading role=tabpanel because default firefox tabs
+		// ("Details" and "Permissions") are explicitly hidden in fetch_xulrunner
 		doc.addEventListener("click", (_) => {
 			setTimeout(() => {
 				let details = doc.querySelector("#details-deck section[role='tabpanel']");

--- a/chrome/content/zotero/standalone/standalone.js
+++ b/chrome/content/zotero/standalone/standalone.js
@@ -715,6 +715,23 @@ const ZoteroStandalone = new function() {
 			);
 			return { remove: result === 0, report: null };
 		};
+		// A11y: when a popup appears, mark which buttons are checked for screen readers
+		doc.addEventListener("shown", (event) => {
+			for (let item of [...event.target.querySelectorAll("panel-item")]) {
+				item.button.setAttribute("role", "menuitemcheckbox");
+				item.button.setAttribute("aria-checked", item.checked);
+			}
+		}, true);
+
+		// A11y: after a click, check if the panel with plugin details appeared.
+		// If so, delete a misleading role=tabpanel
+		doc.addEventListener("click", (_) => {
+			setTimeout(() => {
+				let details = doc.querySelector("#details-deck section[role='tabpanel']");
+				if (!details) return;
+				details.removeAttribute("role");
+			});
+		}, true);
 	}
 	
 	/**


### PR DESCRIPTION
- vpat 31: mark which menuitems' button is checked, otherwise selected options (e.g. Update plugins automatically) are not announced as such
- vpat 33: when plugin details pane appears, remove a misleading role="tabpanel" from its section because it is not structured as a collection of tabs

---

Vpat issues for reference:

- 31: Description: In the Zotero desktop app's 'Add-ons Manager' modal, activating a link for an add-on opens more details about that add-on. The content following the initial section containing the add-on name is incorrectly announced as a tab panel by screen readers. However, the content is not structured as a tab panel and should not have this role.
- 33: Description: Throughout the Zotero desktop app, some menu items can be activated or deactivated, such as the 'Update Add-ons Automatically' option in the 'Add-ons Manager' modal. While these menu items display a checkmark to visually indicate their state, there are no non-visual indicators for screen readers. The menu items are described by screen readers in the same way regardless of their current state, without any "checked" or "pressed" indication. The active state should be communicated non-visually. 