### PR TITLE
Implement Ctrl-Enter handler in child frames

### DIFF
--- a/chrome/content/zotero/actors/ActorManager.jsm
+++ b/chrome/content/zotero/actors/ActorManager.jsm
@@ -63,3 +63,17 @@ ChromeUtils.registerWindowActor("ExternalLinkHandler", {
 	messageManagerGroups: ["feedAbstract", "basicViewer"]
 });
 
+// On macOS only, register the Ctrl-Enter handler actor
+// (No access to Zotero object here)
+if (AppConstants.platform === "macosx") {
+	ChromeUtils.registerWindowActor("SequoiaContextMenu", {
+		parent: {
+			moduleURI: "chrome://zotero/content/actors/SequoiaContextMenuParent.jsm",
+		},
+		child: {
+			moduleURI: "chrome://zotero/content/actors/SequoiaContextMenuChild.jsm",
+		},
+		allFrames: true,
+		includeChrome: true
+	});
+}

--- a/chrome/content/zotero/actors/SequoiaContextMenuChild.jsm
+++ b/chrome/content/zotero/actors/SequoiaContextMenuChild.jsm
@@ -1,0 +1,43 @@
+var { getTargetElement, createContextMenuEvent } = ChromeUtils.importESModule("chrome://zotero/content/contextMenuUtils.sys.mjs");
+
+var EXPORTED_SYMBOLS = ["SequoiaContextMenuChild"];
+
+/**
+ * Child-frame implementation of macOS Sequoia Ctrl-Enter context menu behavior.
+ * See platformKeys.js for the chrome implementation.
+ */
+class SequoiaContextMenuChild extends JSWindowActorChild {
+	_lastPreventedContextMenuTime = 0;
+	
+	async receiveMessage({ name }) {
+		switch (name) {
+			case "handleContextMenuEvent": {
+				// Chrome code received a contextmenu event and wants us to handle it
+				this._handleContextMenuEvent();
+			}
+		}
+	}
+	
+	_handleContextMenuEvent() {
+		let targetElement = getTargetElement(this.document);
+		if (!targetElement) {
+			return;
+		}
+		if ('browsingContext' in targetElement) {
+			// Recursively call child SequoiaContextMenu actor
+			targetElement.browsingContext.currentWindowGlobal.getActor('SequoiaContextMenu')
+				.sendAsyncMessage('handleContextMenuEvent');
+			return;
+		}
+		let contextMenuEvent = createContextMenuEvent(targetElement);
+		let showNative = targetElement.dispatchEvent(contextMenuEvent);
+		// If default wasn't prevented, tell our parent to show the
+		// embedding browser's context menu
+		if (showNative) {
+			this.sendAsyncMessage("openContextMenuAtScreen", {
+				screenX: contextMenuEvent.screenX,
+				screenY: contextMenuEvent.screenY,
+			});
+		}
+	}
+}

--- a/chrome/content/zotero/actors/SequoiaContextMenuParent.jsm
+++ b/chrome/content/zotero/actors/SequoiaContextMenuParent.jsm
@@ -1,0 +1,21 @@
+var EXPORTED_SYMBOLS = ["SequoiaContextMenuParent"];
+
+class SequoiaContextMenuParent extends JSWindowActorParent {
+	async receiveMessage({ name, data }) {
+		switch (name) {
+			case "openContextMenuAtScreen": {
+				let { screenX, screenY } = data;
+				let browser = this.browsingContext?.embedderElement;
+				if (!browser) {
+					return;
+				}
+				let contextMenuID = browser.closest('[context]')?.getAttribute('context');
+				let contextMenu = browser.ownerDocument.getElementById(contextMenuID);
+				if (!contextMenu) {
+					return;
+				}
+				contextMenu.openPopupAtScreen(screenX, screenY, true);
+			}
+		}
+	}
+}

--- a/chrome/content/zotero/contextMenuUtils.sys.mjs
+++ b/chrome/content/zotero/contextMenuUtils.sys.mjs
@@ -1,0 +1,100 @@
+const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+
+/**
+ * @param {Document} doc
+ * @returns {Element | null}
+ */
+export function getTargetElement(doc) {
+	let targetElement = doc.activeElement;
+	if (targetElement && targetElement.hasAttribute('aria-activedescendant')) {
+		let activeDescendant = targetElement.querySelector(
+			'#' + CSS.escape(targetElement.getAttribute('aria-activedescendant'))
+		);
+		if (activeDescendant) {
+			targetElement = activeDescendant;
+		}
+	}
+	return targetElement;
+}
+
+/**
+ * @param {Element} targetElement
+ * @returns {{ clientX: number, clientY: number }}
+ */
+function getContextMenuPosition(targetElement) {
+	let selection;
+	if (targetElement.editor?.selection) {
+		selection = targetElement.editor.selection;
+		if (!selection.rangeCount) {
+			selection = null;
+		}
+	}
+	else {
+		selection = targetElement.ownerDocument.getSelection();
+		if (!selection.rangeCount || !targetElement.contains(selection.getRangeAt(0).startContainer)) {
+			selection = null;
+		}
+	}
+
+	let rect;
+	let anchorToBottom;
+	let anchorToEnd;
+	if (selection) {
+		let range = selection.getRangeAt(0);
+		if (range.getClientRects().length) {
+			rect = range.getBoundingClientRect();
+		}
+		// If the selection is between lines in an editor, it'll be
+		// inside the editor's native anonymous text node and won't
+		// have any rects for some reason.
+		// If that's the case, use the text node's bounds.
+		else if (range.startContainer === range.endContainer && range.startContainer.isNativeAnonymous
+				&& range.startContainer.firstChild?.nodeType === Node.TEXT_NODE) {
+			let quads = range.startContainer.firstChild.getBoxQuads();
+			rect = quads[quads.length - 1].getBounds();
+		}
+		else {
+			rect = range.commonAncestorContainer.getBoundingClientRect();
+		}
+		anchorToBottom = !range.collapsed;
+		anchorToEnd = range.collapsed;
+	}
+	else {
+		rect = targetElement.getBoundingClientRect();
+		anchorToBottom = true;
+		anchorToEnd = false;
+	}
+
+	let clientX;
+	if (Services.locale.isAppLocaleRTL) {
+		clientX = rect.x + (anchorToEnd ? 0 : rect.width - 3);
+	}
+	else {
+		clientX = rect.x + (anchorToEnd ? rect.width + 3 : 0);
+	}
+	let clientY = rect.y + (anchorToBottom ? rect.height + 8 : 5);
+	return { clientX, clientY };
+}
+
+/**
+ * @param {Element} targetElement
+ * @returns {PointerEvent}
+ */
+export function createContextMenuEvent(targetElement) {
+	let { clientX, clientY } = getContextMenuPosition(targetElement);
+	let win = targetElement.ownerGlobal;
+	let screenX = win.mozInnerScreenX + clientX;
+	let screenY = win.mozInnerScreenY + clientY;
+	return new win.PointerEvent('contextmenu', {
+		bubbles: true,
+		cancelable: true,
+		button: 2,
+		buttons: 2,
+		clientX,
+		clientY,
+		layerX: clientX, // Wrong, but nobody should ever use these
+		layerY: clientY,
+		screenX,
+		screenY,
+	});
+}

