### PR TITLE
Fix `localize-ftl` exiting with an error in certain cases

### DIFF
--- a/js-build/localize-ftl.mjs
+++ b/js-build/localize-ftl.mjs
@@ -40,15 +40,6 @@ async function getFTL() {
 		}
 
 		for (let sourceFileBaseName of sourceFileBaseNames) {
-			const ftlFilePath = join(getLocaleDir(locale), sourceFileBaseName + '.ftl');
-			let jsonFromLocalFTL = {};
-			try {
-				const ftl = await fs.readFile(ftlFilePath, 'utf8');
-				jsonFromLocalFTL = ftlToJSON(ftl);
-			}
-			catch (e) {
-				// no local .ftl file
-			}
 			let baseFTL;
 			let jsonFromEnUSFTL = {};
 
@@ -61,8 +52,7 @@ async function getFTL() {
 				throw new Error(`No en-US .ftl file for ${sourceFileBaseName}.ftl`);
 			}
 
-			const mergedSourceJSON = { ...jsonFromEnUSFTL, ...jsonFromLocalFTL };
-			const sourceKeys = Object.keys(mergedSourceJSON);
+			const sourceKeys = Object.keys(jsonFromEnUSFTL);
 			const translated = new Map();
 
 			for (let key of sourceKeys) {
@@ -71,7 +61,7 @@ async function getFTL() {
 					translated.set(key, jsonFromTransifex[key]);
 				}
 				else {
-					translated.set(key, mergedSourceJSON[key]);
+					translated.set(key, jsonFromEnUSFTL[key]);
 				}
 			}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "eslint-plugin-react": "^7.28.0",
         "eslint-plugin-react-hooks": "^4.0.4",
         "fs-extra": "^3.0.1",
-        "ftl-tx": "^0.15.1",
+        "ftl-tx": "^0.16.0",
         "globby": "^6.1.0",
         "jspath": "^0.4.0",
         "mocha": "^10.4.0",
@@ -3667,11 +3667,10 @@
       }
     },
     "node_modules/ftl-tx": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/ftl-tx/-/ftl-tx-0.15.1.tgz",
-      "integrity": "sha512-NEaZVw0nVGy+TK7GpZx8q4u99eUbkg0Yhsh9c9r/kgnPIfHFrS/v9kn8YBDYxwBe/CqmnGPmOuuwXUGdILjSNQ==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/ftl-tx/-/ftl-tx-0.16.0.tgz",
+      "integrity": "sha512-vQgx4oRtBCoVhoda5vSwRF50ukR1+U027on3ncehFsNFAehNfZfe6WzJZpyMXip1IbswPcoF4haAtlLkbvubcA==",
       "dev": true,
-      "license": "AGPL-3.0",
       "dependencies": {
         "@fluent/syntax": "^0.19.0"
       }
@@ -10586,9 +10585,9 @@
       }
     },
     "ftl-tx": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/ftl-tx/-/ftl-tx-0.15.1.tgz",
-      "integrity": "sha512-NEaZVw0nVGy+TK7GpZx8q4u99eUbkg0Yhsh9c9r/kgnPIfHFrS/v9kn8YBDYxwBe/CqmnGPmOuuwXUGdILjSNQ==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/ftl-tx/-/ftl-tx-0.16.0.tgz",
+      "integrity": "sha512-vQgx4oRtBCoVhoda5vSwRF50ukR1+U027on3ncehFsNFAehNfZfe6WzJZpyMXip1IbswPcoF4haAtlLkbvubcA==",
       "dev": true,
       "requires": {
         "@fluent/syntax": "^0.19.0"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "eslint-plugin-react": "^7.28.0",
     "eslint-plugin-react-hooks": "^4.0.4",
     "fs-extra": "^3.0.1",
-    "ftl-tx": "^0.15.1",
+    "ftl-tx": "^0.16.0",
     "globby": "^6.1.0",
     "jspath": "^0.4.0",
     "mocha": "^10.4.0",


### PR DESCRIPTION
* Tweak the script to use `en-us` `.ftl` files as the only source of truth.
* Update `ftl-tx` to a version that can handle referencing terms with arguments.

@dstillman **With this change, previous messages in localized `.ftl` files are assumed to be outdated and will be discarded by the `localize-ftl` script. This means that if no localized `zotero.json` is present to provide the up-to-date strings, these messages will revert to `en-us` strings.**

I assume that the latest localized `zotero.json` is always available for every locale when calling `npm run localize-ftl`. If that’s not the case, please let me know!

Fix #4773