### PR TITLE
Fix export error of item.tags being undefined

### DIFF
--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -929,11 +929,13 @@ Zotero.Utilities.Internal = {
 			}
 
 			// Tags
-			for (let i = 0; i < item.tags.length; i++) {
-				if (!item.tags[i].type) {
-					item.tags[i].type = 0;
+			if (item.tags) {
+				for (let i = 0; i < item.tags.length; i++) {
+					if (!item.tags[i].type) {
+						item.tags[i].type = 0;
+					}
+					// No translator ever used "primary", "fields", or "linkedItems" objects
 				}
-				// No translator ever used "primary", "fields", or "linkedItems" objects
 			}
 
 			// "related" was never used (array of itemIDs)


### PR DESCRIPTION
I encountered this error while exporting a collection in my library.

Item generated from embedded image attachment may not have attribute `tags`.