### PR TITLE
Fix for loss of focus not closing the quick citation dialog

### DIFF
--- a/chrome/content/zotero/integration/quickFormat.xhtml
+++ b/chrome/content/zotero/integration/quickFormat.xhtml
@@ -42,6 +42,7 @@
 	persist="screenX screenY"
 	onkeypress="Zotero_QuickFormat.onWindowKeyPress(event)"
 	onunload="Zotero_QuickFormat.onUnload()"
+	onblur="Zotero_QuickFormat.onUnload()"
 	drawintitlebar-platforms="linux,win"
 	no-titlebar-icon="true"
 	style="width: 800px;">


### PR DESCRIPTION
When focus is lost from the Quick Citation dialog, it does not currently close. I'm unsure if this is expected behaviour, or whether it is unwanted. 

It appears definitely unwanted if you are editing multiple citations, and click out of the window, then select another citation. The Quick Citation dialog then reflects (and will update) the incorrect citation.

Steps to repro:

1) Open Word
2) Insert two citations (and press enter/accept each one to accept).
3) Select one citation, and press Add/Edit to open the Quick Citation dialog
4) Without pressing escape, or accepting the dialog, click back into word, and select the second citation
5) Notice the dialog is still reflecting the first citation

![Screenshot 2024-11-19 192637](https://github.com/user-attachments/assets/62209d9a-d759-498b-b24f-afb1bab8335d)

With a single line of code I believe I've fixed the issue, there appears to be no problem utilising the dialog from my end, but appreciate I cannot test on other platforms/with other word processors.

OS: Windows 11 23H2 22631.4317
Zotero: 7.0.10-beta.2+dc47650eb (64-bit) (also last stable version)

