### PR TITLE
Apply quickSearch filter to trashed collections

### DIFF
--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -229,7 +229,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 				// So that they are displayed among deleted items
 				newSearchItems = newSearchItems
 					.concat(await this.collectionTreeRow.getTrashedCollections())
-					.concat(await Zotero.Searches.getDeleted(this.collectionTreeRow.ref.libraryID));
+					.concat(await this.collectionTreeRow.getTrashedSearches());
 			}
 			// TEMP: Hide annotations
 			newSearchItems = newSearchItems.filter(item => !item.isAnnotation());

--- a/chrome/content/zotero/xpcom/collectionTreeRow.js
+++ b/chrome/content/zotero/xpcom/collectionTreeRow.js
@@ -271,6 +271,7 @@ Zotero.CollectionTreeRow.prototype.getChildren = function () {
 
 // Returns the list of deleted collections in the trash.
 // Subcollections of deleted collections are filtered out.
+// Accounts for case-insensitive quickSearch.
 Zotero.CollectionTreeRow.prototype.getTrashedCollections = async function () {
 	if (!this.isTrash()) {
 		return [];
@@ -281,7 +282,15 @@ Zotero.CollectionTreeRow.prototype.getTrashedCollections = async function () {
 	for (let d of deleted) {
 		deletedParents.add(d.key);
 	}
-	return deleted.filter(d => !d.parentKey || !deletedParents.has(d.parentKey));
+	return deleted.filter(d => d.getDisplayTitle().toLowerCase().includes(this.searchText.toLowerCase())
+		&& (!d.parentKey || !deletedParents.has(d.parentKey)));
+};
+
+// Returns the list of deleted searches in the trash.
+// Accounts for case-insensitive quickSearch.
+Zotero.CollectionTreeRow.prototype.getTrashedSearches = async function () {
+	let deleted = await Zotero.Searches.getDeleted(this.ref.libraryID);
+	return deleted.filter(d => d.getDisplayTitle().toLowerCase().includes(this.searchText.toLowerCase()));
 };
 
 

--- a/test/tests/itemTreeTest.js
+++ b/test/tests/itemTreeTest.js
@@ -826,10 +826,11 @@ describe("Zotero.ItemTree", function() {
 			})
 
 			for (let objectType of ['collection', 'search']) {
-				it(`should remove ${objectType} from trash on delete`, async function (){
+				// eslint-disable-next-line no-loop-func
+				it(`should remove ${objectType} from trash on delete`, async function () {
 					var o1 = await createDataObject(objectType, { deleted: true });
-					var o2 = await createDataObject(objectType, { deleted: true  });
-					var o3 = await createDataObject(objectType, { deleted: true  });
+					var o2 = await createDataObject(objectType, { deleted: true });
+					var o3 = await createDataObject(objectType, { deleted: true });
 
 					// Go to trash
 					await selectTrash(win);
@@ -842,7 +843,23 @@ describe("Zotero.ItemTree", function() {
 					assert.isFalse(zp.itemsView.getRowIndexByID(o1.treeViewID));
 					assert.isFalse(zp.itemsView.getRowIndexByID(o2.treeViewID));
 					assert.isFalse(zp.itemsView.getRowIndexByID(o3.treeViewID));
-				})
+				});
+
+				// eslint-disable-next-line no-loop-func
+				it(`should apply quicksearch filter to deleted ${objectType} in trash`, async function () {
+					var matched = await createDataObject(objectType, { deleted: true });
+					var excluded = await createDataObject(objectType, { deleted: true });
+
+					await selectTrash(win);
+
+					let quickSearch = win.document.getElementById('zotero-tb-search-textbox');
+					quickSearch.value = matched.getDisplayTitle();
+					quickSearch.doCommand();
+
+					await itemsView._refreshPromise;
+					assert.isNumber(itemsView.getRowIndexByID(matched.treeViewID));
+					assert.isFalse(itemsView.getRowIndexByID(excluded.treeViewID));
+				});
 			}
 		});
 		


### PR DESCRIPTION
Added `Zotero.CollectionTreeRow.prototype.getTrashedSearches` to not do filtering of searches in `itemTree.jsx`. That way I think is more consistent with how we fetch items and collections as well.

Also, added a few small eslint tweaks to fix/silence warnings for multiple tests inside of a loop.

Fixes: #4686