### PR TITLE
Load DTD strings lazily

### DIFF
--- a/chrome/content/zotero/xpcom/intl.js
+++ b/chrome/content/zotero/xpcom/intl.js
@@ -94,12 +94,19 @@ Zotero.Intl = new function () {
 		const intlFiles = ['zotero.dtd', 'preferences.dtd', 'mozilla/editMenuOverlay.dtd'];
 
 		let strings = [];
+		let { documentElement: elem } = new DOMParser().parseFromString('<root></root>', 'application/xml');
 		for (let intlFile of intlFiles) {
 			let localeXML = Zotero.File.getContentsFromURL(`chrome://zotero/locale/${intlFile}`);
 			let regexp = /<!ENTITY ([^\s]+)\s+"([^"]+)/g;
 			let regexpResult;
 			while ((regexpResult = regexp.exec(localeXML))) {
-				strings[regexpResult[1]] = regexpResult[2];
+				let key = regexpResult[1];
+				let value = regexpResult[2];
+				// Resolve XML entities
+				elem.innerHTML = value;
+				value = elem.textContent;
+
+				strings[key] = value;
 			}
 		}
 		return strings;

--- a/chrome/content/zotero/xpcom/intl.js
+++ b/chrome/content/zotero/xpcom/intl.js
@@ -79,17 +79,6 @@ Zotero.Intl = new function () {
 		Zotero.arrowPreviousKey = Zotero.rtl ? 'ArrowRight' : 'ArrowLeft';
 		Zotero.arrowNextKey = Zotero.rtl ? 'ArrowLeft' : 'ArrowRight';
 		
-		this.strings = {};
-		const intlFiles = ['zotero.dtd', 'preferences.dtd', 'mozilla/editMenuOverlay.dtd'];
-		for (let intlFile of intlFiles) {
-			let localeXML = Zotero.File.getContentsFromURL(`chrome://zotero/locale/${intlFile}`);
-			let regexp = /<!ENTITY ([^\s]+)\s+"([^"]+)/g;
-			let regexpResult;
-			while (regexpResult = regexp.exec(localeXML)) {
-				this.strings[regexpResult[1]] = regexpResult[2];
-			}
-		}
-		
 		// Provide synchronous access to Fluent strings for getString()
 		ftl = new Localization([
 			'branding/brand.ftl',
@@ -99,6 +88,22 @@ Zotero.Intl = new function () {
 		], true);
 		Zotero.ftl = ftl;
 	};
+
+
+	ChromeUtils.defineLazyGetter(this, 'strings', () => {
+		const intlFiles = ['zotero.dtd', 'preferences.dtd', 'mozilla/editMenuOverlay.dtd'];
+
+		let strings = [];
+		for (let intlFile of intlFiles) {
+			let localeXML = Zotero.File.getContentsFromURL(`chrome://zotero/locale/${intlFile}`);
+			let regexp = /<!ENTITY ([^\s]+)\s+"([^"]+)/g;
+			let regexpResult;
+			while ((regexpResult = regexp.exec(localeXML))) {
+				strings[regexpResult[1]] = regexpResult[2];
+			}
+		}
+		return strings;
+	});
 
 
 	/**


### PR DESCRIPTION
And resolve XML entities in the loaded strings. Doesn't handle references to other DTD strings (e.g. `aboutProduct.label` = `About &brandShortName;`) but might fix display bugs in locales that use lots of `&quot;` in their strings.

Should fix #4661 by delaying the synchronous XHR until the first `getString()` call (which will be well after module loading is completed, I hope).