### PR TITLE
vpat 34-5: aria labels for the error console

### DIFF
--- a/chrome/content/zotero/standalone/standalone.js
+++ b/chrome/content/zotero/standalone/standalone.js
@@ -989,7 +989,7 @@ async function toJavaScriptConsole() {
 	// X button next to "Filter ouput"
 	win.document.querySelector(".devtools-searchinput-clear").setAttribute("aria-label", "Clear filter");
 	// The actual input line
-	win.document.querySelector(".flexible-output-input textarea").setAttribute("aria-label", "Command line input");
+	win.document.querySelector(".flexible-output-input textarea").setAttribute("aria-label", "Input line");
 }
 
 function openRunJSWindow() {

--- a/chrome/content/zotero/standalone/standalone.js
+++ b/chrome/content/zotero/standalone/standalone.js
@@ -984,10 +984,8 @@ async function toJavaScriptConsole() {
 	const { require } = ChromeUtils.import("resource://devtools/shared/loader/Loader.jsm");
 	const { BrowserConsoleManager } = require("resource://devtools/client/webconsole/browser-console-manager.js");
 	await BrowserConsoleManager.openBrowserConsoleOrFocus();
-	var wm = Components.classes["@mozilla.org/appshell/window-mediator;1"]
-		.getService(Components.interfaces.nsIWindowMediator);
 	// Add missing aria labels for the the VPAT review
-	let win = wm.getMostRecentWindow("devtools:webconsole");
+	let win = Services.wm.getMostRecentWindow("devtools:webconsole");
 	// X button next to "Filter ouput"
 	win.document.querySelector(".devtools-searchinput-clear").setAttribute("aria-label", "Clear filter");
 	// The actual input line

--- a/chrome/content/zotero/standalone/standalone.js
+++ b/chrome/content/zotero/standalone/standalone.js
@@ -979,11 +979,19 @@ ZoteroStandalone.DebugOutput = {
 };
 
 
-function toJavaScriptConsole() {
+async function toJavaScriptConsole() {
 	// We need the DevTools' built-in require() for this
 	const { require } = ChromeUtils.import("resource://devtools/shared/loader/Loader.jsm");
 	const { BrowserConsoleManager } = require("resource://devtools/client/webconsole/browser-console-manager.js");
-	BrowserConsoleManager.openBrowserConsoleOrFocus();
+	await BrowserConsoleManager.openBrowserConsoleOrFocus();
+	var wm = Components.classes["@mozilla.org/appshell/window-mediator;1"]
+		.getService(Components.interfaces.nsIWindowMediator);
+	// Add missing aria labels for the the VPAT review
+	let win = wm.getMostRecentWindow("devtools:webconsole");
+	// X button next to "Filter ouput"
+	win.document.querySelector(".devtools-searchinput-clear").setAttribute("aria-label", "Clear filter");
+	// The actual input line
+	win.document.querySelector(".flexible-output-input textarea").setAttribute("aria-label", "Command line input");
 }
 
 function openRunJSWindow() {


### PR DESCRIPTION
Add non-localized labels to the X button next to the input filter and the actual console textarea.

While these issues are not likely to affect anyone, they are still part of the VPAT review and we do want them marked as "done"... 

Because this really is a window not meant for the end user, I assumed we don't need to add localization (same way it's done in for the developer menus in `zoteroPane.xhtml`), so I just hard-coded english strings. Correct me if that's wrong.