### PR TITLE
fx128: hide titlebars in dialogs on win and mac

### DIFF
--- a/chrome/content/zotero/integration/insertNoteDialog.xhtml
+++ b/chrome/content/zotero/integration/insertNoteDialog.xhtml
@@ -42,7 +42,7 @@
 	persist="screenX screenY"
 	onkeypress="Zotero_QuickFormat.onWindowKeyPress(event)"
 	onunload="Zotero_QuickFormat.onUnload()"
-	drawintitlebar-platforms="linux,win"
+	drawintitlebar-platforms="win,mac"
 	no-titlebar-icon="true">
 	
 	<script src="../include.js"/>

--- a/chrome/content/zotero/integration/progressBar.js
+++ b/chrome/content/zotero/integration/progressBar.js
@@ -23,6 +23,8 @@
     ***** END LICENSE BLOCK *****
 */
 
+Services.scriptloader.loadSubScript("chrome://zotero/content/titlebar.js", this);
+
 var Zotero_ProgressBar = new function () {
 	var initialized, io;
 	
@@ -39,13 +41,6 @@ var Zotero_ProgressBar = new function () {
 			
 			if (io.isNote) {
 				document.documentElement.classList.add('note-dialog');
-			}
-			
-			// Only hide chrome on Windows or Mac
-			if(Zotero.isMac) {
-				document.documentElement.setAttribute("drawintitlebar", true);
-			} else if(Zotero.isWin) {
-				document.documentElement.setAttribute("chromemargin", '0,0,15,0');
 			}
 		}
 	};

--- a/chrome/content/zotero/integration/quickFormat.js
+++ b/chrome/content/zotero/integration/quickFormat.js
@@ -23,7 +23,7 @@
     ***** END LICENSE BLOCK *****
 */
 Services.scriptloader.loadSubScript("chrome://zotero/content/customElements.js", this);
-
+Services.scriptloader.loadSubScript("chrome://zotero/content/titlebar.js", this);
 var Zotero_QuickFormat = new function () {
 	const pixelRe = /^([0-9]+)px$/
 	const specifiedLocatorRe = /^(?:,? *(p{1,2})(?:\. *| *)|:)([0-9\-–]+) *$/;
@@ -66,10 +66,6 @@ var Zotero_QuickFormat = new function () {
 				document.getElementById('classic-view').hidden = true;
 			}
 			
-			// Only hide chrome on Windows or Mac
-			if(Zotero.isMac) {
-				document.documentElement.setAttribute("drawintitlebar", true);
-			}
 			// Hide chrome on linux
 			if (Zotero.isLinux) {
 				document.documentElement.setAttribute("hidechrome", true);
@@ -1315,10 +1311,6 @@ var Zotero_QuickFormat = new function () {
 		// Need to wait a moment for the css change above to take effect (mainly for mac)
 		await Zotero.Promise.delay(5);
 		window.resizeTo(width, height);
-		if (Zotero.isMac && Zotero.platformMajorVersion >= 60) {
-			document.children[0].setAttribute('drawintitlebar', 'false');
-			document.children[0].setAttribute('drawintitlebar', 'true');
-		}
 		// Make sure the window's width cannot be changed by dragging the edge of the window
 		document.documentElement.style.maxHeight = height + "px";
 		document.documentElement.style.minHeight = height + "px";

--- a/chrome/content/zotero/integration/quickFormat.xhtml
+++ b/chrome/content/zotero/integration/quickFormat.xhtml
@@ -42,7 +42,7 @@
 	persist="screenX screenY"
 	onkeypress="Zotero_QuickFormat.onWindowKeyPress(event)"
 	onunload="Zotero_QuickFormat.onUnload()"
-	drawintitlebar-platforms="linux,win"
+	drawintitlebar-platforms="win,mac"
 	no-titlebar-icon="true"
 	style="width: 800px;">
 	<script src="../include.js"/>

--- a/chrome/content/zotero/selectItemsDialog.xhtml
+++ b/chrome/content/zotero/selectItemsDialog.xhtml
@@ -40,7 +40,7 @@
 	onunload="doUnload();"
 	persist="screenX screenY width height"
 	class="zotero-dialog"
-	drawintitlebar="true"
+	drawintitlebar-platforms="mac,win"
 >
 <dialog
 	id="select-items-dialog"
@@ -54,6 +54,8 @@
 	// Custom elements
 	Services.scriptloader.loadSubScript("chrome://zotero/content/customElements.js", this);
 	Services.scriptloader.loadSubScript("chrome://zotero/content/selectItemsDialog.js", this);
+
+	Services.scriptloader.loadSubScript("chrome://zotero/content/titlebar.js", this);
 </script>
 
 <linkset>


### PR DESCRIPTION
Use titlebar.js to hide titlebars in windows and mac in all relevant dialogs and windows.