--- a/chrome/content/zotero/contextMenuUtils.sys.mjs
+++ b/chrome/content/zotero/contextMenuUtils.sys.mjs
@@ -78,23 +78,37 @@ function getContextMenuPosition(targetElement) {
 
 /**
  * @param {Element} targetElement
- * @returns {PointerEvent}
+ * @returns {MouseEvent}
  */
 export function createContextMenuEvent(targetElement) {
 	let { clientX, clientY } = getContextMenuPosition(targetElement);
 	let win = targetElement.ownerGlobal;
 	let screenX = win.mozInnerScreenX + clientX;
 	let screenY = win.mozInnerScreenY + clientY;
-	return new win.PointerEvent('contextmenu', {
-		bubbles: true,
-		cancelable: true,
-		button: 2,
+	// Need to use initNSMouseEvent() to set inputSource, so just construct a
+	// minimal instance first
+	let event = new win.MouseEvent('contextmenu', {
+		// ...Except that doesn't set buttons, only button
 		buttons: 2,
-		clientX,
-		clientY,
-		layerX: clientX, // Wrong, but nobody should ever use these
-		layerY: clientY,
+	});
+	event.initNSMouseEvent(
+		'contextmenu',
+		/* bubbles */ true,
+		/* cancelable */ true,
+		/* view */ win,
+		/* detail */ undefined,
 		screenX,
 		screenY,
-	});
+		clientX,
+		clientY,
+		/* ctrlKey */ false,
+		/* altKey */ false,
+		/* shiftKey */ false,
+		/* metaKey */ false,
+		/* button */ 2,
+		/* relatedTarget */ null,
+		/* pressure */ undefined,
+		win.MouseEvent.MOZ_SOURCE_KEYBOARD,
+	);
+	return event;
 }

--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -2482,66 +2482,6 @@ Zotero.Utilities.Internal = {
 		}
 
 		return textContent;
-	},
-
-	/**
-	 * 
-	 * @param {Element} targetElement
-	 * @returns {[number, number]} clientX and clientY
-	 */
-	getContextMenuPosition(targetElement) {
-		let selection;
-		if (targetElement.editor?.selection) {
-			selection = targetElement.editor.selection;
-			if (!selection.rangeCount) {
-				selection = null;
-			}
-		}
-		else {
-			selection = targetElement.ownerDocument.getSelection();
-			if (!selection.rangeCount || !targetElement.contains(selection.getRangeAt(0).startContainer)) {
-				selection = null;
-			}
-		}
-
-		let rect;
-		let anchorToBottom;
-		let anchorToEnd;
-		if (selection) {
-			let range = selection.getRangeAt(0);
-			if (range.getClientRects().length) {
-				rect = range.getBoundingClientRect();
-			}
-			// If the selection is between lines in an editor, it'll be
-			// inside the editor's native anonymous text node and won't
-			// have any rects for some reason.
-			// If that's the case, use the text node's bounds.
-			else if (range.startContainer === range.endContainer && range.startContainer.isNativeAnonymous
-					&& range.startContainer.firstChild?.nodeType === Node.TEXT_NODE) {
-				let quads = range.startContainer.firstChild.getBoxQuads();
-				rect = quads[quads.length - 1].getBounds();
-			}
-			else {
-				rect = range.commonAncestorContainer.getBoundingClientRect();
-			}
-			anchorToBottom = !range.collapsed;
-			anchorToEnd = range.collapsed;
-		}
-		else {
-			rect = targetElement.getBoundingClientRect();
-			anchorToBottom = true;
-			anchorToEnd = false;
-		}
-
-		let clientX;
-		if (Zotero.rtl) {
-			clientX = rect.x + (anchorToEnd ? 0 : rect.width - 3);
-		}
-		else {
-			clientX = rect.x + (anchorToEnd ? rect.width + 3 : 0);
-		}
-		let clientY = rect.y + (anchorToBottom ? rect.height + 8 : 5);
-		return [clientX, clientY];
 	}
 };
 


### PR DESCRIPTION
Tested and working in Scaffold, note-editor, and basicViewer. EPUB and snapshot readers work as well. PDF needs https://github.com/zotero/reader/pull/141.

Fixes #4724