### PR TITLE
Context pane  notes list focus handling followup

### DIFF
--- a/chrome/content/zotero/elements/contextPane.js
+++ b/chrome/content/zotero/elements/contextPane.js
@@ -327,9 +327,7 @@
 					return true;
 				}
 				else if (this.mode == "notes") {
-					// Tab into the notes pane
-					Services.focus.moveFocus(window, this._getCurrentNotesContext(), Services.focus.MOVEFOCUS_FORWARD, 0);
-					return true;
+					return this._getCurrentNotesContext().focus();
 				}
 			}
 			return false;

--- a/chrome/content/zotero/elements/itemPaneSidenav.js
+++ b/chrome/content/zotero/elements/itemPaneSidenav.js
@@ -388,19 +388,17 @@
 		handleKeyDown = (event) => {
 			if (event.key == "Tab" && !event.shiftKey) {
 				// Wrap focus around to the tab bar
-				Services.focus.moveFocus(window, document.getElementById("zotero-title-bar"), Services.focus.MOVEFOCUS_FORWARD, 0);
+				Zotero_Tabs.moveFocus("current");
 				event.preventDefault();
 			}
 			if (event.key == "Tab" && event.shiftKey) {
-				if (this._contextNotesPaneVisible) {
-					// Tab into notes pane to focus search bar
-					Services.focus.moveFocus(window, this._contextNotesPane, Services.focus.MOVEFOCUS_FORWARD, 0);
-				}
-				else {
-					// Shift-Tab out of sidenav to itemPane
-					Services.focus.moveFocus(window, this, Services.focus.MOVEFOCUS_BACKWARD, 0);
-				}
 				event.preventDefault();
+				if (this._contextNotesPaneVisible && this._contextNotesPane.selectedPanel.mode == "notesList") {
+					let focusHandled = this._contextNotesPane.selectedPanel.focus();
+					if (focusHandled) return;
+				}
+				// Shift-Tab out of sidenav to itemPane
+				Services.focus.moveFocus(window, this, Services.focus.MOVEFOCUS_BACKWARD, 0);
 			}
 			if (["ArrowUp", "ArrowDown"].includes(event.key)) {
 				// Up/Down arrow navigation

--- a/chrome/content/zotero/elements/notesContext.js
+++ b/chrome/content/zotero/elements/notesContext.js
@@ -152,7 +152,10 @@
 
 		focus() {
 			if (this.mode == "notesList") {
-				this.input.focus();
+				let refocused = this.notesList.refocusLastFocusedNote();
+				if (!refocused) {
+					this.input.focus();
+				}
 				return true;
 			}
 			else {

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -1138,13 +1138,10 @@ var ZoteroPane = new function()
 		// Shift-tab from the header into the itemsView.
 		if (Services.focus.activeWindow === window && this.lastKeyPress === "Tab"
 			&& (itemPaneLostFocus || contextPaneLostFocus)) {
+			// event.relatedTarget is null when moving focus in or out of <iframe> or <browser>
+			// so make sure to not refocus tabs when focusing inside of note-editor or reader
 			if (receivingFocus) {
 				Zotero_Tabs.moveFocus("current");
-			}
-			// event.relatedTarget is null when the reader is opened and we need a small
-			// delay otherwise the focus lands within the reader
-			else {
-				setTimeout(() => Zotero_Tabs.moveFocus("current"));
 			}
 			this.lastKeyPress = null;
 		}


### PR DESCRIPTION
- remember the last focused `note-row` in the `contextPane` and, if possible, refocus it on shift-tab from `sidenav`, on tab from the reader into the notes pane, or on tab into the notes list from the collapsible-section. Otherwise, focus the search input. Per: https://github.com/zotero/zotero/pull/4837#issuecomment-2478108186
- when a note is opened in the context pane, let `shift-tab` from `sidenav` place focus on the `links-box`. That way, it is not skipped during tab navigation.
- fix focus not entering `note-editor` on tab from the "Go back" button and instead wrapping around to the current tab