### PR TITLE
remove wrong aria-autocomplete from search-textbox

### DIFF
--- a/app/scripts/fetch_xulrunner
+++ b/app/scripts/fetch_xulrunner
@@ -416,6 +416,9 @@ function modify_omni {
        }
        popupset.appendChild(this._autoScrollPopup);' chrome/toolkit/content/global/elements/browser-custom-element.js
     
+	# Remove aria-autocomplete unnecessarily added to search-textbox to not confuse screen readers
+    remove_line 'this.inputField.setAttribute\("aria-autocomplete' chrome/toolkit/content/global/elements/search-textbox.js
+
     # Remove non-native text input styles
     remove_between 'html\|input\:where\(' '^}' chrome/toolkit/skin/classic/global/global-shared.css
 	

--- a/app/scripts/fetch_xulrunner
+++ b/app/scripts/fetch_xulrunner
@@ -416,7 +416,7 @@ function modify_omni {
        }
        popupset.appendChild(this._autoScrollPopup);' chrome/toolkit/content/global/elements/browser-custom-element.js
     
-	# Remove aria-autocomplete unnecessarily added to search-textbox to not confuse screen readers
+    # Remove aria-autocomplete unnecessarily added to search-textbox to not confuse screen readers
     remove_line 'this.inputField.setAttribute\("aria-autocomplete' chrome/toolkit/content/global/elements/search-textbox.js
 
     # Remove non-native text input styles


### PR DESCRIPTION
[searchButton setter](https://searchfox.org/mozilla-esr128/source/toolkit/content/widgets/search-textbox.js#129) in `search-textbox` element adds `aria-autocomplete` to the `<input>`. It makes screen readers announce that there is an autocomplete popup and is misleading. This overrides the `searchButton` setter to remain unchanged but with the line where `aria-autocomplete` is set commented out.

Addresses: #4932

For comparison, this is the JAWS announcement before (note the incorrect "Has popup"):

https://github.com/user-attachments/assets/e1ebb692-be34-43ed-b036-297f3ec1d78b

This is the JAWS announcement after this change (note no "Has popup"):

https://github.com/user-attachments/assets/ec8d268c-d83b-4c2b-bfd6-592d62608a5a

