### PR TITLE
Libraries and Collections: Fix Add button in reader tabs

### DIFF
--- a/chrome/content/zotero/elements/librariesCollectionsBox.js
+++ b/chrome/content/zotero/elements/librariesCollectionsBox.js
@@ -35,10 +35,7 @@ import { getCSSIcon } from 'components/icons';
 			</collapsible-section>
 			
 			<popupset>
-				<menupopup class="add-popup" onpopupshowing="ZoteroPane_Local.buildAddItemToCollectionMenu(event)">
-					<menuitem label="&zotero.toolbar.newCollection.label;" oncommand="ZoteroPane_Local.addSelectedItemsToCollection(null, true)"/>
-					<menuseparator/>
-				</menupopup>
+				<menupopup class="add-popup"/>
 			</popupset>
 		`, ['chrome://zotero/locale/zotero.dtd']);
 
@@ -68,6 +65,10 @@ import { getCSSIcon } from 'components/icons';
 			this._notifierID = Zotero.Notifier.registerObserver(this, ['item', 'collection'], 'librariesCollectionsBox');
 			this._body = this.querySelector('.body');
 			this.initCollapsibleSection();
+			this._addPopup = this.querySelector('.add-popup');
+			this._addPopup.addEventListener('popupshowing', (event) => {
+				ZoteroPane.buildAddItemToCollectionMenu(event, [this._item]);
+			});
 			this._section.addEventListener('add', this._handleAdd);
 		}
 
@@ -266,7 +267,7 @@ import { getCSSIcon } from 'components/icons';
 		}
 
 		_handleAdd = (event) => {
-			this.querySelector('.add-popup').openPopupAtScreen(
+			this._addPopup.openPopupAtScreen(
 				event.detail.button.screenX,
 				event.detail.button.screenY,
 				true

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -284,7 +284,8 @@
 								</menupopup>
 							</menu>
 							<menuseparator class="menu-type-library"/>
-							<menuitem id="menu_newCollection" class="menu-type-library" label="&zotero.toolbar.newCollection.label;"
+							<menuitem id="menu_newCollection" class="menu-type-library"
+									data-l10n-id="menu-new-collection"
 									command="cmd_zotero_newCollection"/>
 							<menu id="menu_libraryAdd"
 									class="menu-type-library"
@@ -912,7 +913,7 @@
 			<!-- Keep order in sync with buildCollectionContextMenu, which adds additional attributes -->
 			<menuitem class="zotero-menuitem-sync"/>
 			<menuseparator/>
-			<menuitem class="zotero-menuitem-new-collection" label="&zotero.toolbar.newCollection.label;"/>
+			<menuitem class="zotero-menuitem-new-collection" data-l10n-id="menu-new-collection"/>
 			<menuitem class="zotero-menuitem-new-saved-search" label="&zotero.toolbar.newSavedSearch.label;"/>
 			<menuitem class="zotero-menuitem-new-collection" label="&zotero.toolbar.newSubcollection.label;"/>
 			<menuitem class="zotero-menuitem-refresh-feed"/>
@@ -984,10 +985,7 @@
 			<menuitem class="menuitem-iconic zotero-menuitem-toggle-read-item" oncommand="ZoteroPane_Local.toggleSelectedItemsRead();"/>
 			<menuitem class="menuitem-iconic zotero-menuitem-change-top-level-item" data-l10n-id="item-menu-change-parent-item" oncommand="ZoteroPane_Local.changeParentItem();"/>
 			<menu class="menu-iconic zotero-menuitem-add-to-collection">
-				<menupopup id="zotero-add-to-collection-popup" onpopupshowing="ZoteroPane_Local.buildAddItemToCollectionMenu(event)">
-					<menuitem id="zotero-add-to-new-collection" label="&zotero.toolbar.newCollection.label;" oncommand="ZoteroPane_Local.addSelectedItemsToCollection(null, true)"/>
-					<menuseparator id="zotero-add-to-collection-separator"/>
-				</menupopup>
+				<menupopup id="zotero-add-to-collection-popup" onpopupshowing="ZoteroPane_Local.buildAddItemToCollectionMenu(event)"/>
 			</menu>
 			<menuitem class="menuitem-iconic zotero-menuitem-remove-items" oncommand="ZoteroPane_Local.deleteSelectedItems();"/>
 			<menuitem class="menuitem-iconic zotero-menuitem-duplicate-and-convert" oncommand="ZoteroPane_Local.duplicateAndConvertSelectedItem();"/>
@@ -1194,7 +1192,7 @@
 								<vbox id="zotero-collections-pane" zotero-persist="width">
 									<toolbar id="zotero-toolbar-collection-tree" tabindex="-1" class="zotero-toolbar toolbar toolbar-primary">
 										<hbox id="zotero-collections-toolbar" align="center">
-											<toolbarbutton id="zotero-tb-collection-add" tabindex="-1" class="zotero-tb-button" tooltiptext="&zotero.toolbar.newCollection.label;" command="cmd_zotero_newCollection"/>
+											<toolbarbutton id="zotero-tb-collection-add" tabindex="-1" class="zotero-tb-button" data-l10n-id="toolbar-new-collection" command="cmd_zotero_newCollection"/>
 											<spacer flex="1"></spacer>
 											<html:div style="display: flex;flex-direction: row; flex-grow: 0; flex-shrink: 1; min-width: 0;">
 												<toolbarbutton id="zotero-tb-collections-search" data-l10n-id="zotero-collections-search-btn" tabindex="-1" class="zotero-tb-button"/>

--- a/chrome/locale/en-US/zotero/zotero.dtd
+++ b/chrome/locale/en-US/zotero/zotero.dtd
@@ -81,7 +81,6 @@
 <!ENTITY zotero.toolbar.lookup.label				"Add Item(s) by Identifier">
 <!ENTITY zotero.toolbar.removeItem.label				"Remove Item…">
 <!ENTITY zotero.toolbar.newLibrary.label			"New Library">
-<!ENTITY zotero.toolbar.newCollection.label			"New Collection…">
 <!ENTITY zotero.toolbar.newGroup						"New Group…">
 <!ENTITY zotero.toolbar.newSubcollection.label			"New Subcollection…">
 <!ENTITY zotero.toolbar.newSavedSearch.label			"New Saved Search…">

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -577,6 +577,12 @@ context-notes-search =
 context-notes-return-button =
     .aria-label = { general-go-back }
 
+new-collection = New Collection…
+menu-new-collection =
+    .label = { new-collection }
+toolbar-new-collection =
+    .tooltiptext = { new-collection }
+
 new-collection-dialog =
     .title = New Collection
     .buttonlabelaccept = Create Collection


### PR DESCRIPTION
And:

- Rework a few ZP functions to take items arrays instead of always acting on selected items
- Move string to Fluent
- Build entire Add to Collection menu programmatically

Fixes #4841