### PR TITLE
Fix a couple of issues related to dark mode icons

### DIFF
--- a/chrome/content/zotero/customElements.js
+++ b/chrome/content/zotero/customElements.js
@@ -206,10 +206,16 @@ Services.scriptloader.loadSubScript('chrome://zotero/content/elements/itemPaneSe
 		};
 	}
 
-	// inject custom CSS into FF built-in custom elements (currently only <wizard>)
+	// The menulist CE is defined lazily. Create one now to get menulist defined, so we can patch it
+	if (!customElements.get("menulist")) {
+		delete document.createXULElement("menulist");
+	}
+
+	// inject custom CSS into FF built-in custom elements
 	const InjectCSSConfig = {
 		global: [
 			"wizard",
+			"menulist",
 			{
 				element: "dialog",
 				patchedFunction: "connectedCallback"

--- a/chrome/content/zotero/newCollectionDialog.js
+++ b/chrome/content/zotero/newCollectionDialog.js
@@ -54,13 +54,6 @@ var Zotero_New_Collection_Dialog = {
 		menupopup.replaceWith(menupopup = document.createXULElement('menupopup'));
 		menupopup.id = id;
 
-		let style = document.createElement('style');
-		style.innerHTML = `image {
-			-moz-context-properties: fill, fill-opacity;
-			fill: var(--fill-secondary);
-		 }`;
-		createInField.shadowRoot.appendChild(style);
-
 		let createdNode = Zotero.Utilities.Internal.createMenuForTarget(
 			Zotero.Libraries.get(this._libraryID),
 			menupopup,

--- a/scss/components/_menu.scss
+++ b/scss/components/_menu.scss
@@ -81,9 +81,11 @@ $menu-icons: (
 	@include macOS-hide-menu-icons;
 }
 
-#zotero-new-collection-menu {
-	image {
-		-moz-context-properties: fill, fill-opacity;
+menupopup image {
+	-moz-context-properties: fill, fill-opacity;
+	fill: var(--fill-secondary);
+	
+	@media (-moz-platform: macos) {
 		fill: currentColor;
 	}
 }

--- a/scss/xulElementPatches/menulist.scss
+++ b/scss/xulElementPatches/menulist.scss
@@ -1,0 +1,8 @@
+image {
+    -moz-context-properties: fill, fill-opacity;
+    fill: var(--fill-secondary);
+    
+    @media (-moz-platform: macos) {
+        fill: currentColor;
+    }
+}


### PR DESCRIPTION
Switched to a more generic approach to fix missing dark mode icons in popup menus in a few places (two?) on macOS. This resolves issue #4654.

Additionally, on macOS, we use `currentColor` for these icons, while on other operating systems, we use a slightly dimmed `--fill-secondary`. Some of macOS-specific styles leaked, causing a subtle inconsistency in some places, which should now be corrected. See example below.

Before:
![Screenshot 2024-09-01 at 14 37 46](https://github.com/user-attachments/assets/44e08b4f-d655-4aab-9e0c-b7f5d9f8257c)

After: 
![Screenshot 2024-09-01 at 14 57 46](https://github.com/user-attachments/assets/844da318-e79b-4f27-8867-3ba4fecad4e6)


