### PR TITLE
fix color scheme getting reset during printing

### DIFF
--- a/app/build.sh
+++ b/app/build.sh
@@ -385,6 +385,8 @@ cat "$CALLDIR/assets/chrome.manifest" >> chrome.manifest
 replace_line 'handle: function bch_handle\(cmdLine\) {' 'handle: function bch_handle(cmdLine) {
   \/\/ TEST_OPTIONS_PLACEHOLDER
   ' modules/BrowserContentHandler.sys.mjs
+# prevent color scheme getting reset to 'light' during printing
+replace_line 'new LightweightThemeConsumer\(document\);' '\/\/new LightweightThemeConsumer\(document\);'  chrome/browser/content/browser/browser.js
 export CALLDIR && perl -pi -e 'BEGIN { local $/; open $fh, "$ENV{CALLDIR}/assets/commandLineHandler.js"; $replacement = <$fh>; close $fh; } s/\/\/ TEST_OPTIONS_PLACEHOLDER/$replacement/' modules/BrowserContentHandler.sys.mjs
 
 # Move test files to root directory


### PR DESCRIPTION
[LightweightThemeConsumer](https://searchfox.org/mozilla-central/source/toolkit/modules/LightweightThemeConsumer.sys.mjs) interacts with the color scheme, so removing it prevents the color scheme from changing whenever `zoteroPrint` runs.

Fixes: #4782