### PR TITLE
Import mendeley notebooks

### DIFF
--- a/chrome/content/zotero/actors/ActorManager.jsm
+++ b/chrome/content/zotero/actors/ActorManager.jsm
@@ -77,3 +77,12 @@ if (AppConstants.platform === "macosx") {
 		includeChrome: true
 	});
 }
+
+ChromeUtils.registerWindowActor("MendeleyAuth", {
+	parent: {
+		moduleURI: "chrome://zotero/content/actors/MendeleyAuthParent.jsm"
+	},
+	child: {
+		moduleURI: "chrome://zotero/content/actors/MendeleyAuthChild.jsm"
+	}
+});

--- a/chrome/content/zotero/actors/MendeleyAuthChild.jsm
+++ b/chrome/content/zotero/actors/MendeleyAuthChild.jsm
@@ -1,0 +1,69 @@
+/* global JSWindowActorChild:false */
+
+var EXPORTED_SYMBOLS = ["MendeleyAuthChild"]; // eslint-disable-line no-unused-vars
+
+class MendeleyAuthChild extends JSWindowActorChild { // eslint-disable-line no-unused-vars
+	async receiveMessage(message) {
+		let window = this.contentWindow;
+		let document = window.document;
+
+		await this.documentIsReady();
+
+		switch (message.name) {
+			case "login":
+				try {
+					document.querySelector('input[name="pf.username"]').value = message.data.login;
+					document.querySelector("button[value=emailContinue]").removeAttribute("disabled");
+					document.querySelector("button[value=emailContinue]").click();
+					return true;
+				}
+				catch (e) {
+					this.sendAsyncMessage('debug', { kind: 'error', message: 'Failed to enter login', error: e.message });
+				}
+				break;
+			case "password":
+				try {
+					document.querySelector('input[name="password"]').value = message.data.password;
+					document.querySelector("button[type=submit][value=signin]").removeAttribute("disabled");
+					document.querySelector("button[type=submit][value=signin]").click();
+					return true;
+				}
+				catch (e) {
+					this.sendAsyncMessage('debug', { kind: 'error', message: 'Failed to enter password', error: e.message });
+				}
+				break;
+		}
+
+		return false;
+	}
+	
+	// From Mozilla's ScreenshotsComponentChild.jsm
+	documentIsReady() {
+		const contentWindow = this.contentWindow;
+		const document = this.document;
+		
+		function readyEnough() {
+			return document.readyState === "complete";
+		}
+		
+		if (readyEnough()) {
+			return Promise.resolve();
+		}
+		return new Promise((resolve, reject) => {
+			function onChange(event) {
+				if (event.type === "pagehide") {
+					document.removeEventListener("readystatechange", onChange);
+					contentWindow.removeEventListener("pagehide", onChange);
+					reject(new Error("document unloaded before it was ready"));
+				}
+				else if (readyEnough()) {
+					document.removeEventListener("readystatechange", onChange);
+					contentWindow.removeEventListener("pagehide", onChange);
+					resolve();
+				}
+			}
+			document.addEventListener("readystatechange", onChange);
+			contentWindow.addEventListener("pagehide", onChange, { once: true });
+		});
+	}
+}

--- a/chrome/content/zotero/actors/MendeleyAuthParent.jsm
+++ b/chrome/content/zotero/actors/MendeleyAuthParent.jsm
@@ -1,0 +1,22 @@
+/* global JSWindowActorParent:false */
+
+var EXPORTED_SYMBOLS = ["MendeleyAuthParent"]; // eslint-disable-line no-unused-vars
+
+ChromeUtils.defineESModuleGetters(this, {
+	Zotero: "chrome://zotero/content/zotero.mjs"
+});
+
+class MendeleyAuthParent extends JSWindowActorParent { // eslint-disable-line no-unused-vars
+	async receiveMessage({ name, data }) {
+		switch (name) {
+			case "debug": {
+				if (data.kind === "log") {
+					Zotero.debug(`MendeleyAuth actor: ${data.message}`);
+				}
+				else if (data.kind === "error") {
+					Zotero.debug(`MendeleyAuth actor: ${data.message}. Error: ${data.error}`);
+				}
+			}
+		}
+	}
+}

