### PR TITLE
qf: allow default arrowUp handling on locator type dropdown

### DIFF
--- a/chrome/content/zotero/integration/quickFormat.js
+++ b/chrome/content/zotero/integration/quickFormat.js
@@ -2278,7 +2278,8 @@ var Zotero_QuickFormat = new function () {
 			}
 		}
 		// Arrow up closes the popup
-		if (event.key === "ArrowUp") {
+		// (except on locator type dropdown to allow for default handling)
+		if (event.key === "ArrowUp" && event.target.tagName !== "menulist") {
 			skipInputRefocus = true;
 			itemPopover.hidePopup();
 			return stopEvent();


### PR DESCRIPTION
Do not close details panel on arrowUp when locator type menulist is focused to allow for default handling (e.g. select the next/previous option on windows).

Fixes: #4953