### PR TITLE
itembox: shift-enter adds new creator + bug fixes

### DIFF
--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -815,14 +815,6 @@
 					// this item, so that added creators aren't
 					// immediately hidden
 					this._displayAllCreators = true;
-					
-					if (this._addCreatorRow !== false) {
-						// Insert an empty creator row in a specified location
-						let beforeCreator = this.querySelector(`#itembox-field-value-creator-${this._addCreatorRow}-lastName`);
-						let beforeRow = beforeCreator?.closest(".meta-row") || null;
-						this.addCreatorRow(false, this.item.getCreator(max - 1).creatorTypeID, true, beforeRow);
-						this._addCreatorRow = false;
-					}
 				}
 			}
 			else if (this.editable && Zotero.CreatorTypes.itemTypeHasCreators(this.item.itemTypeID)) {
@@ -873,6 +865,15 @@
 
 			// Set focus on the last focused field
 			this._restoreFieldFocus();
+
+			if (this._addCreatorRow !== false) {
+				// Insert an empty creator row in a specified location
+				let beforeCreator = this.querySelector(`#itembox-field-value-creator-${this._addCreatorRow}-lastName`);
+				let beforeRow = beforeCreator?.closest(".meta-row") || null;
+				this.addCreatorRow(false, this.item.getCreator(max - 1).creatorTypeID, true, beforeRow);
+				this._addCreatorRow = false;
+			}
+
 			// Make sure that any opened popup closes
 			this.querySelectorAll("menupopup").forEach((popup) => {
 				popup.hidePopup();
@@ -971,6 +972,11 @@
 				: this._creatorTypeMenu.childNodes[0].getAttribute('typeid');
 			
 			var rowIndex = this._creatorCount;
+			// if not all creator rows are displayed and an unsaved row is added,
+			// its index should be the length of all creators to avoid overriding an existing creator
+			if (unsaved && this._creatorCount < this.item.numCreators()) {
+				rowIndex = this.item.numCreators();
+			}
 			
 			// Creator label with draggable grippy icon for creator reordering
 			var rowLabel = document.createElement("div");
@@ -1175,10 +1181,10 @@
 			
 			// Set single/double field toggle mode
 			if (fieldMode) {
-				this.switchCreatorMode(rowData.parentNode, 1, true, rowIndex);
+				this.switchCreatorMode(rowData.parentNode, 1, true, false, rowIndex);
 			}
 			else {
-				this.switchCreatorMode(rowData.parentNode, 0, true, rowIndex);
+				this.switchCreatorMode(rowData.parentNode, 0, true, false, rowIndex);
 			}
 			
 			lastNameElem.sizeToContent();
@@ -1781,35 +1787,23 @@
 			if (!target) return;
 
 			let row = target.closest('.meta-row');
-			// Handle Shift-Enter on creator input field
+			// Shift-Enter on creator input field will add and focus a new creator row
 			if (event.key == "Enter" && event.shiftKey) {
 				event.stopPropagation();
-				// Value has changed - focus empty creator row at the bottom
-				if (target.initialValue != target.value) {
-					this._addCreatorRow = this.item.numCreators();
+				// If "More creators" is next, display all creators
+				if (row.nextElementSibling.querySelector("#more-creators-label")) {
 					this._displayAllCreators = true;
+				}
+				let { position } = this.getCreatorFields(row);
+				// Add and focus new creator row after current one
+				this._addCreatorRow = position + 1;
+				// Blur current row to save changes if needed, otherwise just re-render
+				if (target.initialValue !== target.value) {
 					this.blurOpenField();
-					return;
 				}
-				// Value hasn't changed
-				Zotero.debug("Value hasn't changed");
-				// Next row is a creator - focus that
-				let nextRow = row.nextSibling;
-				if (nextRow.querySelector(".creator-type-value")) {
-					nextRow.querySelector("editable-text").focus();
-					return;
+				else {
+					this._forceRenderAll();
 				}
-				// Next row is a "More creators" label - click that and focus the next creator row
-				let moreCreators = nextRow.querySelector("#more-creators-label");
-				if (moreCreators) {
-					this._selectField = `itembox-field-value-creator-${this._creatorCount}-lastName`;
-					moreCreators.click();
-					return;
-				}
-				var creatorFields = this.getCreatorFields(row);
-				// Do nothing from the last empty row
-				if (creatorFields.lastName == "" && creatorFields.firstName == "") return;
-				this.addCreatorRow(false, creatorFields.creatorTypeID, true);
 			}
 			if (event.key == "Escape" && row.querySelector(".creator-type-value[unsaved=true]")) {
 				// Escape on an unsaved row deletes it and focuses previous creator

--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -1794,11 +1794,16 @@
 				if (row.nextElementSibling.querySelector("#more-creators-label")) {
 					this._displayAllCreators = true;
 				}
-				let { position } = this.getCreatorFields(row);
+				let { position, firstName, lastName } = this.getCreatorFields(row);
+				
+				// If creator name is empty after trimming whitespaces, do nothing. The focus will
+				// remain in the creator row, and it will be deleted on next blur
+				if (!(firstName || lastName)) return;
+			
 				// Add and focus new creator row after current one
 				this._addCreatorRow = position + 1;
 				// Blur current row to save changes if needed, otherwise just re-render
-				if (target.initialValue !== target.value) {
+				if (target.initialValue.trim() !== target.value.trim()) {
 					this.blurOpenField();
 				}
 				else {
@@ -2037,8 +2042,8 @@
 				position = null;
 			}
 			var fields = {
-				lastName: label1.value,
-				firstName: label2.value,
+				lastName: label1.value.trim(),
+				firstName: label2.value.trim(),
 				fieldMode: fieldMode ? parseInt(fieldMode) : 0,
 				creatorTypeID: parseInt(typeID),
 				position: position,

--- a/test/tests/itemPaneTest.js
+++ b/test/tests/itemPaneTest.js
@@ -462,6 +462,42 @@ describe("Item pane", function () {
 			assert.equal(position, 1);
 		});
 
+		it("should do nothing on shift-Enter in an empty unsaved row", async function () {
+			var item = await createDataObject('item');
+			item.setCreators([
+				{
+					lastName: "One",
+					creatorType: "author"
+				}
+			]);
+			let promise = waitForItemEvent('modify');
+			item.saveTx();
+			await promise;
+			var itemBox = doc.getElementById('zotero-editpane-item-box');
+			let creatorLastName = itemBox.querySelector(".creator-type-value editable-text");
+			creatorLastName.focus();
+			// Dispatch shift-Enter event
+			var shiftEnter = new KeyboardEvent('keydown', {
+				key: "Enter",
+				shiftKey: true,
+				bubbles: true
+			});
+			creatorLastName.ref.dispatchEvent(shiftEnter);
+			// Wait a moment for new row to be added
+			await Zotero.Promise.delay();
+			// Make sure an unsaved empty creator row is focused
+			assert.exists(doc.activeElement.closest("[unsaved=true]"));
+			// Mark current creator input
+			doc.activeElement.id = "test_creator_row";
+			// Field with just space should be treated as empty
+			doc.activeElement.value = " ";
+			// Dispatch shift-Enter event again
+			doc.activeElement.dispatchEvent(shiftEnter);
+			// Make sure we're still on the same field
+			await Zotero.Promise.delay();
+			assert.equal(doc.activeElement.id, "test_creator_row");
+		});
+
 		it("should display all creators on shift-Enter on last visible creator", async function () {
 			var item = await createDataObject('item');
 			const creatorsCount = 10;

--- a/test/tests/itemPaneTest.js
+++ b/test/tests/itemPaneTest.js
@@ -209,6 +209,19 @@ describe("Item pane", function () {
 	});
 	
 	describe("Info pane", function () {
+		before(async () => {
+			if (!doc.hasFocus()) {
+				// editable-text behavior relies on focus, so we first need to bring the window to the front.
+				// Not required on all platforms. In some cases (e.g. Linux), the window is at the front from the start.
+				let win = Zotero.getMainWindow();
+				let activatePromise = new Promise(
+					resolve => win.addEventListener('activate', resolve, { once: true })
+				);
+				Zotero.Utilities.Internal.activate();
+				Zotero.Utilities.Internal.activate(win);
+				await activatePromise;
+			}
+		});
 		it("should place Title after Item Type and before creators", async function () {
 			var item = await createDataObject('item');
 			var itemPane = win.ZoteroPane.itemPane;
@@ -409,6 +422,151 @@ describe("Item pane", function () {
 				itemBox.querySelector('[fieldname="creator-0-lastName"]').getAttribute('fieldMode'),
 				'1'
 			);
+		});
+
+		it("should add a new empty creator row on shift-Enter", async function () {
+			var item = await createDataObject('item');
+			item.setCreators([
+				{
+					lastName: "One",
+					creatorType: "author"
+				},
+				{
+					lastName: "Two",
+					creatorType: "author"
+				},
+				{
+					lastName: "Three",
+					creatorType: "author"
+				}
+			]);
+			let promise = waitForItemEvent('modify');
+			item.saveTx();
+			await promise;
+			var itemBox = doc.getElementById('zotero-editpane-item-box');
+			let creatorLastName = itemBox.querySelector(".creator-type-value editable-text");
+			creatorLastName.focus();
+			// Dispatch shift-Enter event
+			var shiftEnter = new KeyboardEvent('keydown', {
+				key: "Enter",
+				shiftKey: true,
+				bubbles: true
+			});
+			creatorLastName.ref.dispatchEvent(shiftEnter);
+			// Wait a moment for new row to be added
+			await Zotero.Promise.delay();
+			// Make sure an unsaved empty creator row is focused
+			assert.exists(doc.activeElement.closest("[unsaved=true]"));
+			// Make sure it is added after the existing row
+			let { position } = itemBox.getCreatorFields(doc.activeElement.closest(".meta-row"));
+			assert.equal(position, 1);
+		});
+
+		it("should display all creators on shift-Enter on last visible creator", async function () {
+			var item = await createDataObject('item');
+			const creatorsCount = 10;
+			let creatorsArr = [];
+			let i = 0;
+			// Add many creators so that some of them are not rendered
+			while (i < creatorsCount) {
+				i += 1;
+				creatorsArr.push({ lastName: "Creator " + i, creatorType: "author" });
+			}
+			item.setCreators(creatorsArr);
+			item.saveTx();
+			await waitForItemEvent('modify');
+			var itemBox = doc.getElementById('zotero-editpane-item-box');
+			let moreCreatorsLabel = itemBox.querySelector("#more-creators-label");
+			let lastVisibleCreator = moreCreatorsLabel.closest(".meta-row").previousElementSibling;
+			let lastVisibleCreatorsPosition = itemBox.getCreatorFields(lastVisibleCreator).position;
+			// Dispatch shift-Enter on the last visible creator row
+			let creatorLastName = lastVisibleCreator.querySelector("editable-text");
+			creatorLastName.focus();
+			var shiftEnter = new KeyboardEvent('keydown', {
+				key: "Enter",
+				shiftKey: true,
+				bubbles: true
+			});
+			creatorLastName.ref.dispatchEvent(shiftEnter);
+			await Zotero.Promise.delay();
+			// Make sure a new creator row is focused
+			assert.exists(doc.activeElement.closest("[unsaved=true]"));
+			// Make sure it is located after the last focused row
+			let { position } = itemBox.getCreatorFields(doc.activeElement.closest(".meta-row"));
+			assert.equal(position, lastVisibleCreatorsPosition + 1);
+			// Make sure all other creator rows were rendered
+			let creators = [...itemBox.querySelectorAll(".creator-type-value")];
+			assert.equal(creators.length, creatorsCount + 1);
+		});
+
+		it("should not delete invisible creators on Escape on unsaved creator", async function () {
+			var item = await createDataObject('item');
+			const creatorsCount = 10;
+			let creatorsArr = [];
+			let i = 0;
+			// Add many creators so that some of them are not rendered
+			while (i < creatorsCount) {
+				i += 1;
+				creatorsArr.push({ lastName: "Creator " + i, creatorType: "author" });
+			}
+			item.setCreators(creatorsArr);
+			item.saveTx();
+			await waitForItemEvent('modify');
+			var itemBox = doc.getElementById('zotero-editpane-item-box');
+			// Add a new empty creator row
+			itemBox.querySelector(".zotero-clicky-plus").click();
+			await Zotero.Promise.delay();
+			assert.exists(doc.activeElement.closest("[unsaved=true]"));
+			// Press Escape
+			var escape = new KeyboardEvent('keydown', {
+				key: "Escape",
+				bubbles: true
+			});
+			doc.activeElement.dispatchEvent(escape);
+			await Zotero.Promise.delay();
+			// Make sure the creator count has not changed and "More creators" label is still there
+			let creators = [...itemBox.querySelectorAll(".creator-type-value")];
+			assert.exists(itemBox.querySelector("#more-creators-label"));
+			assert.equal(creators.length, itemBox._initialVisibleCreators);
+			assert.equal(item.numCreators(), creatorsCount);
+		});
+
+		it("should switch creator type and update pref", async function () {
+			let item = await createDataObject('item');
+			item.setCreators([
+				{
+					name: "First Last",
+					creatorType: "author",
+					fieldMode: 1
+				}
+			]);
+			// Begin with 'single' creator mode
+			Zotero.Prefs.set('lastCreatorFieldMode', 1);
+			let modifyPromise = waitForItemEvent('modify');
+			item.saveTx();
+			await modifyPromise;
+			var itemBox = doc.getElementById('zotero-editpane-item-box');
+			// Click on the button to switch type to dual
+			let switchTypeBtn = itemBox.querySelector(".zotero-clicky-switch-type");
+			assert.equal(switchTypeBtn.getAttribute("type"), "single");
+			modifyPromise = waitForItemEvent('modify');
+			switchTypeBtn.click();
+			await modifyPromise;
+			// Make sure the button was updated and the names are displayed in two separate fields
+			switchTypeBtn = itemBox.querySelector(".zotero-clicky-switch-type");
+			assert.equal(switchTypeBtn.getAttribute("type"), "dual");
+			let [lastName, firstName] = [...itemBox.querySelectorAll(".creator-name-box editable-text")];
+			assert.equal(lastName.value, "Last");
+			assert.equal(firstName.value, "First");
+
+			assert.equal(Zotero.Prefs.get('lastCreatorFieldMode'), '0');
+
+			// Make sure if a new row is added, it is of type dual
+			itemBox.querySelector(".zotero-clicky-plus").click();
+			await Zotero.Promise.delay();
+			let newCreatorRow = doc.activeElement.closest(".meta-row");
+			let fieldMode = newCreatorRow.querySelector("editable-text").getAttribute("fieldMode");
+			assert.equal(fieldMode, "0");
 		});
 	});
 


### PR DESCRIPTION
- shift enter on a creator row will add a new empty creator row after focused row. If shift-Enter is on the last creator before "More creators", all creators will be rendered.
- fixed encountered glitch where switching the mode of creator would not always update the pref, so next time a new creator row is added, it would not be of correct mode.
- fixed encountered bug where a newly added creator row could receive an index of an existing creator that is not rendered (when "More creators" label is displayed). In that case, saving such creator would override an existing creator and erasing that creator would remove invisble creators.
- added a few tests for these edge cases

Fixes: #4393
Fixes: #4710