### PR TITLE
itemTree: handle child row modifications in notify

### DIFF
--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -705,6 +705,17 @@ var ItemTree = class ItemTree extends LibraryTree {
 							sort = id;
 						}
 					}
+					// If a child item is modified and its parent's row is expanded,
+					// collapse and re-open the parent.
+					else {
+						let parentItem = Zotero.Items.get(item.parentItemID);
+						let parentItemRowIndex = this.getRowIndexByID(parentItem.id);
+						if (parentItemRowIndex === false) continue;
+						if (this.isContainerOpen(parentItemRowIndex)) {
+							await this._closeContainer(parentItemRowIndex);
+							await this.toggleOpenState(parentItemRowIndex);
+						}
+					}
 				}
 
 				if (sort && ids.length != 1) {

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -711,7 +711,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 						let parentItemRowIndex = this.getRowIndexByID(item.parentItemID);
 						if (parentItemRowIndex === false) continue;
 						if (this.isContainerOpen(parentItemRowIndex)) {
-							await this._closeContainer(parentItemRowIndex);
+							this.toggleOpenState(parentItemRowIndex, true);
 							await this.toggleOpenState(parentItemRowIndex);
 						}
 					}

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -708,8 +708,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 					// If a child item is modified and its parent's row is expanded,
 					// collapse and re-open the parent.
 					else {
-						let parentItem = Zotero.Items.get(item.parentItemID);
-						let parentItemRowIndex = this.getRowIndexByID(parentItem.id);
+						let parentItemRowIndex = this.getRowIndexByID(item.parentItemID);
 						if (parentItemRowIndex === false) continue;
 						if (this.isContainerOpen(parentItemRowIndex)) {
 							await this._closeContainer(parentItemRowIndex);

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -705,8 +705,8 @@ var ItemTree = class ItemTree extends LibraryTree {
 							sort = id;
 						}
 					}
-					// If a child item is modified and its parent's row is expanded,
-					// collapse and re-open the parent.
+					// If a trashed child item is restored while its parent's row is expanded,
+					// collapse and re-open the parent to have that child item row added.
 					else {
 						let parentItemRowIndex = this.getRowIndexByID(item.parentItemID);
 						if (parentItemRowIndex === false) continue;


### PR DESCRIPTION
If a child item is modified and its parent row exists and is opened, collapse the parent row and expand it to re-render child items.

Fixes: #4791



https://github.com/user-attachments/assets/5df8ed91-d989-4a73-976e-df0dd2300acb

