### PR TITLE
Fix "anyField" conflicting with other search conditions with joinMode=any

### DIFF
--- a/chrome/content/zotero/xpcom/data/search.js
+++ b/chrome/content/zotero/xpcom/data/search.js
@@ -1079,7 +1079,12 @@ Zotero.Search.prototype._buildQuery = Zotero.Promise.coroutine(function* () {
 					// (although we don't detect keys or split into quoted and unquoted segments). 'quicksearch-fields'
 					// is expanded in addCondition(), but we can't do that with this condition because we don't want
 					// to save the conditions it expands to in the search object
-					conditionsToProcess.push({ condition: 'blockStart' });
+					if (joinMode == 'ALL') {
+						// If joinMode is 'any', do not wrap conditions in quickSearch block so that
+						// they become just a series of OR statements. Otherwise, "Any Field" will
+						// conflict with all other conditions (if multiple conditions are present).
+						conditionsToProcess.push({ condition: 'blockStart' });
+					}
 					conditionsToProcess.push({
 						condition: 'field',
 						operator: condition.operator,
@@ -1104,7 +1109,9 @@ Zotero.Search.prototype._buildQuery = Zotero.Promise.coroutine(function* () {
 						value: condition.value,
 						required: false
 					});
-					conditionsToProcess.push({ condition: 'blockEnd' });
+					if (joinMode == 'ALL') {
+						conditionsToProcess.push({ condition: 'blockEnd' });
+					}
 					continue;
 			}
 			

--- a/test/tests/searchTest.js
+++ b/test/tests/searchTest.js
@@ -532,6 +532,33 @@ describe("Zotero.Search", function() {
 					yield s.search();
 				});
 			});
+
+			describe("anyField", function () {
+				it("should return matches for multiple 'any field' conditions with joinMode=any", async function () {
+					var itemOne = await createDataObject('item', { title: "one" });
+					var itemTwo = await createDataObject('item', { title: "two" });
+					
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('joinMode', 'any');
+					s.addCondition('anyField', 'contains', "one");
+					s.addCondition('anyField', 'contains', "two");
+					var matches = await s.search();
+					assert.sameMembers(matches, [itemOne.id, itemTwo.id]);
+				});
+				it("should return matches for 'any field' and title condition with joinMode=any", async function () {
+					var itemOne = await createDataObject('item', { title: "three" });
+					var itemTwo = await createDataObject('item', { title: "four" });
+					
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('joinMode', 'any');
+					s.addCondition('anyField', 'contains', "three");
+					s.addCondition('title', 'contains', "four");
+					var matches = await s.search();
+					assert.sameMembers(matches, [itemOne.id, itemTwo.id]);
+				});
+			});
 			
 			describe("savedSearch", function () {
 				it("should return items in the saved search", function* () {


### PR DESCRIPTION
Fix the glitch where having anyField search condition along with any other condition would return an empty result set if joinMode="any".
This would happen due to a conflict between conditions caused by wrapping "anyField" condition set into a quickSearch block, which [enforces](https://github.com/zotero/zotero/blob/a6c178dfe81e1f44f9a8a33085b5d5fe2fb6695b/chrome/content/zotero/xpcom/data/search.js#L1814) "AND" operator between conditions.

Minor followup to: https://github.com/zotero/zotero/commit/cda0e0cf6d2f2dac04ab9855b468f22c18495ce2

Fixes: #4830