### PR TITLE
fix advanced search anyField condition breakage

### DIFF
--- a/chrome/content/zotero/xpcom/data/search.js
+++ b/chrome/content/zotero/xpcom/data/search.js
@@ -971,6 +971,19 @@ Zotero.Search.prototype._buildQuery = Zotero.Promise.coroutine(function* () {
 	
 	let lastCondition;
 	let conditionsToProcess = Object.values(this._conditions);
+	
+	// If there is a "joinMode" condition, make sure it goes first, since subsequent
+	// conditions may rely on it.
+	// If there is no explicit "joinMode" condition, default to "ALL"
+	var joinMode;
+	let joinModeIndex = conditionsToProcess.findIndex(cond => cond.condition == "joinMode");
+	if (joinModeIndex > 0) {
+		let [joinModeCondition] = conditionsToProcess.splice(joinModeIndex, 1);
+		conditionsToProcess.unshift(joinModeCondition);
+	}
+	else {
+		joinMode = "ALL";
+	}
 	for (let condition of conditionsToProcess) {
 		let name = condition.condition;
 		let conditionData = Zotero.SearchConditions.get(name);
@@ -1059,7 +1072,7 @@ Zotero.Search.prototype._buildQuery = Zotero.Promise.coroutine(function* () {
 				
 				// Join mode ('any' or 'all')
 				case 'joinMode':
-					var joinMode = condition.operator.toUpperCase();
+					joinMode = condition.operator.toUpperCase();
 					continue;
 				
 				case 'fulltextContent':

--- a/test/tests/searchTest.js
+++ b/test/tests/searchTest.js
@@ -558,6 +558,28 @@ describe("Zotero.Search", function() {
 					var matches = await s.search();
 					assert.sameMembers(matches, [itemOne.id, itemTwo.id]);
 				});
+				it("should return matches for a single 'any field' condition", async function () {
+					var itemOne = await createDataObject('item', { title: "five" });
+					var itemTwo = await createDataObject('item');
+					
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('anyField', 'contains', itemOne.getDisplayTitle());
+					var matches = await s.search();
+					assert.sameMembers(matches, [itemOne.id]);
+				});
+				it("should return matches for two 'any field' condition with joinMode=all", async function () {
+					var itemOne = await createDataObject('item', { title: "six-seven" });
+					var itemTwo = await createDataObject('item', { title: "seven-six" });
+					
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('anyField', 'contains', "six");
+					s.addCondition('anyField', 'contains', "seven");
+					s.addCondition('joinMode', 'all');
+					var matches = await s.search();
+					assert.sameMembers(matches, [itemOne.id, itemTwo.id]);
+				});
 			});
 			
 			describe("savedSearch", function () {


### PR DESCRIPTION
- ensure that if the "joinMode" condition is present, it is processed first, since subsequent conditions may rely on it
- ensure that joinMode is initialized by default to "ALL", in case the condition is not explicitly
provided

Fixes: #4871