### PR TITLE
Allow Zotero_Tabs.undoClose to reopen duplicate tabs

### DIFF
--- a/chrome/content/zotero/tabs.js
+++ b/chrome/content/zotero/tabs.js
@@ -399,7 +399,8 @@ var Zotero_Tabs = new function () {
 						null,
 						{
 							tabIndex: tab.index,
-							openInBackground: true
+							openInBackground: true,
+							allowDuplicate: true
 						}
 					));
 					if (tab.index > maxIndex) {


### PR DESCRIPTION
Fixes: #4919