### PR TITLE
Optimize context menus with collection popups

### DIFF
--- a/chrome/content/zotero/xpcom/data/collection.js
+++ b/chrome/content/zotero/xpcom/data/collection.js
@@ -490,7 +490,7 @@ Zotero.Collection.prototype.hasItem = function (item) {
 
 
 Zotero.Collection.prototype.hasDescendent = function (type, id) {
-	var descendents = this.getDescendents();
+	var descendents = this.getDescendents(false, type);
 	for (var i=0, len=descendents.length; i<len; i++) {
 		if (descendents[i].type == type && descendents[i].id == id) {
 			return true;

--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -1715,7 +1715,7 @@ Zotero.Utilities.Internal = {
             return longest;
         }, null);
 		// The images are removed from all menuitems but the first few
-		let menuItemsWithHiddenIcon = menuItemsWithIcons.slice(75);
+		let menuItemsWithHiddenIcon = menuItemsWithIcons.slice(100);
 		for (let node of menuItemsWithHiddenIcon) {
 			// Do not hide the image of the longest row so the menu has the right width from the start
 			if (node == longestNode) continue;

--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -1700,7 +1700,7 @@ Zotero.Utilities.Internal = {
 	 * Then, run a job through requestIdleCallback to make icons visible on remaining menuitems whenever the browser is free.
 	 * @param {Node<menupopup>} popup containing menuitems with icons
 	 */
-	showIconsDynamically(popup) {
+	showMenuIconsOnIdle(popup) {
 		// Here, the images are removed from all menuitems but the first 30
 		let menuItemsWithHiddenIcon = [...popup.childNodes].filter(n => n.getAttribute("image")).slice(30);
 		for (let node of menuItemsWithHiddenIcon) {

--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -1713,14 +1713,14 @@ Zotero.Utilities.Internal = {
 		let currentIndex = 0;
 		function showNextBatchOfIcons(deadline) {
 			while (deadline.timeRemaining() > 0 && currentIndex < menuItemsWithHiddenIcon.length) {
-			  let menuitem = menuItemsWithHiddenIcon[currentIndex++];
-			  menuitem.setAttribute("image", menuitem.getAttribute("hidden-image"));
-			  menuitem.removeAttribute("hidden-image");
+				let menuitem = menuItemsWithHiddenIcon[currentIndex++];
+				menuitem.setAttribute("image", menuitem.getAttribute("hidden-image"));
+				menuitem.removeAttribute("hidden-image");
 			}
 			if (currentIndex < menuItemsWithHiddenIcon.length) {
-			  requestIdleCallback(showNextBatchOfIcons);
+				requestIdleCallback(showNextBatchOfIcons);
 			}
-		  }
+		}
 		
 		requestIdleCallback(showNextBatchOfIcons);
 	},

--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -1701,7 +1701,7 @@ Zotero.Utilities.Internal = {
 	 * @param {Node<menupopup>} popup containing menuitems with icons
 	 */
 	showIconsDynamically(popup) {
-		// Here, the images are removed from all menuitems but the first 30 
+		// Here, the images are removed from all menuitems but the first 30
 		let menuItemsWithHiddenIcon = [...popup.childNodes].filter(n => n.getAttribute("image")).slice(30);
 		for (let node of menuItemsWithHiddenIcon) {
 			node.setAttribute("hidden-image", node.getAttribute("image"));

--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -1695,10 +1695,12 @@ Zotero.Utilities.Internal = {
 	},
 
 	/**
-	 * Adding many top level menuitems specifically with icons freezes UI on macOS.
-	 * To fix it, hide the icons from all menuitems except for the first few and insert them into the DOM.
-	 * Then, run a job through requestIdleCallback to make icons visible on remaining menuitems whenever the browser is free.
-	 * @param {Node<menupopup>} popup containing menuitems with icons
+	 * Adding many top-level menuitems with icons freezes the UI on macOS. To fix it, hide the icons
+	 * from all menuitems except for the first few and insert them into the DOM. Then, run a job
+	 * through requestIdleCallback to make icons visible on remaining menuitems whenever the browser
+	 * is free.
+	 *
+	 * @param {Node<menupopup>} popup
 	 */
 	showMenuIconsOnIdle(popup) {
 		// Here, the images are removed from all menuitems but the first 30

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -4075,10 +4075,10 @@ var ZoteroPane = new function()
 						|| childIDs.has(target.id);
 				}
 			);
-			if (Zotero.isMac) {
-				Zotero.Utilities.Internal.showMenuIconsOnIdle(popup);
-			}
 			popup.append(menuItem);
+		}
+		if (Zotero.isMac) {
+			Zotero.Utilities.Internal.showMenuIconsOnIdle(popup);
 		}
 	};
 
@@ -4172,9 +4172,13 @@ var ZoteroPane = new function()
 
 		items = Zotero.Items.keepTopLevel(items);
 		
-		let newCollectionMenuitem = document.createXULElement('menuitem');
-		document.l10n.setAttributes(newCollectionMenuitem, 'menu-new-collection');
-		newCollectionMenuitem.addEventListener('command', () => this.addItemsToCollection(items, null, true));
+		let newCollectionMenuitem = popup.querySelector(`[data-l10n-id="menu-new-collection"]`);
+		// Do not recreate new collections menu on subsequent calls 
+		if (!newCollectionMenuitem) {
+			newCollectionMenuitem = document.createXULElement('menuitem');
+			document.l10n.setAttributes(newCollectionMenuitem, 'menu-new-collection');
+			newCollectionMenuitem.addEventListener('command', () => this.addItemsToCollection(items, null, true));
+		}
 		let separator = document.createXULElement('menuseparator');
 		popup.replaceChildren(newCollectionMenuitem, separator);
 		

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -4172,12 +4172,14 @@ var ZoteroPane = new function()
 
 		items = Zotero.Items.keepTopLevel(items);
 		
-		let newCollectionMenuitem = popup.querySelector(`[data-l10n-id="menu-new-collection"]`);
-		// Do not recreate new collections menu on subsequent calls 
-		if (!newCollectionMenuitem) {
-			newCollectionMenuitem = document.createXULElement('menuitem');
-			document.l10n.setAttributes(newCollectionMenuitem, 'menu-new-collection');
-			newCollectionMenuitem.addEventListener('command', () => this.addItemsToCollection(items, null, true));
+		let existingNewCollectionMenuItem = popup.querySelector(`[data-l10n-id="menu-new-collection"]`);
+		let newCollectionMenuitem = document.createXULElement('menuitem');
+		document.l10n.setAttributes(newCollectionMenuitem, 'menu-new-collection');
+		newCollectionMenuitem.addEventListener('command', () => this.addItemsToCollection(items, null, true));
+		// If the "New Collection..." menuitem already exists, copy over its label so it
+		// appears immediately and not after the icons are rendered
+		if (existingNewCollectionMenuItem) {
+			newCollectionMenuitem.label = existingNewCollectionMenuItem.label;
 		}
 		let separator = document.createXULElement('menuseparator');
 		popup.replaceChildren(newCollectionMenuitem, separator);

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -4054,6 +4054,8 @@ var ZoteroPane = new function()
 		
 		// Build menus for each top-level collection of this library
 		let collections = Zotero.Collections.getByLibrary(this.getSelectedLibraryID());
+		let children = selected.getDescendents(true, "collection");
+		let childIDs = new Set(children.map(col => col.id));
 		for (let col of collections) {
 			let menuItem = Zotero.Utilities.Internal.createMenuForTarget(
 				col,
@@ -4070,9 +4072,12 @@ var ZoteroPane = new function()
 					// can't move collection into itself, its parent or its children
 					return selected == target
 						|| selected.parentKey == target.key
-						|| selected.hasDescendent('collection', target.id);
+						|| childIDs.has(target.id);
 				}
 			);
+			if (Zotero.isMac) {
+				Zotero.Utilities.Internal.showIconsDynamically(popup);
+			}
 			popup.append(menuItem);
 		}
 	};
@@ -4156,6 +4161,9 @@ var ZoteroPane = new function()
 			);
 			popup.append(menuItem);
 		}
+		if (Zotero.isMac) {
+			Zotero.Utilities.Internal.showIconsDynamically(popup);
+		}
 	};
 
 	this.buildAddItemToCollectionMenu = function (event, items = this.getSelectedItems()) {
@@ -4179,7 +4187,7 @@ var ZoteroPane = new function()
 		if (items.some(item => item.libraryID !== libraryID)) {
 			throw new Error('All items must be the same library');
 		}
-		
+
 		let collections = Zotero.Collections.getByLibrary(libraryID);
 		for (let col of collections) {
 			let menuItem = Zotero.Utilities.Internal.createMenuForTarget(
@@ -4197,6 +4205,9 @@ var ZoteroPane = new function()
 			popup.append(menuItem);
 		}
 
+		if (Zotero.isMac) {
+			Zotero.Utilities.Internal.showIconsDynamically(popup);
+		}
 		separator.hidden = !collections.length;
 	};
 

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -4187,7 +4187,7 @@ var ZoteroPane = new function()
 		if (items.some(item => item.libraryID !== libraryID)) {
 			throw new Error('All items must be the same library');
 		}
-
+		
 		let collections = Zotero.Collections.getByLibrary(libraryID);
 		for (let col of collections) {
 			let menuItem = Zotero.Utilities.Internal.createMenuForTarget(

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -4076,7 +4076,7 @@ var ZoteroPane = new function()
 				}
 			);
 			if (Zotero.isMac) {
-				Zotero.Utilities.Internal.showIconsDynamically(popup);
+				Zotero.Utilities.Internal.showMenuIconsOnIdle(popup);
 			}
 			popup.append(menuItem);
 		}
@@ -4162,7 +4162,7 @@ var ZoteroPane = new function()
 			popup.append(menuItem);
 		}
 		if (Zotero.isMac) {
-			Zotero.Utilities.Internal.showIconsDynamically(popup);
+			Zotero.Utilities.Internal.showMenuIconsOnIdle(popup);
 		}
 	};
 
@@ -4206,7 +4206,7 @@ var ZoteroPane = new function()
 		}
 
 		if (Zotero.isMac) {
-			Zotero.Utilities.Internal.showIconsDynamically(popup);
+			Zotero.Utilities.Internal.showMenuIconsOnIdle(popup);
 		}
 		separator.hidden = !collections.length;
 	};

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -4054,7 +4054,7 @@ var ZoteroPane = new function()
 		
 		// Build menus for each top-level collection of this library
 		let collections = Zotero.Collections.getByLibrary(this.getSelectedLibraryID());
-		let children = selected.getDescendents(true, "collection");
+		let children = selected.getDescendents(false, "collection");
 		let childIDs = new Set(children.map(col => col.id));
 		for (let col of collections) {
 			let menuItem = Zotero.Utilities.Internal.createMenuForTarget(


### PR DESCRIPTION
- more efficiently check if a collection can be moved to another collection without calling `getDescendents` for every single candidate
- when fetching descendents of a collection, only fetch those of the relevant type
- It turns out that adding many top-level menuitems with icons into a menupopup takes a while to process and may freeze the UI on macOS. This issue only emerges when icons are present. To avoid it, the icons are hidden for all but the first few menuitems and then are dynamically added when the browser is idle after the popup appears.

Fixes: #4963

For comparison, this is with 2000 top level collections. The icons may take a while to display but at least the UI is not frozen for multiple seconds. Alternatively, we can consider not showing the icon on macOS for these context menus? Or Refactor them to only show the first few collections and hide the rest under "Show more..." submenu?

Before:

https://github.com/user-attachments/assets/65300282-e85e-4ba1-970a-ea5e840d20a3


After:


https://github.com/user-attachments/assets/1e5c64ff-027a-40a5-a04b-e1c1d0c77120

