### PR TITLE
Allow quicksearch to stretch when there is space in the middle pane

### DIFF
--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -2787,7 +2787,7 @@ var ZoteroPane = new function()
 		spinner.setAttribute("status", "animate");
 		spinner.style.visibility = 'visible';
 		yield this.itemsView.setFilter('search', searchVal);
-		spinner.style.visibility = 'hidden';
+		spinner.style.removeProperty("visibility");
 		spinner.removeAttribute("status");
 		if (runAdvanced) {
 			this.clearItemsPaneMessage();

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -2785,7 +2785,9 @@ var ZoteroPane = new function()
 		}
 		var spinner = document.getElementById('zotero-tb-search-spinner');
 		spinner.setAttribute("status", "animate");
+		spinner.style.visibility = 'visible';
 		yield this.itemsView.setFilter('search', searchVal);
+		spinner.style.visibility = 'hidden';
 		spinner.removeAttribute("status");
 		if (runAdvanced) {
 			this.clearItemsPaneMessage();

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -1334,7 +1334,7 @@
 												</toolbarbutton>
 												
 												<spacer flex="1"/>
-												<image id="zotero-tb-search-spinner" class="zotero-spinner-16"/>
+												<image id="zotero-tb-search-spinner" class="zotero-spinner-16" style="display: inline;visibility: hidden;"/>
 												<quick-search-textbox id="zotero-tb-search" timeout="250"
 														onkeydown="ZoteroPane_Local.handleSearchKeypress(this, event)"
 														oninput="ZoteroPane_Local.handleSearchInput(this, event)"

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -1334,7 +1334,7 @@
 												</toolbarbutton>
 												
 												<spacer flex="1"/>
-												<image id="zotero-tb-search-spinner" class="zotero-spinner-16" style="display: inline;visibility: hidden;"/>
+												<image id="zotero-tb-search-spinner" class="zotero-spinner-16"/>
 												<quick-search-textbox id="zotero-tb-search" timeout="250"
 														onkeydown="ZoteroPane_Local.handleSearchKeypress(this, event)"
 														oninput="ZoteroPane_Local.handleSearchInput(this, event)"

--- a/scss/elements/_quickSearchTextbox.scss
+++ b/scss/elements/_quickSearchTextbox.scss
@@ -1,10 +1,12 @@
 // | 6px padding | 16px icon width | 2px padding | 8px dropmarker width | 4px padding |
 quick-search-textbox {
-	--search-textbox-width: 172px;
+	--search-textbox-width: 146px;
 	font-size: var(--zotero-font-size);
 	margin-right: 0;
 	width: var(--search-textbox-width);
 	height: 28px;
+	max-width: 300px;
+	flex-grow: 1;
 
 	*[zoteroFontSize=small] {
 		font-size: 11px;
@@ -67,8 +69,13 @@ quick-search-textbox {
 	width: var(--search-textbox-width);
 	height: 28px;
 	z-index: 1;
+	width: 100%;
 }
 
 #zotero-tb-search-spinner {
 	margin: 0 8px;
+}
+
+#search-wrapper {
+	width: 100%;
 }

--- a/scss/elements/_quickSearchTextbox.scss
+++ b/scss/elements/_quickSearchTextbox.scss
@@ -74,6 +74,9 @@ quick-search-textbox {
 
 #zotero-tb-search-spinner {
 	margin: 0 8px;
+	// make sure the spinner always occupies space
+	display: inline;
+	visibility: hidden;
 }
 
 #search-wrapper {


### PR DESCRIPTION
Per https://forums.zotero.org/discussion/119312/search-window-in-zotero-7-is-too-small. I suppose, when the middle pane is wide, we do have plenty of space between toolbar buttons and the quickSearch, so allowing it to stretch a bit does not hurt? Maybe the exact width values need to be tweaked - I started with max-width of `300px`.


https://github.com/user-attachments/assets/8033b74d-7613-41d3-9985-da92de3258c2



Also, have spinner always occupy space, so that it does not push quickSearch out of the bounds of the middle pane when it is very narrow. Respectively, make min-width of quicksearch a bit smaller. This resolves the issue that is present currently on `main`, without these quicksearch stretching tweaks. This is the current behavior I am referring to:


https://github.com/user-attachments/assets/797c6db4-970a-4466-8dc5-95415645d404

