### PR TITLE
fx128: cover transparent titlebar gap on linux

### DIFF
--- a/scss/linux/_titleBar.scss
+++ b/scss/linux/_titleBar.scss
@@ -14,6 +14,8 @@
 	-moz-box-pack: center;
 	pointer-events: none;
 	-moz-appearance: -moz-window-titlebar;
+	// fx128: cover transparent gap between titlebar and window body
+	margin-bottom: -1px;
 }
 
 #zotero-title-bar {


### PR DESCRIPTION
Fixes: #4922


Before (note you can see where darker VS code window ends in the gap):

![before](https://github.com/user-attachments/assets/af003b44-4cf4-4b12-a3d9-f49baa60c772)

After:
![after](https://github.com/user-attachments/assets/80d13168-3ef0-42e8-84a7-b6c023a993d6)
