### PR TITLE
Fix osfile.normalize producing invalid paths on Windows.

### DIFF
--- a/chrome/content/zotero/osfile.mjs
+++ b/chrome/content/zotero/osfile.mjs
@@ -349,8 +349,8 @@ export let OS = {
 						stack.push(v);
 				}
 			});
-			let string = stack.join("/");
-			return absolute ? "/" + string : string;
+			let string = this.join(...stack);
+			return (!isWin && absolute) ? "/" + string : string;
 		},
 		
 		split: function (path) {


### PR DESCRIPTION
The path produced is prefixed with a "/" and does not use platform-specific slash on Windows.

Fix #4588