### PR TITLE
Better label to make item standalone in change parent item dialog

### DIFF
--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -5158,7 +5158,7 @@ var ZoteroPane = new function()
 		let canBeMovedOutOfParent = !selectedItems.some(item => item.isWebAttachment() && !item.isPDFAttachment() && !item.isEPUBAttachment());
 		// Add a button to the dialog to make items standalone, if applicable
 		if (canBeMovedOutOfParent) {
-			// Determing which label to show. "Convert to standalone attachment(s)/note(s)"
+			// Determine which label to show. "Convert to standalone attachment(s)/note(s)"
 			let allNotes = selectedItems.every(item => item.isNote());
 			let allAttachments = selectedItems.every(item => item.isAttachment());
 			let l10nId = `select-items-convertToStandalone${allNotes ? "Note" : ""}${allAttachments ? "Attachment" : ""}`;

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -5156,11 +5156,15 @@ var ZoteroPane = new function()
 		let extraButtons = [];
 		// Keep in sync with Zotero.RecognizeDocument.canRecognize()
 		let canBeMovedOutOfParent = !selectedItems.some(item => item.isWebAttachment() && !item.isPDFAttachment() && !item.isEPUBAttachment());
-		// Add a button to the dialog to make attachments standalone, if applicable
+		// Add a button to the dialog to make items standalone, if applicable
 		if (canBeMovedOutOfParent) {
+			// Determing which label to show. "Convert to standalone attachment(s)/note(s)"
+			let allNotes = selectedItems.every(item => item.isNote());
+			let allAttachments = selectedItems.every(item => item.isAttachment());
+			let l10nId = `select-items-convertToStandalone${allNotes ? "Note" : ""}${allAttachments ? "Attachment" : ""}`;
 			extraButtons = [{
 				type: "extra1",
-				l10nLabel: "select-items-convertToStandaloneAttachment",
+				l10nLabel: l10nId,
 				l10nArgs: { count: selectedItems.length },
 				onclick: function (event) {
 					shouldConvertToStandaloneAttachment = true;

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -692,10 +692,18 @@ find-pdf-files-added = { $count ->
 
 select-items-dialog =
     .buttonlabelaccept = Select
+convert-to-standalone = Convert to Standalone
+select-items-convertToStandalone =
+    .label = { convert-to-standalone }
 select-items-convertToStandaloneAttachment =
     .label = { $count ->
-        [one] Convert to Standalone Attachment
-        *[other] Convert to Standalone Attachments
+        [one] { convert-to-standalone } Attachment
+        *[other] { convert-to-standalone } Attachments
+}
+select-items-convertToStandaloneNote =
+    .label = { $count ->
+        [one] { convert-to-standalone } Note
+        *[other] { convert-to-standalone } Notes
 }
 
 file-type-webpage = Webpage

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -692,18 +692,17 @@ find-pdf-files-added = { $count ->
 
 select-items-dialog =
     .buttonlabelaccept = Select
-convert-to-standalone = Convert to Standalone
 select-items-convertToStandalone =
-    .label = { convert-to-standalone }
+    .label = Convert to Standalone
 select-items-convertToStandaloneAttachment =
     .label = { $count ->
-        [one] { convert-to-standalone } Attachment
-        *[other] { convert-to-standalone } Attachments
+        [one] Convert to Standalone Attachment
+        *[other] Convert to Standalone Attachments
 }
 select-items-convertToStandaloneNote =
     .label = { $count ->
-        [one] { convert-to-standalone } Note
-        *[other] { convert-to-standalone } Notes
+        [one] Convert to Standalone Note
+        *[other] Convert to Standalone Notes
 }
 
 file-type-webpage = Webpage


### PR DESCRIPTION
More specific labels for the button to turn selected item(s) into standalone:
- "Convert to Standalone Sttachment(s)" when only attachments are selected
- "Convert to Standalone Note(s)" when only notes are selected
- "Convert to Standalone" otherwise (e.g. if a note and an attachment are selected together)

Fixes: #4766