### PR TITLE
Fix duplicate item pane when switching to library tab before reader is loaded

### DIFF
--- a/chrome/content/zotero/elements/contextPane.js
+++ b/chrome/content/zotero/elements/contextPane.js
@@ -172,7 +172,13 @@
 				ZoteroContextPane.showLoadingMessage(false);
 				this._sidenav.hidden = true;
 			}
-			else if (tabType == 'reader') {
+			else if (tabType == 'reader'
+					// The reader tab load event is triggered asynchronously.
+					// If the tab is no longer selected by the time the event is triggered,
+					// we don't need to update the context pane, since it must already be
+					// updated by another select tab event.
+					&& (action === 'select'
+						|| (action === 'load' && Zotero_Tabs.selectedID == tabID))) {
 				this._handleReaderReady(tabID);
 				this._setupNotesContext(tabID);
 				_contextPaneSplitter.setAttribute('hidden', false);

--- a/test/tests/itemPaneTest.js
+++ b/test/tests/itemPaneTest.js
@@ -1774,4 +1774,25 @@ describe("Item pane", function () {
 			);
 		});
 	});
+
+	describe("Item pane and tabs", function () {
+		it("should switch to the correct pane when switching tabs", async function () {
+			// https://github.com/zotero/zotero/issues/4531#issuecomment-2470874876
+			let attachment = await importFileAttachment('test.pdf');
+			Zotero_Tabs.closeAll();
+			Zotero_Tabs.add({
+				type: 'reader-unloaded',
+				title: "Reader",
+				index: 1,
+				data: {
+					itemID: attachment.id
+				},
+			});
+			Zotero_Tabs.jump(1);
+			Zotero_Tabs.jump(0);
+			await Zotero.Promise.delay(100);
+			// Should not show the context pane for the reader tab
+			assert.isTrue(ZoteroContextPane.splitter.hidden);
+		});
+	});
 });


### PR DESCRIPTION
fix: #4531