### PR TITLE
Negative selection for tags in tag selector

### DIFF
--- a/chrome/content/zotero/components/tagSelector.jsx
+++ b/chrome/content/zotero/components/tagSelector.jsx
@@ -49,6 +49,7 @@ class TagSelector extends React.PureComponent {
 					fontSize={this.props.fontSize}
 					lineHeight={this.props.lineHeight}
 					uiDensity={this.props.uiDensity}
+					excludeTag={this.props.excludeTag}
 				/>
 				<div className="tag-selector-filter-pane">
 					<div className="tag-selector-filter-container">
@@ -90,6 +91,7 @@ TagSelector.propTypes = {
 	}),
 	onSelect: PropTypes.func,
 	onKeyDown: PropTypes.func,
+	excludeTag: PropTypes.func,
 	onTagContext: PropTypes.func,
 	loaded: PropTypes.bool,
 	width: PropTypes.number.isRequired,

--- a/chrome/content/zotero/components/tagSelector/tagSelectorList.jsx
+++ b/chrome/content/zotero/components/tagSelector/tagSelectorList.jsx
@@ -175,6 +175,9 @@ class TagList extends React.PureComponent {
 		if (tag.disabled) {
 			className += ' disabled';
 		}
+		if (tag.excluded) {
+			className += ' excluded';
+		}
 		if (Zotero.Utilities.Internal.containsEmoji(tag.name)) {
 			className += ' emoji';
 		}
@@ -199,6 +202,13 @@ class TagList extends React.PureComponent {
 		props.role = "checkbox";
 		props['aria-checked'] = tag.selected;
 		props['aria-disabled'] = tag.disabled;
+		// Add a note to excluded tags to differentiate them from just selected
+		if (tag.excluded) {
+			props['data-l10n-id'] = "tag-excluded";
+		}
+		else {
+			props['aria-description'] = '';
+		}
 		// Don't specify explicit width unless we're truncating, because for some reason the width
 		// from canvas can sometimes be slightly smaller than the actual width, resulting in an
 		// unnecessary ellipsis.
@@ -305,6 +315,11 @@ class TagList extends React.PureComponent {
 	};
 
 	async handleKeyDown(e) {
+		if (e.key == "Backspace") {
+			let tag = e.target.textContent;
+			this.props.excludeTag(tag);
+			return;
+		}
 		if (!["ArrowRight", "ArrowLeft"].includes(e.key)) return;
 		// If the windowing kicks in, the node of the initially-focused tag may not
 		// exist, so first we may need to scroll to it.
@@ -393,6 +408,7 @@ class TagList extends React.PureComponent {
 		onSelect: PropTypes.func,
 		onKeyDown: PropTypes.func,
 		onTagContext: PropTypes.func,
+		excludeTag: PropTypes.func,
 		loaded: PropTypes.bool,
 		width: PropTypes.number.isRequired,
 		height: PropTypes.number.isRequired,

--- a/chrome/content/zotero/containers/tagSelectorContainer.jsx
+++ b/chrome/content/zotero/containers/tagSelectorContainer.jsx
@@ -583,8 +583,12 @@ Zotero.TagSelector = class TagSelectorContainer extends React.PureComponent {
 			true
 		);
 		this.contextTag = tag;
-		// Disable "Exclude tag" for disabled tags
+		// Disable options for disabled tags, mark if the tag is included vs excluded
+		let tagSelected = this.selectedTags.get(this.contextTag.name);
 		tagContextMenu.querySelector("#tag-menu-exclude-tag").disabled = tag.disabled;
+		tagContextMenu.querySelector("#tag-menu-exclude-tag").setAttribute("checked", tagSelected?.excluded);
+		tagContextMenu.querySelector("#tag-menu-include-tag").disabled = tag.disabled;
+		tagContextMenu.querySelector("#tag-menu-include-tag").setAttribute("checked", tagSelected && !tagSelected.excluded);
 	}
 
 	handleSettings = (ev) => {
@@ -595,9 +599,17 @@ Zotero.TagSelector = class TagSelectorContainer extends React.PureComponent {
 
 	handleTagSelected = (tag) => {
 		let selectedTags = this.selectedTags;
-		if(selectedTags.has(tag)) {
+		let viaClick = true;
+		if (!tag) {
+			tag = this.contextTag.name;
+			viaClick = false;
+		}
+		// remove tag from selection on click or on context-menu selection if it is not excluded
+		if (selectedTags.has(tag) && (viaClick || !selectedTags.get(tag).excluded)) {
 			selectedTags.delete(tag);
-		} else {
+		}
+		// otherwise, select the tag
+		else {
 			selectedTags.set(tag, {});
 		}
 
@@ -809,8 +821,14 @@ Zotero.TagSelector = class TagSelectorContainer extends React.PureComponent {
 		if (!tag) {
 			tag = this.contextTag.name;
 		}
-		this.selectedTags.set(tag, { excluded: true })
-		if (typeof(this.props.onSelection) === 'function') {
+		// If the tag is already excluded - remove it from selection
+		if (this.selectedTags.get(tag)?.excluded) {
+			this.selectedTags.delete(tag);
+		}
+		else {
+			this.selectedTags.set(tag, { excluded: true });
+		}
+		if (typeof (this.props.onSelection) === 'function') {
 			this.props.onSelection(this.selectedTags);
 		}
 	}

--- a/chrome/content/zotero/xpcom/collectionTreeRow.js
+++ b/chrome/content/zotero/xpcom/collectionTreeRow.js
@@ -434,8 +434,15 @@ Zotero.CollectionTreeRow.prototype.getSearchObject = Zotero.Promise.coroutine(fu
 	}
 	
 	if (this.tags){
-		for (let tag of this.tags) {
-			s2.addCondition('tag', 'is', tag);
+		for (let [tagName, tagProps] of this.tags.entries()) {
+			if (tagProps.excluded) {
+				s2.addCondition('tag', 'isNot', tagName);
+				// When an item with a tag is excluded, have its children excluded as well
+				s2.addCondition('includeChildren', 'true');
+			}
+			else {
+				s2.addCondition('tag', 'is', tagName);
+			}
 		}
 	}
 	

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -1017,6 +1017,11 @@
 
 		<!-- Tag Selector -->
 		<menupopup id="tag-menu">
+			<menuitem id="tag-menu-include-tag" data-l10n-id="tagselector-include-tag"
+				oncommand="ZoteroPane.tagSelector.handleTagSelected(); event.stopPropagation();"/>
+			<menuitem id="tag-menu-exclude-tag" data-l10n-id="tagselector-exclude-tag"
+				oncommand="ZoteroPane.tagSelector.excludeTag(); event.stopPropagation();"/>
+			<menuseparator/>
 			<menuitem label="&zotero.tagSelector.assignColor;"
 				oncommand="ZoteroPane.tagSelector.openColorPickerWindow(); event.stopPropagation();"/>
 			<menuitem label="&zotero.tagSelector.renameTag;"
@@ -1026,8 +1031,6 @@
 			<menuitem label="&zotero.tagSelector.deleteTag;"
 				oncommand="ZoteroPane.tagSelector.openDeletePrompt(); event.stopPropagation();"/>
 			<menuseparator/>
-			<menuitem id="tag-menu-exclude-tag" data-l10n-id="tagselector-exclude-tag"
-				oncommand="ZoteroPane.tagSelector.excludeTag(); event.stopPropagation();"/>
 		</menupopup>
 		<menupopup id="tag-selector-view-settings-menu"
 			onpopupshowing="

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -1025,6 +1025,9 @@
 				oncommand="ZoteroPane.tagSelector.openTagSplitterWindow(event)"/>
 			<menuitem label="&zotero.tagSelector.deleteTag;"
 				oncommand="ZoteroPane.tagSelector.openDeletePrompt(); event.stopPropagation();"/>
+			<menuseparator/>
+			<menuitem id="tag-menu-exclude-tag" data-l10n-id="tagselector-exclude-tag"
+				oncommand="ZoteroPane.tagSelector.excludeTag(); event.stopPropagation();"/>
 		</menupopup>
 		<menupopup id="tag-selector-view-settings-menu"
 			onpopupshowing="

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -541,6 +541,10 @@ tag-field =
 
 tagselector-search =
     .placeholder = Filter Tags
+tagselector-exclude-tag =
+    .label = Exclude tag
+tag-excluded = 
+    .aria-description = This tag is excluded from item's list.
 
 context-notes-search =
     .placeholder = Search Notes

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -542,7 +542,9 @@ tag-field =
 tagselector-search =
     .placeholder = Filter Tags
 tagselector-exclude-tag =
-    .label = Exclude tag
+    .label = Hide Items with Tag
+tagselector-include-tag =
+    .label = Keep Items with Tag
 tag-excluded = 
     .aria-description = This tag is excluded from item's list.
 

--- a/scss/components/_tagSelector.scss
+++ b/scss/components/_tagSelector.scss
@@ -131,6 +131,11 @@
 		}
 	}
 
+	&.excluded {
+		background-color: var(--accent-red);
+		text-decoration: line-through;
+	}
+
 	&.colored {
 		font-weight: 600;
 


### PR DESCRIPTION
- added context menu option "Exclude tag" that will exclude the items with the selected tag from search results
- search condition also includes `includeChildren:true`, otherwise if a parent has a tag but a child attachment does not, those rows would still remain in `itemTree`, even though the intention is probably to have them gone.
- Backspace on a focused tag will also mark it as excluded
- clicking on a tag removes the "excluded" status

There is likely a number of other ways to approach the interface but this felt like the most straightforward starting point.

Fixes: #3858 

https://github.com/user-attachments/assets/41d306f5-35e7-4f13-b8c3-feac4134aaf6

