### PR TITLE
simplify reader.ftl

### DIFF
--- a/chrome/locale/en-US/zotero/reader.ftl
+++ b/chrome/locale/en-US/zotero/reader.ftl
@@ -13,30 +13,12 @@ pdfReader-imageAnnotation = Image Annotation
 pdfReader-find-in-document = Find in Document
 
 pdfReader-a11yMoveAnnotation = Use the arrow keys to move the annotation.
-pdfReader-a11yEditTextAnnotation = To move the end of the text annotation, hold { general-key-shift } and use the left/right arrow keys. To move the start of the annotation, hold { general-key-shift }-{ option-or-alt } and use the arrow keys.
+pdfReader-a11yEditTextAnnotation = To move the end of the text annotation, hold { general-key-shift } and use the left/right arrow keys. To move the start of the annotation, hold { general-key-shift }-{ command-or-alt } and use the arrow keys.
 pdfReader-a11yResizeAnnotation = To resize the annotation, hold { general-key-shift } and use the arrow keys.
 pdfReader-a11yAnnotationPopupAppeared = Use Tab to navigate the annotation popup.
 
-pdfReader-a11yAnnotationCreated = { $type ->
-    [highlight] { pdfReader-highlightAnnotation }
-    [underline] { pdfReader-underlineAnnotation }
-    [note] { pdfReader-noteAnnotation }
-    [text] { pdfReader-textAnnotation }
-    [image] { pdfReader-imageAnnotation }
-   *[other] Annotation
-} created.
-
-pdfReader-a11yAnnotationSelected = { $type ->
-    [highlight] { pdfReader-highlightAnnotation } selected. { pdfReader-a11yEditTextAnnotation }
-    [underline] { pdfReader-underlineAnnotation } selected. { pdfReader-a11yEditTextAnnotation }
-    [note] { pdfReader-noteAnnotation } selected. { pdfReader-a11yMoveAnnotation }
-    [text] { pdfReader-textAnnotation } selected. { pdfReader-a11yMoveAnnotation } { pdfReader-a11yResizeAnnotation }
-    [image] { pdfReader-imageAnnotation } selected. { pdfReader-a11yMoveAnnotation } { pdfReader-a11yResizeAnnotation }
-   *[other] Annotation selected.
-} { $popupVisible -> 
-    [yes] { pdfReader-a11yAnnotationPopupAppeared }
-    *[other] { "" }
-}
+pdfReader-a11yAnnotationCreated = { $type } created.
+pdfReader-a11yAnnotationSelected = { $type } selected.
 
 -pdfReader-a11yTextualAnnotationInstruction = To annotate text via the keyboard, first use “{ pdfReader-find-in-document }” to locate the phrase, and then press { general-key-control }-{ option-or-alt }-{ $number } to turn the search result into an annotation.
 -pdfReader-a11yAnnotationInstruction = To add this annotation into the document, focus the document and press { general-key-control }-{ option-or-alt }-{ $number }.
@@ -63,4 +45,4 @@ pdfReader-toolbar-draw =
 pdfReader-findInDocumentInput =
     .title = Find
     .placeholder = { pdfReader-find-in-document }
-    .aria-description = To turn a search result into a highlight or underline annotation, press { general-key-control }-{ option-or-alt }-1. To turn a search result into an underline annotation, press { general-key-control }-{ option-or-alt }-2.
+    .aria-description = To turn a search result into a highlight annotation, press { general-key-control }-{ option-or-alt }-1. To turn a search result into an underline annotation, press { general-key-control }-{ option-or-alt }-2.

--- a/chrome/locale/en-US/zotero/reader.ftl
+++ b/chrome/locale/en-US/zotero/reader.ftl
@@ -12,8 +12,13 @@ pdfReader-imageAnnotation = Image Annotation
 
 pdfReader-find-in-document = Find in Document
 
+pdfReader-move-annotation-start-key =
+    { PLATFORM() ->
+        [macos] { general-key-command }
+        *[other] { general-key-alt }
+    }
 pdfReader-a11yMoveAnnotation = Use the arrow keys to move the annotation.
-pdfReader-a11yEditTextAnnotation = To move the end of the text annotation, hold { general-key-shift } and use the left/right arrow keys. To move the start of the annotation, hold { general-key-shift }-{ command-or-alt } and use the arrow keys.
+pdfReader-a11yEditTextAnnotation = To move the end of the text annotation, hold { general-key-shift } and use the left/right arrow keys. To move the start of the annotation, hold { general-key-shift }-{ pdfReader-move-annotation-start-key } and use the arrow keys.
 pdfReader-a11yResizeAnnotation = To resize the annotation, hold { general-key-shift } and use the arrow keys.
 pdfReader-a11yAnnotationPopupAppeared = Use Tab to navigate the annotation popup.
 

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -5,6 +5,11 @@ option-or-alt =
         [macos] Option
         *[other] Alt
     }
+command-or-alt =
+    { PLATFORM() ->
+        [macos] Command
+        *[other] Alt
+    }
 return-or-enter =
     { PLATFORM() ->
         [macos] Return

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -1,13 +1,10 @@
 general-key-control = Control
 general-key-shift = Shift
+general-key-alt = Alt
+general-key-command = Command
 option-or-alt =
     { PLATFORM() ->
         [macos] Option
-        *[other] Alt
-    }
-command-or-alt =
-    { PLATFORM() ->
-        [macos] Command
         *[other] Alt
     }
 return-or-enter =


### PR DESCRIPTION
Remove logic constructing a11y announcements from reader.ftl. Instead, reader will fetch and put together sentences as needed on the fly.

Followup to https://github.com/zotero/zotero/commit/cde21ac9f2407856d000ea2038ea49cee7e8dd7c per https://github.com/zotero/zotero/pull/4752#discussion_r1800481917

Also, add `{ command-or-alt }` to zotero.ftl and use it for textual annotations instructions. On mac, the end of highlight and underline annotations is resized via Shift+Command+arrows, which is different from the Options modifier used in all other instances (per https://github.com/zotero/reader/pull/138#issuecomment-2373775068). I must have missed that the modifier is different earlier.

Finally, tweak aria-description of "Find in document" as it sounded as if Control+Option/Alt+1 would create either highlight or underline annotation (or both?). But correct me if I'm just mistaken about this part.