--- a/test/tests/data/mendeleyMock/notebook.json
+++ b/test/tests/data/mendeleyMock/notebook.json
@@ -1,0 +1,78 @@
+{
+	"id": "8041a43b-f740-41ec-be42-a24cc5106d68",
+	"created": "2024-07-09T09:56:04.349Z",
+	"modified": "2024-11-04T13:54:23.050Z",
+	"title": "TEST",
+	"blocks": [
+		{
+			"annotation": {
+				"stylesheet": {
+					"type": "CssStylesheet",
+					"value": ".annotation-color-rgb-250-244-209 { background-color: rgb(250,244,209); }"
+				},
+				"creator": [
+					{
+						"id": "https://www.mendeley.com/",
+						"type": "Software"
+					}
+				],
+				"created": "2024-11-04T13:49:03.274Z",
+				"modified": "2024-11-04T13:49:03.274Z",
+				"id": "https://api.mendeley.com/annotations/v2/84f12446-3b49-4052-bbdc-832d28e1e072",
+				"body": [
+					{
+						"purpose": "highlighting",
+						"format": "application/json",
+						"type": "TextualBody",
+						"value": {
+							"textAttributes": {
+								"entityRanges": [
+									{
+										"offset": 0,
+										"length": 142,
+										"key": 0
+									}
+								]
+							},
+							"text": "Highlighted text"
+						}
+					}
+				],
+				"type": "Annotation",
+				"@context": "http://www.w3.org/ns/anno.jsonld",
+				"target": [
+					{
+						"format": "application/pdf",
+						"selector": [
+							{
+								"exact": "Highlighted text",
+								"type": "TextQuoteSelector"
+							},
+							{
+								"conformsTo": "http://tools.ietf.org/rfc/rfc3778",
+								"type": "FragmentSelector",
+								"value": "page=1&viewrect=47.61420000000004,524.3954,200.42259999999993,-18.536&page=1&viewrect=47.61420000000004,499.6994000000001,249.05580000000003,-17.639999999999986&page=1&viewrect=47.61420000000004,479.6934000000001,228.01519999999994,-17.640000000000043&page=1&viewrect=47.61420000000004,459.68740000000014,133.57120000000003,-17.640000000000043"
+							}
+						],
+						"source": "https://api.mendeley.com/documents/e4a6a49b-8622-3064-abb5-f1f1dac5e02e/files/099d8443-dbc9-6925-78ee-e462db2a28f3/",
+						"styleClass": "annotation-color-rgb-250-244-209"
+					}
+				]
+			},
+			"type": "annotation"
+		},
+		{
+			"freetext": {
+				"format": "application/json",
+				"value": {
+					"textAttributes": {
+						"inlineStyleRanges": [],
+						"entityRanges": []
+					},
+					"text": "Lorem Ipsum"
+				}
+			},
+			"type": "freetext"
+		}
+	]
+}


### PR DESCRIPTION
This PR extends the Mendeley importer to also import notebooks, which are only available in the new Mendeley Reference Manager. 

This is based on reverse-engineering, as Mendeley does not provide documentation for this API.

The title of the notebook is translated into an `h1` at the very top of the Zotero note. "Freetext" nodes are translated as HTML paragraphs. Annotations/citations are identified by UUID and then generated using our `serializeAnnotations` function; the actual textual content from the Mendeley is ignored.

Neither the "direct" nor "OAuth" tokens that we use for the Mendeley API enable access to this feature. Therefore, we use the credentials provided by the user to perform a complete sign-in in a hidden browser and then extract an access token that allows us to access this new feature.

The entire process is performed as the last step of the import. If anything fails, the rest of the import should remain unaffected.

Resolve #4361