### PR TITLE
add server connector endpoint to undo save session

### DIFF
--- a/chrome/content/zotero/xpcom/server/server_connector.js
+++ b/chrome/content/zotero/xpcom/server/server_connector.js
@@ -1027,7 +1027,8 @@ Zotero.Server.Connector.GetSelectedCollection.prototype = {
 					id: library.treeViewID,
 					name: library.name,
 					filesEditable: library.filesEditable,
-					level: 0
+					level: 0,
+					isUserLibrary: Zotero.Libraries.userLibraryID == library.libraryID,
 				},
 				...Zotero.Collections.getByLibrary(library.libraryID, true).map(c => ({
 					id: c.treeViewID,

--- a/test/tests/server_connectorTest.js
+++ b/test/tests/server_connectorTest.js
@@ -1928,4 +1928,153 @@ describe("Connector Server", function () {
 			assert.equal(JSON.parse(req.response).status, 200);
 		});
 	});
+
+	describe('/connector/cancelSession', function () {
+		var pdfArrayBuffer;
+		var pdfPath = OS.Path.join(getTestDataDirectory().path, 'test.pdf');
+		before(async () => {
+			await selectLibrary(win, Zotero.Libraries.userLibraryID);
+			pdfArrayBuffer = (await OS.File.read(pdfPath)).buffer;
+		});
+
+		it('should delete saved items if called after everything is saved', async function () {
+			var collection = await createDataObject('collection');
+			let sessionID = Zotero.Utilities.randomString();
+			let bookItemID = Zotero.Utilities.randomString();
+			await select(win, collection);
+
+			let body = {
+				sessionID,
+				items: [
+					{
+						id: bookItemID,
+						itemType: "book",
+						title: "Book Title",
+					}
+				]
+			};
+			let itemAddPromise = waitForItemEvent('add');
+			// Save the item as if by the connector
+			await Zotero.HTTP.request(
+				'POST',
+				connectorServerPath + "/connector/saveItems",
+				{
+					headers: {
+						"Content-Type": "application/json"
+					},
+					body: JSON.stringify(body)
+				}
+			);
+			let itemIDs = await itemAddPromise;
+
+			// Add the attachment to the item
+			let attachmentAddPromise = waitForItemEvent('add');
+			let attachmentReq = await httpRequest(
+				'POST',
+				connectorServerPath + "/connector/saveAttachment",
+				{
+					headers: {
+						"Content-Type": "application/pdf",
+						"X-Metadata": JSON.stringify({
+							sessionID,
+							title: "Book Attachment",
+							parentItemID: bookItemID,
+							url: `${testServerPath}/attachment1.pdf`,
+						})
+					},
+					body: pdfArrayBuffer
+				}
+			);
+			assert.equal(attachmentReq.status, 201);
+			let attachmentIds = await attachmentAddPromise;
+			assert.lengthOf(attachmentIds, 1);
+			let attachment1 = Zotero.Items.get(attachmentIds[0]);
+			let bookItem = Zotero.Items.get(itemIDs[0]);
+			assert.equal(attachment1.parentItemID, bookItem.id);
+
+			// Cancel the session
+			let cancelReq = await Zotero.HTTP.request(
+				'POST',
+				connectorServerPath + '/connector/cancelSession',
+				{
+					headers: { 'content-type': 'application/json' },
+					body: JSON.stringify({ sessionID })
+				}
+			);
+			assert.equal(cancelReq.status, 200);
+
+			// The item and attachment should be deleted
+			let deletedItem = await Zotero.Items.getAsync(attachment1.parentItemID);
+			let deletedAttachment = await Zotero.Items.getAsync(attachment1.id);
+			assert.isFalse(deletedItem);
+			assert.isFalse(deletedAttachment);
+		});
+
+		it('should not save attachment items if session is cancelled half-way through', async function () {
+			var collection = await createDataObject('collection');
+			let sessionID = Zotero.Utilities.randomString();
+			let bookItemID = Zotero.Utilities.randomString();
+			await select(win, collection);
+
+			let body = {
+				sessionID,
+				items: [
+					{
+						id: bookItemID,
+						itemType: "book",
+						title: "Book Title",
+					}
+				]
+			};
+
+			let itemAddPromise = waitForItemEvent('add');
+			// Save the item as if by the connector
+			await Zotero.HTTP.request(
+				'POST',
+				connectorServerPath + "/connector/saveItems",
+				{
+					headers: {
+						"Content-Type": "application/json"
+					},
+					body: JSON.stringify(body)
+				}
+			);
+			let itemIDs = await itemAddPromise;
+
+			// Cancel the session
+			let cancelReq = await Zotero.HTTP.request(
+				'POST',
+				connectorServerPath + '/connector/cancelSession',
+				{
+					headers: { 'content-type': 'application/json' },
+					body: JSON.stringify({ sessionID })
+				}
+			);
+			assert.equal(cancelReq.status, 200);
+
+			// Try to add the attachment to the item
+			let attachmentReq = await getPromiseError(httpRequest(
+				'POST',
+				connectorServerPath + "/connector/saveAttachment",
+				{
+					headers: {
+						"Content-Type": "application/pdf",
+						"X-Metadata": JSON.stringify({
+							sessionID,
+							title: "Book Attachment",
+							parentItemID: bookItemID,
+							url: `${testServerPath}/attachment1.pdf`,
+						})
+					},
+					body: pdfArrayBuffer
+				}
+			));
+			// It should be rejected
+			assert.equal(attachmentReq.status, 409);
+
+			// The parent item should also be removed
+			let bookItem = await Zotero.Items.getAsync(itemIDs[0]);
+			assert.isFalse(bookItem);
+		});
+	});
 });


### PR DESCRIPTION
- Added `/connector/cancel` endpoint to connector server that the connector can call to cancel (or rather undo) the saving process if it was started by mistake.
- If there is no session (meaning, saving did not start yet), it will do nothing as the client will just need to not to hit the `/connector/save*` endpoint.
- If there is a session and all saving is done, added items will be erased right away.
- If there is a session and saving is not done, send all added top-level items so far to the trash so they immediately go away from the current view. Then, start a loop to check periodically if the saving is done, and erase the items as soon as it is. Letting all the saving process finish and handling this in one place seems like the most reliable way to achieve this without the risk of all sorts of possible glitches. While experimenting with other approaches, I ended up corrupting my database a few times, so letting everything settle first in the trash seemed like not a bad idea as it's least likely to go wrong ... Though, correct me if there is a more elegant solution that I missed!

A few additional fixes:
- fixed session not getting removed or garbage-collected
- fixed `isSavingDone` not returning true is any of the attachments failed to get saved

Addresses part of: https://github.com/zotero/zotero-connectors/issues/301