### PR TITLE
fx128: tweak titlebar border color

### DIFF
--- a/scss/linux/_titleBar.scss
+++ b/scss/linux/_titleBar.scss
@@ -19,7 +19,7 @@
 }
 
 #zotero-title-bar {
-	border-top: 1px solid var(--toolbar-field-border-color);
+	border-top: 1px solid transparent;
 }
 
 #toolbar-menubar {


### PR DESCRIPTION
Followup to: #4924
Addresses: #4922

Pre-fx128, `--toolbar-field-border-color` was `ThreeDShadow`, while right now it is `--input-border-color`, which looks more prominent.

Setting border color explicitly to be `ThreeDShadow` now would make the border look a bit blurry. Transparent border looks closest to pre-fx128 look, in my opinion.


Pre-fx128:
![master](https://github.com/user-attachments/assets/69bee8e6-3ca2-4b32-b22c-867b29b712d4)

Now:
![fx128_transparent](https://github.com/user-attachments/assets/c3e6472f-e663-46ab-9e7c-dc145c65c4b5)

Alternatively, if we were to set color to be `ThreeDShadow` as before (and without the `margin-bottom` added earlier):
![fx128](https://github.com/user-attachments/assets/1de9f0c4-3cc0-49d1-aa84-17120a63a0e7)

I think `transparent` looks nicer than `ThreeDShadow` but correct me if just `ThreeDShadow` or some other color is better.