### PR TITLE
arrowUp/down in duplicates view will select the set

### DIFF
--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -982,15 +982,15 @@ var ItemTree = class ItemTree extends LibraryTree {
 		else if (this.collectionTreeRow.isDuplicates() && ["ArrowUp", "ArrowDown"].includes(event.key)
 				&& !event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey) {
 			// Find the first row index before/after the current set
-			let selectedArray = Array.from(this.selection.selected).sort();
-			let nextRowIndex = event.key == "ArrowUp" ? (selectedArray[0] - 1) : (selectedArray[selectedArray.length - 1] + 1);
+			let selectedArray = Array.from(this.selection.selected);
+			let nextRowIndex = event.key == "ArrowUp" ? Math.min(...selectedArray) - 1 : (Math.max(...selectedArray) + 1);
 			if (nextRowIndex < 0 || nextRowIndex > this._rows.length - 1) return false;
 			// Set that row's item as the next set to select
 			let nextItem = this._rows[nextRowIndex].ref;
 			var setItemIDs = this.collectionTreeRow.ref.getSetItemsByItemID(nextItem.id);
 			// Set focus to the first row in the set
-			let itemRows = setItemIDs.map(itemID => this._rowMap[itemID]).sort();
-			this.selection.focused = itemRows[0];
+			let itemRows = setItemIDs.map(itemID => this._rowMap[itemID]);
+			this.selection.focused = Math.min(...itemRows);
 			
 			this.selectItems(setItemIDs);
 			return false;

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -978,6 +978,23 @@ var ItemTree = class ItemTree extends LibraryTree {
 			this.collapseAllRows();
 			return false;
 		}
+		// On arrowUp/down without modifiers in duplicates view, select the entire set
+		else if (this.collectionTreeRow.isDuplicates() && ["ArrowUp", "ArrowDown"].includes(event.key)
+				&& !event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey) {
+			// Find the first row index before/after the current set
+			let selectedArray = Array.from(this.selection.selected).sort();
+			let nextRowIndex = event.key == "ArrowUp" ? (selectedArray[0] - 1) : (selectedArray[selectedArray.length - 1] + 1);
+			if (nextRowIndex < 0 || nextRowIndex > this._rows.length - 1) return false;
+			// Set that row's item as the next set to select
+			let nextItem = this._rows[nextRowIndex].ref;
+			var setItemIDs = this.collectionTreeRow.ref.getSetItemsByItemID(nextItem.id);
+			// Set focus to the first row in the set
+			let itemRows = setItemIDs.map(itemID => this._rowMap[itemID]).sort();
+			this.selection.focused = itemRows[0];
+			
+			this.selectItems(setItemIDs);
+			return false;
+		}
 		return true;
 	}
 

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -981,16 +981,17 @@ var ItemTree = class ItemTree extends LibraryTree {
 		// On arrowUp/down without modifiers in duplicates view, select the entire set
 		else if (this.collectionTreeRow.isDuplicates() && ["ArrowUp", "ArrowDown"].includes(event.key)
 				&& !event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey) {
-			// Find the first row index before/after the current set
-			let selectedArray = Array.from(this.selection.selected);
-			let nextRowIndex = event.key == "ArrowUp" ? Math.min(...selectedArray) - 1 : (Math.max(...selectedArray) + 1);
+			// Find the first row outside of the current consecutive set of rows
+			let findNextRow = index => (event.key == "ArrowUp" ? index - 1 : index + 1);
+			let nextRowIndex = findNextRow(this.selection.focused);
+			while (this.selection.selected.has(nextRowIndex)) {
+				nextRowIndex = findNextRow(nextRowIndex);
+			}
 			if (nextRowIndex < 0 || nextRowIndex > this._rows.length - 1) return false;
-			// Set that row's item as the next set to select
+			// Set that row as focused and select its item as the next set of duplicates
 			let nextItem = this._rows[nextRowIndex].ref;
 			var setItemIDs = this.collectionTreeRow.ref.getSetItemsByItemID(nextItem.id);
-			// Set focus to the first row in the set
-			let itemRows = setItemIDs.map(itemID => this._rowMap[itemID]);
-			this.selection.focused = Math.min(...itemRows);
+			this.selection.focused = nextRowIndex;
 			
 			this.selectItems(setItemIDs);
 			return false;


### PR DESCRIPTION
When duplicates collectionTreeRow is selected, arrowUp/down within itemTree will select the entire previous/next set of duplicate items.

Per discussion based on https://forums.zotero.org/discussion/119217/bug-zotero-7-beta-duplicates-collection-navigation-via-arrow-keys