### PR TITLE
A more generic way to specify the archs to build

### DIFF
--- a/app/build.sh
+++ b/app/build.sh
@@ -922,13 +922,11 @@ fi
 # Linux
 if [ $BUILD_LINUX == 1 ]; then
 	# Skip 32-bit build in tests
-	if [[ "${ZOTERO_TEST:-}" = "1" ]] || [[ "${SKIP_32:-}" = "1" ]]; then
-		archs="x86_64"
-	else
-		archs="i686 x86_64"
+	if [[ "${ZOTERO_TEST:-}" = "1" ]]; then
+		ARCHS="x86_64"
 	fi
 	
-	for arch in $archs; do
+	for arch in ${ARCHS:-i686 x86_64}; do
 		runtime_path="${LINUX_RUNTIME_PATH_PREFIX}${arch}"
 		
 		# Set up directory

--- a/app/scripts/dir_build
+++ b/app/scripts/dir_build
@@ -11,6 +11,8 @@ function usage {
 Usage: $0 -p platforms
 Options
  -p PLATFORMS        Platforms to build (m=Mac, w=Windows, l=Linux)
+ -a ARCHS            Archs to build (win32 win-x64 win-arm64 i686 x86_64)
+                     Multiple archs can be specified as a space separated string.
  -t                  add devtools
  -q                  quick build (skip compression and other optional steps for faster restarts during development)
 DONE
@@ -19,8 +21,9 @@ DONE
 
 DEVTOOLS=0
 PLATFORM=""
+ARCHS=""
 quick_build=0
-while getopts "tp:q" opt; do
+while getopts "tp:qa:" opt; do
 	case $opt in
 		t)
 			DEVTOOLS=1
@@ -39,6 +42,9 @@ while getopts "tp:q" opt; do
 				esac
 			done
 			;;
+		a)
+			ARCHS=${OPTARG}
+			;;
 		q)
 			quick_build=1
 			;;
@@ -55,14 +61,16 @@ if [[ -z $PLATFORM ]]; then
 	elif [ "`uname`" = "Linux" ]; then
 		PLATFORM="l"
 		
-		# If platform not given explicitly, skip 32-bit build if 64-bit system
+		# If platform not given explicitly, skip 32-bit build if 64-bit system by default
 		if [ "$(uname -m)" = "x86_64" ]; then
-			export SKIP_32=1
+			ARCHS=${ARCHS:-x86_64}
 		fi
 	elif [ "`uname -o 2> /dev/null`" = "Cygwin" ]; then
 		PLATFORM="w"
 	fi
 fi
+
+export ARCHS
 
 CHANNEL="source"
 

--- a/app/scripts/fetch_xulrunner
+++ b/app/scripts/fetch_xulrunner
@@ -548,7 +548,7 @@ if [ $BUILD_WIN == 1 ]; then
 	GECKO_VERSION="$GECKO_VERSION_WIN"
 	DOWNLOAD_URL="https://ftp.mozilla.org/pub/firefox/releases/$GECKO_VERSION"
 	
-	for arch in win32 win-x64 win-arm64; do
+	for arch in ${ARCHS:-win32 win-x64 win-arm64}; do
 		xdir=firefox-$arch
 		
 		rm -rf $xdir
@@ -624,12 +624,10 @@ if [ $BUILD_LINUX == 1 ]; then
 
 
 	# Include 32-bit build if not in CI
-	if [[ "${CI:-}" = "1" ]] || [[ "${SKIP_32:-}" = "1" ]]; then
-		arches="x86_64"
-	else
-		arches="i686 x86_64"
+	if [[ "${CI:-}" = "1" ]]; then
+		ARCHS="x86_64"
 	fi
-	for arch in $arches; do
+	for arch in ${ARCHS:-i686 x86_64}; do
 		xdir="firefox-$arch"
 		rm -rf $xdir
 		


### PR DESCRIPTION
This is a follow up on https://github.com/zotero/zotero/pull/4982 since I realized that improving this also makes it way easier for me to build for aarch64 with very minimum patch. (I simply need to provide a firefox tarball at the right cache path).

I think I'm keeping the behavior as closed to the previous one as possible unless something outside the repo was directly setting `SKIP_32`. The arch is passed down via an environment variable to follow the previous approach but could be changed to an argument if really necessary...

Note that due to how the build script works, at least one linux, x86_64 has to be specified at all time. I could try to hard code that logic into fetch_xulrunner.

And I've only tested linux build. I don't have the setup to test windows/mac build at the moment.

