### PR TITLE
Allow to scroll collectionTree during highlighting via control

### DIFF
--- a/app/assets/prefs.js
+++ b/app/assets/prefs.js
@@ -155,3 +155,6 @@ pref("media.ffvpx.mp3.enabled", false);
 pref("media.rdd-vpx.enabled", false);
 pref("media.rdd-ffvpx.enabled", false);
 pref("media.utility-ffvpx.enabled", false);
+
+// Allow collectionTree scrolling when Control is highlighting collections on win
+pref("mousewheel.with_control.action", 1);


### PR DESCRIPTION
Holding Ctrl and scrolling does not dispatch a scroll event as it is used for zooming in/out. To allow one to scroll through collectionTree while holding Ctrl, listen to `wheel` event and scroll manually based on that. I'm using `e.deltaY * 10` to determine how far scroll, and it works OK though a bit different from proper scrolling. On some platforms, it's just a bit faster and on others - just a bit slower. I assume there is a lot of variation here, so not sure if there is a way to get a perfect value by how much to scroll.

Addresses: #4722