### PR TITLE
VPAT: minor settings tweaks 

### DIFF
--- a/chrome/content/zotero/preferences/preferences_general.xhtml
+++ b/chrome/content/zotero/preferences/preferences_general.xhtml
@@ -27,15 +27,16 @@
 		<groupbox aria-labelledby="preferences-appearance-title">
 			<label><html:h2 id="preferences-appearance-title" data-l10n-id="preferences-appearance-title"/></label>
 		
-			<hbox align="center">
-				<label id="color-scheme-label" data-l10n-id="preferences-color-scheme"/>
-				<!-- aria-describedby set on individual radio buttons because voiceover won't announce it if set on radiogroup-->
-				<radiogroup orient="horizontal" id="color-scheme" preference="browser.theme.toolbar-theme">
-					<radio data-l10n-id="preferences-color-scheme-auto" value="2" aria-describedby="color-scheme-label"/>
-					<radio data-l10n-id="preferences-color-scheme-light" value="1" aria-describedby="color-scheme-label"/>
-					<radio data-l10n-id="preferences-color-scheme-dark" value="0" aria-describedby="color-scheme-label"/>
-				</radiogroup>
-			</hbox>
+			<groupbox aria-labelledby="color-scheme-label">
+				<hbox align="center">
+					<label id="color-scheme-label" data-l10n-id="preferences-color-scheme"/>
+					<radiogroup orient="horizontal" id="color-scheme" preference="browser.theme.toolbar-theme">
+						<radio data-l10n-id="preferences-color-scheme-auto" value="2"/>
+						<radio data-l10n-id="preferences-color-scheme-light" value="1"/>
+						<radio data-l10n-id="preferences-color-scheme-dark" value="0"/>
+					</radiogroup>
+				</hbox>
+			</groupbox>
 		
 			<hbox align="center">
 				<label value="&zotero.bibliography.locale.label;" control="locale-menu"/>

--- a/chrome/content/zotero/preferences/preferences_general.xhtml
+++ b/chrome/content/zotero/preferences/preferences_general.xhtml
@@ -61,7 +61,7 @@
 
 			<vbox id="item-pane-header-bib-entry-options" class="indented-pref">
 				<hbox align="center">
-					<label data-l10n-id="preferences-item-pane-header-style"/>
+					<label data-l10n-id="preferences-item-pane-header-style" control="item-pane-header-style-menu"/>
 					<menulist
 							id="item-pane-header-style-menu"
 							preference="extensions.zotero.itemPaneHeader.bibEntry.style"
@@ -71,7 +71,7 @@
 				</hbox>
 
 				<hbox align="center">
-					<label data-l10n-id="preferences-item-pane-header-locale"/>
+					<label data-l10n-id="preferences-item-pane-header-locale" control="item-pane-header-locale-menu"/>
 					<menulist
 							id="item-pane-header-locale-menu"
 							preference="extensions.zotero.itemPaneHeader.bibEntry.locale"

--- a/chrome/locale/en-US/zotero/preferences.ftl
+++ b/chrome/locale/en-US/zotero/preferences.ftl
@@ -66,9 +66,11 @@ preferences-quickCopy-plus =
 
 preferences-styleManager-delete-button =
     .tooltiptext = Delete the selected style
+    .aria-label = { general-remove }
     .label = { $label }
 preferences-styleManager-add-button =
     .tooltiptext = Add a style from a file
+    .aria-label = { general-add }
     .label = { $label }
 
 preferences-advanced-enable-local-api =


### PR DESCRIPTION
A number of small tweaks after the last review.

- it was marked that `+/-` buttons below the cite manager table should have "Add" and "Remove" aria labels because "+" and "-" are not descriptive enough. There is a tooltip that is also announced so I don't think there is much room for confusion here. But `+/-` below export settings do have "Add" and "Remove" so it's worth adding them even just for consistency.
- the "Color scheme" radiogroup had its radio buttons linked to the label via `aria-describedby`. It was indicated that it's not a good thing because semantically it's not quite correct and  it also requires a setting to be checked in JAWS to be heard. Wrapping it into a groupbox will have screen readers announce the "Color scheme" when focus lands on a radiobuton. It feels more appropriate semantically though functionally doesn't change much.
- linked a few missed itemPane header preference labels to their menus