### PR TITLE
Attachment box: Wrap Filename field

### DIFF
--- a/chrome/content/zotero/elements/attachmentBox.js
+++ b/chrome/content/zotero/elements/attachmentBox.js
@@ -39,7 +39,7 @@
 					<html:div class="metadata-table">
 						<html:div id="fileNameRow" class="meta-row">
 							<html:div class="meta-label"><html:label id="fileName-label" class="key" data-l10n-id="attachment-info-filename"/></html:div>
-							<html:div class="meta-data"><editable-text id="fileName" aria-labelledby="fileName-label" nowrap="true" tight="true"/></html:div>
+							<html:div class="meta-data"><editable-text id="fileName" aria-labelledby="fileName-label" tight="true"/></html:div>
 						</html:div>
 						<html:div id="accessedRow" class="meta-row">
 							<html:div class="meta-label"><html:label id="accessed-label" class="key" data-l10n-id="attachment-info-accessed"/></html:div>

--- a/chrome/content/zotero/elements/attachmentBox.js
+++ b/chrome/content/zotero/elements/attachmentBox.js
@@ -561,7 +561,7 @@
 				return "";
 			};
 			newFilename = newFilename.trim();
-			let oldFilename = item.getFilename();
+			let oldFilename = item.attachmentFilename;
 			if (oldFilename === newFilename) {
 				return;
 			}


### PR DESCRIPTION
And replace use of deprecated method.

Fixes #4637 - ellipsizing in the middle is trickier and I think this looks good:

![image](https://github.com/user-attachments/assets/c711d52f-00b7-4120-8a3c-3303657087e1)
