### PR TITLE
no background for readonly focused editable-text

### DIFF
--- a/scss/elements/_editableText.scss
+++ b/scss/elements/_editableText.scss
@@ -101,7 +101,7 @@ editable-text {
 			box-shadow: 0 0 0 1px var(--fill-quinary);
 		}
 
-		&:focus {
+		&:focus:not(:read-only) {
 			background: var(--material-background);
 		}
 		


### PR DESCRIPTION
Fixes: #4789

This is what it would look like:

<img width="338" alt="Screenshot 2024-10-25 at 1 25 26 PM" src="https://github.com/user-attachments/assets/30e42f77-a25b-4d25-9095-9d26294d10b7">
<img width="334" alt="Screenshot 2024-10-25 at 1 25 14 PM" src="https://github.com/user-attachments/assets/e1447253-4335-4704-856e-6b7d55cff250">
