### PR TITLE
QF: increase likeliness of dialogs receiving focus

### DIFF
--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -2656,7 +2656,7 @@ Zotero.Utilities.Internal.activate = new function () {
 				Zotero.Utilities.Internal.executeAppleScript(script);
 			}
 		}
-		else if (!Zotero.isWin && win) {
+		else if (Zotero.isLinux && win) {
 			Components.utils.import("resource://gre/modules/ctypes.jsm");
 
 			if (_x11 === false) return;
@@ -2867,6 +2867,13 @@ Zotero.Utilities.Internal.activate = new function () {
 					_X11BringToForeground(win, intervalID);
 				}, 50);
 			}, false);
+		}
+		else if (Zotero.isWin && win) {
+			// Try to focus the window. This is necessary as focusing a node inside
+			// of the window may not necessarily activate the window.
+			win.focus();
+			// If the window is in the background, flash the icon
+			win.getAttention();
 		}
 	};
 };


### PR DESCRIPTION
Tweak to `Zotero.Utilities.Internal.activate` to make it more likely that dialogs receive focus when opened on win. Addresses the issue of QF not becoming focusable after the first opening from microsoft word and makes it clearer if the dialog appeared but could not be pulled to the foreground.

`getAttention()` is meant to flash the icon in the app bar if the window could not be focused and pulled into foreground, for example with google docs. During testing, it actually pulled the window forward with this setup, so in google docs, the QF is always focused for me now.

`focus()` fixes the issue of QF not getting focused with word on the first opening. Also, without it, a call to `getAttention()` interferes with focus landing on the dialog during subsequent opening in gdocs.

So a combination of both of these calls seems to get us exactly what we want (at least within my environment).  @adomasven I tested this on windows 11 VM Microsoft word and Google Docs connector on Firefox and Google Chrome. Let me know if it's working for you! 

I played around with using `SetForegroundWindow` to  pull the window to the front but it didn't seem needed at this point (again, maybe just for my setup). The initial idea of a powershell call was not viable because the terminal does blink and it has been a discussed issue for some time. I put together an executable to call `SetForegroundWindow` which kinda worked though it did run into the documented behavior of not pulling the window to the front if the main process is in the browser. But if these changes don't work well enough, I can explore more options within that executable as well.