### PR TITLE
Fix attachments box race condition

### DIFF
--- a/chrome/content/zotero/elements/attachmentBox.js
+++ b/chrome/content/zotero/elements/attachmentBox.js
@@ -322,7 +322,6 @@
 
 		async asyncRender() {
 			if (!this.item) return;
-			if (this._asyncRendering) return;
 			if (!this._section.open) return;
 			if (this._isAlreadyRendered("async")) {
 				if (this._previewDiscarded) {


### PR DESCRIPTION
fix: #4611
Since the attachment preview already has a task queue,
don't skip render calls when rendering