### PR TITLE
chore: correct the value of the `private` field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zotero",
-  "private": "private",
+  "private": true,
   "version": "7.0.0",
   "description": "Zotero",
   "main": "",


### PR DESCRIPTION
See the documentation of the `private` field: https://docs.npmjs.com/cli/v10/configuring-npm/package-json#private

> If you set `"private": true` in your package.json, then npm will refuse to publish it.

I think we can replace the string `"private"` to `true`, which is more consistent with NPM's documentation.

> Additional information
> In 2016, the field type specified in NPM's documentation is also Boolean, not string. See: https://web.archive.org/web/20160901200545/https://docs.npmjs.com/files/package.json
