### PR TITLE
vpat 44 followup: no escape handler in editors

### DIFF
--- a/chrome/content/scaffold/scaffold.js
+++ b/chrome/content/scaffold/scaffold.js
@@ -942,13 +942,6 @@ var Scaffold = new function () {
 				}
 			}
 		}, true);
-		// On Escape, focus the selected tab. Use non-capturing listener to not
-		// do anything on Escape events handled by the editor (e.g. to dismiss autocomplete popup)
-		doc.addEventListener("keydown", (event) => {
-			if (event.key == "Escape") {
-				tabbox.selectedTab.focus();
-			}
-		});
 	};
 
 


### PR DESCRIPTION
Since Escape can interfere with existing workflows. One can still move focus away on shift-tab from the beginning of the editor

Followup to https://github.com/zotero/zotero/commit/c14896a64089ed3aed0d8bf04d1e9b3d24e4e3e4 per https://github.com/zotero/zotero/pull/4069#issuecomment-2429665490