### PR TITLE
Fix progress bar ignores color scheme.

### DIFF
--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -1371,12 +1371,12 @@
 				</box>
 				
 				<stack id="zotero-pane-overlay" flex="1" hidden="true">
-					<box style="background: black; opacity: .3" flex="1"/>
+					<box flex="1"/>
 					
 					<deck id="zotero-pane-overlay-deck" style="display: flex; justify-content: center;">
 						<box id="zotero-pane-progress" flex="1" align="center" pack="center">
-							<box style="background: white; border-radius: 1px; box-shadow: gray 4px 6px 4px; width: 300px; height: 30px;">
-								<vbox id="zotero-pane-progressmeter-container" style="padding:10px" flex="1">
+							<box id="zotero-pane-progress-box">
+								<vbox id="zotero-pane-progressmeter-container" flex="1">
 									<label id="zotero-pane-progress-label"/>
 									<!-- See note in Zotero.showZoteroPaneProgressMeter()
 									<progressmeter id="zotero-pane-progressmeter" mode="undetermined"/> -->

--- a/scss/components/_mainWindow.scss
+++ b/scss/components/_mainWindow.scss
@@ -23,3 +23,19 @@
 #browser, #zotero-pane-stack, #zotero-trees {
 	min-height: 0;
 }
+
+#zotero-pane-overlay {
+	background: rgba(0,0,0,.3);
+}
+
+#zotero-pane-progress-box {
+	background: var(--color-sidepane);
+	border-radius: 5px;
+	border: var(--color-panedivider);
+	height: 30px;
+	width: 300px;
+}
+
+#zotero-pane-progressmeter-container {
+	padding: 10px;
+}


### PR DESCRIPTION
Tweaked colors, removed shadows, and added rounded borders. I've also moved some styles to `.scss`.

MacOS:
<img width="1240" alt="Screenshot 2024-08-20 at 13 05 12" src="https://github.com/user-attachments/assets/7a79ca04-b292-46ed-969e-7efcf3e3456f">
<img width="1240" alt="Screenshot 2024-08-20 at 13 05 04" src="https://github.com/user-attachments/assets/4a5a2b17-5875-429a-aba7-bf5feacd4bda">

Windows:
<img width="984" alt="Screenshot 2024-08-20 at 13 12 36" src="https://github.com/user-attachments/assets/7cdacaac-7d4b-4288-9746-7067b5f586c8">
<img width="983" alt="Screenshot 2024-08-20 at 13 13 00" src="https://github.com/user-attachments/assets/6978ea57-5ab5-4d7f-8804-276c5f7dbd76">

Resolve #4589