### PR TITLE
Tweak default data directory location stylesheet for windows

### DIFF
--- a/scss/preferences/_advanced.scss
+++ b/scss/preferences/_advanced.scss
@@ -53,8 +53,12 @@
 #default-data-dir {
 	padding-inline-start: 0;
 	margin-inline-start: 0;
-	margin-top: 2px;
 	flex-grow: 1;
+	background: none;
+	border: none;
+	@media (-moz-platform: macos) {
+		margin-top: 2px;
+	}
 }
 
 .preferences-button-group {


### PR DESCRIPTION
- no margin-top on windows
- explicitly hide background and border, since they remain on windows otherwise

followup to: https://github.com/zotero/zotero/commit/28f3a29f3569f0e86e75406ad306afef4e1db786

Before:

<img width="604" alt="Screenshot 2024-10-23 at 12 26 05 PM" src="https://github.com/user-attachments/assets/59783a64-15ec-4e8e-88ed-225ec5d449f9">


After:
<img width="606" alt="Screenshot 2024-10-23 at 12 24 57 PM" src="https://github.com/user-attachments/assets/d702b15a-f162-4476-b18e-84e30117844b">
