### PR TITLE
scroll to pivot row on arrowUp/Down in duplicates

### DIFF
--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -993,7 +993,13 @@ var ItemTree = class ItemTree extends LibraryTree {
 			var setItemIDs = this.collectionTreeRow.ref.getSetItemsByItemID(nextItem.id);
 			this.selection.focused = nextRowIndex;
 			
-			this.selectItems(setItemIDs);
+			this.selectItems(setItemIDs, false, true).then(() => {
+				// make sure the focused row is visible
+				if (!this.tree.rowIsVisible(nextRowIndex)) {
+					this.ensureRowIsVisible(nextRowIndex);
+				}
+			});
+			
 			return false;
 		}
 		return true;
@@ -1152,7 +1158,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 		return this.selectItems([id], noRecurse);
 	}
 	
-	async selectItems(ids, noRecurse) {
+	async selectItems(ids, noRecurse, noScroll) {
 		if (!ids.length) return 0;
 		
 		// If no row map, we're probably in the process of switching collections,
@@ -1274,8 +1280,9 @@ var ItemTree = class ItemTree extends LibraryTree {
 			
 			this.selection.selectEventsSuppressed = false;
 		}
-		
-		this.ensureRowsAreVisible(rowsToSelect);
+		if (!noScroll) {
+			this.ensureRowsAreVisible(rowsToSelect);
+		}
 		
 		return rowsToSelect.length;
 	}


### PR DESCRIPTION
When items are selected, `itemTree` scrolls to them. Depending on the arrangement of items, it will often default to scrolling to the top-most item in the selection, which is not the focused row in case of duplicates view. To scroll to focused row without unnecessary scrolling or items visibly jumping to one row and then another, added option to skip scrolling in `itemTree.selectItems`.

Fixes: #4821



https://github.com/user-attachments/assets/fde6f1e7-c248-49b3-bbe6-663312776aa0

