### PR TITLE
Local API: Fix 500 error when attachment has unparseable path

### DIFF
--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -5652,12 +5652,13 @@ Zotero.Item.prototype.toResponseJSONAsync = async function (options = {}) {
 				return (await IOUtils.stat(path)).size;
 			}
 			catch (e) {
-				if (e.name != 'NotFoundError') {
+				if (e.name != 'NotFoundError'
+						&& !(e.name == 'OperationError' && e.message.includes('NS_ERROR_FILE_UNRECOGNIZED_PATH'))) {
 					throw e;
 				}
 			}
 		}
-		return undefined
+		return undefined;
 	}
 	
 	let json = this.toResponseJSON(options);

--- a/test/tests/itemTest.js
+++ b/test/tests/itemTest.js
@@ -3147,4 +3147,17 @@ describe("Zotero.Item", function () {
 			}
 		});
 	});
+
+	describe("#toResponseJSONAsync()", function () {
+		it("should not throw when attachment path is invalid", async function () {
+			let item = await createDataObject('item');
+			let attachment = new Zotero.Item('attachment');
+			attachment.parentItemID = item.id;
+			attachment.attachmentLinkMode = Zotero.Attachments.LINK_MODE_LINKED_FILE;
+			attachment.attachmentPath = '\\Invalid//Path/:C:/Users/Bad/\\Documents\\./paper.pdf';
+			await attachment.saveTx();
+
+			assert.isUndefined((await item.toResponseJSONAsync()).links.attachment.attachmentSize);
+		});
+	});
 });


### PR DESCRIPTION
Fixes #5007