### PR TITLE
fx128: `-moz-nativehyperlinktext` -> `LinkText`

### DIFF
--- a/app/assets/mac/chrome/skin/preferences/preferences.css
+++ b/app/assets/mac/chrome/skin/preferences/preferences.css
@@ -194,7 +194,7 @@ caption {
 
 /* styles for the link elements copied from .text-link in global.css */
 .inline-link {
-  color: -moz-nativehyperlinktext;
+  color: LinkText;
   text-decoration: underline;
 }
   

--- a/app/assets/unix/skin/preferences/preferences.css
+++ b/app/assets/unix/skin/preferences/preferences.css
@@ -92,7 +92,7 @@ radio[pane=paneSync] {
 
 /* styles for the link elements copied from .text-link in global.css */
 .inline-link {
-  color: -moz-nativehyperlinktext;
+  color: LinkText;
   text-decoration: underline;
 }
   

--- a/app/assets/win/skin/preferences/preferences.css
+++ b/app/assets/win/skin/preferences/preferences.css
@@ -91,7 +91,7 @@ radio[pane=paneSync] {
 
 /* styles for the link elements copied from .text-link in global.css */
 .inline-link {
-  color: -moz-nativehyperlinktext;
+  color: LinkText;
   text-decoration: underline;
 }
 

--- a/app/scripts/fetch_xulrunner
+++ b/app/scripts/fetch_xulrunner
@@ -310,7 +310,7 @@ function modify_omni {
 	# Hide "Debug Addons" and "Manage Extension Shortcuts"
 	echo 'panel-item[action="debug-addons"], panel-item[action="reset-update-states"] + hr, panel-item[action="manage-shortcuts"] { display: none }' >> $file
 	# Show cursor feedback on plugin homepage links
-	echo '.addon-detail-row-homepage .text-link { cursor: pointer; color: -moz-nativehyperlinktext; }' >> $file
+	echo '.addon-detail-row-homepage .text-link { cursor: pointer; color: LinkText; }' >> $file
 	echo '.addon-detail-row-homepage .text-link:hover { text-decoration: underline; }' >> $file
 	
 	file="chrome/toolkit/content/mozapps/extensions/aboutaddons.js"

--- a/chrome/skin/default/zotero/publicationsDialog.css
+++ b/chrome/skin/default/zotero/publicationsDialog.css
@@ -11,7 +11,7 @@ checkbox, description, groupbox > .groupbox-body, radio, div:not(.license-more-i
 }
 
 a {
-	color: -moz-nativehyperlinktext;
+	color: LinkText;
 	text-decoration: underline;
 }
 

--- a/chrome/skin/default/zotero/zotero.css
+++ b/chrome/skin/default/zotero/zotero.css
@@ -6,7 +6,7 @@ groupbox > label > h2, groupbox > * > label > h2 {
 
 label.zotero-text-link {
 	-moz-user-focus: normal;
-	color: -moz-nativehyperlinktext;
+	color: LinkText;
 	text-decoration: underline;
 	border: 1px solid transparent;
 	cursor: pointer;
@@ -14,7 +14,7 @@ label.zotero-text-link {
 
 .text-link {
 	-moz-user-focus: normal;
-	color: -moz-nativehyperlinktext;
+	color: LinkText;
 	text-decoration: underline;
 	border: 1px solid transparent;
 	cursor: pointer;

--- a/scss/about.scss
+++ b/scss/about.scss
@@ -64,7 +64,7 @@
 
 span.text-link {
 	cursor: pointer;
-	color: -moz-nativehyperlinktext;
+	color: LinkText;
 }
 
 span.text-link:hover {

--- a/scss/components/_import-wizard.scss
+++ b/scss/components/_import-wizard.scss
@@ -20,7 +20,7 @@
 
 	a {
 		display: inline;
-		color: -moz-nativehyperlinktext;
+		color: LinkText;
 		cursor: pointer;
 
 		&:hover, &:active, &:focus {

--- a/scss/components/_textLink.scss
+++ b/scss/components/_textLink.scss
@@ -1,6 +1,6 @@
 .zotero-text-link {
 	-moz-user-focus: normal;
-	color: -moz-nativehyperlinktext;
+	color: LinkText;
 	text-decoration: underline;
 	border: var(--material-border-transparent);
 	cursor: pointer;

--- a/scss/elements/_publicationsLicenseInfo.scss
+++ b/scss/elements/_publicationsLicenseInfo.scss
@@ -30,7 +30,7 @@ publications-license-info {
 
     a {
         display: inline;
-        color: var(--license-info-link-color, -moz-nativehyperlinktext);
+        color: var(--license-info-link-color, LinkText);
         text-decoration: var(--license-info-link-decoration, none);
 
         &:hover,


### PR DESCRIPTION
`-moz-nativehyperlinktext` ~~has been removed~~ [is theoretically still there](https://searchfox.org/mozilla-esr128/search?q=nativehyperlinktext&path=&case=false&regexp=false) but doesn't work anymore for some reason.

`-moz-hyperlinktext` still works, but `LinkText` does the same thing and [isn't proprietary](https://developer.mozilla.org/en-US/docs/Web/CSS/system-color#linktext), so I went with that.

Fixes #4889