### PR TITLE
Fix quicksearch getting cleared after an item is removed from collection

### DIFF
--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -815,9 +815,11 @@ var ItemTree = class ItemTree extends LibraryTree {
 					reselect = true;
 				}
 			}
-			// If single item is selected and was modified
+			// If a single item is selected, was modified, and is not filtered out,
+			// make sure it's selected
 			else if (action == 'modify' && ids.length == 1 &&
-				savedSelection.length == 1 && savedSelection[0].id == ids[0]) {
+				savedSelection.length == 1 && savedSelection[0].id == ids[0]
+				&& this.getRowIndexByID(ids[0]) !== false) {
 				if (activeWindow) {
 					await this.selectItem(ids[0]);
 					reselect = true;

--- a/test/tests/itemTreeTest.js
+++ b/test/tests/itemTreeTest.js
@@ -160,6 +160,23 @@ describe("Zotero.ItemTree", function() {
 				assert.equal(itemsView.getRow(1).level, 1);
 			});
 		});
+		
+		it("should not clear quick search after deleting item from collection", async function () {
+			let col = await createDataObject('collection');
+			let item = await createDataObject('item', { title: "test", collections: [col.id] });
+			await zp.collectionsView.selectCollection(col.id);
+			
+			quicksearch.value = "test";
+			quicksearch.doCommand();
+			await itemsView._refreshPromise;
+			
+			await zp.itemsView.selectItems([item.id]);
+			item.removeFromCollection(col.id);
+			await item.saveTx();
+
+			await itemsView._refreshPromise;
+			assert.equal(quicksearch.value, "test");
+		});
 	});
 	
 	describe("#selectItem()", function () {


### PR DESCRIPTION
Do not try to re-select a previously selected item if it was filtered out from itemTree, e.g. after
it was removed from currently selected collection. Otherwise, quickSearch gets cleared in an attempt to re-select the item.

Fixes: #4616