### PR TITLE
fx128: fix broken database backup

### DIFF
--- a/chrome/content/zotero/xpcom/db.js
+++ b/chrome/content/zotero/xpcom/db.js
@@ -1055,11 +1055,7 @@ Zotero.DBConnection.prototype.backupDatabase = async function (suffix, force) {
 			if (DB_LOCK_EXCLUSIVE) {
 				await this.queryAsync("PRAGMA main.locking_mode=NORMAL", false, { inBackup: true });
 			}
-			storageService.backupDatabaseFile(
-				Zotero.File.pathToFile(file),
-				PathUtils.filename(tmpFile),
-				Zotero.File.pathToFile(file).parent
-			);
+			await this._connection.backup(tmpFile);
 		}
 		catch (e) {
 			Zotero.logError(e);


### PR DESCRIPTION
Per https://bugzilla.mozilla.org/show_bug.cgi?id=1869060#c18, the backup utility was removed from the storage service and [exposed](https://searchfox.org/mozilla-esr128/source/toolkit/modules/Sqlite.sys.mjs#2024) directly on the connection itself in fx128.

Fixes: #4929