### PR TITLE
Check for admin privleges in UninstallOld installer routine

### DIFF
--- a/app/win/installer/installer.nsi
+++ b/app/win/installer/installer.nsi
@@ -236,7 +236,19 @@ Function UninstallOld
     Delete /REBOOTOK "$3\platform.ini"
     Delete /REBOOTOK "$3\precomplete"
     Delete /REBOOTOK "$3\voucher.bin"
-    RMDir $3
+    RMDir /REBOOTOK $3
+
+    ${If} ${FileExists} "$3"
+      # If the directory still exists, check if current user is Admin.
+      # For Admin users, /REBOOTOK works and directory will be removed after reboot
+      # For non-Admin users, we display a message and quit
+      UserInfo::GetAccountType
+      pop $0
+      StrCmp $0 "Admin" continue_installation
+      MessageBox mb_iconstop "Previous installation of Zotero could not be removed. Please manually remove the following directory, and then run the installer again: $\n$\n$3"
+      Quit
+    ${EndIf}
+
   continue_installation:
     ; End uninstallation
     SetShellVarContext current

--- a/app/win/installer/installer.nsi
+++ b/app/win/installer/installer.nsi
@@ -245,7 +245,7 @@ Function UninstallOld
       UserInfo::GetAccountType
       pop $0
       StrCmp $0 "Admin" continue_installation
-      MessageBox mb_iconstop "Previous installation of Zotero could not be removed. Please manually remove the following directory, and then run the installer again: $\n$\n$3"
+      MessageBox mb_iconstop "The previous installation of Zotero could not be removed. Please manually delete the following folder, and then run the installer again: $\n$\n$3"
       Quit
     ${EndIf}
 


### PR DESCRIPTION
This PR adds a check for whether the user is an admin in the `UninstallOld` routine. If not, and the directory still exists at the end of the routine, it displays an error message and exits.

However, we don’t check if the user selected an empty directory for installation, so just re-running the installer will work. That makes me wonder if removing old Zotero should be a "best effort" approach. We could remove `/REBOOTOK` from that section, and if some files are left over, we could just ignore them and proceed with the installation.

This solution should address the most common issue causing the reboot loop, but we should also consider other cases, especially for users who have already run the previous version of the installer and are now stuck in the loop. I'll look into these other cases next.

https://github.com/user-attachments/assets/2ca460e6-a621-4e8e-92b8-e5186a393636


