### PR TITLE
Server: Expose actual bound port

### DIFF
--- a/chrome/content/zotero/preferences/preferences_advanced.js
+++ b/chrome/content/zotero/preferences/preferences_advanced.js
@@ -536,7 +536,7 @@ Zotero_Preferences.Advanced = {
 		serverDisabledSection.hidden = true;
 		
 		document.l10n.setArgs(availableMessage, {
-			url: `http://localhost:${Zotero.Prefs.get('httpServer.port')}/api/`
+			url: `http://localhost:${Zotero.Server.port}/api/`
 		});
 	},
 	

--- a/chrome/content/zotero/xpcom/localAPI/server_localAPI.js
+++ b/chrome/content/zotero/xpcom/localAPI/server_localAPI.js
@@ -808,7 +808,7 @@ async function toResponseJSON(dataObjectOrObjects, searchParams) {
 	let dataObject = dataObjectOrObjects;
 	let responseJSON = dataObject.toResponseJSONAsync
 		? await dataObject.toResponseJSONAsync({
-			apiURL: `http://localhost:${Zotero.Prefs.get('httpServer.port')}/api/`,
+			apiURL: `http://localhost:${Zotero.Server.port}/api/`,
 			includeGroupDetails: true
 		})
 		: dataObject;

--- a/chrome/content/zotero/xpcom/server.js
+++ b/chrome/content/zotero/xpcom/server.js
@@ -42,10 +42,19 @@ Zotero.Server = new function() {
 		504:"Gateway Timeout"
 	};
 	
+	Object.defineProperty(this, 'port', {
+		get() {
+			if (!serv) {
+				throw new Error('Server not initialized');
+			}
+			return serv.port;
+		}
+	});
+	
 	/**
 	 * initializes a very rudimentary web server
 	 */
-	this.init = function(port, bindAllAddr, maxConcurrentConnections) {
+	this.init = function(port, bindAllAddr) {
 		if (Zotero.HTTP.browserIsOffline()) {
 			Zotero.debug('Browser is offline -- not initializing HTTP server');
 			_registerOnlineObserver();

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -137,6 +137,7 @@ user_pref("extensions.zotero.firstRunGuidance", false);
 user_pref("extensions.zotero.firstRun2", false);
 user_pref("extensions.zotero.reportTranslationFailure", false);
 user_pref("extensions.zotero.httpServer.enabled", true);
+user_pref("extensions.zotero.httpServer.port", 23124);	// ascii "ZT"
 user_pref("extensions.zotero.httpServer.localAPI.enabled", true);
 user_pref("extensions.zotero.backup.numBackups", 0);
 user_pref("extensions.zotero.sync.autoSync", false);

--- a/test/tests/attachmentsTest.js
+++ b/test/tests/attachmentsTest.js
@@ -381,7 +381,6 @@ describe("Zotero.Attachments", function() {
 
 		before(async function () {
 			this.timeout(20000);
-			Zotero.Prefs.set("httpServer.enabled", true);
 		});
 
 		beforeEach(async function () {

--- a/test/tests/serverTest.js
+++ b/test/tests/serverTest.js
@@ -5,9 +5,7 @@ describe("Zotero.Server", function () {
 	var serverPath;
 	
 	before(function* () {
-		Zotero.Prefs.set("httpServer.enabled", true);
-		Zotero.Server.init();
-		serverPath = 'http://127.0.0.1:' + Zotero.Prefs.get('httpServer.port');
+		serverPath = 'http://127.0.0.1:' + Zotero.Server.port;
 	});
 	
 	describe('DataListener', function() {

--- a/test/tests/server_connectorIntegrationTest.js
+++ b/test/tests/server_connectorIntegrationTest.js
@@ -5,14 +5,12 @@ describe("Connector HTTP Integration Server", function () {
 	
 	before(function* () {
 		this.timeout(20000);
-		Zotero.Prefs.set("httpServer.enabled", true);
 		yield resetDB({
 			thisArg: this,
 			skipBundledFiles: true
 		});
 		
-		const serverPort = Zotero.Prefs.get('httpServer.port');
-		serverURL = `http://127.0.0.1:${serverPort}/connector/document`;
+		serverURL = `http://127.0.0.1:${Zotero.Server.port}/connector/document`;
 	});
 	
 	describe('/connector/document/execCommand', function () {

--- a/test/tests/server_connectorTest.js
+++ b/test/tests/server_connectorTest.js
@@ -8,7 +8,6 @@ describe("Connector Server", function () {
 	
 	before(function* () {
 		this.timeout(20000);
-		Zotero.Prefs.set("httpServer.enabled", true);
 		yield resetDB({
 			thisArg: this,
 			skipBundledFiles: true
@@ -16,7 +15,7 @@ describe("Connector Server", function () {
 		yield Zotero.Translators.init();
 		
 		win = yield loadZoteroPane();
-		connectorServerPath = 'http://127.0.0.1:' + Zotero.Prefs.get('httpServer.port');
+		connectorServerPath = 'http://127.0.0.1:' + Zotero.Server.port;
 	});
 	
 	beforeEach(function () {
@@ -2689,7 +2688,7 @@ describe("Connector Server", function () {
 					headers: { 'content-type': 'application/json' },
 					body: JSON.stringify({
 						method: 'GET',
-						url: `http://localhost:${Zotero.Prefs.get('httpServer.port')}/`
+						url: `http://localhost:${Zotero.Server.port}/`
 					}),
 					successCodes: false
 				}

--- a/test/tests/server_integrationTest.js
+++ b/test/tests/server_integrationTest.js
@@ -5,14 +5,12 @@ describe("MacOS Integration Server", function () {
 	
 	before(function* () {
 		this.timeout(20000);
-		Zotero.Prefs.set("httpServer.enabled", true);
 		yield resetDB({
 			thisArg: this,
 			skipBundledFiles: true
 		});
 		
-		const serverPort = Zotero.Prefs.get('httpServer.port');
-		serverURL = `http://127.0.0.1:${serverPort}/integration`;
+		serverURL = `http://127.0.0.1:${Zotero.Server.port}/integration`;
 	});
 	
 	describe('/integration/macWordCommand', function () {

--- a/test/tests/server_localAPITest.js
+++ b/test/tests/server_localAPITest.js
@@ -22,8 +22,7 @@ describe("Local API Server", function () {
 	}
 
 	before(async function () {
-		Zotero.Prefs.set('httpServer.enabled', true);
-		apiRoot = 'http://127.0.0.1:' + Zotero.Prefs.get('httpServer.port') + '/api';
+		apiRoot = 'http://127.0.0.1:' + Zotero.Server.port + '/api';
 
 		await resetDB({
 			thisArg: this


### PR DESCRIPTION
And:
- Use a different port for tests so server tests don't break when Zotero is already running
- Remove no-op `httpServer.enabled` pref updates in tests
   - It's already enabled, no test disables it, and any test that did would clean up after itself
   - Updating that pref has no effect without a separate call to `Zotero.Server.init()`
- Remove unused arg to `Zotero.Server.init()`

It's basically just annoying that server tests fail when I forget to close the client first, so this fixes that.