### PR TITLE
Fix renaming behavior for attachment without extension

### DIFF
--- a/chrome/content/zotero/preferences/preferences_file_renaming.js
+++ b/chrome/content/zotero/preferences/preferences_file_renaming.js
@@ -50,9 +50,8 @@ Zotero_Preferences.FileRenaming = {
 			if (selectedItem.isRegularItem() && !selectedItem.parentKey) {
 				return [selectedItem, this.defaultExt, ''];
 			}
-			if (selectedItem.isFileAttachment()) {
-				let path = selectedItem.getFilePath();
-				let ext = Zotero.File.getExtension(Zotero.File.pathToFile(path));
+			if (selectedItem.isFileAttachment() && selectedItem.parentKey) {
+				let ext = Zotero.Attachments.getCorrectFileExension(selectedItem);
 				let parentItem = Zotero.Items.getByLibraryAndKey(selectedItem.libraryID, selectedItem.parentKey);
 				return [parentItem, ext ?? this.defaultExt, selectedItem.getField('title')];
 			}

--- a/chrome/content/zotero/preferences/preferences_file_renaming.js
+++ b/chrome/content/zotero/preferences/preferences_file_renaming.js
@@ -51,7 +51,7 @@ Zotero_Preferences.FileRenaming = {
 				return [selectedItem, this.defaultExt, ''];
 			}
 			if (selectedItem.isFileAttachment() && selectedItem.parentKey) {
-				let ext = Zotero.Attachments.getCorrectFileExension(selectedItem);
+				let ext = Zotero.Attachments.getCorrectFileExtension(selectedItem);
 				let parentItem = Zotero.Items.getByLibraryAndKey(selectedItem.libraryID, selectedItem.parentKey);
 				return [parentItem, ext ?? this.defaultExt, selectedItem.getField('title')];
 			}

--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -2213,7 +2213,7 @@ Zotero.Attachments = new function () {
 			throw new Error("'item' must be a Zotero.Item");
 		}
 		if (typeof options === 'string') {
-			Zotero.warn("Zotero.Attachments.getFileBaseNameFromItem(item, formatString) is deprecated -- use Zotero.Attachments(item, options)");
+			Zotero.warn("Zotero.Attachments.getFileBaseNameFromItem(item, formatString) is deprecated -- use Zotero.Attachments.getFileBaseNameFromItem(item, options)");
 			options = { formatString: options };
 		}
 
@@ -2463,7 +2463,24 @@ Zotero.Attachments = new function () {
 		formatted = Zotero.File.getValidFileName(formatted);
 		return formatted;
 	};
-	
+
+	/**
+	 * @returns {String} Current file extension for the attachment, if it appears to be a valid file extension.
+	 *					 Otherwise, attempts to guess the file extension from the attachment's content type.
+	 **/
+	this.getCorrectFileExension = function (attachment) {
+		let path = attachment.getFilePath();
+		if (!path) {
+			return '';
+		}
+		let ext = Zotero.File.getExtension(path);
+		ext = Zotero.File.isLikeExtension(ext) ? ext : '';
+		if (ext === '') {
+			ext = Zotero.MIME.getPrimaryExtension(attachment.attachmentContentType);
+			Zotero.Debug.log(`Attachment "${path}": Invalid or missing extension. Guessing from content type: ${ext}`);
+		}
+		return ext;
+	};
 	
 	this.shouldAutoRenameFile = function (isLink) {
 		if (!Zotero.Prefs.get('autoRenameFiles')) {

--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -2468,7 +2468,7 @@ Zotero.Attachments = new function () {
 	 * @returns {String} Current file extension for the attachment, if it appears to be a valid file extension.
 	 *					 Otherwise, attempts to guess the file extension from the attachment's content type.
 	 **/
-	this.getCorrectFileExension = function (attachment) {
+	this.getCorrectFileExtension = function (attachment) {
 		let path = attachment.getFilePath();
 		if (!path) {
 			return '';

--- a/chrome/content/zotero/xpcom/file.js
+++ b/chrome/content/zotero/xpcom/file.js
@@ -37,7 +37,6 @@ Zotero.File = new function(){
 	this.putContents = putContents;
 	this.getValidFileName = getValidFileName;
 	this.truncateFileName = truncateFileName;
-	this.isLikeExtension = isLikeExtension;
 	
 	this.REPLACEMENT_CHARACTER = "\uFFFD";
 	
@@ -85,7 +84,7 @@ Zotero.File = new function(){
 		return pos==-1 ? '' : file.leafName.substr(pos+1);
 	}
 
-	function isLikeExtension(extension) {
+	this.isLikeExtension = function (extension) {
 		return !!extension.match(/^\w{1,10}$/i);
 	}
 	

--- a/chrome/content/zotero/xpcom/file.js
+++ b/chrome/content/zotero/xpcom/file.js
@@ -37,6 +37,7 @@ Zotero.File = new function(){
 	this.putContents = putContents;
 	this.getValidFileName = getValidFileName;
 	this.truncateFileName = truncateFileName;
+	this.isLikeExtension = isLikeExtension;
 	
 	this.REPLACEMENT_CHARACTER = "\uFFFD";
 	
@@ -82,6 +83,10 @@ Zotero.File = new function(){
 		file = this.pathToFile(file);
 		var pos = file.leafName.lastIndexOf('.');
 		return pos==-1 ? '' : file.leafName.substr(pos+1);
+	}
+
+	function isLikeExtension(extension) {
+		return !!extension.match(/^\w{1,10}$/i);
 	}
 	
 	

--- a/chrome/content/zotero/xpcom/recognizeDocument.js
+++ b/chrome/content/zotero/xpcom/recognizeDocument.js
@@ -295,7 +295,7 @@ Zotero.RecognizeDocument = new function () {
 		// Rename attachment file to match new metadata
 		if (Zotero.Attachments.shouldAutoRenameAttachment(attachment)) {
 			let fileBaseName = Zotero.Attachments.getFileBaseNameFromItem(parentItem, { attachmentTitle: originalTitle });
-			let ext = Zotero.Attachments.getCorrectFileExension(attachment);
+			let ext = Zotero.Attachments.getCorrectFileExtension(attachment);
 			let newName = fileBaseName + (ext ? '.' + ext : '');
 			let result = await attachment.renameAttachmentFile(newName, false, true);
 			if (result !== true) {

--- a/chrome/content/zotero/xpcom/recognizeDocument.js
+++ b/chrome/content/zotero/xpcom/recognizeDocument.js
@@ -294,8 +294,8 @@ Zotero.RecognizeDocument = new function () {
 		
 		// Rename attachment file to match new metadata
 		if (Zotero.Attachments.shouldAutoRenameAttachment(attachment)) {
-			let ext = Zotero.File.getExtension(path);
 			let fileBaseName = Zotero.Attachments.getFileBaseNameFromItem(parentItem, { attachmentTitle: originalTitle });
+			let ext = Zotero.Attachments.getCorrectFileExension(attachment);
 			let newName = fileBaseName + (ext ? '.' + ext : '');
 			let result = await attachment.renameAttachmentFile(newName, false, true);
 			if (result !== true) {

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -5349,8 +5349,8 @@ var ZoteroPane = new function()
 					Zotero.debug('No path for attachment ' + item.key);
 					continue;
 				}
-				let ext = Zotero.File.getExtension(path);
 				let fileBaseName = Zotero.Attachments.getFileBaseNameFromItem(item.parentItem, { attachmentTitle: item.getField('title') });
+				let ext = Zotero.Attachments.getCorrectFileExension(item);
 				let newName = fileBaseName + (ext ? '.' + ext : '');
 				let result = await item.renameAttachmentFile(newName, false, true);
 				if (result !== true) {
@@ -5680,14 +5680,9 @@ var ZoteroPane = new function()
 			let parentItemID = item.parentItemID;
 			let parentItem = await Zotero.Items.getAsync(parentItemID);
 			var oldBaseName = item.attachmentFilename.replace(/\.[^.]+$/, '');
-			var newName = Zotero.Attachments.getFileBaseNameFromItem(parentItem, { attachmentTitle: item.getField('title') });
-			
-			let extRE = /\.[^\.]+$/;
-			let origFilename = PathUtils.split(file).pop();
-			let ext = origFilename.match(extRE);
-			if (ext) {
-				newName = newName + ext[0];
-			}
+			var fileBaseName = Zotero.Attachments.getFileBaseNameFromItem(parentItem, { attachmentTitle: item.getField('title') });
+			let ext = Zotero.Attachments.getCorrectFileExension(item);
+			let newName = fileBaseName + (ext ? '.' + ext : '');
 			
 			var renamed = await item.renameAttachmentFile(newName, false, true);
 			if (renamed !== true) {

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -5350,7 +5350,7 @@ var ZoteroPane = new function()
 					continue;
 				}
 				let fileBaseName = Zotero.Attachments.getFileBaseNameFromItem(item.parentItem, { attachmentTitle: item.getField('title') });
-				let ext = Zotero.Attachments.getCorrectFileExension(item);
+				let ext = Zotero.Attachments.getCorrectFileExtension(item);
 				let newName = fileBaseName + (ext ? '.' + ext : '');
 				let result = await item.renameAttachmentFile(newName, false, true);
 				if (result !== true) {
@@ -5681,7 +5681,7 @@ var ZoteroPane = new function()
 			let parentItem = await Zotero.Items.getAsync(parentItemID);
 			var oldBaseName = item.attachmentFilename.replace(/\.[^.]+$/, '');
 			var fileBaseName = Zotero.Attachments.getFileBaseNameFromItem(parentItem, { attachmentTitle: item.getField('title') });
-			let ext = Zotero.Attachments.getCorrectFileExension(item);
+			let ext = Zotero.Attachments.getCorrectFileExtension(item);
 			let newName = fileBaseName + (ext ? '.' + ext : '');
 			
 			var renamed = await item.renameAttachmentFile(newName, false, true);

--- a/test/tests/zoteroPaneTest.js
+++ b/test/tests/zoteroPaneTest.js
@@ -629,8 +629,8 @@ describe("ZoteroPane", function() {
 		
 		it("should use unique name for linked file without extension if target name is taken", async function () {
 			var oldFilename = 'old';
-			var newFilename = 'Test';
-			var uniqueFilename = 'Test 2';
+			var newFilename = 'Test.png';
+			var uniqueFilename = 'Test 2.png';
 			var file = getTestDataDirectory();
 			file.append('test.png');
 			var tmpDir = await getTempDirectory();
@@ -652,7 +652,7 @@ describe("ZoteroPane", function() {
 			await zp.renameSelectedAttachmentsFromParents();
 			assert.equal(attachment.attachmentFilename, uniqueFilename);
 			var path = await attachment.getFilePathAsync();
-			assert.equal(OS.Path.basename(path), uniqueFilename)
+			assert.equal(OS.Path.basename(path), uniqueFilename);
 			await OS.File.exists(path);
 		});
 		
@@ -690,6 +690,27 @@ describe("ZoteroPane", function() {
 			assert.equal(attachment.attachmentFilename, 'Title.png');
 			// After a manual rename, the title becomes the default for this type
 			assert.equal(attachment.getField('title'), Zotero.getString('file-type-image'));
+		});
+
+		it("should restore an extension when renaming a misnamed file", async function () {
+			let pdfFile = getTestDataDirectory();
+			pdfFile.append('test.pdf');
+			let tmpDir = await getTempDirectory();
+			let tmpFileToImport = OS.Path.join(tmpDir, 'bad name . not an extension');
+			await OS.File.copy(pdfFile.path, tmpFileToImport);
+
+			var item = createUnsavedDataObject('item');
+			item.setField('title', 'Title');
+			await item.saveTx();
+			
+			let attachment = await Zotero.Attachments.importFromFile({
+				file: tmpFileToImport,
+				parentItemID: item.id
+			});
+
+			await zp.selectItem(attachment.id);
+			await zp.renameSelectedAttachmentsFromParents();
+			assert.equal(attachment.attachmentFilename, 'Title.pdf');
 		});
 	});
 	


### PR DESCRIPTION
Added a check to see if the current extension matches the `/^\w{1,10}$/i` regex. If it doesn't, it's considered invalid and discarded. For missing or invalid extensions, Zotero will attempt to guess the correct extension based on the mime type.

This is updated for "Rename File from Parent Metadata", when recognizing a file and for the preview in preferences.

I took the regex from here (it's used when editing a file name manually): https://github.com/zotero/zotero/blob/237a2e5b86edab2d09166d3368054be0c3f4239b/chrome/content/zotero/elements/attachmentBox.js#L579

Resolve #4739