### PR TITLE
Ensure no child rows in regularOnly itemTree

### DIFF
--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -1640,6 +1640,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 		if (!this.isContainer(index)) {
 			return;
 		}
+		if (this.regularOnly) return;
 
 		this._lastToggleOpenStateIndex = index;
 


### PR DESCRIPTION
Needed to avoid glitches in citation explorer and citation dialog.

Fixes: #4941

Discussed in https://github.com/zotero/zotero/pull/3468#issuecomment-2551945060