### PR TITLE
Fix group libraries disappearing from Libraries and Collections section

### DIFF
--- a/chrome/content/zotero/elements/librariesCollectionsBox.js
+++ b/chrome/content/zotero/elements/librariesCollectionsBox.js
@@ -235,8 +235,7 @@ import { getCSSIcon } from 'components/icons';
 			if (this._isAlreadyRendered()) return;
 
 			this._body.replaceChildren();
-			
-			for (let item of [this._item]) {
+			for (let item of [this._item, ...this._linkedItems]) {
 				this._addObject(Zotero.Libraries.get(item.libraryID), item);
 				for (let collection of Zotero.Collections.get(item.getCollections())) {
 					this._addObject(collection, item);


### PR DESCRIPTION
So that they do not disappear after Libraries and Collections section is collapsed and expanded.

Fixes: #4784