### PR TITLE
Remove missing-component integration error.

### DIFF
--- a/chrome/content/zotero/xpcom/integration.js
+++ b/chrome/content/zotero/xpcom/integration.js
@@ -230,19 +230,12 @@ Zotero.Integration = new function() {
 		if (agent == 'http') {
 			return new Zotero.HTTPIntegrationClient.Application();
 		}
-		// Try to load the appropriate Zotero component; otherwise display an error
-		try {
-			// Replace MacWord2016 and MacWord16 with just MacWord.
-			agent = agent.startsWith('MacWord') ? 'MacWord' : agent;
-			var entryPoint = PLUGIN_PATHS[agent];
-			Zotero.debug("Integration: Instantiating "+agent+" plugin handler for command "+command+(docId ? " with doc "+docId : ""));
-			const { Application } = ChromeUtils.importESModule(entryPoint);
-			return new Application();
-		}
-		catch (e) {
-			throw new Zotero.Exception.Alert("integration.error.notInstalled",
-				[], "integration.error.title");
-		}
+		// Replace MacWord2016 and MacWord16 with just MacWord.
+		agent = agent.startsWith('MacWord') ? 'MacWord' : agent;
+		var entryPoint = PLUGIN_PATHS[agent];
+		Zotero.debug("Integration: Instantiating "+agent+" plugin handler for command "+command+(docId ? " with doc "+docId : ""));
+		const { Application } = ChromeUtils.importESModule(entryPoint);
+		return new Application();
 	};
 	
 	/**

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -916,7 +916,6 @@ integration.openInLibrary				= Open in %S
 integration.error.incompatibleVersion	= This version of the Zotero word processor plugin ($INTEGRATION_VERSION) is incompatible with the currently installed version of Zotero (%1$S). Please ensure you are using the latest versions of both components.
 integration.error.incompatibleVersion2  = Zotero %1$S requires %2$S %3$S or later. Please download the latest version of %2$S from zotero.org.
 integration.error.title					= Zotero Integration Error
-integration.error.notInstalled			= Zotero could not load the component necessary to communicate with your word processor. Go to Tools → Add-ons → Extensions in Zotero and make sure that the extension for your word processor is enabled.
 integration.error.generic				= Zotero experienced an error updating your document.
 integration.error.mustInsertCitation 	= You must insert a citation before performing this operation.
 integration.error.mustInsertBibliography = You must insert a bibliography before performing this operation.


### PR DESCRIPTION
This is no longer a thing since word plugins are not Zotero extensions. If that code throws - it's because we've done something wrong and it's a bug.

I removed the associated string, but I'm not sure if we can do that and things will propagate properly to Transifex.

Closes #4916.