### PR TITLE
 fx128: Remove non-native text input styles

### DIFF
--- a/app/scripts/fetch_xulrunner
+++ b/app/scripts/fetch_xulrunner
@@ -389,6 +389,10 @@ function modify_omni {
          document.documentElement.appendChild(popupset);
        }
        popupset.appendChild(this._autoScrollPopup);' chrome/toolkit/content/global/elements/browser-custom-element.js
+    
+    # Remove non-native text input styles
+    remove_line 'html\|input\:where\([\s\S]+
+\}' chrome/toolkit/skin/classic/global/global-shared.css
 	
 	zip -qr9XD omni.ja *
 	mv omni.ja ..


### PR DESCRIPTION
Still not quite right:

![image](https://github.com/user-attachments/assets/c2f5d822-2208-44ea-ae04-4002b15c3837)

Missing border/weird margins inline inputs (days in that screenshot) and misaligned cursor on all inputs. But this is an improvement!

Addresses #4888