### PR TITLE
Close citation dialog if user interacts with the integration plugin

### DIFF
--- a/chrome/content/zotero/bibliography.js
+++ b/chrome/content/zotero/bibliography.js
@@ -32,6 +32,8 @@
 // Class to provide options for bibliography
 // Used by integrationDocPrefs.xhtml and bibliography.xhtml
 
+window.isPristine = true;
+
 window.Zotero_File_Interface_Bibliography = new function () {
 	var _io;
 	
@@ -200,6 +202,11 @@ window.Zotero_File_Interface_Bibliography = new function () {
 		if (hasCheckedAdvancedOption) {
 			this.toggleAdvancedOptions(false);
 		}
+		
+		const checkboxes = document.querySelectorAll('.advanced-checkbox');
+		for (const checkbox of checkboxes) {
+			checkbox.addEventListener('command', _ => window.isPristine = false);
+		}
 	};
 	
 	this.openHelpLink = function () {
@@ -232,6 +239,7 @@ window.Zotero_File_Interface_Bibliography = new function () {
 	};
 
 	this.onDocPrefsWindowStyleChange = function (style) {
+		window.isPristine = false;
 		if (windowType !== "docPrefs") return;
 
 		let isNote = style.class == "note";
@@ -358,3 +366,7 @@ window.Zotero_File_Interface_Bibliography = new function () {
 		}
 	};
 };
+
+window.cancel = () => {
+	window.close();
+}

--- a/chrome/content/zotero/bibliography.js
+++ b/chrome/content/zotero/bibliography.js
@@ -193,7 +193,7 @@ window.Zotero_File_Interface_Bibliography = new function () {
 
 		document.querySelector("#exportDocument")?.addEventListener("command", this.exportDocument.bind(this));
 
-		this.onDocPrefsWindowStyleChange(Zotero.Styles.get(styleConfigurator.style));
+		this.onDocPrefsWindowStyleChange(Zotero.Styles.get(styleConfigurator.style), true);
 
 		// If any advanced options are checked, expand the advanced options section
 		let hasCheckedAdvancedOption
@@ -238,9 +238,9 @@ window.Zotero_File_Interface_Bibliography = new function () {
 		citations.dataset.l10nArgs = `{"type": "${style.class}"}`;
 	};
 
-	this.onDocPrefsWindowStyleChange = function (style) {
-		window.isPristine = false;
+	this.onDocPrefsWindowStyleChange = function (style, init = false) {
 		if (windowType !== "docPrefs") return;
+		window.isPristine = init;
 
 		let isNote = style.class == "note";
 		// update status of formatUsing box based on style class

--- a/chrome/content/zotero/integration/addCitationDialog.js
+++ b/chrome/content/zotero/integration/addCitationDialog.js
@@ -26,6 +26,8 @@
 import { getCSSItemTypeIcon } from 'components/icons';
 
 
+window.isPristine = true;
+
 var Zotero_Citation_Dialog = new function () {
 	// Array value [0] is property name.
 	// Array value [1] is default value of property.
@@ -321,6 +323,7 @@ var Zotero_Citation_Dialog = new function () {
 			}
 			_updateAccept();
 			_updatePreview();
+			window.isPristine = false;
 		}
 	}
 	
@@ -380,6 +383,7 @@ var Zotero_Citation_Dialog = new function () {
 		_itemSelected(itemDataID);
 		_updatePreview();
 		_configListPosition(false, (selectedListIndex + direction));
+		window.isPristine = false;
 	}
 
 	function up() {
@@ -394,9 +398,9 @@ var Zotero_Citation_Dialog = new function () {
 	 * Adds an item to the multipleSources list
 	 */
 	this.add = Zotero.Promise.coroutine(function* (first_item) {
-		
 		var pos, len;
 		var items = itemsView.getSelectedItems(); // treeview from xpcom/itemTreeView.js
+		window.isPristine = false;
 		
 		if (!items.length) {
 			yield sortCitation();
@@ -463,6 +467,7 @@ var Zotero_Citation_Dialog = new function () {
 
 		_updateAccept();
 		_updatePreview();
+		window.isPristine = false;
 	}
 	
 	/*
@@ -663,9 +668,7 @@ var Zotero_Citation_Dialog = new function () {
 	 */
 	function cancel() {
 		if(_accepted) return true;
-		io.citation.citationItems = new Array();
-
-		io.accept();
+		io.cancel();
 		_accepted = true;
 		return true;
 	}
@@ -869,3 +872,5 @@ var Zotero_Citation_Dialog = new function () {
 		Zotero.Utilities.Internal.activate(pane.document.defaultView);
 	}
 }
+
+window.cancel = Zotero_Citation_Dialog.cancel;

--- a/chrome/content/zotero/integration/editBibliographyDialog.js
+++ b/chrome/content/zotero/integration/editBibliographyDialog.js
@@ -25,6 +25,8 @@
 
 import { getCSSItemTypeIcon } from 'components/icons';
 
+window.isPristine = true;
+
 var Zotero_Bibliography_Dialog = new function () {
 	var bibEditInterface;
 	var _lastSelectedItemID = false;
@@ -153,6 +155,7 @@ var Zotero_Bibliography_Dialog = new function () {
 	 * Adds references to the reference list
 	 */
 	this.add = function() {
+		window.isPristine = false;
 		for (let itemID of itemsView.getSelectedItems(true)) {
 			bibEditInterface.add(itemID);
 		}
@@ -176,6 +179,7 @@ var Zotero_Bibliography_Dialog = new function () {
 		);
 		
 		if(regenerate != 0) return;
+		window.isPristine = false;
 		
 		bibEditInterface.revertAll();
 		
@@ -199,6 +203,7 @@ var Zotero_Bibliography_Dialog = new function () {
 		);
 		
 		if(regenerate != 0) return;
+		window.isPristine = false;
 		
 		for (let itemID of _getSelectedListItemIDs()) {
 			bibEditInterface.revert(itemID);
@@ -231,6 +236,7 @@ var Zotero_Bibliography_Dialog = new function () {
 			);
 			if(regenerate != 0) return;
 		}
+		window.isPristine = false;
 		
 		// remove
 		for (let itemID of selectedListItemIDs) {
@@ -244,6 +250,7 @@ var Zotero_Bibliography_Dialog = new function () {
 	 */
 	this.textChanged = function() {
 		_revertButton.disabled = _revertAllButton.disabled = false;
+		window.isPristine = false;
 	}
 	
 	/**
@@ -253,6 +260,7 @@ var Zotero_Bibliography_Dialog = new function () {
 		if(_accepted) return;
 		_updatePreview(true);
 		_accepted = true;
+		window.close();
 	}
 	
 	/**
@@ -262,6 +270,7 @@ var Zotero_Bibliography_Dialog = new function () {
 		if(_accepted) return;
 		bibEditInterface.cancel();
 		_accepted = true;
+		window.close();
 	}
 	
 	/**
@@ -341,3 +350,5 @@ var Zotero_Bibliography_Dialog = new function () {
 		_updatePreview();
 	}
 }
+
+window.cancel = Zotero_Bibliography_Dialog.close;

--- a/chrome/content/zotero/xpcom/integration.js
+++ b/chrome/content/zotero/xpcom/integration.js
@@ -358,9 +358,13 @@ Zotero.Integration = new function() {
 				Zotero.Utilities.Internal.activate();
 				Zotero.Integration.currentWindow.focus();
 				// Prompt user that changes will be lost in the existing dialog
-				let result = ps.confirm(null, Zotero.getString('integration.error.title'),
-					Zotero.getString(`integration-warning-${Zotero.Integration.currentWindowType}-changes-will-be-lost`));
-				if (result === false) {
+				let result = Zotero.Prompt.confirm({
+					title: Zotero.getString('general.warning'),
+					text: Zotero.getString(`integration-warning-${Zotero.Integration.currentWindowType}-changes-will-be-lost`),
+					button0: Zotero.getString('integration-warning-discard-changes'),
+					button1: Zotero.Prompt.BUTTON_TITLE_CANCEL
+				});
+				if (result == 1) {
 					return true;
 				}
 			}

--- a/chrome/content/zotero/xpcom/integration.js
+++ b/chrome/content/zotero/xpcom/integration.js
@@ -82,6 +82,7 @@ Zotero.Integration = new function() {
 	Components.utils.import("resource://gre/modules/AddonManager.jsm");
 	
 	this.currentWindow = false;
+	this.currentCommandPromise = Zotero.Promise.resolve();
 	this.sessions = {};
 	var upgradeTemplateNotNowTime = 0;
 
@@ -246,14 +247,13 @@ Zotero.Integration = new function() {
 		Zotero.debug(`Integration: ${agent}-${command}${docId ? `:'${docId}'` : ''} invoked`)
 		if (Zotero.Integration.warnOutdatedTemplate(agent, templateVersion)) return;
 
-		if (Zotero.Integration.currentDoc) {
-			Zotero.Utilities.Internal.activate();
-			if(Zotero.Integration.currentWindow && !Zotero.Integration.currentWindow.closed) {
-				Zotero.Integration.currentWindow.focus();
-			}
+		let shouldAbort = await this.shouldAbortCommand();
+		if (shouldAbort) {
 			Zotero.debug("Integration: Request already in progress; not executing "+agent+" "+command);
 			return;
 		}
+		let deferred = Zotero.Promise.defer();
+		Zotero.Integration.currentCommandPromise = deferred.promise;
 		Zotero.Integration.currentDoc = true;
 
 		var startTime = (new Date()).getTime();
@@ -342,7 +342,39 @@ Zotero.Integration = new function() {
 			}
 			
 			Zotero.Integration.currentDoc = Zotero.Integration.currentWindow = false;
+			deferred.resolve();
 		}
+	};
+
+	/**
+	 * @returns {Promise<boolean>} Whether the new integration command should be aborted or continue
+	 */
+	this.shouldAbortCommand = async function () {
+		const ps = Services.prompt;
+		if (!Zotero.Integration.currentDoc) return false;
+		
+		if (Zotero.Integration.currentWindow) {
+			if (!Zotero.Integration.currentWindow.isPristine) {
+				Zotero.Utilities.Internal.activate();
+				Zotero.Integration.currentWindow.focus();
+				// Prompt user that changes will be lost in the existing dialog
+				let result = ps.confirm(null, Zotero.getString('integration.error.title'),
+					Zotero.getString(`integration-warning-${Zotero.Integration.currentWindowType}-changes-will-be-lost`));
+				if (result === false) {
+					return true;
+				}
+			}
+			Zotero.Integration.currentWindow.cancel();
+			await Zotero.Integration.currentCommandPromise;
+		}
+		else {
+			// Prompt the user that an integration command is already running
+			let ps = Services.prompt;
+			ps.alert(null, Zotero.getString('general.warning'),
+				Zotero.getString('integration-warning-command-is-running'));
+			return true;
+		}
+		return false;
 	};
 	
 	this._handleCommandError = async function (document, session, e) {
@@ -429,7 +461,7 @@ Zotero.Integration = new function() {
 	 * @param {String} [io] Data to pass to the window
 	 * @return {Promise} Promise resolved when the window is closed
 	 */
-	this.displayDialog = async function displayDialog(url, options, io) {
+	this.displayDialog = async function displayDialog(url, options, io, windowType) {
 		Zotero.debug(`Integration: Displaying dialog ${url}`);
 		// On macOS (and potentially in the future with Word JS)
 		// we can only run request sequentially (native async field fetching was dropped
@@ -442,6 +474,7 @@ Zotero.Integration = new function() {
 		// we should not delay the dialog display
 		let cleanupPromise = Zotero.Integration.currentDoc.cleanup();
 		await Zotero.Integration.currentSession?.progressBar.hide(true);
+		Zotero.Integration.currentWindowType = windowType;
 		
 		var allOptions = 'chrome,centerscreen';
 		// without this, Firefox gets raised with our windows under Compiz
@@ -1500,15 +1533,15 @@ Zotero.Integration.Session.prototype.cite = async function (field, addNote=false
 		? 'popup' : 'alwaysRaised')+',resizable=false';
 	if (addNote) {
 		Zotero.Integration.displayDialog('chrome://zotero/content/integration/insertNoteDialog.xhtml',
-			mode, io);
+			mode, io, "citation");
 	}
 	else if (Zotero.Prefs.get("integration.useClassicAddCitationDialog")) {
 		Zotero.Integration.displayDialog('chrome://zotero/content/integration/addCitationDialog.xhtml',
-			'alwaysRaised,resizable', io);
+			'alwaysRaised,resizable', io, "citation");
 	}
 	else {
 		Zotero.Integration.displayDialog('chrome://zotero/content/integration/quickFormat.xhtml',
-			mode, io);
+			mode, io, "citation");
 	}
 
 	// -------------------
@@ -1702,6 +1735,14 @@ Zotero.Integration.CitationEditInterface.prototype = {
 	},
 	
 	/**
+	 * Cancel changes to the citation
+	 */
+	cancel: function () {
+		this.citation.citationItems = [];
+		return this.accept();
+	},
+	
+	/**
 	 * Get a list of items used in the current document
 	 * @return {Promise} A promise resolved by the items
 	 */
@@ -1892,7 +1933,7 @@ Zotero.Integration.Session.prototype.setDocPrefs = async function (showImportExp
 	
 	// Make sure styles are initialized for new docs
 	await Zotero.Styles.init();
-	await Zotero.Integration.displayDialog('chrome://zotero/content/integration/integrationDocPrefs.xhtml', '', io);
+	await Zotero.Integration.displayDialog('chrome://zotero/content/integration/integrationDocPrefs.xhtml', '', io, "documentPreferences");
 
 	if (io.exportDocument) {
 		return this.exportDocument();
@@ -2365,7 +2406,7 @@ Zotero.Integration.Session.prototype.promptForRetraction = function (citedItem, 
  */
 Zotero.Integration.Session.prototype.editBibliography = async function (bibliography) {
 	if (!Object.keys(this.citationsByIndex).length) {
-		throw new Error('Integration.Session.editBibliography: called without loaded citations');	
+		throw new Error('Integration.Session.editBibliography: called without loaded citations');
 	}
 	// Update citeproc with citations in the doc
 	await this._updateCitations();
@@ -2374,7 +2415,7 @@ Zotero.Integration.Session.prototype.editBibliography = async function (bibliogr
 	
 	var bibliographyEditor = new Zotero.Integration.BibliographyEditInterface(bibliography, this.citationsByItemID, this.style);
 	
-	await Zotero.Integration.displayDialog('chrome://zotero/content/integration/editBibliographyDialog.xhtml', 'resizable', bibliographyEditor);
+	await Zotero.Integration.displayDialog('chrome://zotero/content/integration/editBibliographyDialog.xhtml', 'resizable', bibliographyEditor, "bibliography");
 	if (bibliographyEditor.cancelled) throw new Zotero.Exception.UserCancelled("bibliography editing");
 	
 	this.bibliographyDataHasChanged = this.bibliographyHasChanged = true;

--- a/chrome/content/zotero/xpcom/server_integration.js
+++ b/chrome/content/zotero/xpcom/server_integration.js
@@ -32,12 +32,19 @@ Zotero.Server.Endpoints['/integration/macWordCommand'].prototype = {
 		// Some dark magic to fix incorrectly encoded unicode characters here
 		// from https://stackoverflow.com/questions/5396560/how-do-i-convert-special-utf-8-chars-to-their-iso-8859-1-equivalent-using-javasc
 		const document = decodeURIComponent(escape(data.searchParams.get('document')));
-		Zotero.Integration.execCommand(
-			data.searchParams.get('agent'),
-			data.searchParams.get('command'),
-			document,
-			data.searchParams.get('templateVersion')
-		);
+		
+		// Run this in the next event loop (making sure we first send the 200 response)
+		// otherwise if a blocking command (alert) runs in execCommand before an await call
+		// it makes the Word call to Zotero timeout and display an error
+		setTimeout(() => {
+			Zotero.Integration.execCommand(
+				data.searchParams.get('agent'),
+				data.searchParams.get('command'),
+				document,
+				data.searchParams.get('templateVersion')
+			);
+		});
+		
 		return 200;
 	},
 };

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -387,6 +387,12 @@ integration-prefs-exportDocument =
 
 integration-error-unable-to-find-winword = { -app-name } could not find a running Word instance.
 
+integration-warning-citation-changes-will-be-lost = You have made changes to a citation that will be lost if you continue. Do you want to discard your changes?
+integration-warning-bibliography-changes-will-be-lost = You have made changes to the bibliography that will be lost if you continue. Do you want to discard your changes?
+integration-warning-documentPreferences-changes-will-be-lost = You have made changes to the document preferences that will be lost if you continue. Do you want to discard your changes?
+
+integration-warning-command-is-running = A word processor integration command is already running.
+
 publications-intro-page = My Publications
 
 publications-intro = Items you add to My Publications will be shown on your profile page on zotero.org. If you choose to include attached files, they will be made publicly available under the license you specify. Only add work you yourself have created, and only include files if you have the rights to distribute them and wish to do so.

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -387,9 +387,10 @@ integration-prefs-exportDocument =
 
 integration-error-unable-to-find-winword = { -app-name } could not find a running Word instance.
 
-integration-warning-citation-changes-will-be-lost = You have made changes to a citation that will be lost if you continue. Do you want to discard your changes?
-integration-warning-bibliography-changes-will-be-lost = You have made changes to the bibliography that will be lost if you continue. Do you want to discard your changes?
-integration-warning-documentPreferences-changes-will-be-lost = You have made changes to the document preferences that will be lost if you continue. Do you want to discard your changes?
+integration-warning-citation-changes-will-be-lost = You have made changes to a citation that will be lost if you continue.
+integration-warning-bibliography-changes-will-be-lost = You have made changes to the bibliography that will be lost if you continue.
+integration-warning-documentPreferences-changes-will-be-lost = You have made changes to the document preferences that will be lost if you continue.
+integration-warning-discard-changes = Discard Changes
 
 integration-warning-command-is-running = A word processor integration command is already running.
 

--- a/test/tests/integrationTest.js
+++ b/test/tests/integrationTest.js
@@ -387,11 +387,11 @@ describe("Zotero.Integration", function () {
 		});
 		
 		displayDialogStub = sinon.stub(Zotero.Integration, 'displayDialog');
-		displayDialogStub.callsFake(async function(dialogName, prefs, io) {
+		displayDialogStub.callsFake(async function(dialogName, prefs, io, windowType) {
 			Zotero.debug(`Display dialog: ${dialogName}`, 2);
 			var ioResult = dialogResults[dialogName.substring(dialogName.lastIndexOf('/')+1, dialogName.length-6)];
 			if (typeof ioResult == 'function') {
-				await ioResult(dialogName, io);
+				await ioResult(dialogName, io, windowType);
 			} else {
 				Object.assign(io, ioResult);
 			}
@@ -515,6 +515,86 @@ describe("Zotero.Integration", function () {
 					styleInstallStub.restore();
 					styleGetStub.restore();	
 				});
+			});
+		});
+		
+		describe('#shouldAbortCommand', function () {
+			it('should return false if no command is running', async function () {
+				assert.isFalse(await Zotero.Integration.shouldAbortCommand());
+			});
+
+			it('should return false if an integration dialog is open but is pristine', async function () {
+				await insertMultipleCitations.call(this);
+				let docID = this.test.fullTitle();
+				let quickFormatOpenedDeferred = Zotero.Promise.defer();
+				let quickFormatCancelledDeferred = Zotero.Promise.defer();
+				dialogResults.quickFormat = async function(dialogName, io) {
+					Zotero.Integration.currentWindow = { isPristine: true, focus: () => 0, cancel: quickFormatCancelledDeferred.resolve };
+					quickFormatOpenedDeferred.resolve();
+					await quickFormatCancelledDeferred.promise;
+					io._acceptDeferred.resolve(() => {});
+					Zotero.Integration.currentWindow = null;
+				};
+				let firstCommandPromise = execCommand('addEditCitation', docID);
+				await quickFormatOpenedDeferred.promise;
+				assert.isFalse(await Zotero.Integration.shouldAbortCommand());
+				await quickFormatCancelledDeferred.promise;
+				await firstCommandPromise;
+			});
+			
+			it('should display an alert and return true if an integration command without a dialog is running', async function () {
+				let stub = sinon.stub();
+				let promptService = Services.prompt;
+				Services.prompt = { alert: stub };
+				try {
+					await insertMultipleCitations.call(this);
+					let docID = this.test.fullTitle();
+					let quickFormatOpenedDeferred = Zotero.Promise.defer();
+					let quickFormatDeferred = Zotero.Promise.defer();
+					dialogResults.quickFormat = async function (dialogName, io) {
+						quickFormatOpenedDeferred.resolve();
+						await quickFormatDeferred.promise;
+						io._acceptDeferred.resolve(() => {});
+					};
+					let firstCommandPromise = execCommand('addEditCitation', docID);
+					await quickFormatOpenedDeferred.promise;
+					assert.isTrue(await Zotero.Integration.shouldAbortCommand());
+					assert.isTrue(stub.called);
+					quickFormatDeferred.resolve({});
+					await firstCommandPromise;
+				}
+				finally {
+					Services.prompt = promptService;
+				}
+			});
+
+			it('should display a confirmation dialog if an integration dialog is open and not pristine', async function () {
+				let stub = sinon.stub().returns(true);
+				let promptService = Services.prompt;
+				Services.prompt = { confirm: stub };
+				try {
+					await insertMultipleCitations.call(this);
+					let docID = this.test.fullTitle();
+					let quickFormatOpenedDeferred = Zotero.Promise.defer();
+					let quickFormatCancelledDeferred = Zotero.Promise.defer();
+					dialogResults.quickFormat = async function(dialogName, io, windowType) {
+						Zotero.Integration.currentWindow = { isPristine: false, focus: () => 0, cancel: quickFormatCancelledDeferred.resolve };
+						Zotero.Integration.currentWindowType = windowType;
+						quickFormatOpenedDeferred.resolve();
+						await quickFormatCancelledDeferred.promise;
+						io._acceptDeferred.resolve(() => {});
+						Zotero.Integration.currentWindow = null;
+					};
+					let firstCommandPromise = execCommand('addEditCitation', docID);
+					await quickFormatOpenedDeferred.promise;
+					assert.isFalse(await Zotero.Integration.shouldAbortCommand());
+					assert.isTrue(stub.called);
+					await quickFormatCancelledDeferred.promise;
+					await firstCommandPromise;
+				}
+				finally {
+					Services.prompt = promptService;
+				}
 			});
 		});
 		

--- a/test/tests/integrationTest.js
+++ b/test/tests/integrationTest.js
@@ -569,9 +569,9 @@ describe("Zotero.Integration", function () {
 			});
 
 			it('should display a confirmation dialog if an integration dialog is open and not pristine', async function () {
-				let stub = sinon.stub().returns(true);
+				let stub = sinon.stub().returns(0);
 				let promptService = Services.prompt;
-				Services.prompt = { confirm: stub };
+				Services.prompt = { confirmEx: stub };
 				try {
 					await insertMultipleCitations.call(this);
 					let docID = this.test.fullTitle();


### PR DESCRIPTION
Asks the user if they want to discard the changes in their existing dialog if they have made changes.

If there is no citation dialog, but a command is running (like updating the document) an alert is displayed.

Closes #4855