### PR TITLE
Implement macOS Sequoia Ctrl-Enter context menu shortcut

### DIFF
--- a/chrome/content/zotero/components/virtualized-table.jsx
+++ b/chrome/content/zotero/components/virtualized-table.jsx
@@ -256,7 +256,7 @@ class TreeSelection {
 	_updateTree(shouldDebounce) {
 		if (!this.selectEventsSuppressed && this._tree.props.onSelectionChange) {
 			this._tree.props.onSelectionChange(this, shouldDebounce);
-			this._tree._setAriaAciveDescendant();
+			this._tree._setAriaActiveDescendant();
 		}
 	}
 
@@ -1431,11 +1431,11 @@ class VirtualizedTable extends React.Component {
 	}
 	
 	// Set aria-activedescendant on table container
-	_setAriaAciveDescendant() {
+	_setAriaActiveDescendant() {
 		if (!this.selection.count) return;
 		let selected = this._jsWindow?.getElementByIndex(this.selection.focused);
 		if (selected) {
-			selected.closest(".virtualized-table").setAttribute("aria-activedescendant", selected.id);
+			this._topDiv.setAttribute("aria-activedescendant", selected.id);
 		}
 	}
 }

--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -2482,6 +2482,66 @@ Zotero.Utilities.Internal = {
 		}
 
 		return textContent;
+	},
+
+	/**
+	 * 
+	 * @param {Element} targetElement
+	 * @returns {[number, number]} clientX and clientY
+	 */
+	getContextMenuPosition(targetElement) {
+		let selection;
+		if (targetElement.editor?.selection) {
+			selection = targetElement.editor.selection;
+			if (!selection.rangeCount) {
+				selection = null;
+			}
+		}
+		else {
+			selection = targetElement.ownerDocument.getSelection();
+			if (!selection.rangeCount || !targetElement.contains(selection.getRangeAt(0).startContainer)) {
+				selection = null;
+			}
+		}
+
+		let rect;
+		let anchorToBottom;
+		let anchorToEnd;
+		if (selection) {
+			let range = selection.getRangeAt(0);
+			if (range.getClientRects().length) {
+				rect = range.getBoundingClientRect();
+			}
+			// If the selection is between lines in an editor, it'll be
+			// inside the editor's native anonymous text node and won't
+			// have any rects for some reason.
+			// If that's the case, use the text node's bounds.
+			else if (range.startContainer === range.endContainer && range.startContainer.isNativeAnonymous
+					&& range.startContainer.firstChild?.nodeType === Node.TEXT_NODE) {
+				let quads = range.startContainer.firstChild.getBoxQuads();
+				rect = quads[quads.length - 1].getBounds();
+			}
+			else {
+				rect = range.commonAncestorContainer.getBoundingClientRect();
+			}
+			anchorToBottom = !range.collapsed;
+			anchorToEnd = range.collapsed;
+		}
+		else {
+			rect = targetElement.getBoundingClientRect();
+			anchorToBottom = true;
+			anchorToEnd = false;
+		}
+
+		let clientX;
+		if (Zotero.rtl) {
+			clientX = rect.x + (anchorToEnd ? 0 : rect.width - 3);
+		}
+		else {
+			clientX = rect.x + (anchorToEnd ? rect.width + 3 : 0);
+		}
+		let clientY = rect.y + (anchorToBottom ? rect.height + 8 : 5);
+		return [clientX, clientY];
 	}
 };
 


### PR DESCRIPTION
This implements Sequoia's native behavior pretty exactly (I think!). The context menu is positioned:

- Below active list items, even if the list itself is focused (using `aria-activedescendant`)
- Below selected text in input fields
- To the right of the cursor in input fields if no text is selected
- Below all other focused controls

Closes #4724