### PR TITLE
Do not handle tabbing out of reader iframe in standalone window

### DIFF
--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -502,12 +502,14 @@ class ReaderInstance {
 				win.ZoteroContextPane.togglePane();
 			},
 			onToolbarShiftTab: () => {
-				// Shift-tab from the toolbar focuses the sync button
+				// Shift-tab from the toolbar focuses the sync button (if reader instance is opened in a tab)
+				if (!this.tabID) return;
 				let win = Zotero.getMainWindow();
 				win.document.getElementById("zotero-tb-sync").focus();
 			},
 			onIframeTab: () => {
-				// Tab after the last tabstop will focus the contextPane
+				// Tab after the last tabstop will focus the contextPane (if reader instance is opened in a tab)
+				if (!this.tabID) return;
 				let win = Zotero.getMainWindow();
 				let focused = win.ZoteroContextPane.focus();
 				// If context pane wasn't focused (e.g. it's collapsed), focus the tab bar


### PR DESCRIPTION
Only move focus out of the reader iframe on tab/shift-tab if the reader instance is opened within a tab, meaning the sync button and the contextPane exist. If the reader is opened in a standalone window, do nothing.

Fixes: #4823