### PR TITLE
Special handling for tabbox focus-ring

### DIFF
--- a/scss/mac/_tabbox.scss
+++ b/scss/mac/_tabbox.scss
@@ -88,6 +88,16 @@ tabbox {
 				}
 			}
 		}
+
+		// focus-ring if tabbox is not marked as clicked (to avoid blinking)
+		&:not([clicked]) tab:focus-visible {
+			outline: none;
+			// box-shadow should appear around hbox with rounded corners
+			hbox {
+				box-shadow: 0 0 0 var(--width-focus-border) -moz-mac-focusring !important;
+				z-index: 1;
+			}
+		}
 	}
 	tabpanels {
 		appearance: none;

--- a/scss/scaffold.scss
+++ b/scss/scaffold.scss
@@ -213,9 +213,3 @@ browser,
 		}
 	}
 }
-
-// show focusring only during keyboard navigation
-#tabs:not([clicked]) tab:focus-visible {
-	outline: none;
-	box-shadow: 0 0 0 var(--width-focus-border) var(--color-focus-border);
-}

--- a/scss/win/components/_tabbox.scss
+++ b/scss/win/components/_tabbox.scss
@@ -35,8 +35,6 @@ tabbox {
 				border-inline-end: 1px solid var(--fill-quinary);
 			}
 
-			@include focus-ring;
-
 			.tab-middle {
 				outline: none !important;
 				padding: 4px 11px 5px 11px;
@@ -53,6 +51,16 @@ tabbox {
 					padding: 4px 11px 5px 11px;
 					border-radius: 4px;
 				}
+			}
+		}
+
+		// focus-ring if tabbox is not marked as clicked (to avoid blinking)
+		&:not([clicked]) tab:focus-visible {
+			outline: none;
+			// outline should appear around hbox with rounded corners
+			hbox {
+				outline: var(--color-focus-outer-border) solid var(--width-focus-outer-border) !important;
+				z-index: 1;
 			}
 		}
 	}


### PR DESCRIPTION
Set focusring on the child `hbox`, instead of the actual tab. The `hbox` is the element with visibly rounded corners, so this way the focus-ring will have the right shape.

Fixes: #4744

<img width="365" alt="Screenshot 2024-10-16 at 4 27 49 PM" src="https://github.com/user-attachments/assets/3b1f0d2a-b5af-4628-a403-738dbb0feb2e">

<img width="385" alt="Screenshot 2024-10-16 at 4 27 08 PM" src="https://github.com/user-attachments/assets/54c3afce-0da2-4000-b18b-37c92c30a8ed">
