### PR TITLE
Add an option to disable alternating row colors

### DIFF
--- a/chrome/content/zotero/components/virtualized-table.jsx
+++ b/chrome/content/zotero/components/virtualized-table.jsx
@@ -1258,7 +1258,8 @@ class VirtualizedTable extends React.Component {
 			onMouseLeave: e => this._handleMouseLeave(e),
 			className: cx(["virtualized-table", {
 				resizing: this.state.resizing,
-				'multi-select': this.props.multiSelect
+				'multi-select': this.props.multiSelect,
+				'no-alternating-rows': Zotero.Prefs.get('ui.noAlternatingRows'),
 			}]),
 			id: this.props.id,
 			ref: ref => this._topDiv = ref,

--- a/chrome/content/zotero/preferences/preferences_general.xhtml
+++ b/chrome/content/zotero/preferences/preferences_general.xhtml
@@ -58,6 +58,13 @@
 				</menulist>
 			</hbox>
 
+			<hbox align="center">
+				<checkbox data-l10n-id="preferences-item-pane-disable-alternating-rows"
+					preference="extensions.zotero.ui.noAlternatingRows"
+					native="true"
+				/>
+			</hbox>
+
 			<vbox id="item-pane-header-bib-entry-options" class="indented-pref">
 				<hbox align="center">
 					<label data-l10n-id="preferences-item-pane-header-style"/>

--- a/chrome/locale/en-US/zotero/preferences.ftl
+++ b/chrome/locale/en-US/zotero/preferences.ftl
@@ -51,6 +51,9 @@ preferences-item-pane-header-style = Header Citation Style:
 preferences-item-pane-header-locale = Header Language:
 preferences-item-pane-header-missing-style = Missing style: <{ $shortName }>
 
+preferences-item-pane-disable-alternating-rows =
+    .label = Disable alternating row colors
+
 preferences-locate-library-lookup-intro = Library Lookup can find a resource online using your library’s OpenURL resolver.
 preferences-locate-resolver = Resolver:
 preferences-locate-base-url = Base URL:

--- a/scss/components/_item-tree.scss
+++ b/scss/components/_item-tree.scss
@@ -79,8 +79,10 @@
 	
 	.virtualized-table, .drag-image-container {
 		.row {
-			&.odd:not(.selected) {
-				background-color: var(--material-stripe);
+			@include state(".virtualized-table:not(.no-alternating-rows)") {
+				&.odd:not(.selected) {
+					background-color: var(--material-stripe);
+				}
 			}
 
 			&.even:not(.selected) {

--- a/scss/components/_rtfScan.scss
+++ b/scss/components/_rtfScan.scss
@@ -68,8 +68,10 @@
 
 		.virtualized-table {
 			.row {
-				&.odd:not(.selected) {
-					background-color: var(--material-stripe);
+				@include state(".virtualized-table:not(.no-alternating-rows)") {
+					&.odd:not(.selected) {
+						background-color: var(--material-stripe);
+					}
 				}
 			
 				&.even:not(.selected) {


### PR DESCRIPTION
The preference name is `extensions.zotero.ui.noAlternatingRows` and can be toggled using a checkbox in the General preferences labeled "**Disable alternating row colors**".

It’s a bit unusual to have a "negative" preference (i.e., check to disable), but in this case, it makes sense, as the default is much nicer and likely preferred by the vast majority of users.

Resolves #4628.