### PR TITLE
Update tab titles independently of the reader

### DIFF
--- a/chrome/content/zotero/tabs.js
+++ b/chrome/content/zotero/tabs.js
@@ -191,9 +191,9 @@ var Zotero_Tabs = new function () {
 		if (event !== "modify") return;
 		for (let id of ids) {
 			let item = Zotero.Items.get(id);
-			// If a top level item is updated, update all tabs that have its attachments
+			// If a top-level item is updated, update all tabs that have its attachments
 			// Otherwise, just update the tab with the updated attachment
-			let attachmentIDs = item.isAttachment() ? [id] : (item.getAttachments()).flat();
+			let attachmentIDs = item.isAttachment() ? [id] : item.getAttachments();
 			for (let attachmentID of attachmentIDs) {
 				let relevantTabs = this._tabs.filter(tab => tab.data.itemID == attachmentID);
 				if (!relevantTabs.length) continue;

--- a/chrome/content/zotero/tabs.js
+++ b/chrome/content/zotero/tabs.js
@@ -84,6 +84,18 @@ var Zotero_Tabs = new function () {
 	this._tabsMenuFocusedIndex = 0;
 	this._tabsMenuIgnoreMouseover = false;
 
+	// Keep track of item modifications to update the title
+	Zotero.Notifier.registerObserver(this, ['item'], 'tabs');
+
+	// Update the title when pref of title format is changed
+	Zotero.Prefs.registerObserver('tabs.title.reader', async () => {
+		for (let tab of this._tabs) {
+			if (!tab.data.itemID) continue;
+			let title = await Zotero.Utilities.Internal.constructItemTitle(tab.data.itemID);
+			this.rename(tab.id, title);
+		}
+	});
+
 	this._unloadInterval = setInterval(() => {
 		this.unloadUnusedTabs();
 	}, 60000); // Trigger every minute
@@ -174,6 +186,25 @@ var Zotero_Tabs = new function () {
 		);
 	};
 
+	// When an item is modified, update the title accordingly
+	this.notify = async (event, type, ids, _) => {
+		if (event !== "modify") return;
+		for (let id of ids) {
+			let item = Zotero.Items.get(id);
+			// If a top level item is updated, update all tabs that have its attachments
+			// Otherwise, just update the tab with the updated attachment
+			let attachmentIDs = item.isAttachment() ? [id] : (item.getAttachments()).flat();
+			for (let attachmentID of attachmentIDs) {
+				let relevantTabs = this._tabs.filter(tab => tab.data.itemID == attachmentID);
+				if (!relevantTabs.length) continue;
+				for (let tab of relevantTabs) {
+					let title = await Zotero.Utilities.Internal.constructItemTitle(attachmentID);
+					this.rename(tab.id, title);
+				}
+			}
+		}
+	};
+
 	this.getState = function () {
 		return this._tabs.map((tab) => {
 			let type = tab.type;
@@ -262,6 +293,15 @@ var Zotero_Tabs = new function () {
 			if (!preventJumpback) {
 				this._prevSelectedID = previousID;
 			}
+		}
+		// When a new tab is opened synchronously by ReaderTab constructor, the title is empty.
+		// However, { id, container } needs to return immediately, so do not wait for the new title
+		// and construct it in async manner below.
+		if (!title && data.itemID) {
+			(async () => {
+				title = await Zotero.Utilities.Internal.constructItemTitle(data.itemID);
+				this.rename(tab.id, title);
+			})();
 		}
 		return { id, container };
 	};

--- a/chrome/content/zotero/tabs.js
+++ b/chrome/content/zotero/tabs.js
@@ -91,7 +91,8 @@ var Zotero_Tabs = new function () {
 	Zotero.Prefs.registerObserver('tabs.title.reader', async () => {
 		for (let tab of this._tabs) {
 			if (!tab.data.itemID) continue;
-			let title = await Zotero.Reader.getTabTitle(tab.data.itemID);
+			let item = Zotero.Items.get(tab.data.itemID);
+			let title = await item.getTabTitle();
 			this.rename(tab.id, title);
 		}
 	});
@@ -195,10 +196,11 @@ var Zotero_Tabs = new function () {
 			// Otherwise, just update the tab with the updated attachment
 			let attachmentIDs = item.isAttachment() ? [id] : item.getAttachments();
 			for (let attachmentID of attachmentIDs) {
+				let attachment = Zotero.Items.get(attachmentID);
 				let relevantTabs = this._tabs.filter(tab => tab.data.itemID == attachmentID);
 				if (!relevantTabs.length) continue;
 				for (let tab of relevantTabs) {
-					let title = await Zotero.Reader.getTabTitle(attachmentID);
+					let title = await attachment.getTabTitle();
 					this.rename(tab.id, title);
 				}
 			}
@@ -299,7 +301,8 @@ var Zotero_Tabs = new function () {
 		// and construct it in async manner below.
 		if (!title && data.itemID) {
 			(async () => {
-				title = await Zotero.Reader.getTabTitle(data.itemID);
+				let item = Zotero.Items.get(data.itemID);
+				title = await item.getTabTitle();
 				this.rename(tab.id, title);
 			})();
 		}

--- a/chrome/content/zotero/tabs.js
+++ b/chrome/content/zotero/tabs.js
@@ -91,7 +91,7 @@ var Zotero_Tabs = new function () {
 	Zotero.Prefs.registerObserver('tabs.title.reader', async () => {
 		for (let tab of this._tabs) {
 			if (!tab.data.itemID) continue;
-			let title = await Zotero.Utilities.Internal.constructItemTitle(tab.data.itemID);
+			let title = await Zotero.Reader.getTabTitle(tab.data.itemID);
 			this.rename(tab.id, title);
 		}
 	});
@@ -198,7 +198,7 @@ var Zotero_Tabs = new function () {
 				let relevantTabs = this._tabs.filter(tab => tab.data.itemID == attachmentID);
 				if (!relevantTabs.length) continue;
 				for (let tab of relevantTabs) {
-					let title = await Zotero.Utilities.Internal.constructItemTitle(attachmentID);
+					let title = await Zotero.Reader.getTabTitle(attachmentID);
 					this.rename(tab.id, title);
 				}
 			}
@@ -299,7 +299,7 @@ var Zotero_Tabs = new function () {
 		// and construct it in async manner below.
 		if (!title && data.itemID) {
 			(async () => {
-				title = await Zotero.Utilities.Internal.constructItemTitle(data.itemID);
+				title = await Zotero.Reader.getTabTitle(data.itemID);
 				this.rename(tab.id, title);
 			})();
 		}

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -585,7 +585,7 @@ class ReaderInstance {
 	}
 
 	async updateTitle() {
-		this._title = await Zotero.Utilities.Internal.constructItemTitle(this._item.id);
+		this._title = await Zotero.Reader.getTabTitle(this._item.id);
 		this._setTitleValue(this._title);
 	}
 
@@ -1958,6 +1958,55 @@ class Reader {
 				Zotero.logError(e);
 			}
 		}
+	}
+	
+	/**
+	 * Construct item title for a given attachment.
+	 * @param {Number} itemID - itemID of the attachment to be opened in the reader.
+	 */
+	async getTabTitle(itemID) {
+		let type = Zotero.Prefs.get('tabs.title.reader');
+		let item = Zotero.Items.get(itemID);
+		let readerTitle = item.getDisplayTitle();
+		let parentItem = item.parentItem;
+		if (type === 'filename') {
+			readerTitle = item.attachmentFilename;
+		}
+		else if (parentItem) {
+			let attachment = await parentItem.getBestAttachment();
+			let isPrimaryAttachment = attachment && attachment.id == item.id;
+			
+			let parts = [];
+			// Windows displays bidi control characters as placeholders in window titles, so strip them
+			// See https://github.com/mozilla-services/screenshots/issues/4863
+			let unformatted = Zotero.isWin;
+			let creator = parentItem.getField('firstCreator', unformatted);
+			let year = parentItem.getField('year');
+			if (year == '0000') {
+				year = '';
+			}
+			// Only include parent title if primary attachment
+			let title = isPrimaryAttachment ? parentItem.getDisplayTitle() : false;
+			// If creator is missing fall back to titleCreatorYear
+			if (type === 'creatorYearTitle' && creator) {
+				parts = [creator, year, title];
+			}
+			else if (type === 'title') {
+				parts = [title];
+			}
+			// If type is titleCreatorYear, or is missing, or another type falls back
+			else {
+				parts = [title, creator, year];
+			}
+			
+			// If not primary attachment, show attachment title first
+			if (!isPrimaryAttachment) {
+				parts.unshift(item.getDisplayTitle());
+			}
+			
+			readerTitle = parts.filter(Boolean).join(' - ');
+		}
+		return readerTitle;
 	}
 }
 

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -585,7 +585,7 @@ class ReaderInstance {
 	}
 
 	async updateTitle() {
-		this._title = await Zotero.Reader.getTabTitle(this._item.id);
+		this._title = await this._item.getTabTitle();
 		this._setTitleValue(this._title);
 	}
 
@@ -1958,56 +1958,6 @@ class Reader {
 				Zotero.logError(e);
 			}
 		}
-	}
-	
-	/**
-	 * Construct title for the reader tab of a given attachment accounting for "Show tabs as" pref
-	 * @param {Number} itemID - itemID of the attachment
-	 * @returns {String} title for the tab of this item
-	 */
-	async getTabTitle(itemID) {
-		let type = Zotero.Prefs.get('tabs.title.reader');
-		let item = Zotero.Items.get(itemID);
-		let readerTitle = item.getDisplayTitle();
-		let parentItem = item.parentItem;
-		if (type === 'filename') {
-			readerTitle = item.attachmentFilename;
-		}
-		else if (parentItem) {
-			let attachment = await parentItem.getBestAttachment();
-			let isPrimaryAttachment = attachment && attachment.id == item.id;
-			
-			let parts = [];
-			// Windows displays bidi control characters as placeholders in window titles, so strip them
-			// See https://github.com/mozilla-services/screenshots/issues/4863
-			let unformatted = Zotero.isWin;
-			let creator = parentItem.getField('firstCreator', unformatted);
-			let year = parentItem.getField('year');
-			if (year == '0000') {
-				year = '';
-			}
-			// Only include parent title if primary attachment
-			let title = isPrimaryAttachment ? parentItem.getDisplayTitle() : false;
-			// If creator is missing fall back to titleCreatorYear
-			if (type === 'creatorYearTitle' && creator) {
-				parts = [creator, year, title];
-			}
-			else if (type === 'title') {
-				parts = [title];
-			}
-			// If type is titleCreatorYear, or is missing, or another type falls back
-			else {
-				parts = [title, creator, year];
-			}
-			
-			// If not primary attachment, show attachment title first
-			if (!isPrimaryAttachment) {
-				parts.unshift(item.getDisplayTitle());
-			}
-			
-			readerTitle = parts.filter(Boolean).join(' - ');
-		}
-		return readerTitle;
 	}
 }
 

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -1961,8 +1961,9 @@ class Reader {
 	}
 	
 	/**
-	 * Construct item title for a given attachment.
-	 * @param {Number} itemID - itemID of the attachment to be opened in the reader.
+	 * Construct title for the reader tab of a given attachment accounting for "Show tabs as" pref
+	 * @param {Number} itemID - itemID of the attachment
+	 * @returns {String} title for the tab of this item
 	 */
 	async getTabTitle(itemID) {
 		let type = Zotero.Prefs.get('tabs.title.reader');

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -585,49 +585,8 @@ class ReaderInstance {
 	}
 
 	async updateTitle() {
-		let type = Zotero.Prefs.get('tabs.title.reader');
-		let item = Zotero.Items.get(this._item.id);
-		let readerTitle = item.getDisplayTitle();
-		let parentItem = item.parentItem;
-		if (type === 'filename') {
-			readerTitle = item.attachmentFilename;
-		}
-		else if (parentItem) {
-			let attachment = await parentItem.getBestAttachment();
-			let isPrimaryAttachment = attachment && attachment.id == item.id;
-			
-			let parts = [];
-			// Windows displays bidi control characters as placeholders in window titles, so strip them
-			// See https://github.com/mozilla-services/screenshots/issues/4863
-			let unformatted = Zotero.isWin;
-			let creator = parentItem.getField('firstCreator', unformatted);
-			let year = parentItem.getField('year');
-			if (year == '0000') {
-				year = '';
-			}
-			// Only include parent title if primary attachment
-			let title = isPrimaryAttachment ? parentItem.getDisplayTitle() : false;
-			// If creator is missing fall back to titleCreatorYear
-			if (type === 'creatorYearTitle' && creator) {
-				parts = [creator, year, title];
-			}
-			else if (type === 'title') {
-				parts = [title];
-			}
-			// If type is titleCreatorYear, or is missing, or another type falls back
-			else {
-				parts = [title, creator, year];
-			}
-			
-			// If not primary attachment, show attachment title first
-			if (!isPrimaryAttachment) {
-				parts.unshift(item.getDisplayTitle());
-			}
-			
-			readerTitle = parts.filter(Boolean).join(' - ');
-		}
-		this._title = readerTitle;
-		this._setTitleValue(readerTitle);
+		this._title = await Zotero.Utilities.Internal.constructItemTitle(this._item.id);
+		this._setTitleValue(this._title);
 	}
 
 	async setAnnotations(items) {
@@ -1197,9 +1156,7 @@ class ReaderTab extends ReaderInstance {
 		}
 	};
 
-	_setTitleValue(title) {
-		this._window.Zotero_Tabs.rename(this.tabID, title);
-	}
+	_setTitleValue() {}
 
 	_addToNote(annotations) {
 		annotations = annotations.map(x => ({ ...x, attachmentItemID: this._item.id }));

--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -2488,56 +2488,7 @@ Zotero.Utilities.Internal = {
 		}
 
 		return textContent;
-	},
-
-	/**
-	 * Construct item title for a given attachment.
-	 * @param {Number} itemID - itemID of the attachment to be opened in the reader.
-	 */
-	async constructItemTitle(itemID) {
-		let type = Zotero.Prefs.get('tabs.title.reader');
-		let item = Zotero.Items.get(itemID);
-		let readerTitle = item.getDisplayTitle();
-		let parentItem = item.parentItem;
-		if (type === 'filename') {
-			readerTitle = item.attachmentFilename;
-		}
-		else if (parentItem) {
-			let attachment = await parentItem.getBestAttachment();
-			let isPrimaryAttachment = attachment && attachment.id == item.id;
-			
-			let parts = [];
-			// Windows displays bidi control characters as placeholders in window titles, so strip them
-			// See https://github.com/mozilla-services/screenshots/issues/4863
-			let unformatted = Zotero.isWin;
-			let creator = parentItem.getField('firstCreator', unformatted);
-			let year = parentItem.getField('year');
-			if (year == '0000') {
-				year = '';
-			}
-			// Only include parent title if primary attachment
-			let title = isPrimaryAttachment ? parentItem.getDisplayTitle() : false;
-			// If creator is missing fall back to titleCreatorYear
-			if (type === 'creatorYearTitle' && creator) {
-				parts = [creator, year, title];
-			}
-			else if (type === 'title') {
-				parts = [title];
-			}
-			// If type is titleCreatorYear, or is missing, or another type falls back
-			else {
-				parts = [title, creator, year];
-			}
-			
-			// If not primary attachment, show attachment title first
-			if (!isPrimaryAttachment) {
-				parts.unshift(item.getDisplayTitle());
-			}
-			
-			readerTitle = parts.filter(Boolean).join(' - ');
-		}
-		return readerTitle;
-	},
+	}
 };
 
 /**

--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -2491,8 +2491,8 @@ Zotero.Utilities.Internal = {
 	},
 
 	/**
-	 * Costruct item title for a given attachment.
-	 * @param itemID - itemID of the attachment to be opened in the reader.
+	 * Construct item title for a given attachment.
+	 * @param {Number} itemID - itemID of the attachment to be opened in the reader.
 	 */
 	async constructItemTitle(itemID) {
 		let type = Zotero.Prefs.get('tabs.title.reader');


### PR DESCRIPTION
Move handling of tabs' renaming when an item is modified from `Reader` into `Zotero_Tabs`, so that the titles of unloaded tabs can get properly renamed.

Have the `Reader` and `Zotero_Tabs` share `Zotero.Utilities.Internal.constructItemTitle` to handle title updates in both tabs and standalone reader windows.

Fixes: #4646