### PR TITLE
Register all plugin locales with best-fit aliasing

### DIFF
--- a/chrome/content/zotero/xpcom/plugins.js
+++ b/chrome/content/zotero/xpcom/plugins.js
@@ -451,7 +451,7 @@ Zotero.Plugins = new function () {
 			));
 		}
 		L10nRegistry.getInstance().registerSources(sources);
-		addonL10nSources.set(addon.id, sources.map(source => source.id));
+		addonL10nSources.set(addon.id, sources.map(source => source.name));
 	}
 	
 	


### PR DESCRIPTION
- We match plugin locales to Zotero locales in `registerLocales()`, and we only ever pass Zotero locales to `L10nRegistry#registerSources()`. We don't leave any matching up to the Fluent system. That's because it doesn't seem to do much or any.

	For example, this:
	
	```js
	L10nRegistry.getInstance().registerSources([new L10nFileSource(
		addon.id,
		'app',
		['en-US'], // <===
		rootURI.spec + 'locale/{locale}/',
	)]);
	```
	
	with this file structure:
	
	```
	src-2.0/
		locale/
			en/
				make-it-red.ftl
	```
	
	prints a `Missing resource in locale en-US: make-it-red.ftl` warning and nothing is localized. Same thing if `en-US` is changed to `en`. So I don't think that the code in https://github.com/diegodlh/zotero-cita/blob/15de93bed3e8412e0eea3e3023b21731fe4af174/src/utils/locale.ts#L24 is doing what it's meant to do (although I haven't tried running that plugin specifically).
- Supported locales are automatically discovered based on the subdirectories of the magic `locale/` directory. The locale-related `manifest.json` properties turn on a WebExtension localization system (`_locales/messages.json`) that we don't have any need for. We're already using `locale/`, so I ported over Mozilla's `_readDirectory()` method and we use that.
- We log a message when we alias a locale (`[Plugin ID]: Aliasing [folder name] to [resolved locale]`) to alert developers in case the mismatch is unintentional. In most cases I think plugins should just be using Zotero's locale codes, even if they don't totally fit. Cita probably needs to follow Wikidata's localizations, though, so that makes sense.

Closes #4604