### PR TITLE
fx128: Add `remove_between`, fully fix input styles

### DIFF
--- a/app/scripts/fetch_xulrunner
+++ b/app/scripts/fetch_xulrunner
@@ -95,6 +95,22 @@ function remove_line {
 	fi
 }
 
+function remove_between {
+	start_pattern=$1
+	end_pattern=$2
+	file=$3
+	
+	if egrep -q "$start_pattern" "$file" && egrep -q "$end_pattern" "$file"; then
+		perl -ni -e '
+		if (/'"$start_pattern"'/) { $skip = 1; next; }
+		elsif ($skip && /'"$end_pattern"'/) { $skip = 0; next; }
+		print unless $skip;' "$file"
+	else
+		echo "$start_pattern" and "$end_pattern" not found in "$file" -- aborting 2>&1
+		exit 1
+	fi
+}
+
 function get_utf16_chars {
 	str=$(echo -n "$1" | xxd -p | fold -w 2 | sed -r 's/(.+)/\\\\x{\1}\\\\x{00}/')
 	# Add NUL padding
@@ -391,8 +407,7 @@ function modify_omni {
        popupset.appendChild(this._autoScrollPopup);' chrome/toolkit/content/global/elements/browser-custom-element.js
     
     # Remove non-native text input styles
-    remove_line 'html\|input\:where\([\s\S]+
-\}' chrome/toolkit/skin/classic/global/global-shared.css
+    remove_between 'html\|input\:where\(' '^}' chrome/toolkit/skin/classic/global/global-shared.css
 	
 	zip -qr9XD omni.ja *
 	mv omni.ja ..


### PR DESCRIPTION
`global-shared.css` ended up broken after #4890. Turns out multiline Perl regex substitutions do not work the way I thought they did! Every closing brace in the file was getting removed. That was why inputs still looked wrong. So I've added a new `remove_between` function that removes all lines between (and including) a start pattern and an end pattern, non-greedily, and used that to apply the intended fix.