### PR TITLE
share collection canDropCheck logic with Copy to/Move to context menus

### DIFF
--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -4065,20 +4065,14 @@ var ZoteroPane = new function()
 						event.stopPropagation();
 					}
 				},
-				
-				(target) => {
-					// can't move collection into itself, its parent or its children
-					return selected == target
-						|| selected.parentKey == target.key
-						|| selected.hasDescendent('collection', target.id);
-				}
+				target => !selected.canMoveToTarget(target)
 			);
 			popup.append(menuItem);
 		}
 	};
 
 
-	this.buildCopyCollectionMenu = function (event) {
+	this.buildCopyCollectionMenu = Zotero.Utilities.Internal.serial(async function (event) {
 		if (event.target !== event.currentTarget) return;
 		let popup = document.getElementById("zotero-copy-collection-popup");
 		popup.replaceChildren();
@@ -4087,33 +4081,6 @@ var ZoteroPane = new function()
 		// Fetch all libraries
 		let topLevelEntries = Zotero.Libraries.getAll().filter(lib => !(lib instanceof Zotero.Feed));
 
-		// Check which libraries have collections linked to the selected collection
-		// and disable their menuitems. Same logic as in CollectionTree.canDropCheckAsync.
-		let linkedCollectionsExist = {};
-		(async () => {
-			for (let library of topLevelEntries) {
-				if (library.libraryID == selected.libraryID) continue;
-				// Check which library has a collection linked to the selected collection
-				let linkedCollection = await selected.getLinkedCollection(library.libraryID, true);
-				linkedCollectionsExist[library.libraryID] = linkedCollection;
-				// Also check which library has collections linked to a subcollection of the selected collection
-				for (let descendent of selected.getDescendents(false, 'collection')) {
-					let subcollection = Zotero.Collections.get(descendent.id);
-					let linkedSubcollection = await subcollection.getLinkedCollection(library.libraryID, true);
-					if (linkedSubcollection) {
-						linkedCollectionsExist[library.libraryID] = linkedSubcollection;
-					}
-				}
-			}
-			// Libraries that have linked collections have their menus disabled
-			for (let libraryMenuItem of [...popup.childNodes]) {
-				let menuItemLibID = libraryMenuItem.getAttribute("value").substring(1);
-				if (linkedCollectionsExist[menuItemLibID]) {
-					libraryMenuItem.disabled = true;
-				}
-			}
-		})();
-		
 		// If there is only one library, display its collections as top-level menuitems
 		if (topLevelEntries.length == 1) {
 			// Manually add My Library menuitem at the top, so one can still copy into it
@@ -4147,16 +4114,22 @@ var ZoteroPane = new function()
 						event.stopPropagation();
 					}
 				},
-				
-				(target) => {
-					// can't copy collection into itself or into non-editable groups
-					return selected == target
-						|| (target instanceof Zotero.Group && !target.editable);
-				}
+				target => !selected.canMoveToTarget(target)
 			);
 			popup.append(menuItem);
 		}
-	};
+
+		// Disable libraries to which collection cannot be copied
+		if (topLevelEntries[0] instanceof Zotero.Library) {
+			for (let entry of topLevelEntries) {
+				let canCopy = await selected.canMoveToTargetAsync(entry);
+				if (!canCopy) {
+					let menuitem = popup.querySelector(`[value="L${entry.libraryID}"]`);
+					menuitem.disabled = true;
+				}
+			}
+		}
+	});
 
 	this.buildAddItemToCollectionMenu = function (event, items = this.getSelectedItems()) {
 		if (event.target !== event.currentTarget) return;

--- a/test/tests/zoteroPaneTest.js
+++ b/test/tests/zoteroPaneTest.js
@@ -1926,6 +1926,44 @@ describe("ZoteroPane", function() {
 			// Menu of the library with linked sub-collection should be disabled
 			assert.equal(groupMenu.disabled, true);
 		});
+		it("should allow copying between libraries if there is a linked collection but it is in trash", async function () {
+			let groupDestination = await createGroup();
+			let groupCollection = await createDataObject('collection', { libraryID: groupDestination.libraryID });
+
+			let collection = await createDataObject('collection');
+			let collectionChild = await createDataObject('collection', { parentID: collection.id });
+
+			await zp.collectionsView.selectByID("C" + collectionChild.id);
+
+			await zp.copyCollection(groupCollection);
+
+			await waitForNotifierEvent("add", "collection");
+
+			// Collection has been copies
+			let newCollection = zp.getSelectedCollection();
+			assert.equal(newCollection.libraryID, groupCollection.libraryID);
+			assert.equal(newCollection.name, collectionChild.name);
+
+			// Send new collection to trash
+			newCollection.deleted = true;
+			await newCollection.saveTx();
+
+			// Right click on the selected collection
+			await zp.collectionsView.selectByID("C" + collectionChild.id);
+			await zp.buildCopyCollectionMenu({});
+			await Zotero.Promise.delay();
+
+			let groupMenu = doc.querySelector(`#zotero-copy-collection-popup menu[value="L${groupDestination.libraryID}"]`);
+			// Menu of the library with linked collection should be enabled
+			assert.equal(groupMenu.disabled, false);
+
+			// Copy collection again
+			await zp.copyCollection(groupCollection);
+			await waitForNotifierEvent("add", "collection");
+			let anotherNewCollection = zp.getSelectedCollection();
+			// Newly created collection is in the group
+			assert.equal(anotherNewCollection.libraryID, groupCollection.libraryID);
+		});
 	});
 	describe("#moveCollection", function () {
 		it("should move collection into another collection of the same library", async function () {


### PR DESCRIPTION
- move collectionTree `canDropCheck` and `canDropCheckAsync` to` Zotero.Collection::canMoveToTarget` and `Zotero.Collection::canMoveToTargetAsync` per https://github.com/zotero/zotero/pull/4420#issuecomment-2406579899 That way, we share the logic to determine if collection row can be dropped onto another row, as well as to disable/enable context menus.
- allow to copy a collection to another library if there already is a linked collection but it is in trash. Fixes: #4862