### PR TITLE
Use `uname -m` instead of `arch`

### DIFF
--- a/app/scripts/dir_build
+++ b/app/scripts/dir_build
@@ -56,7 +56,7 @@ if [[ -z $PLATFORM ]]; then
 		PLATFORM="l"
 		
 		# If platform not given explicitly, skip 32-bit build if 64-bit system
-		if [ "$(arch)" = "x86_64" ]; then
+		if [ "$(uname -m)" = "x86_64" ]; then
 			export SKIP_32=1
 		fi
 	elif [ "`uname -o 2> /dev/null`" = "Cygwin" ]; then


### PR DESCRIPTION
`uname` is used in the script elsewhere already and `arch` does not seem to be available everywhere.

In the future, it might be better to have more fine grain control on what to build but for now this should work.
