### PR TITLE
Improve the Windows installer to prevent users without admin privileges from getting stuck in a reboot loop

### DIFF
--- a/app/win/download-nsis-plugins
+++ b/app/win/download-nsis-plugins
@@ -46,6 +46,11 @@ for plugin in $plugins; do
 	curl https://hg.mozilla.org/mozilla-central/raw-file/052d53200cf8/other-licenses/nsis/Plugins/$plugin.dll > $plugin.dll
 done
 
+curl https://nsis.sourceforge.io/mediawiki/images/1/18/NsProcess.zip > NsProcess.zip
+7z e NsProcess.zip "Plugin/nsProcessW.dll"
+mv nsProcessW.dll nsProcess.dll
+rm NsProcess.zip
+
 echo
 echo
 echo "Files downloaded to ./Plugins -- move to ${NSIS_DIR}Plugins"

--- a/app/win/installer/installer.nsi
+++ b/app/win/installer/installer.nsi
@@ -218,37 +218,26 @@ Function UninstallOld
     ${GetFileName} $3 $4
     StrCpy $5 $4 6
     StrCmp $5 "Zotero" +1 continue_installation
-    RMDir /r /REBOOTOK "$3\chrome"
-    RMDir /r /REBOOTOK "$3\components"
-    RMDir /r /REBOOTOK "$3\defaults"
-    RMDir /r /REBOOTOK "$3\dictionaries"
-    RMDir /r /REBOOTOK "$3\extensions"
-    RMDir /r /REBOOTOK "$3\fonts"
-    RMDir /r /REBOOTOK "$3\gmp-clearkey"
-    RMDir /r /REBOOTOK "$3\uninstall"
-    RMDir /r /REBOOTOK "$3\xulrunner"
-    Delete /REBOOTOK "$3\*.chk"
-    Delete /REBOOTOK "$3\*.dll"
-    Delete /REBOOTOK "$3\*.exe"
-    Delete /REBOOTOK "$3\Accessible.tlb"
-    Delete /REBOOTOK "$3\dependentlibs.list"
-    Delete /REBOOTOK "$3\firefox.VisualElementsManifest.xml"
-    Delete /REBOOTOK "$3\omni.ja"
-    Delete /REBOOTOK "$3\platform.ini"
-    Delete /REBOOTOK "$3\precomplete"
-    Delete /REBOOTOK "$3\voucher.bin"
-    RMDir /REBOOTOK $3
-
-    ${If} ${FileExists} "$3"
-      # If the directory still exists, check if current user is Admin.
-      # For Admin users, /REBOOTOK works and directory will be removed after reboot
-      # For non-Admin users, we display a message and quit
-      UserInfo::GetAccountType
-      pop $0
-      StrCmp $0 "Admin" continue_installation
-      MessageBox mb_iconstop "The previous installation of Zotero could not be removed. Please manually delete the following folder, and then run the installer again: $\n$\n$3"
-      Quit
-    ${EndIf}
+    RMDir /r "$3\chrome"
+    RMDir /r "$3\components"
+    RMDir /r "$3\defaults"
+    RMDir /r "$3\dictionaries"
+    RMDir /r "$3\extensions"
+    RMDir /r "$3\fonts"
+    RMDir /r "$3\gmp-clearkey"
+    RMDir /r "$3\uninstall"
+    RMDir /r "$3\xulrunner"
+    Delete "$3\*.chk"
+    Delete "$3\*.dll"
+    Delete "$3\*.exe"
+    Delete "$3\Accessible.tlb"
+    Delete "$3\dependentlibs.list"
+    Delete "$3\firefox.VisualElementsManifest.xml"
+    Delete "$3\omni.ja"
+    Delete "$3\platform.ini"
+    Delete "$3\precomplete"
+    Delete "$3\voucher.bin"
+    RMDir $3
 
   continue_installation:
     ; End uninstallation

--- a/app/win/installer/installer.nsi
+++ b/app/win/installer/installer.nsi
@@ -59,6 +59,7 @@ Var InstallType
 !insertmacro WordFind
 !insertmacro WordReplace
 
+!include nsProcess.nsh
 ; The following includes are custom.
 !include branding.nsi
 !include defines.nsi
@@ -961,6 +962,21 @@ Function .onInit
       Quit
     ${EndIf}
   !endif
+
+  # Check if Zotero is running. If it is, prompt the user to close Zotero and exit.
+  # For silent installs, kill Zotero and if successful, continue with the install.
+  ${nsProcess::FindProcess} ${FileMainEXE} $R0
+  ${If} $R0 = 0
+    IfSilent +3
+    MessageBox MB_OK|MB_ICONSTOP "Zotero is already running. Please close Zotero before running the installer."
+    Quit
+    ${nsProcess::KillProcess} ${FileMainEXE} $R0
+    Sleep 500
+    ${nsProcess::FindProcess} ${FileMainEXE} $R0
+    ${If} $R0 = 0
+      Quit
+    ${EndIf}
+  ${EndIf}
 
   StrCpy $R1 "Zotero Standalone"
   StrCpy $R2 "An older version of Zotero is installed. If you continue, the existing version will be removed.$\n$\nYour Zotero data will not be affected."

