### PR TITLE
macOS: Move Window -> Zotero to platformKeys

### DIFF
--- a/chrome/content/zotero/platformKeys.js
+++ b/chrome/content/zotero/platformKeys.js
@@ -3,7 +3,9 @@ document.addEventListener('DOMContentLoaded', (event) => {
 		return;
 	}
 	
-	// Don't need to depend on Zotero object here
+	const { AppConstants } = ChromeUtils.importESModule('resource://gre/modules/AppConstants.sys.mjs');
+	
+	// Can't depend on Zotero object in hidden window initialization
 	let isWin = AppConstants.platform == 'win';
 	let isMac = AppConstants.platform == 'macosx';
 
@@ -20,6 +22,11 @@ document.addEventListener('DOMContentLoaded', (event) => {
 	let applicationMenu = document.getElementById('mac_application_menu');
 	let windowMenu = document.getElementById('windowMenu');
 	let macKeyset = document.getElementById('macKeyset');
+	
+	let genericCommandSet = document.createXULElement('commandset');
+	document.documentElement.append(genericCommandSet);
+	let genericKeyset = document.createXULElement('keyset');
+	document.documentElement.append(genericKeyset);
 
 	if (isWin) {
 		// Set behavior on Windows only
@@ -44,6 +51,44 @@ document.addEventListener('DOMContentLoaded', (event) => {
 		if (fileQuitItemUnix) fileQuitItemUnix.hidden = true;
 		if (editPreferencesSeparator) editPreferencesSeparator.hidden = true;
 		if (editPreferencesItem) editPreferencesItem.hidden = true;
+		
+		// Non-main windows: Add Window -> Zotero to focus/reopen main window
+		if (windowMenu && window.location.href !== AppConstants.BROWSER_CHROME_URL) {
+			MozXULElement.insertFTLIfNeeded('branding/brand.ftl');
+			MozXULElement.insertFTLIfNeeded('zotero.ftl');
+			
+			let mainWindowCommand = document.createXULElement('command');
+			mainWindowCommand.id = 'cmd_mainWindow';
+			document.l10n.setAttributes(mainWindowCommand, 'main-window-command');
+			mainWindowCommand.addEventListener('command', () => {
+				// Zotero.getMainWindow()
+				let win = Services.wm.getMostRecentWindow("navigator:browser");
+				if (win) {
+					win.focus();
+					return;
+				}
+				
+				// Zotero.openMainWindow()
+				var chromeURI = AppConstants.BROWSER_CHROME_URL;
+				var flags = "chrome,all,dialog=no,resizable=yes";
+				var ww = Components.classes['@mozilla.org/embedcomp/window-watcher;1']
+					.getService(Components.interfaces.nsIWindowWatcher);
+				ww.openWindow(null, chromeURI, '_blank', flags, null);
+			});
+			genericCommandSet.append(mainWindowCommand);
+			
+			let mainWindowKey = document.createXULElement('key');
+			mainWindowKey.id = 'key_mainWindow';
+			mainWindowKey.setAttribute('command', mainWindowCommand.id);
+			mainWindowKey.setAttribute('modifiers', 'accel shift');
+			document.l10n.setAttributes(mainWindowKey, 'main-window-key');
+			genericKeyset.append(mainWindowKey);
+
+			let mainWindowItem = document.createXULElement('menuitem');
+			mainWindowItem.setAttribute('command', mainWindowCommand.id);
+			mainWindowItem.setAttribute('key', mainWindowKey.id);
+			windowMenu.menupopup.append(mainWindowItem);
+		}
 
 		// macOS 15 Sequoia has a new system keyboard shortcut, Ctrl-Return,
 		// that shows a context menu on the focused control. Firefox currently

--- a/chrome/content/zotero/platformKeys.js
+++ b/chrome/content/zotero/platformKeys.js
@@ -71,9 +71,7 @@ document.addEventListener('DOMContentLoaded', (event) => {
 				// Zotero.openMainWindow()
 				var chromeURI = AppConstants.BROWSER_CHROME_URL;
 				var flags = "chrome,all,dialog=no,resizable=yes";
-				var ww = Components.classes['@mozilla.org/embedcomp/window-watcher;1']
-					.getService(Components.interfaces.nsIWindowWatcher);
-				ww.openWindow(null, chromeURI, '_blank', flags, null);
+				Services.ww.openWindow(null, chromeURI, '_blank', flags, null);
 			});
 			genericCommandSet.append(mainWindowCommand);
 			

--- a/chrome/content/zotero/platformKeys.js
+++ b/chrome/content/zotero/platformKeys.js
@@ -52,7 +52,7 @@ document.addEventListener('DOMContentLoaded', (event) => {
 		if (editPreferencesSeparator) editPreferencesSeparator.hidden = true;
 		if (editPreferencesItem) editPreferencesItem.hidden = true;
 		
-		// Non-main windows: Add Window -> Zotero to focus/reopen main window
+		// Non-main windows: Add Window → Zotero to focus/reopen main window
 		if (windowMenu && window.location.href !== AppConstants.BROWSER_CHROME_URL) {
 			MozXULElement.insertFTLIfNeeded('branding/brand.ftl');
 			MozXULElement.insertFTLIfNeeded('zotero.ftl');

--- a/chrome/content/zotero/standalone/hiddenWindow.xhtml
+++ b/chrome/content/zotero/standalone/hiddenWindow.xhtml
@@ -42,20 +42,11 @@
 	<html:link rel="localization" href="browser/browserSets.ftl"/>
 	
 	<script type="application/javascript">
-		Components.utils.import("resource://gre/modules/Services.jsm");
-		var { AppConstants } = ChromeUtils.import("resource://gre/modules/AppConstants.jsm");
+		var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+		Services.scriptloader.loadSubScript("chrome://global/content/globalOverlay.js", this);
+		Services.scriptloader.loadSubScript("chrome://zotero/content/platformKeys.js", this);
 	</script>
-	<script type="application/javascript" src="chrome://global/content/globalOverlay.js"/>
 	<script>
-		// Equivalent to Zotero.openMainWindow()
-		function openMainWindow() {
-			var chromeURI = AppConstants.BROWSER_CHROME_URL;
-			var flags = "chrome,all,dialog=no,resizable=yes";
-			var ww = Components.classes['@mozilla.org/embedcomp/window-watcher;1']
-				.getService(Components.interfaces.nsIWindowWatcher);
-			ww.openWindow(null, chromeURI, '_blank', flags, null);
-		}
-		
 		function openAbout() {
 			var ww = Components.classes['@mozilla.org/embedcomp/window-watcher;1']
 				.getService(Components.interfaces.nsIWindowWatcher);
@@ -84,12 +75,10 @@
 		<command id="cmd_close" disabled="true"/>
 		<command id="minimizeWindow" disabled="true" data-l10n-id="window-minimize-command"/>
 		<command id="zoomWindow" disabled="true" data-l10n-id="window-zoom-command"/>
-		<command id="cmd_mainWindow" data-l10n-id="main-window-command" oncommand="openMainWindow();"/>
 	</commandset>
 	
 	<keyset id="mainKeyset">
 		<key id="key_close" data-l10n-id="close-shortcut" command="cmd_close" modifiers="accel"/>
-		<key id="key_mainWindow" key="0" command="cmd_mainWindow" modifiers="accel"/>
 		<key id="key_preferencesCmdMac"
 				data-l10n-id="preferences-shortcut"
 				modifiers="accel"
@@ -158,7 +147,6 @@
 					<menuseparator/>
 					<menuitem label="&bringAllToFront.label;" disabled="true"/> -->
 				<menuseparator id="sep-window-list"/>
-				<menuitem command="cmd_mainWindow" key="key_mainWindow"/>
 			</menupopup>
 		</menu>
 	</menubar>

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -82,7 +82,7 @@ menu-view-columns-move-right =
     .label = Move Column Right
 
 main-window-command =
-    .label = { -app-name }
+    .label = Library
 main-window-key =
     .key = L
 

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -83,6 +83,8 @@ menu-view-columns-move-right =
 
 main-window-command =
     .label = { -app-name }
+main-window-key =
+    .key = L
 
 zotero-toolbar-tabs-menu =
     .tooltiptext = List all tabs


### PR DESCRIPTION
And change shortcut to Cmd-Shift-L to avoid conflicts with various font size and zoom shortcuts.

This makes Window -> Zotero available in every non-main window that uses `platformKeys.js`, which is Scaffold, the reader, and the basic viewer right now. The second commit extends that to include note windows as well. (Those don't actually show _in_ the Window menu, though, because they're opened with `openDialog()`.)

There's no great way to hide the Window -> Zotero menuitem when the main window is open. Messing with `windowMenu` children in `popupshowing` breaks macOS's auto-population. We could probably get around it with some kind of window observer, but I think it's actually better this way: the keyboard shortcut should work consistently, regardless of whether the main window is already open, and a menuitem allows that. Thunderbird's Tools -> Mail & Newsgroups menuitem also shows all the time.

Closes #4171