### PR TITLE
Item box: Wrap all fields

### DIFF
--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -660,11 +660,6 @@
 				|| Zotero.ItemFields.isFieldOfBase(fieldID, 'publicationTitle'))) {
 					let optionsButton = document.createXULElement("toolbarbutton");
 					optionsButton.className = "zotero-clicky zotero-clicky-options show-on-hover";
-					// Options button after single-line fields will not occupy space unless hovered.
-					// This does not apply to multiline fields because it would move textarea on hover.
-					if (!(Zotero.ItemFields.isLong(fieldName) || Zotero.ItemFields.isMultiline(fieldName))) {
-						optionsButton.classList.add("no-display");
-					}
 					optionsButton.setAttribute('data-l10n-id', "itembox-button-options");
 					optionsButton.id = `itembox-field-${fieldName}-options`;
 					// eslint-disable-next-line no-loop-func
@@ -1457,7 +1452,7 @@
 			}
 			let openLink = document.createXULElement("toolbarbutton");
 			openLink.id = `itembox-field-${fieldName}-link`;
-			openLink.className = "zotero-clicky zotero-clicky-open-link show-on-hover no-display";
+			openLink.className = "zotero-clicky zotero-clicky-open-link show-on-hover";
 			openLink.addEventListener("click", event => ZoteroPane.loadURI(value, event));
 			openLink.setAttribute('data-l10n-id', "item-button-view-online");
 			if (!value) openLink.hidden = true;
@@ -1472,15 +1467,14 @@
 			}
 			
 			let isMultiline = Zotero.ItemFields.isMultiline(fieldName);
-			let isLong = Zotero.ItemFields.isLong(fieldName);
+			let isNoWrap = fieldName.startsWith('creator-');
 			
 			var valueElement = document.createXULElement("editable-text");
 			valueElement.className = 'value';
 			if (isMultiline) {
 				valueElement.setAttribute('multiline', true);
 			}
-			else if (!isLong) {
-				// Usual fields occupy all available space and keep info on one line
+			else if (isNoWrap) {
 				valueElement.setAttribute("nowrap", true);
 			}
 			

--- a/chrome/content/zotero/xpcom/data/itemFields.js
+++ b/chrome/content/zotero/xpcom/data/itemFields.js
@@ -384,19 +384,10 @@ Zotero.ItemFields = new function() {
 	}
 	
 	
-	/**
-	 * A long field expands into a multiline textbox while editing; newlines are not allowed
-	 */
-	this.isLong = function (field) {
-		field = this.getName(field);
-		var fields = [
-			'title',
-			...this.getTypeFieldsFromBase('title', true),
-			'publicationTitle',
-			...this.getTypeFieldsFromBase('publicationTitle', true),
-		];
-		return fields.indexOf(field) != -1;
-	}
+	this.isLong = function () {
+		Zotero.warn('Zotero.ItemFields.isLong() is deprecated -- update your code');
+		return true;
+	};
 	
 	
 	/**


### PR DESCRIPTION
Everything works like Title now besides creator name fields, since those don't have room to wrap in the layout.

We lose a little horizontal space on fields with three-dot menu and URL launcher buttons that weren't previously "long" - I think that's Series Title, Short Title, URL, and DOI - but the vertical space gain should make up for that.

`Zotero.ItemFields.isLong()` just logs a warning and returns true. I doubt that anyone else is using it, but still.

Closes #4801