--- a/app/win/installer/installer.nsi
+++ b/app/win/installer/installer.nsi
@@ -618,19 +618,33 @@ Function AddQuickLaunchShortcut
 FunctionEnd
 
 Function CheckExistingInstall
+  UserInfo::GetAccountType
+  pop $0 ; $0 = "Admin" or "User" or "Guest". This is the account type.
+
   ; If there is a pending file copy from a previous upgrade don't allow
   ; installing until after the system has rebooted.
-  IfFileExists "$INSTDIR\${FileMainEXE}.moz-upgrade" +1 +4
-  MessageBox MB_YESNO|MB_ICONEXCLAMATION "$(WARN_RESTART_REQUIRED_UPGRADE)" IDNO +2
-  Reboot
-  Quit
+  ${If} ${FileExists} "$INSTDIR\${FileMainEXE}.moz-upgrade"
+    StrCmp $0 "Admin" +1 +4
+    MessageBox MB_YESNO|MB_ICONEXCLAMATION "$(WARN_RESTART_REQUIRED_UPGRADE)" IDNO +2
+    Reboot
+    Quit
+    ; Non-admins cannot depend on files being removed on restart. 
+    ; Our only option is to remove these files and continue with the installation.
+    Delete "$INSTDIR\${FileMainEXE}.moz-upgrade"
+    Delete "$INSTDIR\${FileMainEXE}"
+  ${EndIf}
 
   ; If there is a pending file deletion from a previous uninstall don't allow
   ; installing until after the system has rebooted.
-  IfFileExists "$INSTDIR\${FileMainEXE}.moz-delete" +1 +4
-  MessageBox MB_YESNO|MB_ICONEXCLAMATION "$(WARN_RESTART_REQUIRED_UNINSTALL)" IDNO +2
-  Reboot
-  Quit
+  ${If} ${FileExists} "$INSTDIR\${FileMainEXE}.moz-delete"
+    StrCmp $0 "Admin" +1 +4
+    MessageBox MB_YESNO|MB_ICONEXCLAMATION "$(WARN_RESTART_REQUIRED_UNINSTALL)" IDNO +2
+    Reboot
+    Quit
+    ; Non-admins cannot depend on files being removed on restart.
+    Delete "$INSTDIR\${FileMainEXE}.moz-delete"
+    Delete "$INSTDIR\${FileMainEXE}"
+  ${EndIf}
 
   ${If} ${FileExists} "$INSTDIR\${FileMainEXE}"
     ; Disable the next, cancel, and back buttons

--- a/app/win/installer/nsProcess.nsh
+++ b/app/win/installer/nsProcess.nsh
@@ -1,0 +1,28 @@
+!define nsProcess::FindProcess `!insertmacro nsProcess::FindProcess`
+
+!macro nsProcess::FindProcess _FILE _ERR
+	nsProcess::_FindProcess /NOUNLOAD `${_FILE}`
+	Pop ${_ERR}
+!macroend
+
+
+!define nsProcess::KillProcess `!insertmacro nsProcess::KillProcess`
+
+!macro nsProcess::KillProcess _FILE _ERR
+	nsProcess::_KillProcess /NOUNLOAD `${_FILE}`
+	Pop ${_ERR}
+!macroend
+
+!define nsProcess::CloseProcess `!insertmacro nsProcess::CloseProcess`
+
+!macro nsProcess::CloseProcess _FILE _ERR
+	nsProcess::_CloseProcess /NOUNLOAD `${_FILE}`
+	Pop ${_ERR}
+!macroend
+
+
+!define nsProcess::Unload `!insertmacro nsProcess::Unload`
+
+!macro nsProcess::Unload
+	nsProcess::_Unload
+!macroend


### PR DESCRIPTION
This PR contains modifications to the install process as discussed in https://github.com/zotero/zotero/pull/4750#issuecomment-2410392033

1. The installer now checks if Zotero is running before proceeding. This is a quick check for a running process, which is simpler and faster than the more thorough check in `CheckExistingInstall`, where a list of files is tested for write access. If Zotero is running, the installer shows an error message and quits during normal installations. For silent installations, it attempts to kill `zotero.exe` process and quits unless successful.
2. Removed all instances of `/REBOOTOK` in the `UninstallOld` routine and removed the message introduced in #4750.
3. If a previous incomplete installation is encountered and the user is not an admin, the installer will now attempt to continue with a fresh installation. This might result in leftover junk in the target directory but should still produce a working installation, avoiding a reboot loop.

To check and kill the process, I've introduced a new NSIS plugin called `nsProcess`. The [download-nsis-plugins](https://github.com/zotero/zotero/commit/86f222f6fa68d525d65f32475f56575d583e0780#diff-445a8f541c9419a31e1f0cf35a6f3ca8ba9aa8471c048cac44a1792fb40b91a3) script has been extended to automatically fetch it.

Screencasts:

Install as a non-admin user, while Zotero is running:
https://github.com/user-attachments/assets/9dddd04e-5bbd-4395-ba91-2bf70db1d875

Silent install as non-admin user, while Zotero is running:
https://github.com/user-attachments/assets/bd3fc171-3b6b-4a37-a11a-36502318546f

Install as a non-admin user, while previous installation left `.moz-delete` file:
https://github.com/user-attachments/assets/7d7139bd-e26f-4a50-896c-cec774f202d9
