### PR TITLE
File renaming: Add pascal case. Fix unicode handling.

### DIFF
--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -2348,7 +2348,11 @@ Zotero.Attachments = new function () {
 					value = value.toLowerCase().replace(/\s+/g, '_');
 					break;
 				case 'camel':
-					value = value.toLowerCase().replace(/[^a-zA-Z0-9]+(.)/g, (m, chr) => chr.toUpperCase());
+					value = value.toLowerCase().replace(/[^\p{L}\d]+(.)/gu, (m, chr) => chr.toUpperCase());
+					break;
+				case 'pascal':
+					value = value.toLowerCase().replace(/[^\p{L}\d]+(.)/gu, (m, chr) => chr.toUpperCase());
+					value = value.slice(0, 1).toUpperCase() + value.slice(1);
 					break;
 			}
 			return value;

--- a/test/tests/attachmentsTest.js
+++ b/test/tests/attachmentsTest.js
@@ -1365,7 +1365,7 @@ describe("Zotero.Attachments", function() {
 	
 	describe("#getFileBaseNameFromItem()", function () {
 		var item, itemManyAuthors, itemPatent, itemIncomplete, itemBookSection, itemSpaces, itemSuffixes, itemKeepHyphens,
-			itemNoRepeatedHyphens, itemNoRepeatedUnderscores;
+			itemNoRepeatedHyphens, itemNoRepeatedUnderscores, itemLowerCase, itemMixedCase, itemUnicode;
 
 		before(() => {
 			item = createUnsavedDataObject('item', { title: 'Lorem Ipsum', itemType: 'journalArticle' });
@@ -1418,6 +1418,9 @@ describe("Zotero.Attachments", function() {
 			itemNoRepeatedHyphens.setField('publicationTitle', "no- repeated- hyphens");
 			itemNoRepeatedUnderscores = createUnsavedDataObject('item', { title: 'no _ repeated _ underscores', itemType: 'journalArticle' });
 			itemNoRepeatedUnderscores.setField('publicationTitle', "no_ repeated_ underscores");
+			itemLowerCase = createUnsavedDataObject('item', { title: 'lower case title', itemType: 'journalArticle' });
+			itemMixedCase = createUnsavedDataObject('item', { title: 'Old MacDonald Had a Farm', itemType: 'journalArticle' });
+			itemUnicode = createUnsavedDataObject('item', { title: '金毛猎犬 - Golden Retriever', itemType: 'journalArticle' });
 		});
 		
 		it('should strip HTML tags from title', function () {
@@ -1584,6 +1587,41 @@ describe("Zotero.Attachments", function() {
 			assert.equal(
 				Zotero.Attachments.getFileBaseNameFromItem(item, { formatString: '{{ publicationTitle case="snake" }}' }),
 				'best_publications_place'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, { formatString: '{{ publicationTitle case="pascal" }}' }),
+				'BestPublicationsPlace'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemLowerCase, { formatString: '{{ title case="pascal" }}' }),
+				'LowerCaseTitle'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemMixedCase, { formatString: '{{ title case="pascal" }}' }),
+				'OldMacdonaldHadAFarm'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemNoRepeatedHyphens, { formatString: '{{ title case="camel" }}' }),
+				'noRepeatedHyphens'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemNoRepeatedHyphens, { formatString: '{{ title case="pascal" }}' }),
+				'NoRepeatedHyphens'
+			);
+		});
+
+		it('should preserve unicode characters', async function () {
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemUnicode, { formatString: '{{ title case="camel" }}' }),
+				'金毛猎犬GoldenRetriever'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemUnicode, { formatString: '{{ title case="pascal" }}' }),
+				'金毛猎犬GoldenRetriever'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemUnicode, { formatString: '{{ title case="hyphen" }}' }),
+				'金毛猎犬-golden-retriever'
 			);
 		});
 


### PR DESCRIPTION
This PR adds support for the "pascal" text case option in the file renaming template. It's based on this request: https://forums.zotero.org/discussion/comment/480520.

I've also noticed that our "camel" case (and the new "pascal" case) does not preserve Unicode characters, so I've fixed that.