### PR TITLE
Context notes pane focus fixes

### DIFF
--- a/chrome/content/zotero/elements/contextNotesList.js
+++ b/chrome/content/zotero/elements/contextNotesList.js
@@ -202,14 +202,16 @@
 		};
 
 		// ArrowUp/Down navigation between notes
-		// Tab from a note-row focuses sidenav, Shift-Tab from a note focuses the section header
+		// Tab from a note-row focuses sidenav, Shift-Tab from a note focuses the twisty of the section header
 		// Tab from twisty icon into the notes list will try to refocus the last focused note
 		_handleKeyDown = (event) => {
-			if (event.key == "Tab" && event.target.classList.contains("twisty")) {
+			if (event.key == "Tab" && !event.shiftKey && event.target.classList.contains("twisty")) {
 				let section = event.target.closest("collapsible-section");
 				if (this._lastFocusedNote && section.contains(this._lastFocusedNote)) {
-					this.refocusLastFocusedNote();
-					event.preventDefault();
+					let refocused = this.refocusLastFocusedNote();
+					if (refocused) {
+						event.preventDefault();
+					}
 				}
 			}
 			if (event.target.tagName !== "note-row" && !event.target.classList.contains("more")) return;
@@ -225,8 +227,7 @@
 				event.preventDefault();
 			}
 			else if (event.key == "Tab" && event.shiftKey) {
-				Services.focus.moveFocus(window, event.target.closest("collapsible-section"),
-					Services.focus.MOVEFOCUS_FORWARD, 0);
+				event.target.closest("collapsible-section").querySelector(".twisty").focus();
 				event.preventDefault();
 			}
 		};

--- a/chrome/content/zotero/elements/itemPaneSidenav.js
+++ b/chrome/content/zotero/elements/itemPaneSidenav.js
@@ -392,7 +392,7 @@
 			if (event.key == "Tab" && event.shiftKey) {
 				event.preventDefault();
 				if (this._contextNotesPaneVisible && this._contextNotesPane.selectedPanel.mode == "notesList") {
-					let focusHandled = this._contextNotesPane.selectedPanel.focus();
+					let focusHandled = this._contextNotesPane.selectedPanel.notesList.refocusLastFocusedNote();
 					if (focusHandled) return;
 				}
 				// Shift-Tab out of sidenav to itemPane

--- a/chrome/content/zotero/elements/notesContext.js
+++ b/chrome/content/zotero/elements/notesContext.js
@@ -152,10 +152,7 @@
 
 		focus() {
 			if (this.mode == "notesList") {
-				let refocused = this.notesList.refocusLastFocusedNote();
-				if (!refocused) {
-					this.input.focus();
-				}
+				this.input.focus();
 				return true;
 			}
 			else {


### PR DESCRIPTION
- shift-tab from a note row focuses section header's twisty
- tab from reader into context pane will focus the search field. Previously focused note row will be focused on tab from a section header's twisty
- fix focus not leaving context notes pane if all sections are collapsed
- shift-tab from sidenav will again just focus the last node in the contextPane, instead of search input. That is to have consistent tab order in each direction. Earlier, in https://github.com/zotero/zotero/pull/4837#issuecomment-2478121979, I had focus land on the search field, otherwise focus would land on the last note-row (or "X more" button), which felt off and it would take a while to tab through all the note rows. Now, though, focus lands on the previously focused note (if there is one), which makes more sense, and getting to the section header is just another Shift-tab.

Fixes: #4858


https://github.com/user-attachments/assets/a391c5a5-28b5-4938-a7a5-358857dcc289

