### PR TITLE
QuickFormat: potential fix to locator popup not properly rendering

### DIFF
--- a/chrome/content/zotero/integration/quickFormat.xhtml
+++ b/chrome/content/zotero/integration/quickFormat.xhtml
@@ -97,7 +97,7 @@
 			<description id="citation-properties-info" tabindex="2"/>
 		</vbox>
 		<html:div id="citation-properties-grid">
-			<menulist id="locator-label" sizetopopup="none" tabindex="3"
+			<menulist id="locator-label" tabindex="3"
 					  oncommand="Zotero_QuickFormat.onCitationPropertiesChanged(event)" native="true">
 				<menupopup id="locator-label-popup" onpopuphidden="Zotero_QuickFormat.ignoreEvent(event)"/>
 			</menulist>


### PR DESCRIPTION
This may help with the issue of locator popup sometimes not being properly rendered per https://github.com/zotero/zotero/issues/4814#issuecomment-2477538297

Also, it allows the popup to have a proper width on windows when "Always show scrollbar" setting is on.

Addresses: #4814
Addresses: #4805