### PR TITLE
Fix attachment box preview discard and try to avoid race condition

### DIFF
--- a/chrome/content/zotero/elements/attachmentBox.js
+++ b/chrome/content/zotero/elements/attachmentBox.js
@@ -326,13 +326,12 @@
 
 			Zotero.debug('Refreshing attachment box');
 			this._asyncRendering = true;
-			
-			await this.renderAttachmentInfo();
 
-			if (this.usePreview) {
-				this.previewElem.item = this.item;
-				await this.previewElem.render();
-			}
+			// Execute sub-tasks concurrently to avoid race condition between different calls
+			await Promise.all([
+				this.updateInfo(),
+				this.updatePreview()
+			]);
 
 			this._asyncRendering = false;
 
@@ -358,7 +357,7 @@
 			ZoteroPane_Local.showAttachmentInFilesystem(this.item.id, event.originalTarget, !this.editable);
 		}
 
-		async renderAttachmentInfo() {
+		async updateInfo() {
 			// Cancel editing filename when refreshing
 			this._isEditingFilename = false;
 			
@@ -501,6 +500,13 @@
 			}
 			else {
 				selectButton.hidden = true;
+			}
+		}
+
+		async updatePreview() {
+			if (this.usePreview) {
+				this.previewElem.item = this.item;
+				await this.previewElem.render();
 			}
 		}
 

--- a/chrome/content/zotero/elements/attachmentBox.js
+++ b/chrome/content/zotero/elements/attachmentBox.js
@@ -320,12 +320,45 @@
 					this._previewDiscarded = false;
 					this.previewElem.render();
 				}
-				this._lastPreviewRenderTime = Date.now();
+				this._lastPreviewRenderId = `${Date.now()}-${Math.random()}`;
 				return;
 			}
 
 			Zotero.debug('Refreshing attachment box');
 			this._asyncRendering = true;
+			
+			await this.renderAttachmentInfo();
+
+			if (this.usePreview) {
+				this.previewElem.item = this.item;
+				await this.previewElem.render();
+			}
+
+			this._asyncRendering = false;
+
+			this._lastPreviewRenderId = `${Date.now()}-${Math.random()}`;
+		}
+
+		discard() {
+			if (!this._preview) return;
+			let lastPreviewRenderId = this._lastPreviewRenderId;
+			setTimeout(() => {
+				if (!this._asyncRendering && this._lastPreviewRenderId === lastPreviewRenderId) {
+					this._preview?.discard();
+					this._previewDiscarded = true;
+				}
+			}, this._discardPreviewTimeout);
+		}
+
+		onViewClick(event) {
+			ZoteroPane_Local.viewAttachment(this.item.id, event, !this.editable);
+		}
+
+		onShowClick(event) {
+			ZoteroPane_Local.showAttachmentInFilesystem(this.item.id, event.originalTarget, !this.editable);
+		}
+
+		async renderAttachmentInfo() {
 			// Cancel editing filename when refreshing
 			this._isEditingFilename = false;
 			
@@ -469,34 +502,6 @@
 			else {
 				selectButton.hidden = true;
 			}
-
-			if (this.usePreview) {
-				this.previewElem.item = this.item;
-				await this.previewElem.render();
-			}
-
-			this._asyncRendering = false;
-
-			this._lastPreviewRenderTime = `${Date.now()}-${Math.random()}`;
-		}
-
-		discard() {
-			if (!this._preview) return;
-			let lastRenderTime = this._lastPreviewRenderId;
-			setTimeout(() => {
-				if (!this._asyncRendering && this._lastPreviewRenderId === lastRenderTime) {
-					this._preview?.discard();
-					this._previewDiscarded = true;
-				}
-			}, this._discardPreviewTimeout);
-		}
-
-		onViewClick(event) {
-			ZoteroPane_Local.viewAttachment(this.item.id, event, !this.editable);
-		}
-
-		onShowClick(event) {
-			ZoteroPane_Local.showAttachmentInFilesystem(this.item.id, event.originalTarget, !this.editable);
 		}
 
 		updateItemIndexedState() {

--- a/chrome/content/zotero/elements/attachmentsBox.js
+++ b/chrome/content/zotero/elements/attachmentsBox.js
@@ -195,15 +195,12 @@
 			this._renderStage = "final";
 			this._asyncRendering = true;
 			
-			await this._updateAttachmentIDs();
+			// Execute sub-tasks concurrently to avoid race condition between different calls
+			await Promise.all([
+				this.updateRows(),
+				this.updatePreview(),
+			]);
 
-			let itemAttachments = Zotero.Items.get(this._attachmentIDs);
-
-			this._attachments.querySelectorAll("attachment-row").forEach(e => e.remove());
-			for (let attachment of itemAttachments) {
-				this.addRow(attachment);
-			}
-			await this.updatePreview();
 			this._asyncRendering = false;
 		}
 
@@ -224,6 +221,17 @@
 			}
 			let count = this._item.numAttachments(this.inTrash);
 			this._section.setCount(count);
+		}
+
+		async updateRows() {
+			await this._updateAttachmentIDs();
+
+			let itemAttachments = Zotero.Items.get(this._attachmentIDs);
+
+			this._attachments.querySelectorAll("attachment-row").forEach(e => e.remove());
+			for (let attachment of itemAttachments) {
+				this.addRow(attachment);
+			}
 		}
 
 		async updatePreview() {

--- a/chrome/content/zotero/elements/attachmentsBox.js
+++ b/chrome/content/zotero/elements/attachmentsBox.js
@@ -48,7 +48,7 @@
 
 		_preview = null;
 
-		_lastPreviewRenderTime = "";
+		_lastPreviewRenderId = "";
 
 		_discardPreviewTimeout = 60000;
 
@@ -189,7 +189,7 @@
 					this._previewDiscarded = false;
 					this.previewElem.render();
 				}
-				this._lastPreviewRenderTime = `${Date.now()}-${Math.random()}`;
+				this._lastPreviewRenderId = `${Date.now()}-${Math.random()}`;
 				return;
 			}
 			this._renderStage = "final";
@@ -209,9 +209,9 @@
 
 		discard() {
 			if (!this._preview) return;
-			let lastRenderTime = this._lastPreviewRenderTime;
+			let lastPreviewRenderId = this._lastPreviewRenderId;
 			setTimeout(() => {
-				if (!this._asyncRendering && this._lastPreviewRenderTime === lastRenderTime) {
+				if (!this._asyncRendering && this._lastPreviewRenderId === lastPreviewRenderId) {
 					this._preview?.discard();
 					this._previewDiscarded = true;
 				}
@@ -246,7 +246,7 @@
 			}
 			this.previewElem.item = attachment;
 			await this.previewElem.render();
-			this._lastPreviewRenderTime = `${Date.now()}-${Math.random()}`;
+			this._lastPreviewRenderId = `${Date.now()}-${Math.random()}`;
 		}
 
 		async _getPreviewAttachment() {


### PR DESCRIPTION
resolve: #4611
Try to avoid race condition in dense render calls.
We used to notify the preview to update
after all other renders are done,
which can cause unexpected race condition.

fix: #4659
This bug is mainly from the misaligned flag variable name in attachment box implementation while the early-return of the render function also contributes to it. Should be fixed now.