### PR TITLE
save tagsBox updates when an item is changed

### DIFF
--- a/chrome/content/zotero/elements/tagsBox.js
+++ b/chrome/content/zotero/elements/tagsBox.js
@@ -83,7 +83,7 @@
 				return;
 			}
 			// Blur events do not fire when item is changed by clicking on an itemTree row.
-			// Make sure any changes to the tags get saved before item is upadted.
+			// Make sure any changes to the tags get saved before item is updated.
 			this.blurOpenField();
 			this._item = val;
 		}

--- a/chrome/content/zotero/elements/tagsBox.js
+++ b/chrome/content/zotero/elements/tagsBox.js
@@ -82,6 +82,9 @@
 			if (this._item == val) {
 				return;
 			}
+			// Blur events do not fire when item is changed by clicking on an itemTree row.
+			// Make sure any changes to the tags get saved before item is upadted.
+			this.blurOpenField();
 			this._item = val;
 		}
 
@@ -132,7 +135,7 @@
 
 			this._tagColors = Zotero.Tags.getColors(this.item.libraryID);
 			
-			let focusedTag = this._id('rows').querySelector('editable-text:focus')?.value;
+			let focusedTag = this._id('rows').querySelector('editable-text:focus-within')?.value;
 
 			let tagRows = this._id('rows');
 			tagRows.replaceChildren();

--- a/test/tests/tagsboxTest.js
+++ b/test/tests/tagsboxTest.js
@@ -95,6 +95,31 @@ describe("Item Tags Box", function () {
 			// New empty tag should have focus
 			assert.exists(doc.activeElement.closest("[isNew]"));
 		});
+
+		it("should save tag edits when an item is changed", async function () {
+			let notSelectedItem = await createDataObject('item');
+			var tag = Zotero.Utilities.randomString();
+			var updatedTag = Zotero.Utilities.randomString();
+			
+			let selectedItem = await createDataObject('item', { tags: [{ tag }] });
+			var tagsbox = doc.querySelector('#zotero-editpane-tags');
+			var rows = tagsbox.querySelectorAll('.row editable-text');
+			assert.equal(rows.length, 1);
+			
+			// type something
+			var firstRow = rows[0];
+			firstRow.focus();
+			firstRow.ref.value = updatedTag;
+			firstRow.ref.dispatchEvent(new Event('input'));
+			
+			// change the item by clicking on another row in itemTree
+			let promise = waitForItemEvent('modify');
+			win.ZoteroPane.selectItem(notSelectedItem.id);
+			// selectedItem should be modified
+			await promise;
+			// make sure that the tag was actually updated
+			assert.equal(selectedItem.getTags()[0].tag, updatedTag);
+		});
 	});
 	
 	

--- a/test/tests/tagsboxTest.js
+++ b/test/tests/tagsboxTest.js
@@ -96,7 +96,7 @@ describe("Item Tags Box", function () {
 			assert.exists(doc.activeElement.closest("[isNew]"));
 		});
 
-		it("should save tag edits when an item is changed", async function () {
+		it("should save tag edits when another item is selected", async function () {
 			let notSelectedItem = await createDataObject('item');
 			var tag = Zotero.Utilities.randomString();
 			var updatedTag = Zotero.Utilities.randomString();


### PR DESCRIPTION
When `tagsBox` item is changed by clicking on an `itemTree` row, the `blur` even never fires on the currently focused tag. So whatever changes were made will be discarded. To avoid it, blur any opened tag rows (which triggers a `saveTx`) when an item is being set, same way it is [done in itemBox](https://github.com/zotero/zotero/blob/fa48e978c7001a3b3b487f738756600e312fe23d/chrome/content/zotero/elements/itemBox.js#L358).

Also, a small tweak to properly fetch the focused tag via `editable-text:focus-within` selector, since `editable-text:focus` should be always empty because the focus is on the `<input>` inside of editable-text.

Fixes: #4942