### PR TITLE
Context pane notes list focus handling edits

### DIFF
--- a/chrome/content/zotero/elements/contextNotesList.js
+++ b/chrome/content/zotero/elements/contextNotesList.js
@@ -185,6 +185,7 @@
 		};
 
 		// ArrowUp/Down navigation between notes
+		// Tab from a note-row focuses sidenav, Shift-Tab from a note focuses the section header
 		_handleKeyDown = (event) => {
 			if (event.target.tagName !== "note-row" && !event.target.classList.contains("more")) return;
 			if (event.key == "ArrowDown") {
@@ -192,6 +193,16 @@
 			}
 			else if (event.key == "ArrowUp") {
 				event.target.previousElementSibling?.focus();
+			}
+			else if (event.key == "Tab" && !event.shiftKey) {
+				Services.focus.moveFocus(window, document.getElementById("zotero-context-pane-sidenav"),
+					Services.focus.MOVEFOCUS_FORWARD, 0);
+				event.preventDefault();
+			}
+			else if (event.key == "Tab" && event.shiftKey) {
+				Services.focus.moveFocus(window, event.target.closest("collapsible-section"),
+					Services.focus.MOVEFOCUS_FORWARD, 0);
+				event.preventDefault();
 			}
 		};
 		

--- a/chrome/content/zotero/elements/contextPane.js
+++ b/chrome/content/zotero/elements/contextPane.js
@@ -326,8 +326,10 @@
 					Services.focus.moveFocus(window, header, Services.focus.MOVEFOCUS_FORWARD, 0);
 					return true;
 				}
-				else {
-					this._getCurrentNotesContext()?.focus();
+				else if (this.mode == "notes") {
+					// Tab into the notes pane
+					Services.focus.moveFocus(window, this._getCurrentNotesContext(), Services.focus.MOVEFOCUS_FORWARD, 0);
+					return true;
 				}
 			}
 			return false;

--- a/chrome/content/zotero/elements/itemPaneSidenav.js
+++ b/chrome/content/zotero/elements/itemPaneSidenav.js
@@ -392,8 +392,14 @@
 				event.preventDefault();
 			}
 			if (event.key == "Tab" && event.shiftKey) {
-				// Return focus to item pane
-				Services.focus.moveFocus(window, this, Services.focus.MOVEFOCUS_BACKWARD, 0);
+				if (this._contextNotesPaneVisible) {
+					// Tab into notes pane to focus search bar
+					Services.focus.moveFocus(window, this._contextNotesPane, Services.focus.MOVEFOCUS_FORWARD, 0);
+				}
+				else {
+					// Shift-Tab out of sidenav to itemPane
+					Services.focus.moveFocus(window, this, Services.focus.MOVEFOCUS_BACKWARD, 0);
+				}
 				event.preventDefault();
 			}
 			if (["ArrowUp", "ArrowDown"].includes(event.key)) {


### PR DESCRIPTION
- fix the issue of focus not landing on search field of the notes pane when it is opened on tab from the reader
- shift-tab from the `sidenav` when notes pane is opened will focus the search input as well, instead of the last focusable node in the pane (e.g. "X more..." button at the bottom)
- tab from a `note-row` in the list of notes will focus the `sidenav`
- shift-tab from a `note-row` will focus the header of the `collapsible-section`. I thought focusing the reader right away would be too much, since one might need to get to the `+` button to add a note, or something like that. And once you are at a section header, you can jump to the header of the previous section (if there is one) with `arrowUp`, at which point, you are at the top of the notes pane.

Per https://github.com/zotero/zotero/pull/4235#issuecomment-2472397642