### PR TITLE
Local API: Add write endpoints, track local data object versions

### DIFF
--- a/chrome/content/zotero/preferences/preferences_advanced.js
+++ b/chrome/content/zotero/preferences/preferences_advanced.js
@@ -437,24 +437,42 @@ Zotero_Preferences.Advanced = {
 		
 		let checkbox = document.getElementById('zotero-prefpane-advanced-enable-local-api');
 		let availableMessage = document.getElementById('zotero-prefpane-advanced-local-api-available');
+		let authorizationsSection = document.getElementById('zotero-prefpane-advanced-local-api-write-authorizations');
 		let serverDisabledSection = document.getElementById('zotero-prefpane-advanced-server-disabled');
 		
 		if (!serverEnabled) {
 			checkbox.disabled = true;
 			availableMessage.hidden = true;
+			authorizationsSection.hidden = true;
 			serverDisabledSection.hidden = false;
 			return;
 		}
 		
 		checkbox.disabled = false;
 		availableMessage.hidden = !localAPIEnabled;
+		authorizationsSection.hidden = !localAPIEnabled;
 		serverDisabledSection.hidden = true;
 		
 		document.l10n.setArgs(availableMessage, {
 			url: `http://localhost:${Zotero.Server.port}/api/`
 		});
+		
+		if (localAPIEnabled) {
+			this.updateLocalAPIClearAuthorizationsButton();
+		}
 	},
 	
+	async updateLocalAPIClearAuthorizationsButton() {
+		let clearButton = document.getElementById('zotero-prefpane-advanced-local-api-clear');
+		let count = await Zotero.Server.LocalAPI.getAuthorizationCount();
+		clearButton.disabled = count === 0;
+	},
+
+	async clearLocalAPIAuthorizations() {
+		await Zotero.Server.LocalAPI.clearAuthorizations();
+		await this.updateLocalAPIClearAuthorizationsButton();
+	},
+
 	enableServerForLocalAPI() {
 		Zotero.Prefs.set('httpServer.enabled', true);
 		Zotero.Utilities.Internal.quit(true);

--- a/chrome/content/zotero/preferences/preferences_advanced.xhtml
+++ b/chrome/content/zotero/preferences/preferences_advanced.xhtml
@@ -49,6 +49,13 @@
 				>
 					<html:code class="local-api-url" data-l10n-name="url"/>
 				</label>
+				<hbox id="zotero-prefpane-advanced-local-api-write-authorizations" align="center" hidden="true">
+					<button
+						id="zotero-prefpane-advanced-local-api-clear"
+						data-l10n-id="preferences-advanced-local-api-clear-authorizations"
+						oncommand="Zotero_Preferences.Advanced.clearLocalAPIAuthorizations()"
+					/>
+				</hbox>
 				<hbox id="zotero-prefpane-advanced-server-disabled" align="center" hidden="true">
 					<label data-l10n-id="preferences-advanced-server-disabled"/>
 					<button

--- a/chrome/content/zotero/xpcom/data/collection.js
+++ b/chrome/content/zotero/xpcom/data/collection.js
@@ -67,6 +67,10 @@ Zotero.defineProperty(Zotero.Collection.prototype, 'version', {
 	get: function () { return this._get('version'); },
 	set: function (val) { return this._set('version', val); }
 });
+Zotero.defineProperty(Zotero.Collection.prototype, 'clientVersion', {
+	get: function() { return this._get('clientVersion'); },
+	set: function(val) { return this._set('clientVersion', val); }
+});
 Zotero.defineProperty(Zotero.Collection.prototype, 'synced', {
 	get: function () { return this._get('synced'); },
 	set: function (val) { return this._set('synced', val); }

--- a/chrome/content/zotero/xpcom/data/collections.js
+++ b/chrome/content/zotero/xpcom/data/collections.js
@@ -38,6 +38,7 @@ Zotero.Collections = function () {
 		libraryID: "O.libraryID",
 		key: "O.key",
 		version: "O.version",
+		clientVersion: "O.clientVersion",
 		synced: "O.synced",
 		
 		deleted: "DC.collectionID IS NOT NULL AS deleted",

--- a/chrome/content/zotero/xpcom/data/dataObject.js
+++ b/chrome/content/zotero/xpcom/data/dataObject.js
@@ -23,6 +23,8 @@
     ***** END LICENSE BLOCK *****
 */
 
+const { XPCOMUtils } = ChromeUtils.importESModule("resource://gre/modules/XPCOMUtils.sys.mjs");
+
 let lazy = {};
 XPCOMUtils.defineLazyPreferenceGetter(
 	lazy,

--- a/chrome/content/zotero/xpcom/data/dataObject.js
+++ b/chrome/content/zotero/xpcom/data/dataObject.js
@@ -23,15 +23,6 @@
     ***** END LICENSE BLOCK *****
 */
 
-const { XPCOMUtils } = ChromeUtils.importESModule("resource://gre/modules/XPCOMUtils.sys.mjs");
-
-let lazy = {};
-XPCOMUtils.defineLazyPreferenceGetter(
-	lazy,
-	'shouldTrackClientVersions',
-	'extensions.zotero.httpServer.localAPI.enabled',
-);
-
 /**
  * @property {String} (readOnly) objectType
  * @property {String} (readOnly) libraryKey
@@ -1307,14 +1298,12 @@ Zotero.DataObject.prototype._finalizeSave = async function (env) {
 		Zotero.logError("skipCache is only for new objects");
 	}
 
-	if (lazy.shouldTrackClientVersions) {
-		let libraryClientVersion = await this.library.incrementClientVersion();
-		await Zotero.DB.queryAsync(
-			`UPDATE ${this.ObjectsClass.table} SET clientVersion = ? WHERE ${this.ObjectsClass.idColumn}=?`,
-			[libraryClientVersion, this.id]
-		);
-		this._clientVersion = libraryClientVersion;
-	}
+	let libraryClientVersion = await this.library.incrementClientVersion();
+	await Zotero.DB.queryAsync(
+		`UPDATE ${this.ObjectsClass.table} SET clientVersion = ? WHERE ${this.ObjectsClass.idColumn}=?`,
+		[libraryClientVersion, this.id]
+	);
+	this._clientVersion = libraryClientVersion;
 };
 
 

--- a/chrome/content/zotero/xpcom/data/dataObject.js
+++ b/chrome/content/zotero/xpcom/data/dataObject.js
@@ -1524,6 +1524,9 @@ Zotero.DataObject.prototype.toResponseJSON = function (options = {}) {
 		meta: {},
 		data: this.toJSON(options)
 	};
+	// Keep the data block's version consistent with the top-level version (toJSON() reports
+	// the synced version, which differs from clientVersion when syncedVersionProperty is false)
+	json.data.version = json.version;
 	if (options.version) {
 		json.version = json.data.version = options.version;
 	}

--- a/chrome/content/zotero/xpcom/data/dataObject.js
+++ b/chrome/content/zotero/xpcom/data/dataObject.js
@@ -1462,6 +1462,8 @@ Zotero.DataObject.prototype._initErase = function (env) {
 };
 
 Zotero.DataObject.prototype._finalizeErase = async function (env) {
+	await this.library.incrementClientVersion();
+	
 	// Delete versions from sync cache
 	if (this._objectType != 'feedItem') {
 		await Zotero.Sync.Data.Local.deleteCacheObjectVersions(

--- a/chrome/content/zotero/xpcom/data/dataObject.js
+++ b/chrome/content/zotero/xpcom/data/dataObject.js
@@ -1499,10 +1499,15 @@ Zotero.DataObject.prototype._finalizeErase = async function (env) {
 
 
 Zotero.DataObject.prototype.toResponseJSON = function (options = {}) {
+	// Default to showing synced properties, since that's what the API does, and this function
+	// is generally used to emulate the API
+	options.syncedStorageProperties ??= true;
+	options.syncedVersionProperty ??= true;
+
 	let uri = Zotero.URI.getObjectURI(this);
 	var json = {
 		key: this.key,
-		version: this.clientVersion,
+		version: options.syncedVersionProperty ? this.version : this.clientVersion,
 		library: this.library.toResponseJSON({ ...options, includeGroupDetails: false }),
 		links: {
 			self: {

--- a/chrome/content/zotero/xpcom/data/dataObject.js
+++ b/chrome/content/zotero/xpcom/data/dataObject.js
@@ -23,6 +23,13 @@
     ***** END LICENSE BLOCK *****
 */
 
+let lazy = {};
+XPCOMUtils.defineLazyPreferenceGetter(
+	lazy,
+	'shouldTrackClientVersions',
+	'extensions.zotero.httpServer.localAPI.enabled',
+);
+
 /**
  * @property {String} (readOnly) objectType
  * @property {String} (readOnly) libraryKey
@@ -50,6 +57,7 @@ Zotero.DataObject = function () {
 	this._dateAdded = null;
 	this._dateModified = null;
 	this._version = null;
+	this._clientVersion = null;
 	this._synced = null;
 	this._identified = false;
 	this._parentID = null;
@@ -1296,6 +1304,15 @@ Zotero.DataObject.prototype._finalizeSave = async function (env) {
 	else if (env.skipCache) {
 		Zotero.logError("skipCache is only for new objects");
 	}
+
+	if (lazy.shouldTrackClientVersions) {
+		let libraryClientVersion = await this.library.incrementClientVersion();
+		await Zotero.DB.queryAsync(
+			`UPDATE ${this.ObjectsClass.table} SET clientVersion = ? WHERE ${this.ObjectsClass.idColumn}=?`,
+			[libraryClientVersion, this.id]
+		);
+		this._clientVersion = libraryClientVersion;
+	}
 };
 
 
@@ -1485,7 +1502,7 @@ Zotero.DataObject.prototype.toResponseJSON = function (options = {}) {
 	let uri = Zotero.URI.getObjectURI(this);
 	var json = {
 		key: this.key,
-		version: this.version,
+		version: this.clientVersion,
 		library: this.library.toResponseJSON({ ...options, includeGroupDetails: false }),
 		links: {
 			self: {

--- a/chrome/content/zotero/xpcom/data/group.js
+++ b/chrome/content/zotero/xpcom/data/group.js
@@ -244,7 +244,7 @@ Zotero.Group.prototype.toResponseJSON = function (options = {}) {
 		let uri = Zotero.URI.getGroupURI(this);
 		return {
 			id: this.id,
-			version: this.clientVersion,
+			version: options.syncedVersionProperty ? this.version : this.clientVersion,
 			links: {
 				self: {
 					href: Zotero.URI.toAPIURL(uri, options.apiURL),

--- a/chrome/content/zotero/xpcom/data/group.js
+++ b/chrome/content/zotero/xpcom/data/group.js
@@ -244,7 +244,7 @@ Zotero.Group.prototype.toResponseJSON = function (options = {}) {
 		let uri = Zotero.URI.getGroupURI(this);
 		return {
 			id: this.id,
-			version: this.version,
+			version: this.clientVersion,
 			links: {
 				self: {
 					href: Zotero.URI.toAPIURL(uri, options.apiURL),

--- a/chrome/content/zotero/xpcom/data/group.js
+++ b/chrome/content/zotero/xpcom/data/group.js
@@ -244,7 +244,10 @@ Zotero.Group.prototype.toResponseJSON = function (options = {}) {
 		let uri = Zotero.URI.getGroupURI(this);
 		return {
 			id: this.id,
-			version: options.syncedVersionProperty ? this.version : this.clientVersion,
+			// Group metadata isn't locally writable, so group responses always report the
+			// synced group version -- unlike group.clientVersion, which is inherited from
+			// Zotero.Library and tracks the group library's contents
+			version: this.version,
 			links: {
 				self: {
 					href: Zotero.URI.toAPIURL(uri, options.apiURL),

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -128,8 +128,8 @@ Zotero.defineProperty(Zotero.Item.prototype, 'itemID', {
 	enumerable: false
 });
 
-for (let name of ['libraryID', 'key', 'dateAdded', 'dateModified', 'version', 'synced',
-		'createdByUserID', 'lastModifiedByUserID']) {
+for (let name of ['libraryID', 'key', 'dateAdded', 'dateModified', 'version', 'clientVersion',
+		'synced', 'createdByUserID', 'lastModifiedByUserID']) {
 	let prop = '_' + name;
 	Zotero.defineProperty(Zotero.Item.prototype, name, {
 		get: function () { return this[prop]; },

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -6128,12 +6128,6 @@ Zotero.Item.prototype.toJSON = function (options = {}) {
 
 
 Zotero.Item.prototype.toResponseJSON = function (options = {}) {
-	// Default to showing synced storage properties, since that's what the API does, and this function
-	// is generally used to emulate the API
-	if (options.syncedStorageProperties === undefined) {
-		options.syncedStorageProperties = true;
-	}
-	
 	var json = this.constructor._super.prototype.toResponseJSON.call(this, options);
 	
 	// creatorSummary

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -6032,21 +6032,24 @@ Zotero.Item.prototype.toJSON = function (options = {}) {
 			}
 			
 			if (this.isStoredFileAttachment() && !options.skipStorageProperties) {
-				// Add synced storage properties even if syncedStorageProperties is false,
-				// since we can't get the local properties synchronously
-				// We'll overwrite them in toResponseJSONAsync() if possible
-				
-				let mtime = this.attachmentSyncedModificationTime;
-				// There's never a reason to include these if they're null. This can happen if
-				// we're restoring to server from a copy of the database that was never
-				// file-synced. We don't want to clear the remote file associations when that
-				// happens.
-				if (mtime !== null) {
-					obj.mtime = mtime;
+				if (options.syncedStorageProperties) {
+					let mtime = this.attachmentSyncedModificationTime;
+					// There's never a reason to include these if they're null. This can happen if
+					// we're restoring to server from a copy of the database that was never
+					// file-synced. We don't want to clear the remote file associations when that
+					// happens.
+					if (mtime !== null) {
+						obj.mtime = mtime;
+					}
+					let md5 = this.attachmentSyncedHash;
+					if (md5 !== null) {
+						obj.md5 = md5;
+					}
 				}
-				let md5 = this.attachmentSyncedHash;
-				if (md5 !== null) {
-					obj.md5 = md5;
+				else {
+					// TEMP
+					//obj.mtime = (yield this.attachmentModificationTime) || null;
+					//obj.md5 = (yield this.attachmentHash) || null;
 				}
 			}
 		}
@@ -6153,6 +6156,21 @@ Zotero.Item.prototype.toResponseJSON = function (options = {}) {
 			type: this.attachmentContentType,
 			title: this.attachmentFilename
 		};
+	}
+	
+	// Include storage properties in the response even when syncedStorageProperties is false (i.e.,
+	// when reporting the local version). The local values are only available asynchronously, so
+	// we need to use synced values as a fallback. toResponseJSONAsync() overwrites them with
+	// up-to-date local values.
+	if (this.isStoredFileAttachment() && !options.skipStorageProperties && !options.syncedStorageProperties) {
+		let mtime = this.attachmentSyncedModificationTime;
+		if (mtime !== null) {
+			json.data.mtime = mtime;
+		}
+		let md5 = this.attachmentSyncedHash;
+		if (md5 !== null) {
+			json.data.md5 = md5;
+		}
 	}
 	
 	return json;

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -6032,24 +6032,21 @@ Zotero.Item.prototype.toJSON = function (options = {}) {
 			}
 			
 			if (this.isStoredFileAttachment() && !options.skipStorageProperties) {
-				if (options.syncedStorageProperties) {
-					let mtime = this.attachmentSyncedModificationTime;
-					// There's never a reason to include these if they're null. This can happen if
-					// we're restoring to server from a copy of the database that was never
-					// file-synced. We don't want to clear the remote file associations when that
-					// happens.
-					if (mtime !== null) {
-						obj.mtime = mtime;
-					}
-					let md5 = this.attachmentSyncedHash;
-					if (md5 !== null) {
-						obj.md5 = md5;
-					}
+				// Add synced storage properties even if syncedStorageProperties is false,
+				// since we can't get the local properties synchronously
+				// We'll overwrite them in toResponseJSONAsync() if possible
+				
+				let mtime = this.attachmentSyncedModificationTime;
+				// There's never a reason to include these if they're null. This can happen if
+				// we're restoring to server from a copy of the database that was never
+				// file-synced. We don't want to clear the remote file associations when that
+				// happens.
+				if (mtime !== null) {
+					obj.mtime = mtime;
 				}
-				else {
-					// TEMP
-					//obj.mtime = (yield this.attachmentModificationTime) || null;
-					//obj.md5 = (yield this.attachmentHash) || null;
+				let md5 = this.attachmentSyncedHash;
+				if (md5 !== null) {
+					obj.md5 = md5;
 				}
 			}
 		}
@@ -6194,6 +6191,12 @@ Zotero.Item.prototype.toResponseJSONAsync = async function (options = {}) {
 	else if (this.isImportedAttachment()) {
 		json.links.enclosure.length = await getFileSize(this);
 	}
+	
+	if (this.isStoredFileAttachment() && !options.skipStorageProperties) {
+		json.data.mtime = await this.attachmentModificationTime ?? null;
+		json.data.md5 = await this.attachmentHash ?? null;
+	}
+	
 	return json;
 };
 

--- a/chrome/content/zotero/xpcom/data/items.js
+++ b/chrome/content/zotero/xpcom/data/items.js
@@ -48,6 +48,7 @@ Zotero.Items = function () {
 				libraryID: "O.libraryID",
 				key: "O.key",
 				version: "O.version",
+				clientVersion: "O.clientVersion",
 				synced: "O.synced",
 				
 				createdByUserID: "createdByUserID",

--- a/chrome/content/zotero/xpcom/data/library.js
+++ b/chrome/content/zotero/xpcom/data/library.js
@@ -39,6 +39,7 @@ Zotero.Library = function (params = {}) {
 	this._storageDownloadNeeded = false;
 	
 	this._lastReadItemInSession = null;
+	this._lastClientVersionIncrementTransactionID = null;
 	
 	Zotero.Utilities.Internal.assignProps(
 		this,
@@ -48,6 +49,7 @@ Zotero.Library = function (params = {}) {
 			'editable',
 			'filesEditable',
 			'libraryVersion',
+			'clientVersion',
 			'storageVersion',
 			'lastSync',
 			'archived'
@@ -71,7 +73,7 @@ Zotero.Library = function (params = {}) {
 // DB columns
 Zotero.defineProperty(Zotero.Library, '_dbColumns', {
 	value: Object.freeze([
-		'type', 'editable', 'filesEditable', 'version', 'storageVersion', 'lastSync', 'archived', 'isAdmin'
+		'type', 'editable', 'filesEditable', 'version', 'clientVersion', 'storageVersion', 'lastSync', 'archived', 'isAdmin'
 	])
 });
 
@@ -209,7 +211,7 @@ Zotero.defineProperty(Zotero.Library.prototype, 'allowsLinkedFiles', {
 
 // Create other accessors
 (function () {
-	let accessors = ['editable', 'filesEditable', 'storageVersion', 'archived', 'isAdmin'];
+	let accessors = ['editable', 'filesEditable', 'clientVersion', 'storageVersion', 'archived', 'isAdmin'];
 	for (let i=0; i<accessors.length; i++) {
 		let prop = Zotero.Library._colToProp(accessors[i]);
 		Zotero.defineProperty(Zotero.Library.prototype, accessors[i], {
@@ -299,6 +301,20 @@ Zotero.Library.prototype._set = function (prop, val) {
 			
 			break;
 		
+		case '_libraryClientVersion':
+			var newVal = Number.parseInt(val, 10);
+			if (newVal != val) {
+				throw new Error(`${prop} must be an integer (${typeof val} '${val}' given)`);
+			}
+			val = newVal;
+			
+			if (val < 0) throw new Error(prop + ' must not be less than 0');
+			
+			// Ensure that it is never decreasing
+			if (val < this._libraryClientVersion) throw new Error(prop + ' cannot decrease');
+			
+			break;
+		
 		case '_libraryStorageVersion':
 			var newVal = parseInt(val);
 			if (newVal != val) {
@@ -360,6 +376,7 @@ Zotero.Library.prototype._loadDataFromRow = function (row) {
 	this._libraryEditable = !!row._libraryEditable;
 	this._libraryFilesEditable = !!row._libraryFilesEditable;
 	this._libraryVersion = row._libraryVersion;
+	this._libraryClientVersion = row._libraryClientVersion;
 	this._libraryStorageVersion = row._libraryStorageVersion;
 	this._libraryLastSync =  row._libraryLastSync !== 0 ? new Date(row._libraryLastSync * 1000) : false;
 	this._libraryArchived = !!row._libraryArchived;
@@ -769,3 +786,18 @@ Zotero.Library.prototype.hasItem = function (item) {
 	}
 	return item.libraryID == this.libraryID;
 }
+
+Zotero.Library.prototype.incrementClientVersion = async function () {
+	let transactionID = Zotero.DB.requireTransaction();
+	if (transactionID === this._lastClientVersionIncrementTransactionID) {
+		return this._libraryClientVersion;
+	}
+
+	let clientVersion = await Zotero.DB.valueQueryAsync(
+		"UPDATE libraries SET clientVersion = clientVersion + 1 WHERE libraryID=? RETURNING clientVersion",
+		[this.libraryID]
+	);
+	this._libraryClientVersion = clientVersion;
+	this._lastClientVersionIncrementTransactionID = transactionID;
+	return clientVersion;
+};

--- a/chrome/content/zotero/xpcom/data/search.js
+++ b/chrome/content/zotero/xpcom/data/search.js
@@ -86,6 +86,10 @@ Zotero.defineProperty(Zotero.Search.prototype, 'version', {
 	get: function () { return this._get('version'); },
 	set: function (val) { return this._set('version', val); }
 });
+Zotero.defineProperty(Zotero.Search.prototype, 'clientVersion', {
+	get: function() { return this._get('clientVersion'); },
+	set: function(val) { return this._set('clientVersion', val); }
+});
 Zotero.defineProperty(Zotero.Search.prototype, 'synced', {
 	get: function () { return this._get('synced'); },
 	set: function (val) { return this._set('synced', val); }

--- a/chrome/content/zotero/xpcom/data/searches.js
+++ b/chrome/content/zotero/xpcom/data/searches.js
@@ -36,6 +36,7 @@ Zotero.Searches = function () {
 		libraryID: "O.libraryID",
 		key: "O.key",
 		version: "O.version",
+		clientVersion: "O.clientVersion",
 		synced: "O.synced",
 		deleted: "DS.savedSearchID IS NOT NULL AS deleted",
 	}

--- a/chrome/content/zotero/xpcom/data/tags.js
+++ b/chrome/content/zotero/xpcom/data/tags.js
@@ -439,15 +439,19 @@ Zotero.Tags = new function () {
 					
 					await this.purge(chunk);
 					
-					// Update internal timestamps on all items that had these tags
+					// Update internal timestamps and versions on all items that had these tags
+					var clientVersion;
+					if (itemIDs.length) {
+						clientVersion = await Zotero.Libraries.get(libraryID).incrementClientVersion();
+					}
 					await Zotero.Utilities.Internal.forEachChunkAsync(
 						Zotero.Utilities.arrayUnique(itemIDs),
-						Zotero.DB.MAX_BOUND_PARAMETERS - 1,
+						Zotero.DB.MAX_BOUND_PARAMETERS - 2,
 						async function (chunk) {
-							var sql = 'UPDATE items SET synced=0, clientDateModified=? '
+							var sql = 'UPDATE items SET synced=0, clientDateModified=?, clientVersion=? '
 								+ 'WHERE itemID IN (' + Array(chunk.length).fill('?').join(',') + ')';
 							await Zotero.DB.queryAsync(
-								sql, [Zotero.DB.transactionDateTime].concat(chunk), { noCache: true }
+								sql, [Zotero.DB.transactionDateTime, clientVersion].concat(chunk), { noCache: true }
 							);
 							
 							await Zotero.Items.reload(itemIDs, ['primaryData', 'tags'], true);

--- a/chrome/content/zotero/xpcom/db.js
+++ b/chrome/content/zotero/xpcom/db.js
@@ -594,6 +594,7 @@ Zotero.DBConnection.prototype.requireTransaction = function () {
 	if (!this._transactionID) {
 		throw new Error("Not in transaction");
 	}
+	return this._transactionID;
 };
 
 

--- a/chrome/content/zotero/xpcom/schema.js
+++ b/chrome/content/zotero/xpcom/schema.js
@@ -3722,6 +3722,13 @@ Zotero.Schema = new function () {
 					await Zotero.DB.queryAsync("UPDATE itemAttachments SET path=? WHERE itemID=?", ['storage:' + filename, row.itemID]);
 				}
 			}
+
+			else if (i == 129) {
+				let clientVersionTables = ['items', 'collections', 'savedSearches', 'libraries', 'groups'];
+				for (let table of clientVersionTables) {
+					await Zotero.DB.queryAsync(`ALTER TABLE ${table} ADD COLUMN clientVersion INT NOT NULL DEFAULT 0`);
+				}
+			}
 		}
 		
 		await _updateDBVersion('userdata', toVersion);

--- a/chrome/content/zotero/xpcom/schema.js
+++ b/chrome/content/zotero/xpcom/schema.js
@@ -3724,7 +3724,7 @@ Zotero.Schema = new function () {
 			}
 
 			else if (i == 129) {
-				let clientVersionTables = ['items', 'collections', 'savedSearches', 'libraries', 'groups'];
+				let clientVersionTables = ['items', 'collections', 'savedSearches', 'libraries'];
 				for (let table of clientVersionTables) {
 					await Zotero.DB.queryAsync(`ALTER TABLE ${table} ADD COLUMN clientVersion INT NOT NULL DEFAULT 0`);
 				}

--- a/chrome/content/zotero/xpcom/server/server.js
+++ b/chrome/content/zotero/xpcom/server/server.js
@@ -260,7 +260,7 @@ Zotero.Server.RequestHandler.prototype._bodyData = function () {
 		}
 	}
 	// handle envelope
-	this._processEndpoint("POST", data); // async
+	this._processEndpoint(this.requestMethod || "POST", data); // async
 }
 
 
@@ -367,16 +367,23 @@ Zotero.Server.RequestHandler.prototype.handleRequest = async function () {
 	else if (request.method == "GET") {
 		this._processEndpoint("GET", null); // async
 	}
-	else if (request.method == "POST") {
+	else if (request.method == "POST" || request.method == "PUT"
+			|| request.method == "PATCH" || request.method == "DELETE") {
 		const contentLengthRe = /^([0-9]+)$/;
-		
+		this.requestMethod = request.method;
+
 		// parse content length
 		var m = contentLengthRe.exec(this.headers['content-length']);
-		if(!m) {
+		if (!m) {
+			// DELETE is allowed to have no body
+			if (request.method == "DELETE") {
+				this._processEndpoint("DELETE", null); // async
+				return;
+			}
 			this._requestFinished(this._generateResponse(400, "text/plain", "Content-length not provided\n"));
 			return;
 		}
-		
+
 		this.bodyLength = parseInt(m[1]);
 		this._bodyData();
 	} else {
@@ -420,7 +427,8 @@ Zotero.Server.RequestHandler.prototype._processEndpoint = async function (method
 		}
 		
 		var data = null;
-		if (method === 'POST' && this.contentType) {
+		if ((method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'DELETE')
+				&& this.contentType) {
 			// check that endpoint supports contentType
 			var supportedDataTypes = endpoint.supportedDataTypes;
 			if (supportedDataTypes && supportedDataTypes != '*'

--- a/chrome/content/zotero/xpcom/server/server.js
+++ b/chrome/content/zotero/xpcom/server/server.js
@@ -57,12 +57,15 @@ Zotero.Server = new function () {
 	/**
 	 * initializes a very rudimentary web server
 	 */
-	this.init = function (port) {
+	this.init = async function (port) {
 		if (serv) {
 			Zotero.debug("Already listening on port " + serv.port);
 			return;
 		}
 		
+		// Do any necessary pre-listen initialization first
+		await Zotero.Server.LocalAPI.init();
+
 		port = port || Zotero.Prefs.get('httpServer.port');
 		try {
 			serv = new HttpServer();

--- a/chrome/content/zotero/xpcom/server/server.js
+++ b/chrome/content/zotero/xpcom/server/server.js
@@ -592,10 +592,13 @@ Zotero.Server.RequestHandler.prototype._decodeMultipartData = function (data) {
 		let windowsHeaderBoundary = field.indexOf("\r\n\r\n");
 		if (unixHeaderBoundary < windowsHeaderBoundary && unixHeaderBoundary != -1) {
 			fieldData.header = field.slice(0, unixHeaderBoundary).trim();
-			fieldData.body = field.slice(unixHeaderBoundary+2).trim();
+			// Strip only the trailing delimiter newline before the next boundary, not all
+			// surrounding whitespace -- trimming would corrupt binary bodies (e.g., a file
+			// ending in a newline byte)
+			fieldData.body = field.slice(unixHeaderBoundary+2).replace(/\n$/, '');
 		} else if (windowsHeaderBoundary != -1) {
 			fieldData.header = field.slice(0, windowsHeaderBoundary).trim();
-			fieldData.body = field.slice(windowsHeaderBoundary+4).trim();
+			fieldData.body = field.slice(windowsHeaderBoundary+4).replace(/\r\n$/, '');
 		} else {
 			// Only log first 200 characters in case the part is large
 			Zotero.debug('Malformed multipart/form-data body: ' + field.substr(0, 200), 1);

--- a/chrome/content/zotero/xpcom/server/server_localAPI.js
+++ b/chrome/content/zotero/xpcom/server/server_localAPI.js
@@ -219,19 +219,6 @@ function checkAuthorizeRateLimit() {
 	return 0;
 }
 
-/**
- * Get this server's persistent ID, generating and storing it on first use.
- * @returns {string} A 12-character server ID
- */
-function getLocalAPIServerID() {
-	let id = Zotero.Prefs.get('httpServer.localAPI.serverID');
-	if (!id) {
-		id = Zotero.Utilities.randomString(12);
-		Zotero.Prefs.set('httpServer.localAPI.serverID', id);
-	}
-	return id;
-}
-
 const exportFormats = new Map([
 	['bibtex', '9cb70025-a888-4a29-a210-93ec52da40d4'],
 	['biblatex', 'b6e39b57-8942-4d11-8259-342c46ce395f'],
@@ -574,7 +561,7 @@ class LocalAPIEndpoint {
 		}
 		contentTypeOrHeaders['Zotero-API-Version'] = LOCAL_API_VERSION;
 		contentTypeOrHeaders['Zotero-Schema-Version'] = Zotero.Schema.globalSchemaVersion;
-		contentTypeOrHeaders['Zotero-Server-ID'] = getLocalAPIServerID();
+		contentTypeOrHeaders['Zotero-Server-ID'] = Zotero.Server.LocalAPI.getServerID();
 		return [status, contentTypeOrHeaders, body];
 	}
 
@@ -613,7 +600,7 @@ class LocalAPIEndpoint {
 			}
 			return null;
 		}
-		if (provided !== getLocalAPIServerID()) {
+		if (provided !== Zotero.Server.LocalAPI.getServerID()) {
 			return this.makeResponse(412, 'text/plain', 'Zotero-Server-ID does not match this server');
 		}
 		return null;
@@ -744,6 +731,44 @@ class LocalAPIEndpoint {
 const _404 = [404, 'text/plain', 'Not found'];
 
 Zotero.Server.LocalAPI = {};
+
+Zotero.Server.LocalAPI._serverID = null;
+
+/**
+ * Load this server's persistent ID from the database, generating and storing it
+ * on first use, and cache it in memory.
+ *
+ * This value is stored in the settings table (not a pref) because it identifies
+ * the data in the local database, not the profile; a database restored from a
+ * backup or copied to another profile should keep the same ID, and a new
+ * database in the same profile should get a new one.
+ *
+ * @returns {Promise<string>} A 12-character server ID
+ */
+Zotero.Server.LocalAPI.init = async function () {
+	let sql = "SELECT value FROM settings WHERE setting='localAPI' AND key='serverID'";
+	let id = await Zotero.DB.valueQueryAsync(sql);
+	if (!id) {
+		id = Zotero.Utilities.randomString(12);
+		await Zotero.DB.queryAsync(
+			"REPLACE INTO settings VALUES ('localAPI', 'serverID', ?)", id
+		);
+	}
+	this._serverID = id;
+	return id;
+};
+
+/**
+ * Get this server's persistent ID. Must have been loaded via init() first.
+ *
+ * @returns {string} A 12-character server ID
+ */
+Zotero.Server.LocalAPI.getServerID = function () {
+	if (!this._serverID) {
+		throw new Error("Local API server ID has not been loaded");
+	}
+	return this._serverID;
+};
 
 Zotero.Server.LocalAPI.Root = class extends LocalAPIEndpoint {
 	supportedMethods = ['GET'];

--- a/chrome/content/zotero/xpcom/server/server_localAPI.js
+++ b/chrome/content/zotero/xpcom/server/server_localAPI.js
@@ -576,6 +576,16 @@ class LocalAPIEndpoint {
 		let key = requestData.headers.get('Zotero-API-Key')
 			|| requestData.searchParams.get('key')
 			|| '';
+		// Also accept an "Authorization: Bearer <key>" token
+		if (!key) {
+			let authHeader = requestData.headers.get('Authorization');
+			if (authHeader) {
+				let match = /^Bearer\s+([a-zA-Z0-9]+)$/i.exec(authHeader.trim());
+				if (match) {
+					key = match[1];
+				}
+			}
+		}
 		if (!key) {
 			return [
 				401,

--- a/chrome/content/zotero/xpcom/server/server_localAPI.js
+++ b/chrome/content/zotero/xpcom/server/server_localAPI.js
@@ -43,7 +43,7 @@ Limitations compared to api.zotero.org:
       the key is missing or unrecognized.
 
       Local API keys are unrelated to zotero.org API keys. They are obtained by POSTing to
-      /api/authorize-local (a local-only endpoint with no web API analog) with a JSON body
+      /api/local/authorize (a local-only endpoint with no web API analog) with a JSON body
       of the form { "appName": "<caller's display name>" }. This shows a modal with three
       buttons: "Allow" (one-time access), "Always Allow" (persistent access), and "Deny".
       On allow, the response is of the form:
@@ -110,7 +110,7 @@ const WRITE_TOKEN_CACHE_SECONDS = 12 * 60 * 60;
 const PENDING_UPLOADS = new Map();
 const UPLOAD_KEY_TTL_SECONDS = 60 * 60;
 
-// Rate-limiting state for /api/authorize-local. Each entry is a timestamp (ms)
+// Rate-limiting state for /api/local/authorize. Each entry is a timestamp (ms)
 // for a request that resulted in (or would result in) a confirmation prompt.
 // When the window holds AUTHORIZE_RATE_LIMIT_MAX entries that are all less
 // than AUTHORIZE_RATE_LIMIT_WINDOW_MS old, further requests are rejected with
@@ -566,7 +566,7 @@ class LocalAPIEndpoint {
 	 *
 	 * Returns null when the request is authorized to proceed, or an HTTP
 	 * response array when it should be rejected. Keys are obtained by callers
-	 * via POST /api/authorize-local; single-use keys are consumed (deleted
+	 * via POST /api/local/authorize; single-use keys are consumed (deleted
 	 * from the persistent store) here.
 	 *
 	 * @param {Object} requestData
@@ -593,7 +593,7 @@ class LocalAPIEndpoint {
 					'Content-Type': 'text/plain',
 					'WWW-Authenticate': 'Zotero-API-Key realm="Zotero Local API"',
 				},
-				'API key required -- POST /api/authorize-local to obtain one'
+				'API key required -- POST /api/local/authorize to obtain one'
 			];
 		}
 		let entry = await consumeLocalAPIKey(key);
@@ -750,7 +750,7 @@ Zotero.Server.LocalAPI.AuthorizeLocal = class extends LocalAPIEndpoint {
 		);
 	}
 };
-Zotero.Server.Endpoints["/api/authorize-local"] = Zotero.Server.LocalAPI.AuthorizeLocal;
+Zotero.Server.Endpoints["/api/local/authorize"] = Zotero.Server.LocalAPI.AuthorizeLocal;
 
 Zotero.Server.LocalAPI.Schema = class extends LocalAPIEndpoint {
 	supportedMethods = ['GET'];

--- a/chrome/content/zotero/xpcom/server/server_localAPI.js
+++ b/chrome/content/zotero/xpcom/server/server_localAPI.js
@@ -1192,10 +1192,18 @@ Zotero.Server.LocalAPI.UploadReceiver = class extends LocalAPIEndpoint {
 				let available = binaryStream.available();
 				bytes = new Uint8Array(binaryStream.readByteArray(available));
 			}
+			else if (Array.isArray(data)) {
+				// multipart/form-data upload (params=1): the server has already parsed the
+				// body into form fields, so take the file bytes from the `file` part's body,
+				// which the parser preserves as a binary string (one char per byte)
+				let filePart = data.find(part => part.params && part.params.name === 'file');
+				if (!filePart) {
+					return this.makeResponse(400, 'text/plain', 'No file content provided');
+				}
+				bytes = Uint8Array.from(filePart.body, c => c.charCodeAt(0) & 0xff);
+			}
 			else if (typeof data === 'string') {
-				// Best effort: text-decoded body. Will produce a corrupted file
-				// for true binary content -- the client should send a binary
-				// content-type so the server hands us the raw stream.
+				// Raw text body (a non-binary upload sent with a text content type)
 				let encoder = new TextEncoder();
 				bytes = encoder.encode(data);
 			}
@@ -2339,19 +2347,19 @@ async function authorizeUpload(item, params, headers, requestData) {
 	let host = requestData.headers.get('Host') || `localhost:${Zotero.Server.port}`;
 	let url = `http://${host}/api/local/uploads/${uploadKey}`;
 
-	if (requestData.searchParams.get('params') === '1') {
+	// params=1 in the body requests the multipart upload form (vs. the default prefix/suffix)
+	if (String(params.params) === '1') {
 		return [
 			200,
 			{ 'Content-Type': 'application/json' },
 			JSON.stringify({
 				url,
 				uploadKey,
-				contentType,
+				// In the web API, params holds S3 HTML form fields (key, policy, signature, etc.).
+				// There's no S3 locally, but we emit `key` so clients have something to iterate.
+				// The receiver ignores the returned values.
 				params: {
-					// Local uploads don't need S3-style form fields, but emit
-					// the field so clients expecting a 'params' array can
-					// iterate. They can be sent and will be ignored.
-					key: uploadKey,
+					key: md5,
 				},
 			})
 		];

--- a/chrome/content/zotero/xpcom/server/server_localAPI.js
+++ b/chrome/content/zotero/xpcom/server/server_localAPI.js
@@ -154,7 +154,7 @@ class LocalAPIEndpoint {
 					return this.makeResponse(400, 'text/plain', `Invalid 'since' value '${requestData.searchParams.get('since')}'`);
 				}
 				if (since !== 0) {
-					response.data = response.data.filter(dataObject => dataObject.version > since);
+					response.data = response.data.filter(dataObject => dataObject.clientVersion > since);
 				}
 			}
 			
@@ -226,8 +226,8 @@ class LocalAPIEndpoint {
 				'Link': Object.entries(links).map(([rel, url]) => `<${url}>; rel="${rel}"`).join(', ')
 			};
 			let lastModifiedVersion = dataIsArray
-				? Zotero.Libraries.get(requestData.libraryID).libraryVersion
-				: response.data.version;
+				? Zotero.Libraries.get(requestData.libraryID).clientVersion
+				: response.data.clientVersion;
 			if (lastModifiedVersion !== undefined) {
 				headers['Last-Modified-Version'] = lastModifiedVersion;
 			}

--- a/chrome/content/zotero/xpcom/server/server_localAPI.js
+++ b/chrome/content/zotero/xpcom/server/server_localAPI.js
@@ -900,7 +900,8 @@ async function toResponseJSON(dataObjectOrObjects, searchParams) {
 	let responseJSON = dataObject.toResponseJSONAsync
 		? await dataObject.toResponseJSONAsync({
 			apiURL: `http://localhost:${Zotero.Server.port}/api/`,
-			includeGroupDetails: true
+			includeGroupDetails: true,
+			syncedVersionProperty: false,
 		})
 		: dataObject;
 	

--- a/chrome/content/zotero/xpcom/server/server_localAPI.js
+++ b/chrome/content/zotero/xpcom/server/server_localAPI.js
@@ -901,6 +901,7 @@ async function toResponseJSON(dataObjectOrObjects, searchParams) {
 		? await dataObject.toResponseJSONAsync({
 			apiURL: `http://localhost:${Zotero.Server.port}/api/`,
 			includeGroupDetails: true,
+			syncedStorageProperties: false,
 			syncedVersionProperty: false,
 		})
 		: dataObject;

--- a/chrome/content/zotero/xpcom/server/server_localAPI.js
+++ b/chrome/content/zotero/xpcom/server/server_localAPI.js
@@ -51,6 +51,17 @@ Limitations compared to api.zotero.org:
       When the user picks "Allow" rather than "Always Allow", the key is single-use: the first
       write that successfully validates it consumes it. Local API consumers should always be
       prepared to handle a 401 response by reauthenticating.
+- Every response includes a Zotero-Server-ID header: a stable ID identifying this Zotero
+  instance. Clients should cache it and pass it back via the Zotero-Server-ID request
+  header to confirm they're still talking to the same instance. Providing the request is
+  optional on read requests but **required** for writes - write requests without a
+  Zotero-Server-ID will be rejected with 428 Precondition Required. When provided, it
+  must match the current server or the request is rejected with 412 Precondition Failed.
+  
+  Clients should use Zotero-Server-ID to partition cached data, especially data object
+  versions, returned from the API. Local API versions have no relation to Web API
+  versions, nor do they have any relation to local API versions returned by other
+  Zotero instances.
 - Minimal access to metadata about groups.
 - Atom is not supported.
 - Item type/field endpoints (https://www.zotero.org/support/dev/web_api/v3/types_and_fields) will
@@ -208,6 +219,19 @@ function checkAuthorizeRateLimit() {
 	return 0;
 }
 
+/**
+ * Get this server's persistent ID, generating and storing it on first use.
+ * @returns {string} A 12-character server ID
+ */
+function getLocalAPIServerID() {
+	let id = Zotero.Prefs.get('httpServer.localAPI.serverID');
+	if (!id) {
+		id = Zotero.Utilities.randomString(12);
+		Zotero.Prefs.set('httpServer.localAPI.serverID', id);
+	}
+	return id;
+}
+
 const exportFormats = new Map([
 	['bibtex', '9cb70025-a888-4a29-a210-93ec52da40d4'],
 	['biblatex', 'b6e39b57-8942-4d11-8259-342c46ce395f'],
@@ -234,6 +258,12 @@ class LocalAPIEndpoint {
 			return this.makeResponse(403, 'text/plain', 'Local API is not enabled');
 		}
 		requestData.headers = new Headers(requestData.headers);
+		
+		let serverIDResponse = this._validateServerID(requestData);
+		if (serverIDResponse) {
+			return serverIDResponse;
+		}
+		
 		try {
 			return await this._initInternal(requestData);
 		}
@@ -544,6 +574,7 @@ class LocalAPIEndpoint {
 		}
 		contentTypeOrHeaders['Zotero-API-Version'] = LOCAL_API_VERSION;
 		contentTypeOrHeaders['Zotero-Schema-Version'] = Zotero.Schema.globalSchemaVersion;
+		contentTypeOrHeaders['Zotero-Server-ID'] = getLocalAPIServerID();
 		return [status, contentTypeOrHeaders, body];
 	}
 
@@ -558,6 +589,34 @@ class LocalAPIEndpoint {
 	// eslint-disable-next-line no-unused-vars
 	run(requestData) {
 		throw new Error("run() must be implemented");
+	}
+
+	/**
+	 * Validate the caller's Zotero-Server-ID header against this server's ID.
+	 *
+	 * - When the client provides the header, it must match this server's ID, or
+	 *   the request is rejected with 412 (Precondition Failed).
+	 * - Write requests (POST, PUT, PATCH, DELETE) must provide the header, or
+	 *   they're rejected with 428 (Precondition Required). Read requests may
+	 *   omit it.
+	 *
+	 * Returns null when the request may proceed, or an HTTP response array when
+	 * it should be rejected.
+	 *
+	 * @param {Object} requestData
+	 */
+	_validateServerID(requestData) {
+		let provided = requestData.headers.get('Zotero-Server-ID');
+		if (!provided) {
+			if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(requestData.method)) {
+				return this.makeResponse(428, 'text/plain', 'Zotero-Server-ID not provided');
+			}
+			return null;
+		}
+		if (provided !== getLocalAPIServerID()) {
+			return this.makeResponse(412, 'text/plain', 'Zotero-Server-ID does not match this server');
+		}
+		return null;
 	}
 
 	/**

--- a/chrome/content/zotero/xpcom/server/server_localAPI.js
+++ b/chrome/content/zotero/xpcom/server/server_localAPI.js
@@ -2257,6 +2257,11 @@ async function authorizeUpload(item, params, headers, requestData) {
 	if (!filename) {
 		return [400, 'text/plain', 'File name not provided'];
 	}
+	// Reject anything that isn't a bare filename, since it's joined onto the storage
+	// directory path when the upload is received
+	if (filename.includes('/') || filename.includes('\\') || filename === '..' || filename === '.') {
+		return [400, 'text/plain', 'Invalid file name'];
+	}
 	let filesize = params.filesize;
 	if (filesize === undefined || filesize === null || filesize === '') {
 		return [400, 'text/plain', 'File size not provided'];

--- a/chrome/content/zotero/xpcom/server/server_localAPI.js
+++ b/chrome/content/zotero/xpcom/server/server_localAPI.js
@@ -2007,7 +2007,6 @@ async function writeSingleObject(endpoint, requestData, kind, isPatch) {
 	let body;
 	try {
 		validateObjectKey(key);
-		endpoint._checkLibraryIfUnmodifiedSinceVersion(requestData);
 		body = endpoint._parseJSONBody(data);
 	}
 	catch (e) {
@@ -2038,8 +2037,23 @@ async function writeSingleObject(endpoint, requestData, kind, isPatch) {
 				];
 			}
 		}
-		else if (!requestData.headers.get('If-Unmodified-Since-Version')) {
-			return [428, 'text/plain', 'If-Unmodified-Since-Version not provided'];
+		else {
+			let header = requestData.headers.get('If-Unmodified-Since-Version');
+			if (header === null) {
+				return [428, 'text/plain', 'If-Unmodified-Since-Version not provided'];
+			}
+			let expectedVersion = parseInt(header);
+			if (Number.isNaN(expectedVersion) || expectedVersion < 0) {
+				return [400, 'text/plain', 'Invalid If-Unmodified-Since-Version value'];
+			}
+			if (obj.clientVersion > expectedVersion) {
+				return [
+					412,
+					'text/plain',
+					`${kind} has been modified since specified version `
+					+ `(expected ${expectedVersion}, found ${obj.clientVersion})`
+				];
+			}
 		}
 
 		if (isPatch) {

--- a/chrome/content/zotero/xpcom/server/server_localAPI.js
+++ b/chrome/content/zotero/xpcom/server/server_localAPI.js
@@ -738,10 +738,8 @@ Zotero.Server.LocalAPI._serverID = null;
  * Load this server's persistent ID from the database, generating and storing it
  * on first use, and cache it in memory.
  *
- * This value is stored in the settings table (not a pref) because it identifies
- * the data in the local database, not the profile; a database restored from a
- * backup or copied to another profile should keep the same ID, and a new
- * database in the same profile should get a new one.
+ * We store this value in the settings table so it follows the database, not the
+ * profile (as it would if it were stored as a pref).
  *
  * @returns {Promise<string>} A 12-character server ID
  */

--- a/chrome/content/zotero/xpcom/server/server_localAPI.js
+++ b/chrome/content/zotero/xpcom/server/server_localAPI.js
@@ -527,7 +527,7 @@ class LocalAPIEndpoint {
 					return this.makeResponse(400, 'text/plain', 'Only multi-object requests can output versions');
 				}
 				contentType = 'application/json';
-				body = JSON.stringify(Object.fromEntries(dataObjectOrObjects.map(o => [o.key, o.version])), null, 4);
+				body = JSON.stringify(Object.fromEntries(dataObjectOrObjects.map(o => [o.key, o.clientVersion])), null, 4);
 				break;
 			case 'json':
 			case null:

--- a/chrome/content/zotero/xpcom/server/server_localAPI.js
+++ b/chrome/content/zotero/xpcom/server/server_localAPI.js
@@ -1,9 +1,9 @@
 /*
 	***** BEGIN LICENSE BLOCK *****
 	
-	Copyright © 2022 Corporation for Digital Scholarship
+	Copyright © 2026 Corporation for Digital Scholarship
                      Vienna, Virginia, USA
-					http://zotero.org
+					 https://digitalscholar.org
 	
 	This file is part of Zotero.
 	
@@ -34,10 +34,23 @@ Limitations compared to api.zotero.org:
   one API version will ever be supported at a time. If a new API version is released and your
   client needs to maintain support for older versions, first query /api/ and read the
   Zotero-API-Version response header, then make requests conditionally.
-- Write access is not yet supported.
-- No authentication.
 - No access to user data for users other than the local logged-in user. Use user ID 0 or the user's
   actual API user ID (https://www.zotero.org/settings/keys).
+- Authentication works differently:
+    - Read requests (GET) require no authentication.
+    - Write requests (POST, PUT, PATCH, DELETE) must include a local API key, either using the
+      Zotero-API-Key header (recommended) or the ?key= query parameter. A 401 is returned if
+      the key is missing or unrecognized.
+
+      Local API keys are unrelated to zotero.org API keys. They are obtained by POSTing to
+      /api/authorize-local (a local-only endpoint with no web API analog) with a JSON body
+      of the form { "appName": "<caller's display name>" }. This shows a modal with three
+      buttons: "Allow" (one-time access), "Always Allow" (persistent access), and "Deny".
+      On allow, the response is of the form:
+        { "key": "<key>", "remember": <bool> }
+      When the user picks "Allow" rather than "Always Allow", the key is single-use: the first
+      write that successfully validates it consumes it. Local API consumers should always be
+      prepared to handle a 401 response by reauthenticating.
 - Minimal access to metadata about groups.
 - Atom is not supported.
 - Item type/field endpoints (https://www.zotero.org/support/dev/web_api/v3/types_and_fields) will
@@ -50,6 +63,8 @@ Limitations compared to api.zotero.org:
   but it does not make any attempt to replicate implementation details that your code might rely on.
   Sort orders might differ, quicksearch results will probably differ, and JSON you get from the
   local API is never going to be exactly identical to what you would get from the web API.
+- PATCH-style partial (binary diff) uploads are not implemented; clients should fall back to a
+  full upload.
 
 That said, there are benefits:
 
@@ -64,6 +79,134 @@ That said, there are benefits:
 */
 
 const LOCAL_API_VERSION = 3;
+
+// Maximum number of objects in a single write batch (mirrors dataserver $maxWriteItems, etc.)
+const MAX_WRITE_OBJECTS = 50;
+
+// Maximum number of keys in a multi-delete query parameter
+const MAX_DELETE_OBJECTS = 50;
+
+/**
+ * @type {Map<string, number>} token -> expiryEpochMs
+ */
+const WRITE_TOKEN_CACHE = new Map();
+const WRITE_TOKEN_CACHE_SECONDS = 12 * 60 * 60;
+
+/**
+ * In-progress file uploads.
+ * @type {Map<any, {
+ *     libraryID: number;
+ *     itemKey: string;
+ *     md5: string;
+ *     filename: string;
+ *     filesize: string;
+ *     mtime: number;
+ *     contentType: string;
+ *     charset: string | null;
+ *     uploaded: boolean;
+ *     expires: number;
+ * }>}
+ */
+const PENDING_UPLOADS = new Map();
+const UPLOAD_KEY_TTL_SECONDS = 60 * 60;
+
+// Rate-limiting state for /api/authorize-local. Each entry is a timestamp (ms)
+// for a request that resulted in (or would result in) a confirmation prompt.
+// When the window holds AUTHORIZE_RATE_LIMIT_MAX entries that are all less
+// than AUTHORIZE_RATE_LIMIT_WINDOW_MS old, further requests are rejected with
+// 429 + Retry-After until the oldest entry ages out.
+const AUTHORIZE_RATE_LIMIT_MAX = 5;
+const AUTHORIZE_RATE_LIMIT_WINDOW_MS = 60 * 1000;
+
+let _localAPIKeysCache = null;
+
+function _localAPIKeysPath() {
+	return PathUtils.join(Zotero.Profile.dir, 'localAPIKeys.json');
+}
+
+async function _loadLocalAPIKeys() {
+	if (_localAPIKeysCache) return _localAPIKeysCache;
+	let path = _localAPIKeysPath();
+	try {
+		if (!(await IOUtils.exists(path))) {
+			_localAPIKeysCache = [];
+			return _localAPIKeysCache;
+		}
+		let text = await IOUtils.readUTF8(path);
+		let data = JSON.parse(text);
+		_localAPIKeysCache = Array.isArray(data.keys) ? data.keys : [];
+	}
+	catch (e) {
+		Zotero.logError(e);
+		_localAPIKeysCache = [];
+	}
+	return _localAPIKeysCache;
+}
+
+async function _saveLocalAPIKeys() {
+	if (!_localAPIKeysCache) return;
+	let path = _localAPIKeysPath();
+	let json = JSON.stringify({ keys: _localAPIKeysCache }, null, 4);
+	await IOUtils.writeUTF8(path, json);
+}
+
+/**
+ * Register a new local API key. If remember is true, the key persists and can
+ * be reused indefinitely; otherwise the next successful use will consume it.
+ *
+ * @returns {Promise<string>} The newly generated key
+ */
+async function addLocalAPIKey(appName, remember) {
+	let keys = await _loadLocalAPIKeys();
+	let key = Zotero.Utilities.randomString(32);
+	keys.push({
+		key,
+		appName: typeof appName === 'string' ? appName : '',
+		remember: !!remember,
+		createdAt: new Date().toISOString(),
+	});
+	await _saveLocalAPIKeys();
+	return key;
+}
+
+/**
+ * Look up a candidate API key. If valid, single-use keys (non-"remember") are deleted
+ * before being returned.
+ * Returns null if the key isn't registered.
+ */
+async function consumeLocalAPIKey(key) {
+	if (!key) return null;
+	let keys = await _loadLocalAPIKeys();
+	let idx = keys.findIndex(k => k.key === key);
+	if (idx === -1) return null;
+	let entry = keys[idx];
+	if (entry.remember) {
+		return entry;
+	}
+	// Mark used immediately to prevent race conditions
+	keys.splice(idx, 1);
+	await _saveLocalAPIKeys();
+	return entry;
+}
+
+let _authorizeTimestamps = [];
+
+/**
+ * Record a confirmation-requiring request and check whether the rate limit has
+ * been exceeded. Returns the number of seconds until the next slot is available
+ * when the caller should be rejected with 429, or 0 when the request may proceed.
+ */
+function checkAuthorizeRateLimit() {
+	let now = Date.now();
+	_authorizeTimestamps = _authorizeTimestamps.filter(t => now - t < AUTHORIZE_RATE_LIMIT_WINDOW_MS);
+	if (_authorizeTimestamps.length >= AUTHORIZE_RATE_LIMIT_MAX) {
+		let oldest = _authorizeTimestamps[0];
+		let waitMS = AUTHORIZE_RATE_LIMIT_WINDOW_MS - (now - oldest);
+		return Math.max(1, Math.ceil(waitMS / 1000));
+	}
+	_authorizeTimestamps.push(now);
+	return 0;
+}
 
 const exportFormats = new Map([
 	['bibtex', '9cb70025-a888-4a29-a210-93ec52da40d4'],
@@ -87,24 +230,22 @@ const exportFormats = new Map([
  */
 class LocalAPIEndpoint {
 	async init(requestData) {
+		if (!Zotero.Prefs.get('httpServer.localAPI.enabled')) {
+			return this.makeResponse(403, 'text/plain', 'Local API is not enabled');
+		}
+		requestData.headers = new Headers(requestData.headers);
 		try {
 			return await this._initInternal(requestData);
 		}
 		catch (e) {
-			if (!(e instanceof BadRequestError)) {
-				throw e;
+			if (e instanceof HTTPError) {
+				return this.makeResponse(e.status, 'text/plain', e.message);
 			}
-			return this.makeResponse(400, 'text/plain', e.message);
+			throw e;
 		}
 	}
-	
+
 	async _initInternal(requestData) {
-		if (!Zotero.Prefs.get('httpServer.localAPI.enabled')) {
-			return this.makeResponse(403, 'text/plain', 'Local API is not enabled');
-		}
-		
-		requestData.headers = new Headers(requestData.headers);
-		
 		let apiVersion = parseInt(
 			requestData.headers.get('Zotero-API-Version')
 				|| requestData.searchParams.get('v')
@@ -145,6 +286,22 @@ class LocalAPIEndpoint {
 			await library.waitForDataLoad('item');
 		}
 		
+		let isWriteMethod = ['POST', 'PUT', 'PATCH', 'DELETE'].includes(requestData.method);
+		if (isWriteMethod) {
+			let authResponse = await this._authenticateWriteRequest(requestData);
+			if (authResponse) return authResponse;
+
+			if (!library.editable) {
+				return this.makeResponse(403, 'text/plain', 'Write access denied');
+			}
+
+			let response = await this.run(requestData);
+			if (Array.isArray(response)) {
+				return this.makeResponse(...response);
+			}
+			throw new Error("Write endpoint did not return an HTTP response array");
+		}
+
 		let response = await this.run(requestData);
 		if (response.data) {
 			let dataIsArray = Array.isArray(response.data);
@@ -223,7 +380,7 @@ class LocalAPIEndpoint {
 			
 			let headers = {
 				'Total-Results': totalResults,
-				'Link': Object.entries(links).map(([rel, url]) => `<${url}>; rel="${rel}"`).join(', ')
+				Link: Object.entries(links).map(([rel, url]) => `<${url}>; rel="${rel}"`).join(', ')
 			};
 			let lastModifiedVersion = dataIsArray
 				? Zotero.Libraries.get(requestData.libraryID).clientVersion
@@ -375,9 +532,9 @@ class LocalAPIEndpoint {
 	 * Make an HTTP response array with API headers.
 	 *
 	 * @param {Number} status
-	 * @param {String | Object} contentTypeOrHeaders
-	 * @param {String} body
-	 * @returns {[Number, Object, String]}
+	 * @param {string | Object} contentTypeOrHeaders
+	 * @param {string} body
+	 * @returns {number | string | object}
 	 */
 	makeResponse(status, contentTypeOrHeaders, body) {
 		if (typeof contentTypeOrHeaders == 'string') {
@@ -402,6 +559,117 @@ class LocalAPIEndpoint {
 	run(requestData) {
 		throw new Error("run() must be implemented");
 	}
+
+	/**
+	 * Validate the caller's local API key. The key may be provided either via
+	 * the Zotero-API-Key header or the ?key= query parameter.
+	 *
+	 * Returns null when the request is authorized to proceed, or an HTTP
+	 * response array when it should be rejected. Keys are obtained by callers
+	 * via POST /api/authorize-local; single-use keys are consumed (deleted
+	 * from the persistent store) here.
+	 *
+	 * @param {Object} requestData
+	 * @returns {Promise<null | [Number, (String | Object), String]>}
+	 */
+	async _authenticateWriteRequest(requestData) {
+		let key = requestData.headers.get('Zotero-API-Key')
+			|| requestData.searchParams.get('key')
+			|| '';
+		if (!key) {
+			return [
+				401,
+				{
+					'Content-Type': 'text/plain',
+					'WWW-Authenticate': 'Zotero-API-Key realm="Zotero Local API"',
+				},
+				'API key required -- POST /api/authorize-local to obtain one'
+			];
+		}
+		let entry = await consumeLocalAPIKey(key);
+		if (!entry) {
+			return [401, 'text/plain', 'Invalid or expired API key'];
+		}
+		requestData.apiKey = entry;
+		return null;
+	}
+
+	/**
+	 * Validate the Zotero-Write-Token header (5-32 chars). If present, check that it
+	 * hasn't been used for a successful write within the last 12 hours; otherwise,
+	 * return a 412 response. The caller must invoke {@link _recordWriteToken()}
+	 * after the write succeeds.
+	 *
+	 * @param {object} requestData
+	 * @returns {string | null} The validated token, or null if not provided
+	 * @throws HTTPError on invalid or duplicate token
+	 */
+	_checkWriteToken(requestData) {
+		let token = requestData.headers.get('Zotero-Write-Token');
+		if (!token) return null;
+		if (token.length < 5 || token.length > 32) {
+			throw new HTTPError(400, "Write token must be 5-32 characters in length");
+		}
+		pruneExpired(WRITE_TOKEN_CACHE);
+		if (WRITE_TOKEN_CACHE.has(token)) {
+			throw new HTTPError(412, "Write token already used");
+		}
+		return token;
+	}
+
+	_recordWriteToken(token) {
+		if (!token) return;
+		WRITE_TOKEN_CACHE.set(token, Date.now() + WRITE_TOKEN_CACHE_SECONDS * 1000);
+	}
+
+	/**
+	 * Parse and validate If-Unmodified-Since-Version against the library's clientVersion.
+	 *
+	 * @param {Object} requestData
+	 * @param {Object} options
+	 * @param {Boolean} [options.required] If true and the header is missing, throw 428
+	 * @throws HTTPError on missing/invalid/out-of-date version
+	 */
+	_checkLibraryIfUnmodifiedSinceVersion(requestData, { required = false } = {}) {
+		let header = requestData.headers.get('If-Unmodified-Since-Version');
+		if (header === null) {
+			if (required) {
+				throw new HTTPError(428, "If-Unmodified-Since-Version not provided");
+			}
+			return;
+		}
+		let value = parseInt(header);
+		if (Number.isNaN(value) || value < 0) {
+			throw new HTTPError(400, "Invalid If-Unmodified-Since-Version value");
+		}
+		let library = Zotero.Libraries.get(requestData.libraryID);
+		if (library.clientVersion > value) {
+			throw new HTTPError(412, `Library has been modified since specified version (expected ${value}, found ${library.clientVersion})`);
+		}
+	}
+
+	/**
+	 * Parse a JSON body. Accepts either an already-parsed object (when content-type
+	 * was application/json) or a string. Throws HTTPError(400) on parse failure.
+	 */
+	_parseJSONBody(data) {
+		if (data === null || data === undefined || data === '') {
+			throw new HTTPError(400, "Empty request body");
+		}
+		// Reject binary bodies on JSON endpoints
+		if (data instanceof Ci.nsIInputStream) {
+			throw new HTTPError(400, "Content-Type must be application/json");
+		}
+		if (typeof data === 'object') {
+			return data;
+		}
+		try {
+			return JSON.parse(data);
+		}
+		catch (e) {
+			throw new HTTPError(400, "Invalid JSON: " + e.message);
+		}
+	}
 }
 
 const _404 = [404, 'text/plain', 'Not found'];
@@ -417,6 +685,62 @@ Zotero.Server.LocalAPI.Root = class extends LocalAPIEndpoint {
 };
 Zotero.Server.Endpoints["/api/"] = Zotero.Server.LocalAPI.Root;
 
+/**
+ * Local-only authorization endpoint. Has no analog in the web API. Callers
+ * that receive a 401 from a write endpoint should POST here with their app
+ * name; the user is shown a dialog and can grant or deny access. On grant,
+ * the response includes a 32-character key the caller must pass on subsequent
+ * write requests via the Zotero-API-Key header (or ?key= query parameter).
+ *
+ * If the user picked "Allow" rather than "Always Allow", the returned key
+ * will be invalidated after its first successful use.
+ */
+Zotero.Server.LocalAPI.AuthorizeLocal = class extends LocalAPIEndpoint {
+	supportedMethods = ['POST'];
+	
+	supportedDataTypes = ['application/json'];
+
+	async _initInternal(requestData) {
+		let body = requestData.data;
+		if (!body
+				|| typeof body !== 'object'
+				|| Array.isArray(body)
+				|| typeof body.appName !== 'string'
+				|| !body.appName.trim()) {
+			return this.makeResponse(400, 'text/plain', 'appName is required');
+		}
+		let appName = body.appName.trim();
+
+		let retryAfter = checkAuthorizeRateLimit();
+		if (retryAfter > 0) {
+			return this.makeResponse(
+				429,
+				{
+					'Content-Type': 'text/plain',
+					'Retry-After': String(retryAfter),
+				},
+				'Too many authorization requests'
+			);
+		}
+
+		let { allow, remember } = await Zotero.Server.LocalAPI._promptForAuthorization(appName);
+		if (!allow) {
+			return this.makeResponse(
+				403,
+				'application/json',
+				JSON.stringify({ denied: true })
+			);
+		}
+
+		let key = await addLocalAPIKey(appName, remember);
+		return this.makeResponse(
+			200,
+			'application/json',
+			JSON.stringify({ key, remember: !!remember })
+		);
+	}
+};
+Zotero.Server.Endpoints["/api/authorize-local"] = Zotero.Server.LocalAPI.AuthorizeLocal;
 
 Zotero.Server.LocalAPI.Schema = class extends LocalAPIEndpoint {
 	supportedMethods = ['GET'];
@@ -523,9 +847,23 @@ Zotero.Server.Endpoints["/api/users/:userID/settings"] = Zotero.Server.LocalAPI.
 
 
 Zotero.Server.LocalAPI.Collections = class extends LocalAPIEndpoint {
-	supportedMethods = ['GET'];
-	
-	run({ pathname, pathParams, libraryID }) {
+	supportedMethods = ['GET', 'POST', 'DELETE'];
+
+	async run(requestData) {
+		const WRITE_PATH_RE = /^\/api\/(?:users|groups)\/[^/]+\/collections\/?$/;
+		if (requestData.method === 'POST') {
+			if (!WRITE_PATH_RE.test(requestData.pathname)) {
+				return [405, 'text/plain', 'Method not allowed for this path'];
+			}
+			return writeMultipleObjects(this, requestData, 'collection');
+		}
+		if (requestData.method === 'DELETE') {
+			if (!WRITE_PATH_RE.test(requestData.pathname)) {
+				return [405, 'text/plain', 'Method not allowed for this path'];
+			}
+			return deleteMultipleObjects(this, requestData, 'collection', 'collectionKey');
+		}
+		let { pathname, pathParams, libraryID } = requestData;
 		let top = pathname.endsWith('/top');
 		let collections = pathParams.collectionKey
 			? Zotero.Collections.getByParent(Zotero.Collections.getIDFromLibraryAndKey(libraryID, pathParams.collectionKey))
@@ -541,9 +879,16 @@ Zotero.Server.Endpoints["/api/users/:userID/collections/:collectionKey/collectio
 Zotero.Server.Endpoints["/api/groups/:groupID/collections/:collectionKey/collections"] = Zotero.Server.LocalAPI.Collections;
 
 Zotero.Server.LocalAPI.Collection = class extends LocalAPIEndpoint {
-	supportedMethods = ['GET'];
+	supportedMethods = ['GET', 'PUT', 'PATCH', 'DELETE'];
 
-	run({ pathParams, libraryID }) {
+	async run(requestData) {
+		if (requestData.method === 'PUT' || requestData.method === 'PATCH') {
+			return writeSingleObject(this, requestData, 'collection', requestData.method === 'PATCH');
+		}
+		if (requestData.method === 'DELETE') {
+			return deleteSingleObject(this, requestData, 'collection');
+		}
+		let { pathParams, libraryID } = requestData;
 		let collection = Zotero.Collections.getByLibraryAndKey(libraryID, pathParams.collectionKey);
 		if (!collection) return _404;
 		return { data: collection };
@@ -577,9 +922,26 @@ Zotero.Server.Endpoints["/api/users/:userID/groups/:groupID"] = Zotero.Server.Lo
 
 
 Zotero.Server.LocalAPI.Items = class extends LocalAPIEndpoint {
-	supportedMethods = ['GET'];
+	supportedMethods = ['GET', 'POST', 'DELETE'];
 
-	async run({ pathname, pathParams, searchParams, libraryID }) {
+	async run(requestData) {
+		const WRITE_PATH_RE = /^\/api\/(?:users|groups)\/[^/]+\/items\/?$/;
+		if (requestData.method === 'POST') {
+			if (!WRITE_PATH_RE.test(requestData.pathname)) {
+				return [405, 'text/plain', 'Method not allowed for this path'];
+			}
+			return writeMultipleObjects(this, requestData, 'item');
+		}
+		if (requestData.method === 'DELETE') {
+			if (!WRITE_PATH_RE.test(requestData.pathname)) {
+				return [405, 'text/plain', 'Method not allowed for this path'];
+			}
+			return deleteMultipleObjects(this, requestData, 'item', 'itemKey');
+		}
+		return this._runGet(requestData);
+	}
+
+	async _runGet({ pathname, pathParams, searchParams, libraryID }) {
 		let isTags = pathname.endsWith('/tags');
 		if (isTags) {
 			// Cut it off so other .endsWith() checks work
@@ -732,9 +1094,16 @@ Zotero.Server.Endpoints["/api/users/:userID/searches/:searchKey/items"] = Zotero
 Zotero.Server.Endpoints["/api/groups/:groupID/searches/:searchKey/items"] = Zotero.Server.LocalAPI.Items;
 
 Zotero.Server.LocalAPI.Item = class extends LocalAPIEndpoint {
-	supportedMethods = ['GET'];
+	supportedMethods = ['GET', 'PUT', 'PATCH', 'DELETE'];
 
-	async run({ pathParams, libraryID }) {
+	async run(requestData) {
+		if (requestData.method === 'PUT' || requestData.method === 'PATCH') {
+			return writeSingleObject(this, requestData, 'item', requestData.method === 'PATCH');
+		}
+		if (requestData.method === 'DELETE') {
+			return deleteSingleObject(this, requestData, 'item');
+		}
+		let { pathParams, libraryID } = requestData;
 		let item = await Zotero.Items.getByLibraryAndKeyAsync(libraryID, pathParams.itemKey);
 		if (!item) return _404;
 		return { data: item };
@@ -745,9 +1114,24 @@ Zotero.Server.Endpoints["/api/groups/:groupID/items/:itemKey"] = Zotero.Server.L
 
 
 Zotero.Server.LocalAPI.ItemFile = class extends LocalAPIEndpoint {
-	supportedMethods = ['GET'];
+	supportedMethods = ['GET', 'POST', 'PATCH'];
 
-	async run({ pathname, pathParams, libraryID }) {
+	async run(requestData) {
+		let { method, pathname, pathParams, libraryID } = requestData;
+		if (method === 'POST') {
+			if (pathname.endsWith('/view') || pathname.endsWith('/url')) {
+				return [405, 'text/plain', 'Method not allowed for this path'];
+			}
+			return handleFileWrite(this, requestData);
+		}
+		if (method === 'PATCH') {
+			if (pathname.endsWith('/view') || pathname.endsWith('/url')) {
+				return [405, 'text/plain', 'Method not allowed for this path'];
+			}
+			// Partial uploads (binary diffs) aren't supported locally; the
+			// client should fall back to a full upload (per dataserver docs).
+			return [405, 'text/plain', 'Partial uploads are not supported by the local API'];
+		}
 		let item = await Zotero.Items.getByLibraryAndKeyAsync(libraryID, pathParams.itemKey);
 		if (!item) return _404;
 		if (!item.isFileAttachment()) {
@@ -756,7 +1140,7 @@ Zotero.Server.LocalAPI.ItemFile = class extends LocalAPIEndpoint {
 		if (pathname.endsWith('/url')) {
 			return [200, 'text/plain', item.getLocalFileURL()];
 		}
-		return [302, { 'Location': item.getLocalFileURL() }, ''];
+		return [302, { Location: item.getLocalFileURL() }, ''];
 	}
 };
 Zotero.Server.Endpoints["/api/users/:userID/items/:itemKey/file"] = Zotero.Server.LocalAPI.ItemFile;
@@ -766,11 +1150,135 @@ Zotero.Server.Endpoints["/api/groups/:groupID/items/:itemKey/file/view"] = Zoter
 Zotero.Server.Endpoints["/api/users/:userID/items/:itemKey/file/view/url"] = Zotero.Server.LocalAPI.ItemFile;
 Zotero.Server.Endpoints["/api/groups/:groupID/items/:itemKey/file/view/url"] = Zotero.Server.LocalAPI.ItemFile;
 
+/**
+ * Local-only endpoint that receives the raw bytes for a previously authorized
+ * upload (the URL returned in the authorize phase). Writes the file directly
+ * into the attachment's storage directory.
+ */
+Zotero.Server.LocalAPI.UploadReceiver = class extends LocalAPIEndpoint {
+	supportedMethods = ['POST'];
+
+	// Required so the post-write block doesn't insist on a library write check
+	async _initInternal(requestData) {
+		try {
+			if (!Zotero.Prefs.get('httpServer.localAPI.enabled')) {
+				return this.makeResponse(403, 'text/plain', 'Local API is not enabled');
+			}
+			requestData.headers = new Headers(requestData.headers);
+
+			let uploadKey = requestData.pathParams.uploadKey;
+			pruneExpired(PENDING_UPLOADS);
+			let upload = PENDING_UPLOADS.get(uploadKey);
+			if (!upload) {
+				return this.makeResponse(404, 'text/plain', 'Unknown or expired upload key');
+			}
+
+			let data = requestData.data;
+			let bytes;
+			if (data instanceof Ci.nsIInputStream) {
+				let binaryStream = Cc["@mozilla.org/binaryinputstream;1"]
+					.createInstance(Ci.nsIBinaryInputStream);
+				binaryStream.setInputStream(data);
+				let available = binaryStream.available();
+				bytes = new Uint8Array(binaryStream.readByteArray(available));
+			}
+			else if (typeof data === 'string') {
+				// Best effort: text-decoded body. Will produce a corrupted file
+				// for true binary content -- the client should send a binary
+				// content-type so the server hands us the raw stream.
+				let encoder = new TextEncoder();
+				bytes = encoder.encode(data);
+			}
+			else {
+				return this.makeResponse(400, 'text/plain', 'No file content provided');
+			}
+
+			let item = await Zotero.Items.getByLibraryAndKeyAsync(upload.libraryID, upload.itemKey);
+			if (!item || !item.isFileAttachment()) {
+				PENDING_UPLOADS.delete(uploadKey);
+				return this.makeResponse(404, 'text/plain', 'Attachment item no longer exists');
+			}
+
+			let dir = Zotero.Attachments.getStorageDirectory(item);
+			await IOUtils.makeDirectory(dir.path, { ignoreExisting: true });
+			let destPath = PathUtils.join(dir.path, upload.filename);
+			await IOUtils.write(destPath, bytes);
+
+			// Verify the actual md5 matches what was claimed in the authorize phase.
+			let actualMD5 = await Zotero.Utilities.Internal.md5Async(destPath);
+			if (actualMD5 !== upload.md5) {
+				await IOUtils.remove(destPath, { ignoreAbsent: true });
+				PENDING_UPLOADS.delete(uploadKey);
+				return this.makeResponse(400, 'text/plain',
+					`File MD5 does not match expected (got ${actualMD5}, expected ${upload.md5})`);
+			}
+
+			upload.uploaded = true;
+			return this.makeResponse(201, 'text/plain', '');
+		}
+		catch (e) {
+			Zotero.logError(e);
+			return this.makeResponse(500, 'text/plain', 'Upload failed: ' + e.message);
+		}
+	}
+};
+Zotero.Server.Endpoints["/api/local/uploads/:uploadKey"] = Zotero.Server.LocalAPI.UploadReceiver;
+
+
+// Mirrors dataserver's Zotero_API::$maxWriteFullText
+const MAX_WRITE_FULLTEXT = 10;
+
+/**
+ * Validate a single fulltext write payload. Throws HTTPError(400) on failure.
+ */
+function validateFullTextItemBody(body) {
+	if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+		throw new HTTPError(400, 'Body must be a JSON object');
+	}
+	if (typeof body.content !== 'string') {
+		throw new HTTPError(400, "'content' must be a string");
+	}
+	for (let stat of ['indexedChars', 'totalChars', 'indexedPages', 'totalPages']) {
+		if (body[stat] !== undefined && body[stat] !== null && !Number.isInteger(body[stat])) {
+			throw new HTTPError(400, `'${stat}' must be an integer`);
+		}
+	}
+}
 
 Zotero.Server.LocalAPI.ItemFullText = class extends LocalAPIEndpoint {
-	supportedMethods = ['GET'];
+	supportedMethods = ['GET', 'PUT'];
 
-	async run({ pathParams, libraryID }) {
+	supportedDataTypes = ['application/json'];
+
+	async run(requestData) {
+		let { pathParams, libraryID, data } = requestData;
+		if (requestData.method === 'PUT') {
+			let body;
+			try {
+				body = this._parseJSONBody(data);
+				validateFullTextItemBody(body);
+			}
+			catch (e) {
+				if (e instanceof HTTPError) return [e.status, 'text/plain', e.message];
+				throw e;
+			}
+
+			let newVersion;
+			try {
+				newVersion = await storeItemFullText(libraryID, pathParams.itemKey, body);
+			}
+			catch (e) {
+				if (e instanceof HTTPError) return [e.status, 'text/plain', e.message];
+				throw e;
+			}
+
+			return [
+				204,
+				{ 'Last-Modified-Version': newVersion },
+				''
+			];
+		}
+
 		let item = await Zotero.Items.getByLibraryAndKeyAsync(libraryID, pathParams.itemKey);
 		if (!item || !item.isFileAttachment() || !Zotero.Fulltext.isCachedMIMEType(item.attachmentContentType)) {
 			return _404;
@@ -808,9 +1316,15 @@ Zotero.Server.Endpoints["/api/groups/:groupID/items/:itemKey/fulltext"] = Zotero
 
 
 Zotero.Server.LocalAPI.FullText = class extends LocalAPIEndpoint {
-	supportedMethods = ['GET'];
+	supportedMethods = ['GET', 'POST'];
 
-	async run({ searchParams, libraryID }) {
+	supportedDataTypes = ['application/json'];
+
+	async run(requestData) {
+		if (requestData.method === 'POST') {
+			return writeBulkFullText(this, requestData);
+		}
+		let { searchParams, libraryID } = requestData;
 		let since = parseInt(searchParams.get('since'));
 		if (Number.isNaN(since)) {
 			return [400, 'text/plain', `Invalid 'since' value '${searchParams.get('since')}'`];
@@ -832,10 +1346,90 @@ Zotero.Server.Endpoints["/api/users/:userID/fulltext"] = Zotero.Server.LocalAPI.
 Zotero.Server.Endpoints["/api/groups/:groupID/fulltext"] = Zotero.Server.LocalAPI.FullText;
 
 
-Zotero.Server.LocalAPI.Searches = class extends LocalAPIEndpoint {
-	supportedMethods = ['GET'];
+async function writeBulkFullText(endpoint, requestData) {
+	let { libraryID, data } = requestData;
 
-	async run({ libraryID }) {
+	let body;
+	try {
+		endpoint._checkLibraryIfUnmodifiedSinceVersion(requestData, { required: true });
+		body = endpoint._parseJSONBody(data);
+	}
+	catch (e) {
+		if (e instanceof HTTPError) return [e.status, 'text/plain', e.message];
+		throw e;
+	}
+
+	if (!Array.isArray(body)) {
+		return [400, 'text/plain', 'Uploaded data must be a JSON array'];
+	}
+	if (body.length === 0) {
+		return [400, 'text/plain', 'No full-text entries provided'];
+	}
+	if (body.length > MAX_WRITE_FULLTEXT) {
+		return [
+			413,
+			'text/plain',
+			`Cannot write more than ${MAX_WRITE_FULLTEXT} full-text entries at a time`
+		];
+	}
+
+	let results = new MultiWriteResults();
+	for (let i = 0; i < body.length; i++) {
+		let entry = body[i];
+		let providedKey = '';
+		try {
+			if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+				throw new HTTPError(400, `Invalid value for index ${i}; expected JSON object`);
+			}
+			if (typeof entry.key !== 'string' || !entry.key) {
+				throw new HTTPError(400, "'key' is required");
+			}
+			providedKey = entry.key;
+			validateObjectKey(providedKey);
+			validateFullTextItemBody(entry);
+
+			await storeItemFullText(libraryID, providedKey, entry);
+			// Mirrors dataserver: successful fulltext entries return only the key, no full JSON
+			results.addSuccess(i, { key: providedKey });
+		}
+		catch (e) {
+			Zotero.debug(`Local API: fulltext write index ${i} failed: ${e.message || e}`, 2);
+			if (!(e instanceof HTTPError)) {
+				Zotero.logError(e);
+			}
+			results.addFailure(i, providedKey, e);
+		}
+	}
+
+	return [
+		200,
+		{
+			'Content-Type': 'application/json',
+			'Last-Modified-Version': Zotero.Libraries.get(libraryID).clientVersion,
+		},
+		JSON.stringify(results.toJSON(), null, 4)
+	];
+}
+
+
+Zotero.Server.LocalAPI.Searches = class extends LocalAPIEndpoint {
+	supportedMethods = ['GET', 'POST', 'DELETE'];
+
+	async run(requestData) {
+		const WRITE_PATH_RE = /^\/api\/(?:users|groups)\/[^/]+\/searches\/?$/;
+		if (requestData.method === 'POST') {
+			if (!WRITE_PATH_RE.test(requestData.pathname)) {
+				return [405, 'text/plain', 'Method not allowed for this path'];
+			}
+			return writeMultipleObjects(this, requestData, 'search');
+		}
+		if (requestData.method === 'DELETE') {
+			if (!WRITE_PATH_RE.test(requestData.pathname)) {
+				return [405, 'text/plain', 'Method not allowed for this path'];
+			}
+			return deleteMultipleObjects(this, requestData, 'search', 'searchKey');
+		}
+		let { libraryID } = requestData;
 		let searches = await Zotero.Searches.getAll(libraryID);
 		return { data: searches };
 	}
@@ -844,9 +1438,16 @@ Zotero.Server.Endpoints["/api/users/:userID/searches"] = Zotero.Server.LocalAPI.
 Zotero.Server.Endpoints["/api/groups/:groupID/searches"] = Zotero.Server.LocalAPI.Searches;
 
 Zotero.Server.LocalAPI.Search = class extends LocalAPIEndpoint {
-	supportedMethods = ['GET'];
+	supportedMethods = ['GET', 'PUT', 'PATCH', 'DELETE'];
 
-	async run({ pathParams, libraryID }) {
+	async run(requestData) {
+		if (requestData.method === 'PUT' || requestData.method === 'PATCH') {
+			return writeSingleObject(this, requestData, 'search', requestData.method === 'PATCH');
+		}
+		if (requestData.method === 'DELETE') {
+			return deleteSingleObject(this, requestData, 'search');
+		}
+		let { pathParams, libraryID } = requestData;
 		let search = Zotero.Searches.getByLibraryAndKey(libraryID, pathParams.searchKey);
 		if (!search) return _404;
 		return { data: search };
@@ -857,12 +1458,42 @@ Zotero.Server.Endpoints["/api/groups/:groupID/searches/:searchKey"] = Zotero.Ser
 
 
 Zotero.Server.LocalAPI.Tags = class extends LocalAPIEndpoint {
-	supportedMethods = ['GET'];
+	supportedMethods = ['GET', 'DELETE'];
 
-	async run({ libraryID }) {
-		let tags = await Zotero.Tags.getAll(libraryID);
-		let json = await Zotero.Tags.toResponseJSON(libraryID, tags);
-		return { data: json };
+	async run(requestData) {
+		let { libraryID, searchParams } = requestData;
+		if (requestData.method === 'DELETE') {
+			this._checkLibraryIfUnmodifiedSinceVersion(requestData, { required: true });
+
+			let raw = searchParams.get('tag');
+			if (!raw) {
+				return [400, 'text/plain', "'tag' not provided"];
+			}
+			// '||' separates tag names; values are already URL-decoded at this point.
+			let names = raw.split('||').map(t => t.trim()).filter(Boolean);
+			if (!names.length) {
+				return [400, 'text/plain', "'tag' not provided"];
+			}
+			if (names.length > MAX_DELETE_OBJECTS) {
+				return [413, 'text/plain', `Cannot delete more than ${MAX_DELETE_OBJECTS} tags at a time`];
+			}
+
+			let tagIDs = names.map(name => Zotero.Tags.getID(name)).filter(id => !!id);
+			if (tagIDs.length) {
+				await Zotero.Tags.removeFromLibrary(libraryID, tagIDs);
+			}
+
+			return [
+				204,
+				{ 'Last-Modified-Version': Zotero.Libraries.get(libraryID).clientVersion },
+				''
+			];
+		}
+		else {
+			let tags = await Zotero.Tags.getAll(libraryID);
+			let json = await Zotero.Tags.toResponseJSON(libraryID, tags);
+			return { data: json };
+		}
 	}
 };
 Zotero.Server.Endpoints["/api/users/:userID/tags"] = Zotero.Server.LocalAPI.Tags;
@@ -883,8 +1514,54 @@ Zotero.Server.Endpoints["/api/groups/:groupID/tags/:tag"] = Zotero.Server.LocalA
 
 
 /**
+ * Show the local API authorization dialog. Stubbable in tests.
+ * @returns {Promise<{ allow: boolean, remember: boolean }>}
+ */
+Zotero.Server.LocalAPI._promptForAuthorization = async function (appName) {
+	let title = Zotero.ftl.formatValueSync('local-api-authorize-title');
+	let text = Zotero.ftl.formatValueSync('local-api-authorize-text', { appName });
+	let allowLabel = Zotero.ftl.formatValueSync('local-api-authorize-allow');
+	let alwaysAllowLabel = Zotero.ftl.formatValueSync('local-api-authorize-always-allow');
+	let denyLabel = Zotero.ftl.formatValueSync('local-api-authorize-deny');
+
+	let index = Zotero.Prompt.confirm({
+		title,
+		text,
+		button0: allowLabel,
+		button1: alwaysAllowLabel,
+		button2: denyLabel,
+		defaultButton: 2,
+	});
+	return { allow: index === 0 || index === 1, remember: index === 1 };
+};
+
+/**
+ * Number of remembered (persistent) local API authorizations.
+ */
+Zotero.Server.LocalAPI.getAuthorizationCount = async function () {
+	let keys = await _loadLocalAPIKeys();
+	return keys.filter(k => k.remember).length;
+};
+
+/**
+ * Discard every stored local API authorization. Subsequent write requests will
+ * have to reauthorize.
+ */
+Zotero.Server.LocalAPI.clearAuthorizations = async function () {
+	_localAPIKeysCache = [];
+	let path = _localAPIKeysPath();
+	if (await IOUtils.exists(path)) {
+		await IOUtils.remove(path);
+	}
+};
+
+Zotero.Server.LocalAPI._resetAuthorizeRateLimit = function () {
+	_authorizeTimestamps = [];
+};
+
+/**
  * Convert a {@link Zotero.DataObject}, or an array of DataObjects, to response JSON
- * 		with appropriate included data based on the 'include' query parameter.
+ * with appropriate included data based on the 'include' query parameter.
  *
  * @param {Zotero.DataObject | Zotero.DataObject[]} dataObjectOrObjects
  * @param {URLSearchParams} searchParams
@@ -972,7 +1649,7 @@ async function citeprocToHTML(itemOrItems, searchParams, asCitationList) {
 			style = Zotero.Styles.get(styleID);
 		}
 		catch (e) {
-			throw new BadRequestError(`Invalid style: ${styleIDOrURL} (${e.message})`);
+			throw new HTTPError(400, `Invalid style: ${styleIDOrURL} (${e.message})`);
 		}
 	}
 	if (!style) {
@@ -980,6 +1657,7 @@ async function citeprocToHTML(itemOrItems, searchParams, asCitationList) {
 	}
 	
 	let cslEngine = style.getCiteProc(locale, 'html', { cache: true });
+	// eslint-disable-next-line camelcase
 	cslEngine.opt.development_extensions.wrap_url_and_doi = linkWrap;
 	return Zotero.Cite.makeFormattedBibliographyOrCitationList(cslEngine, items, 'html', asCitationList);
 }
@@ -988,7 +1666,7 @@ async function citeprocToHTML(itemOrItems, searchParams, asCitationList) {
  * Export items to a string with the given translator.
  *
  * @param {Zotero.Item|Zotero.Item[]} itemOrItems
- * @param {String} translatorID
+ * @param {string} translatorID
  * @returns {Promise<String>}
  */
 function exportItems(itemOrItems, translatorID) {
@@ -1015,8 +1693,8 @@ function exportItems(itemOrItems, translatorID) {
  * Evaluate the API's search syntax: https://www.zotero.org/support/dev/web_api/v3/basics#search_syntax
  *
  * @param {Zotero.Search} parentSearch
- * @param {String[]} searchStrings The search strings provided by the client as query parameters
- * @param {String} condition The search condition name
+ * @param {string[]} searchStrings The search strings provided by the client as query parameters
+ * @param {string} condition The search condition name
  */
 function buildSearchFromSearchSyntax(parentSearch, searchStrings, condition) {
 	for (let searchString of searchStrings) {
@@ -1056,4 +1734,787 @@ function searchToDebugJSON(search) {
 	};
 }
 
-class BadRequestError extends Error {}
+/**
+ * Validate an object key from a query parameter or JSON body. Throws HTTPError(400) if invalid.
+ */
+function validateObjectKey(key) {
+	if (typeof key !== 'string' || !Zotero.Utilities.isValidObjectKey(key)) {
+		throw new HTTPError(400, `Invalid key: '${key}'`);
+	}
+	return key;
+}
+
+/**
+ * Parse a comma-separated list of keys from a query parameter, validating each.
+ * Throws HTTPError if missing, malformed, or exceeds the max-delete limit.
+ */
+function parseKeyList(searchParams, paramName) {
+	let raw = searchParams.get(paramName);
+	if (!raw) {
+		throw new HTTPError(400, `'${paramName}' not provided`);
+	}
+	let keys = raw.split(',').map(k => k.trim()).filter(Boolean);
+	if (!keys.length) {
+		throw new HTTPError(400, `'${paramName}' not provided`);
+	}
+	if (keys.length > MAX_DELETE_OBJECTS) {
+		throw new HTTPError(413, `Cannot delete more than ${MAX_DELETE_OBJECTS} objects at a time`);
+	}
+	for (let key of keys) {
+		validateObjectKey(key);
+	}
+	return keys;
+}
+
+/**
+ * Return the response JSON for a successfully written data object, using the
+ * same options used elsewhere in the local API.
+ */
+async function dataObjectToResponseJSON(dataObject) {
+	return dataObject.toResponseJSONAsync({
+		apiURL: `http://localhost:${Zotero.Server.port}/api/`,
+		includeGroupDetails: true,
+		syncedStorageProperties: false,
+		syncedVersionProperty: false,
+	});
+}
+
+/**
+ * Look up an existing object by library + key, returning null if not found.
+ * `kind` is one of 'item', 'collection', 'search'.
+ */
+async function getExistingObjectByKey(libraryID, key, kind) {
+	switch (kind) {
+		case 'item':
+			return Zotero.Items.getByLibraryAndKeyAsync(libraryID, key);
+		case 'collection':
+			return Zotero.Collections.getByLibraryAndKey(libraryID, key);
+		case 'search':
+			return Zotero.Searches.getByLibraryAndKey(libraryID, key);
+		default:
+			throw new Error(`Unknown object kind: ${kind}`);
+	}
+}
+
+/**
+ * Construct a new object of the given kind in the given library, ready
+ * for fromJSON(). For items, the itemType must be passed.
+ */
+function makeNewObject(libraryID, kind, itemType) {
+	let obj;
+	switch (kind) {
+		case 'item':
+			if (!itemType) {
+				throw new HTTPError(400, "itemType property not provided");
+			}
+			if (!Zotero.ItemTypes.getID(itemType)) {
+				throw new HTTPError(400, `Unknown itemType '${itemType}'`);
+			}
+			obj = new Zotero.Item(itemType);
+			break;
+		case 'collection':
+			obj = new Zotero.Collection();
+			break;
+		case 'search':
+			obj = new Zotero.Search();
+			break;
+		default:
+			throw new Error(`Unknown object kind: ${kind}`);
+	}
+	obj.libraryID = libraryID;
+	return obj;
+}
+
+/**
+ * Apply JSON to an existing or new data object. Throws HTTPError on validation
+ * failure. Caller is responsible for calling saveTx().
+ */
+function applyJSONToObject(obj, json, kind) {
+	try {
+		obj.fromJSON(json, { strict: false });
+	}
+	catch (e) {
+		if (e && e.name === 'ZoteroInvalidDataError') {
+			throw new HTTPError(400, e.message);
+		}
+		throw e;
+	}
+	if (kind === 'item' && obj.isNote() && typeof json.note === 'string') {
+		// fromJSON already sets the note for note/attachment items
+	}
+}
+
+/**
+ * Merge a PATCH JSON object onto the current item/collection/search JSON
+ * representation. Keys present in `patchJSON` (even if empty) take precedence;
+ * keys absent from `patchJSON` keep their existing values.
+ */
+function mergePatchJSON(existingJSON, patchJSON) {
+	let merged = { ...existingJSON };
+	for (let k of Object.keys(patchJSON)) {
+		merged[k] = patchJSON[k];
+	}
+	return merged;
+}
+
+/**
+ * Multi-object write (POST). Handles items, collections, searches uniformly.
+ */
+async function writeMultipleObjects(endpoint, requestData, kind) {
+	let { libraryID, data } = requestData;
+
+	let token;
+	let body;
+	try {
+		token = endpoint._checkWriteToken(requestData);
+		endpoint._checkLibraryIfUnmodifiedSinceVersion(requestData);
+		body = endpoint._parseJSONBody(data);
+	}
+	catch (e) {
+		if (e instanceof HTTPError) {
+			return [e.status, 'text/plain', e.message];
+		}
+		throw e;
+	}
+
+	if (!Array.isArray(body)) {
+		return [400, 'text/plain', `Uploaded data must be a JSON array`];
+	}
+	if (body.length === 0) {
+		return [400, 'text/plain', `No ${kind}s provided`];
+	}
+	if (body.length > MAX_WRITE_OBJECTS) {
+		return [
+			413,
+			'text/plain',
+			`Cannot add more than ${MAX_WRITE_OBJECTS} ${kind}s at a time`
+		];
+	}
+
+	let results = new MultiWriteResults();
+
+	for (let i = 0; i < body.length; i++) {
+		let entry = body[i];
+		let providedKey = '';
+		try {
+			if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+				throw new HTTPError(400, `Invalid value for index ${i} in uploaded data; expected JSON ${kind} object`);
+			}
+			providedKey = typeof entry.key === 'string' ? entry.key : '';
+
+			let obj;
+			let isUpdate = false;
+			if (providedKey) {
+				validateObjectKey(providedKey);
+				obj = await getExistingObjectByKey(libraryID, providedKey, kind);
+				if (obj) {
+					isUpdate = true;
+					if (entry.version !== undefined && entry.version !== null) {
+						let expectedVersion = parseInt(entry.version);
+						if (Number.isNaN(expectedVersion)) {
+							throw new HTTPError(400, "Invalid version value");
+						}
+						if (expectedVersion !== obj.clientVersion) {
+							throw new HTTPError(412, `${kind} version mismatch: expected ${expectedVersion}, found ${obj.clientVersion}`);
+						}
+					}
+					// POST follows PATCH semantics: merge patch with existing
+					let existingJSON = obj.toJSON();
+					entry = mergePatchJSON(existingJSON, entry);
+				}
+				else {
+					obj = makeNewObject(libraryID, kind, entry.itemType);
+					obj.key = providedKey;
+				}
+			}
+			else {
+				obj = makeNewObject(libraryID, kind, entry.itemType);
+			}
+
+			applyJSONToObject(obj, entry, kind);
+
+			if (obj.hasChanged()) {
+				await obj.saveTx();
+				let json = await dataObjectToResponseJSON(obj);
+				results.addSuccess(i, json);
+			}
+			else if (isUpdate) {
+				results.addUnchanged(i, obj.key);
+			}
+			else {
+				// New object with nothing to set -- treat as success
+				await obj.saveTx();
+				let json = await dataObjectToResponseJSON(obj);
+				results.addSuccess(i, json);
+			}
+		}
+		catch (e) {
+			Zotero.debug(`Local API: ${kind} write index ${i} failed: ${e.message || e}`, 2);
+			if (!(e instanceof HTTPError)) {
+				Zotero.logError(e);
+			}
+			results.addFailure(i, providedKey, e);
+		}
+	}
+
+	endpoint._recordWriteToken(token);
+
+	let headers = {
+		'Content-Type': 'application/json',
+		'Last-Modified-Version': Zotero.Libraries.get(libraryID).clientVersion,
+	};
+	return [200, headers, JSON.stringify(results.toJSON(), null, 4)];
+}
+
+/**
+ * Single-object write (PUT or PATCH).
+ */
+async function writeSingleObject(endpoint, requestData, kind, isPatch) {
+	let { libraryID, pathParams, data } = requestData;
+	let key;
+	switch (kind) {
+		case 'item':
+			key = pathParams.itemKey;
+			break;
+		case 'collection':
+			key = pathParams.collectionKey;
+			break;
+		case 'search':
+			key = pathParams.searchKey;
+			break;
+		default:
+			throw new Error(`Unknown kind: ${kind}`);
+	}
+
+	let body;
+	try {
+		validateObjectKey(key);
+		endpoint._checkLibraryIfUnmodifiedSinceVersion(requestData);
+		body = endpoint._parseJSONBody(data);
+	}
+	catch (e) {
+		if (e instanceof HTTPError) {
+			return [e.status, 'text/plain', e.message];
+		}
+		throw e;
+	}
+	if (!body || typeof body !== 'object' || Array.isArray(body)) {
+		return [400, 'text/plain', 'Uploaded data must be a JSON object'];
+	}
+
+	let obj = await getExistingObjectByKey(libraryID, key, kind);
+	let isUpdate = !!obj;
+
+	if (isUpdate) {
+		// Per-object version check
+		if (body.version !== undefined && body.version !== null) {
+			let expectedVersion = parseInt(body.version);
+			if (Number.isNaN(expectedVersion)) {
+				return [400, 'text/plain', 'Invalid version value'];
+			}
+			if (expectedVersion !== obj.clientVersion) {
+				return [
+					412,
+					'text/plain',
+					`${kind} version mismatch: expected ${expectedVersion}, found ${obj.clientVersion}`
+				];
+			}
+		}
+		else if (!requestData.headers.get('If-Unmodified-Since-Version')) {
+			return [428, 'text/plain', 'If-Unmodified-Since-Version not provided'];
+		}
+
+		if (isPatch) {
+			let existingJSON = obj.toJSON();
+			body = mergePatchJSON(existingJSON, body);
+		}
+	}
+	else {
+		if (!body.itemType && kind === 'item') {
+			return [400, 'text/plain', 'itemType property not provided'];
+		}
+		try {
+			obj = makeNewObject(libraryID, kind, body.itemType);
+			obj.key = key;
+		}
+		catch (e) {
+			if (e instanceof HTTPError) {
+				return [e.status, 'text/plain', e.message];
+			}
+			throw e;
+		}
+	}
+
+	try {
+		applyJSONToObject(obj, body, kind);
+	}
+	catch (e) {
+		if (e instanceof HTTPError) {
+			return [e.status, 'text/plain', e.message];
+		}
+		throw e;
+	}
+
+	if (obj.hasChanged()) {
+		await obj.saveTx();
+	}
+
+	return [
+		204,
+		{ 'Last-Modified-Version': Zotero.Libraries.get(libraryID).clientVersion },
+		''
+	];
+}
+
+/**
+ * Multi-object DELETE (e.g. ?itemKey=KEY1,KEY2,...).
+ *
+ * `paramName` is the query parameter name ('itemKey', 'collectionKey', 'searchKey').
+ */
+async function deleteMultipleObjects(endpoint, requestData, kind, paramName) {
+	let { libraryID, searchParams } = requestData;
+
+	try {
+		endpoint._checkLibraryIfUnmodifiedSinceVersion(requestData, { required: true });
+	}
+	catch (e) {
+		if (e instanceof HTTPError) {
+			return [e.status, 'text/plain', e.message];
+		}
+		throw e;
+	}
+
+	let keys;
+	try {
+		keys = parseKeyList(searchParams, paramName);
+	}
+	catch (e) {
+		if (e instanceof HTTPError) {
+			return [e.status, 'text/plain', e.message];
+		}
+		throw e;
+	}
+
+	for (let key of keys) {
+		let obj = await getExistingObjectByKey(libraryID, key, kind);
+		if (obj) {
+			await obj.eraseTx();
+		}
+	}
+
+	return [
+		204,
+		{ 'Last-Modified-Version': Zotero.Libraries.get(libraryID).clientVersion },
+		''
+	];
+}
+
+/**
+ * Single-object DELETE.
+ */
+async function deleteSingleObject(endpoint, requestData, kind) {
+	let { libraryID, pathParams } = requestData;
+	let key;
+	switch (kind) {
+		case 'item':
+			key = pathParams.itemKey;
+			break;
+		case 'collection':
+			key = pathParams.collectionKey;
+			break;
+		case 'search':
+			key = pathParams.searchKey;
+			break;
+		default:
+			throw new Error(`Unknown kind: ${kind}`);
+	}
+
+	try {
+		validateObjectKey(key);
+	}
+	catch (e) {
+		if (e instanceof HTTPError) {
+			return [e.status, 'text/plain', e.message];
+		}
+		throw e;
+	}
+
+	let obj = await getExistingObjectByKey(libraryID, key, kind);
+	if (!obj) {
+		return _404;
+	}
+
+	// Per-object version check: prefer If-Unmodified-Since-Version against the
+	// object's own clientVersion, falling back to library-level when checking
+	// the bare header against library version (which the base helper does).
+	let header = requestData.headers.get('If-Unmodified-Since-Version');
+	if (header === null) {
+		return [428, 'text/plain', 'If-Unmodified-Since-Version not provided'];
+	}
+	let expectedVersion = parseInt(header);
+	if (Number.isNaN(expectedVersion) || expectedVersion < 0) {
+		return [400, 'text/plain', 'Invalid If-Unmodified-Since-Version value'];
+	}
+	if (obj.clientVersion > expectedVersion) {
+		return [
+			412,
+			'text/plain',
+			`${kind} has been modified since specified version `
+			+ `(expected ${expectedVersion}, found ${obj.clientVersion})`
+		];
+	}
+
+	await obj.eraseTx();
+
+	return [
+		204,
+		{ 'Last-Modified-Version': Zotero.Libraries.get(libraryID).clientVersion },
+		''
+	];
+}
+
+/**
+ * Handle POST /items/:itemKey/file: either an authorize call (no `upload=`)
+ * or a register call (`upload=<uploadKey>`).
+ *
+ * Content-Type must be application/x-www-form-urlencoded per the web API spec.
+ */
+async function handleFileWrite(endpoint, requestData) {
+	let { libraryID, pathParams, data, headers } = requestData;
+
+	if (!data || typeof data !== 'object') {
+		return [400, 'text/plain', 'Content-Type must be application/x-www-form-urlencoded'];
+	}
+
+	let item = await Zotero.Items.getByLibraryAndKeyAsync(libraryID, pathParams.itemKey);
+	if (!item) return _404;
+	if (!item.isFileAttachment()) {
+		return [400, 'text/plain', `Not a file attachment: ${item.key}`];
+	}
+	let linkMode = item.attachmentLinkMode;
+	if (linkMode !== Zotero.Attachments.LINK_MODE_IMPORTED_FILE
+			&& linkMode !== Zotero.Attachments.LINK_MODE_IMPORTED_URL) {
+		return [400, 'text/plain', 'Cannot upload files for non-imported attachments'];
+	}
+	if (!Zotero.Libraries.get(libraryID).filesEditable) {
+		return [403, 'text/plain', 'File editing denied'];
+	}
+
+	// Register phase
+	if (data.upload !== undefined) {
+		return registerUpload(item, data, headers);
+	}
+
+	// Authorize phase
+	return authorizeUpload(item, data, headers, requestData);
+}
+
+/**
+ * Authorize a new file upload. Validates the request, then returns either
+ * {exists: 1} if the file already matches locally, or upload details with an
+ * uploadKey that the client uses to actually transmit the file bytes.
+ */
+async function authorizeUpload(item, params, headers, requestData) {
+	// Validate If-Match / If-None-Match
+	let ifMatch = headers.get('If-Match');
+	let ifNoneMatch = headers.get('If-None-Match');
+	if (!ifMatch && !ifNoneMatch) {
+		return [428, 'text/plain', 'If-Match/If-None-Match header not provided'];
+	}
+
+	// Current synced hash for this attachment, if any
+	let currentSyncedMD5 = item.attachmentSyncedHash || null;
+
+	if (ifMatch) {
+		let match = /^"?([a-f0-9]{32})"?$/.exec(ifMatch);
+		if (!match) {
+			return [400, 'text/plain', 'Invalid If-Match header'];
+		}
+		let expected = match[1];
+		if (!currentSyncedMD5) {
+			return [412, 'text/plain', 'If-Match set but file does not exist'];
+		}
+		if (currentSyncedMD5 !== expected) {
+			return [412, 'text/plain', 'ETag does not match current version of file'];
+		}
+	}
+	if (ifNoneMatch !== null) {
+		if (ifNoneMatch !== '*') {
+			return [400, 'text/plain', 'Invalid value for If-None-Match header'];
+		}
+		if (currentSyncedMD5) {
+			return [412, 'text/plain', 'If-None-Match: * set but file exists'];
+		}
+	}
+
+	// Validate form params
+	let md5 = params.md5;
+	if (!md5 || !/^[a-f0-9]{32}$/i.test(md5)) {
+		return [400, 'text/plain', 'MD5 hash not provided'];
+	}
+	md5 = md5.toLowerCase();
+	let filename = params.filename;
+	if (!filename) {
+		return [400, 'text/plain', 'File name not provided'];
+	}
+	let filesize = params.filesize;
+	if (filesize === undefined || filesize === null || filesize === '') {
+		return [400, 'text/plain', 'File size not provided'];
+	}
+	filesize = parseInt(filesize);
+	if (Number.isNaN(filesize) || filesize < 0) {
+		return [400, 'text/plain', 'Invalid file size value'];
+	}
+	if (filesize > 4 * 1024 * 1024 * 1024) {
+		return [400, 'text/plain', 'Files above 4 GB are not currently supported'];
+	}
+	let mtime = params.mtime;
+	if (mtime === undefined || mtime === null || mtime === '') {
+		return [400, 'text/plain', 'File modification time not provided'];
+	}
+	mtime = parseInt(mtime);
+	if (Number.isNaN(mtime) || mtime < 0) {
+		return [400, 'text/plain', 'Invalid mtime value'];
+	}
+	// Per the spec, mtime is in milliseconds; reject values that look like seconds.
+	if (mtime > 0 && mtime < 10000000000) {
+		return [400, 'text/plain', 'mtime must be provided in milliseconds, not seconds'];
+	}
+
+	// If the local file already matches the requested MD5, no upload is needed.
+	try {
+		let existingPath = await item.getFilePathAsync();
+		if (existingPath) {
+			let existingMD5 = await Zotero.Utilities.Internal.md5Async(existingPath);
+			if (existingMD5 === md5) {
+				// Persist the requested mtime so subsequent reads agree
+				item.attachmentSyncedHash = md5;
+				item.attachmentSyncedModificationTime = mtime;
+				await item.saveTx();
+				return [
+					200,
+					{ 'Content-Type': 'application/json' },
+					JSON.stringify({ exists: 1 })
+				];
+			}
+		}
+	}
+	catch (e) {
+		Zotero.debug(`File exists check failed: ${e.message}`, 2);
+	}
+
+	let contentType = params.contentType || item.attachmentContentType || 'application/octet-stream';
+
+	// Generate an uploadKey, remember the pending upload, return URL
+	pruneExpired(PENDING_UPLOADS);
+	let uploadKey = Zotero.Utilities.randomString(32);
+	PENDING_UPLOADS.set(uploadKey, {
+		libraryID: item.libraryID,
+		itemKey: item.key,
+		md5,
+		filename,
+		filesize,
+		mtime,
+		contentType,
+		charset: params.charset || item.attachmentCharset || null,
+		uploaded: false,
+		expires: Date.now() + UPLOAD_KEY_TTL_SECONDS * 1000,
+	});
+
+	let host = requestData.headers.get('Host') || `localhost:${Zotero.Server.port}`;
+	let url = `http://${host}/api/local/uploads/${uploadKey}`;
+
+	if (requestData.searchParams.get('params') === '1') {
+		return [
+			200,
+			{ 'Content-Type': 'application/json' },
+			JSON.stringify({
+				url,
+				uploadKey,
+				contentType,
+				params: {
+					// Local uploads don't need S3-style form fields, but emit
+					// the field so clients expecting a 'params' array can
+					// iterate. They can be sent and will be ignored.
+					key: uploadKey,
+				},
+			})
+		];
+	}
+
+	return [
+		200,
+		{ 'Content-Type': 'application/json' },
+		JSON.stringify({
+			url,
+			uploadKey,
+			contentType,
+			prefix: '',
+			suffix: '',
+		})
+	];
+}
+
+/**
+ * Register a previously-uploaded file (phase 3 of the upload flow).
+ * Updates the attachment item with the new filename, md5, and mtime, then
+ * returns 204 with the new library version.
+ */
+async function registerUpload(item, params, headers) {
+	pruneExpired(PENDING_UPLOADS);
+	let uploadKey = params.upload;
+	let upload = PENDING_UPLOADS.get(uploadKey);
+	if (!upload) {
+		return [400, 'text/plain', 'Invalid or expired upload key'];
+	}
+	if (upload.libraryID !== item.libraryID || upload.itemKey !== item.key) {
+		return [400, 'text/plain', 'Upload key does not match item'];
+	}
+	if (!upload.uploaded) {
+		return [400, 'text/plain', 'File contents were not uploaded'];
+	}
+
+	// Re-check If-Match / If-None-Match (the client repeats these in register)
+	let ifMatch = headers.get('If-Match');
+	let ifNoneMatch = headers.get('If-None-Match');
+	let currentSyncedMD5 = item.attachmentSyncedHash || null;
+	if (ifMatch) {
+		let m = /^"?([a-f0-9]{32})"?$/.exec(ifMatch);
+		if (!m || !currentSyncedMD5 || currentSyncedMD5 !== m[1]) {
+			PENDING_UPLOADS.delete(uploadKey);
+			return [412, 'text/plain', 'ETag does not match current version of file'];
+		}
+	}
+	if (ifNoneMatch === '*' && currentSyncedMD5) {
+		PENDING_UPLOADS.delete(uploadKey);
+		return [412, 'text/plain', 'If-None-Match: * set but file exists'];
+	}
+
+	item.attachmentFilename = upload.filename;
+	item.attachmentSyncedHash = upload.md5;
+	item.attachmentSyncedModificationTime = upload.mtime;
+	if (upload.contentType) {
+		item.attachmentContentType = upload.contentType;
+	}
+	if (upload.charset) {
+		item.attachmentCharset = upload.charset;
+	}
+	await item.saveTx();
+
+	PENDING_UPLOADS.delete(uploadKey);
+
+	return [
+		204,
+		{ 'Last-Modified-Version': Zotero.Libraries.get(item.libraryID).clientVersion },
+		''
+	];
+}
+
+/**
+ * Apply a validated fulltext write to a single item. Returns the new library
+ * client version. Throws HTTPError(404) if the item is missing or isn't a file
+ * attachment, and HTTPError(400) if it isn't an indexable MIME type.
+ */
+async function storeItemFullText(libraryID, itemKey, body) {
+	let item = await Zotero.Items.getByLibraryAndKeyAsync(libraryID, itemKey);
+	if (!item || !item.isFileAttachment()) {
+		throw new HTTPError(404, 'Not found');
+	}
+	if (!Zotero.Fulltext.isCachedMIMEType(item.attachmentContentType)) {
+		throw new HTTPError(400, 'Full-text content is not supported for this item type');
+	}
+
+	let library = Zotero.Libraries.get(libraryID);
+	let newVersion = await Zotero.DB.executeTransaction(async () => library.incrementClientVersion());
+
+	await Zotero.Fulltext.setItemContent(libraryID, itemKey, {
+		content: body.content,
+		indexedChars: body.indexedChars,
+		totalChars: body.totalChars,
+		indexedPages: body.indexedPages,
+		totalPages: body.totalPages,
+	}, newVersion);
+	// setItemContent() queues the write via the background processor. Flush it now so the
+	// content is immediately visible to subsequent GETs.
+	await Zotero.Fulltext.indexSyncedContent(item.id);
+
+	return newVersion;
+}
+
+function pruneExpired(map) {
+	let now = Date.now();
+	for (let [k, v] of map) {
+		let expiry = typeof v === 'number' ? v : v.expires;
+		if (expiry && expiry < now) {
+			map.delete(k);
+		}
+	}
+}
+
+class HTTPError extends Error {
+	constructor(status, message) {
+		super(message);
+		this.status = status;
+	}
+}
+
+/**
+ * Builder for the canonical multi-object write response shape.
+ *
+ * Implements dataserver's Zotero_Results (model/Results.inc.php):
+ *   {
+ *     "successful": { "<index>": <full response JSON object> },
+ *     "success":    { "<index>": "<objectKey>" },
+ *     "unchanged":  { "<index>": "<objectKey>" },
+ *     "failed":     { "<index>": { "key": "<objectKey>", "code": <int>, "message": "<str>" } }
+ *   }
+ */
+class MultiWriteResults {
+	constructor() {
+		this.successful = {};
+		this.success = {};
+		this.unchanged = {};
+		this.failed = {};
+	}
+
+	addSuccess(index, responseJSON) {
+		let i = String(index);
+		this.successful[i] = responseJSON;
+		this.success[i] = responseJSON.key;
+	}
+
+	addUnchanged(index, key) {
+		this.unchanged[String(index)] = key;
+	}
+
+	addFailure(index, key, codeOrError, message) {
+		let code;
+		let msg;
+		if (codeOrError instanceof HTTPError) {
+			code = codeOrError.status;
+			msg = codeOrError.message;
+		}
+		else if (codeOrError instanceof Error) {
+			code = 400;
+			msg = codeOrError.message;
+		}
+		else {
+			code = codeOrError;
+			msg = message;
+		}
+		this.failed[String(index)] = {
+			key: key || "",
+			code,
+			message: msg
+		};
+	}
+
+	toJSON() {
+		return {
+			successful: this.successful,
+			success: this.success,
+			unchanged: this.unchanged,
+			failed: this.failed,
+		};
+	}
+}

--- a/chrome/content/zotero/xpcom/server/server_localAPI.js
+++ b/chrome/content/zotero/xpcom/server/server_localAPI.js
@@ -685,6 +685,7 @@ class LocalAPIEndpoint {
 	 * @param {Object} requestData
 	 * @param {Object} options
 	 * @param {Boolean} [options.required] If true and the header is missing, throw 428
+	 * @returns {Boolean} Whether the header was provided (and validated)
 	 * @throws HTTPError on missing/invalid/out-of-date version
 	 */
 	_checkLibraryIfUnmodifiedSinceVersion(requestData, { required = false } = {}) {
@@ -693,7 +694,7 @@ class LocalAPIEndpoint {
 			if (required) {
 				throw new HTTPError(428, "If-Unmodified-Since-Version not provided");
 			}
-			return;
+			return false;
 		}
 		let value = parseInt(header);
 		if (Number.isNaN(value) || value < 0) {
@@ -703,6 +704,7 @@ class LocalAPIEndpoint {
 		if (library.clientVersion > value) {
 			throw new HTTPError(412, `Library has been modified since specified version (expected ${value}, found ${library.clientVersion})`);
 		}
+		return true;
 	}
 
 	/**
@@ -1968,10 +1970,11 @@ async function writeMultipleObjects(endpoint, requestData, kind) {
 	let { libraryID, data } = requestData;
 
 	let token;
+	let libraryVersionValidated;
 	let body;
 	try {
 		token = endpoint._checkWriteToken(requestData);
-		endpoint._checkLibraryIfUnmodifiedSinceVersion(requestData);
+		libraryVersionValidated = endpoint._checkLibraryIfUnmodifiedSinceVersion(requestData);
 		body = endpoint._parseJSONBody(data);
 	}
 	catch (e) {
@@ -2010,6 +2013,13 @@ async function writeMultipleObjects(endpoint, requestData, kind) {
 			let isUpdate = false;
 			if (providedKey) {
 				validateObjectKey(providedKey);
+				// Keyed writes require a concurrency precondition, either request-level or
+				// per-object (mirroring dataserver's checkJSONObjectVersion())
+				if (!libraryVersionValidated
+						&& (entry.version === undefined || entry.version === null)) {
+					throw new HTTPError(428, "Either If-Unmodified-Since-Version or "
+						+ "'version' property must be provided for 'key'-based writes");
+				}
 				obj = await getExistingObjectByKey(libraryID, providedKey, kind);
 				if (obj) {
 					isUpdate = true;
@@ -2027,6 +2037,11 @@ async function writeMultipleObjects(endpoint, requestData, kind) {
 					entry = mergePatchJSON(existingJSON, entry);
 				}
 				else {
+					if (entry.version !== undefined && entry.version !== null
+							&& parseInt(entry.version) > 0) {
+						throw new HTTPError(404, `${kind} doesn't exist `
+							+ `(expected version ${parseInt(entry.version)}; use 0 instead)`);
+					}
 					obj = makeNewObject(libraryID, kind, entry.itemType);
 					obj.key = providedKey;
 				}

--- a/chrome/content/zotero/xpcom/server/server_localAPI.js
+++ b/chrome/content/zotero/xpcom/server/server_localAPI.js
@@ -400,9 +400,25 @@ class LocalAPIEndpoint {
 				'Total-Results': totalResults,
 				Link: Object.entries(links).map(([rel, url]) => `<${url}>; rel="${rel}"`).join(', ')
 			};
-			let lastModifiedVersion = dataIsArray
-				? Zotero.Libraries.get(requestData.libraryID).clientVersion
-				: response.data.clientVersion;
+			let lastModifiedVersion;
+			// Unlike other multi-object responses, a group list has no meaningful
+			// Last-Modified-Version: each group has its own synced metadata version, and the
+			// user library version that array responses otherwise report says nothing about
+			// group metadata
+			if (this instanceof Zotero.Server.LocalAPI.Groups) {
+				lastModifiedVersion = undefined;
+			}
+			else if (dataIsArray) {
+				lastModifiedVersion = Zotero.Libraries.get(requestData.libraryID).clientVersion;
+			}
+			// Group metadata isn't locally writable, so single-group responses report the
+			// synced group version, matching the version fields in the response body
+			else if (response.data instanceof Zotero.Group) {
+				lastModifiedVersion = response.data.version;
+			}
+			else {
+				lastModifiedVersion = response.data.clientVersion;
+			}
 			if (lastModifiedVersion !== undefined) {
 				headers['Last-Modified-Version'] = lastModifiedVersion;
 			}
@@ -527,7 +543,13 @@ class LocalAPIEndpoint {
 					return this.makeResponse(400, 'text/plain', 'Only multi-object requests can output versions');
 				}
 				contentType = 'application/json';
-				body = JSON.stringify(Object.fromEntries(dataObjectOrObjects.map(o => [o.key, o.clientVersion])), null, 4);
+				// Groups are keyed by id and report their synced metadata version, which is
+				// independent of the local content versions used for other object types
+				body = JSON.stringify(Object.fromEntries(dataObjectOrObjects.map(
+					o => (o instanceof Zotero.Group
+						? [o.id, o.version]
+						: [o.key, o.clientVersion])
+				)), null, 4);
 				break;
 			case 'json':
 			case null:

--- a/chrome/content/zotero/xpcom/server/server_localAPI.js
+++ b/chrome/content/zotero/xpcom/server/server_localAPI.js
@@ -115,6 +115,7 @@ const WRITE_TOKEN_CACHE_SECONDS = 12 * 60 * 60;
  *     contentType: string;
  *     charset: string | null;
  *     uploaded: boolean;
+ *     stagedPath: string | null;
  *     expires: number;
  * }>}
  */
@@ -1244,8 +1245,9 @@ Zotero.Server.Endpoints["/api/groups/:groupID/items/:itemKey/file/view/url"] = Z
 
 /**
  * Local-only endpoint that receives the raw bytes for a previously authorized
- * upload (the URL returned in the authorize phase). Writes the file directly
- * into the attachment's storage directory.
+ * upload (the URL returned in the authorize phase). Stages the file in the
+ * temp directory; it's moved into the attachment's storage directory when the
+ * upload is registered.
  */
 Zotero.Server.LocalAPI.UploadReceiver = class extends LocalAPIEndpoint {
 	supportedMethods = ['POST'];
@@ -1295,24 +1297,26 @@ Zotero.Server.LocalAPI.UploadReceiver = class extends LocalAPIEndpoint {
 
 			let item = await Zotero.Items.getByLibraryAndKeyAsync(upload.libraryID, upload.itemKey);
 			if (!item || !item.isFileAttachment()) {
-				PENDING_UPLOADS.delete(uploadKey);
+				await discardPendingUpload(uploadKey);
 				return this.makeResponse(404, 'text/plain', 'Attachment item no longer exists');
 			}
 
-			let dir = Zotero.Attachments.getStorageDirectory(item);
-			await IOUtils.makeDirectory(dir.path, { ignoreExisting: true });
-			let destPath = PathUtils.join(dir.path, upload.filename);
-			await IOUtils.write(destPath, bytes);
+			// Stage the file in the temp directory, so that the attachment's existing file
+			// isn't touched unless registration preconditions pass
+			let stagedPath = PathUtils.join(
+				Zotero.getTempDirectory().path, 'localAPIUpload-' + uploadKey);
+			await IOUtils.write(stagedPath, bytes);
 
 			// Verify the actual md5 matches what was claimed in the authorize phase.
-			let actualMD5 = await Zotero.Utilities.Internal.md5Async(destPath);
+			let actualMD5 = await Zotero.Utilities.Internal.md5Async(stagedPath);
 			if (actualMD5 !== upload.md5) {
-				await IOUtils.remove(destPath, { ignoreAbsent: true });
+				await IOUtils.remove(stagedPath, { ignoreAbsent: true });
 				PENDING_UPLOADS.delete(uploadKey);
 				return this.makeResponse(400, 'text/plain',
 					`File MD5 does not match expected (got ${actualMD5}, expected ${upload.md5})`);
 			}
 
+			upload.stagedPath = stagedPath;
 			upload.uploaded = true;
 			return this.makeResponse(201, 'text/plain', '');
 		}
@@ -2437,6 +2441,7 @@ async function authorizeUpload(item, params, headers, requestData) {
 		contentType,
 		charset: params.charset || item.attachmentCharset || null,
 		uploaded: false,
+		stagedPath: null,
 		expires: Date.now() + UPLOAD_KEY_TTL_SECONDS * 1000,
 	});
 
@@ -2476,8 +2481,9 @@ async function authorizeUpload(item, params, headers, requestData) {
 
 /**
  * Register a previously-uploaded file (phase 3 of the upload flow).
- * Updates the attachment item with the new filename, md5, and mtime, then
- * returns 204 with the new library version.
+ * Moves the staged file into the attachment's storage directory and updates
+ * the attachment item with the new filename, md5, and mtime, then returns 204
+ * with the new library version.
  */
 async function registerUpload(item, params, headers) {
 	pruneExpired(PENDING_UPLOADS);
@@ -2500,14 +2506,20 @@ async function registerUpload(item, params, headers) {
 	if (ifMatch) {
 		let m = /^"?([a-f0-9]{32})"?$/.exec(ifMatch);
 		if (!m || !currentSyncedMD5 || currentSyncedMD5 !== m[1]) {
-			PENDING_UPLOADS.delete(uploadKey);
+			await discardPendingUpload(uploadKey);
 			return [412, 'text/plain', 'ETag does not match current version of file'];
 		}
 	}
 	if (ifNoneMatch === '*' && currentSyncedMD5) {
-		PENDING_UPLOADS.delete(uploadKey);
+		await discardPendingUpload(uploadKey);
 		return [412, 'text/plain', 'If-None-Match: * set but file exists'];
 	}
+
+	// Preconditions passed, so move the staged file into the storage directory
+	let dir = Zotero.Attachments.getStorageDirectory(item);
+	await IOUtils.makeDirectory(dir.path, { ignoreExisting: true });
+	let destPath = PathUtils.join(dir.path, upload.filename);
+	await IOUtils.move(upload.stagedPath, destPath);
 
 	item.attachmentFilename = upload.filename;
 	item.attachmentSyncedHash = upload.md5;
@@ -2566,7 +2578,23 @@ function pruneExpired(map) {
 		let expiry = typeof v === 'number' ? v : v.expires;
 		if (expiry && expiry < now) {
 			map.delete(k);
+			if (v.stagedPath) {
+				IOUtils.remove(v.stagedPath, { ignoreAbsent: true })
+					.catch(e => Zotero.logError(e));
+			}
 		}
+	}
+}
+
+/**
+ * Delete a pending upload, along with its staged file if the bytes were
+ * already received.
+ */
+async function discardPendingUpload(uploadKey) {
+	let upload = PENDING_UPLOADS.get(uploadKey);
+	PENDING_UPLOADS.delete(uploadKey);
+	if (upload && upload.stagedPath) {
+		await IOUtils.remove(upload.stagedPath, { ignoreAbsent: true });
 	}
 }
 

--- a/chrome/content/zotero/xpcom/server/server_localAPI.js
+++ b/chrome/content/zotero/xpcom/server/server_localAPI.js
@@ -323,7 +323,10 @@ class LocalAPIEndpoint {
 		let response = await this.run(requestData);
 		if (response.data) {
 			let dataIsArray = Array.isArray(response.data);
-			if (dataIsArray && requestData.searchParams.has('since')) {
+			// 'since' is ignored for group lists, as in the dataserver -- per-group metadata
+			// versions don't form a valid aggregate cursor
+			if (dataIsArray && requestData.searchParams.has('since')
+					&& !(this instanceof Zotero.Server.LocalAPI.Groups)) {
 				let since = parseInt(requestData.searchParams.get('since'));
 				if (Number.isNaN(since)) {
 					return this.makeResponse(400, 'text/plain', `Invalid 'since' value '${requestData.searchParams.get('since')}'`);

--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -712,8 +712,8 @@ const { CommandLineOptions } = ChromeUtils.importESModule("chrome://zotero/conte
 			Zotero.locked = false;
 			
 			// Initialize various services
-			if(Zotero.Prefs.get("httpServer.enabled")) {
-				Zotero.Server.init();
+			if (Zotero.Prefs.get("httpServer.enabled")) {
+				await Zotero.Server.init();
 			}
 			
 			await Zotero.Fulltext.init();

--- a/chrome/locale/en-US/zotero/preferences.ftl
+++ b/chrome/locale/en-US/zotero/preferences.ftl
@@ -86,6 +86,8 @@ preferences-citation-dialog-mode-library =
 preferences-advanced-enable-local-api =
     .label = Allow other applications on this computer to communicate with { -app-name }
 preferences-advanced-local-api-available = Available at <code data-l10n-name="url">{ $url }</span>
+preferences-advanced-local-api-clear-authorizations =
+    .label = Clear Write Authorizations
 preferences-advanced-server-disabled = The { -app-name } HTTP server is disabled.
 preferences-advanced-server-enable-and-restart =
     .label = Enable and Restart

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -1258,3 +1258,9 @@ undo-action-merge-items = { $count ->
 }
 menu-edit-undo-action = Undo { $action }
 menu-edit-redo-action = Redo { $action }
+
+local-api-authorize-title = Local API Authorization
+local-api-authorize-text = “{ $appName }”, an application running on your computer, wants to modify your { -app-name } library.
+local-api-authorize-allow = Allow
+local-api-authorize-always-allow = Always Allow
+local-api-authorize-deny = Deny

--- a/resource/schema/userdata.sql
+++ b/resource/schema/userdata.sql
@@ -421,7 +421,6 @@ CREATE TABLE groups (
     name TEXT NOT NULL,
     description TEXT NOT NULL,
     version INT NOT NULL,
-    clientVersion INT NOT NULL DEFAULT 0,
     FOREIGN KEY (libraryID) REFERENCES libraries(libraryID) ON DELETE CASCADE
 );
 

--- a/resource/schema/userdata.sql
+++ b/resource/schema/userdata.sql
@@ -1,4 +1,4 @@
--- 128
+-- 129
 
 -- Copyright (c) 2009 Center for History and New Media
 --                    George Mason University, Fairfax, Virginia, USA
@@ -164,6 +164,7 @@ CREATE TABLE items (
     libraryID INT NOT NULL,
     key TEXT NOT NULL,
     version INT NOT NULL DEFAULT 0,
+    clientVersion INT NOT NULL DEFAULT 0,
     synced INT NOT NULL DEFAULT 0,
     UNIQUE (libraryID, key),
     FOREIGN KEY (libraryID) REFERENCES libraries(libraryID) ON DELETE CASCADE
@@ -301,6 +302,7 @@ CREATE TABLE collections (
     libraryID INT NOT NULL,
     key TEXT NOT NULL,
     version INT NOT NULL DEFAULT 0,
+    clientVersion INT NOT NULL DEFAULT 0,
     synced INT NOT NULL DEFAULT 0,
     UNIQUE (libraryID, key),
     FOREIGN KEY (libraryID) REFERENCES libraries(libraryID) ON DELETE CASCADE,
@@ -357,6 +359,7 @@ CREATE TABLE savedSearches (
     libraryID INT NOT NULL,
     key TEXT NOT NULL,
     version INT NOT NULL DEFAULT 0,
+    clientVersion INT NOT NULL DEFAULT 0,
     synced INT NOT NULL DEFAULT 0,
     UNIQUE (libraryID, key),
     FOREIGN KEY (libraryID) REFERENCES libraries(libraryID) ON DELETE CASCADE
@@ -400,6 +403,7 @@ CREATE TABLE libraries (
     editable INT NOT NULL,
     filesEditable INT NOT NULL,
     version INT NOT NULL DEFAULT 0,
+    clientVersion INT NOT NULL DEFAULT 0,
     storageVersion INT NOT NULL DEFAULT 0,
     lastSync INT NOT NULL DEFAULT 0,
     archived INT NOT NULL DEFAULT 0,
@@ -417,6 +421,7 @@ CREATE TABLE groups (
     name TEXT NOT NULL,
     description TEXT NOT NULL,
     version INT NOT NULL,
+    clientVersion INT NOT NULL DEFAULT 0,
     FOREIGN KEY (libraryID) REFERENCES libraries(libraryID) ON DELETE CASCADE
 );
 

--- a/test/content/support.js
+++ b/test/content/support.js
@@ -650,7 +650,7 @@ var modifyDataObject = function (obj, params = {}, saveOptions) {
 	default:
 		obj.name = params.name !== undefined ? params.name : Zotero.Utilities.randomString();
 	}
-	return obj.save({ ...saveOptions, tx: !Zotero.DB.inTransaction() });
+	return obj.save({ tx: true, ...saveOptions });
 };
 
 /**

--- a/test/content/support.js
+++ b/test/content/support.js
@@ -650,7 +650,7 @@ var modifyDataObject = function (obj, params = {}, saveOptions) {
 	default:
 		obj.name = params.name !== undefined ? params.name : Zotero.Utilities.randomString();
 	}
-	return obj.saveTx(saveOptions);
+	return obj.save({ ...saveOptions, tx: !Zotero.DB.inTransaction() });
 };
 
 /**

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -157,6 +157,7 @@ user_pref("extensions.zotero.reportTranslationFailure", false);
 user_pref("extensions.zotero.httpServer.enabled", true);
 user_pref("extensions.zotero.httpServer.port", 23124);	// ascii "ZT"
 user_pref("extensions.zotero.httpServer.localAPI.enabled", true);
+user_pref("extensions.zotero.httpServer.localAPI.serverID", "testserverid");
 user_pref("extensions.zotero.backup.numBackups", 0);
 user_pref("extensions.zotero.sync.autoSync", false);
 user_pref("extensions.zoteroMacWordIntegration.installed", true);

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -157,7 +157,6 @@ user_pref("extensions.zotero.reportTranslationFailure", false);
 user_pref("extensions.zotero.httpServer.enabled", true);
 user_pref("extensions.zotero.httpServer.port", 23124);	// ascii "ZT"
 user_pref("extensions.zotero.httpServer.localAPI.enabled", true);
-user_pref("extensions.zotero.httpServer.localAPI.serverID", "testserverid");
 user_pref("extensions.zotero.backup.numBackups", 0);
 user_pref("extensions.zotero.sync.autoSync", false);
 user_pref("extensions.zoteroMacWordIntegration.installed", true);

--- a/test/tests/dataObjectTest.js
+++ b/test/tests/dataObjectTest.js
@@ -52,6 +52,61 @@ describe("Zotero.DataObject", function () {
 		})
 	})
 	
+	describe("#clientVersion", function () {
+		it("should be set to library clientVersion after creating object", async function () {
+			for (let type of types) {
+				let obj = await createDataObject(type);
+				assert.equal(obj.clientVersion, obj.library.clientVersion);
+				await obj.eraseTx();
+			}
+		});
+
+		it("should increase after modifying object", async function () {
+			for (let type of types) {
+				let obj = await createDataObject(type);
+				let clientVersion = obj.clientVersion;
+
+				await modifyDataObject(obj);
+				
+				assert.isAbove(obj.clientVersion, clientVersion);
+				assert.equal(obj.clientVersion, obj.library.clientVersion);
+				
+				await obj.eraseTx();
+			}
+		});
+
+		it("should increase once per library per transaction", async function () {
+			for (let type of types) {
+				let obj1 = await createDataObject(type);
+				let obj2 = await createDataObject(type);
+				
+				let group = await getGroup();
+				let obj3 = await createDataObject(type, { libraryID: group.libraryID });
+				
+				assert.isBelow(obj1.clientVersion, obj2.clientVersion);
+				assert.equal(obj2.clientVersion, Zotero.Libraries.userLibrary.clientVersion);
+				
+				await modifyDataObject(obj1);
+				assert.isAbove(obj1.clientVersion, obj2.clientVersion);
+				assert.equal(obj1.clientVersion, Zotero.Libraries.userLibrary.clientVersion);
+				
+				let libraryVersionBefore = Zotero.Libraries.userLibrary.clientVersion;
+				let groupVersionBefore = group.clientVersion;
+				await Zotero.DB.executeTransaction(async () => {
+					await modifyDataObject(obj1);
+					await modifyDataObject(obj2);
+					await modifyDataObject(obj3);
+				});
+				assert.equal(obj1.clientVersion, Zotero.Libraries.userLibrary.clientVersion);
+				assert.equal(obj1.clientVersion, obj2.clientVersion);
+				assert.notEqual(obj1.clientVersion, libraryVersionBefore);
+				
+				assert.equal(obj3.clientVersion, group.clientVersion);
+				assert.notEqual(obj3.clientVersion, groupVersionBefore);
+			}
+		});
+	});
+	
 	describe("#synced", function () {
 		it("should be set to false after creating object", async function () {
 			for (let type of types) {

--- a/test/tests/dataObjectTest.js
+++ b/test/tests/dataObjectTest.js
@@ -93,9 +93,9 @@ describe("Zotero.DataObject", function () {
 				let libraryVersionBefore = Zotero.Libraries.userLibrary.clientVersion;
 				let groupVersionBefore = group.clientVersion;
 				await Zotero.DB.executeTransaction(async () => {
-					await modifyDataObject(obj1);
-					await modifyDataObject(obj2);
-					await modifyDataObject(obj3);
+					await modifyDataObject(obj1, undefined, { tx: false });
+					await modifyDataObject(obj2, undefined, { tx: false });
+					await modifyDataObject(obj3, undefined, { tx: false });
 				});
 				assert.equal(obj1.clientVersion, Zotero.Libraries.userLibrary.clientVersion);
 				assert.equal(obj1.clientVersion, obj2.clientVersion);

--- a/test/tests/dataObjectTest.js
+++ b/test/tests/dataObjectTest.js
@@ -105,6 +105,15 @@ describe("Zotero.DataObject", function () {
 				assert.notEqual(obj3.clientVersion, groupVersionBefore);
 			}
 		});
+
+		it("should increment library clientVersion when object is deleted", async function () {
+			for (let type of types) {
+				let obj = await createDataObject(type);
+				let libraryVersion = obj.library.clientVersion;
+				await obj.eraseTx();
+				assert.equal(obj.library.clientVersion, libraryVersion + 1);
+			}
+		});
 	});
 	
 	describe("#synced", function () {

--- a/test/tests/libraryTest.js
+++ b/test/tests/libraryTest.js
@@ -63,6 +63,27 @@ describe("Zotero.Library", function () {
 		});
 	});
 	
+	describe("#clientVersion", function () {
+		it("should be settable to increasing values", function () {
+			let library = new Zotero.Library();
+			assert.throws(() => library.clientVersion = -2);
+			assert.throws(() => library.clientVersion = "a");
+			assert.throws(() => library.clientVersion = 1.1);
+			assert.doesNotThrow(() => library.clientVersion = 0);
+			assert.doesNotThrow(() => library.clientVersion = 5);
+		});
+		it("should not be possible to decrement", function () {
+			let library = new Zotero.Library();
+			library.clientVersion = 5;
+			assert.throws(() => library.clientVersion = 0);
+		});
+		it("should not be possible to set to -1", function () {
+			let library = new Zotero.Library();
+			library.clientVersion = 5;
+			assert.throws(() => library.clientVersion = -1);
+		});
+	});
+
 	describe("#editable", function () {
 		it("should return editable status", function () {
 			let library = Zotero.Libraries.get(Zotero.Libraries.userLibraryID);

--- a/test/tests/serverTest.js
+++ b/test/tests/serverTest.js
@@ -240,6 +240,45 @@ describe("Zotero.Server", function () {
 					assert.equal(req.status, 204);
 				});
 
+				it("should not trim whitespace bytes from a binary part body", async function () {
+					let called = false;
+					let endpoint = "/test/" + Zotero.Utilities.randomString();
+					// Begins and ends with whitespace bytes, which trimming would strip
+					let raw = new Uint8Array([0x0a, 0x20, 0x25, 0x50, 0x44, 0x46, 0xff, 0x0d, 0x0a]);
+					let expected = String.fromCharCode(...raw);
+
+					Zotero.Server.Endpoints[endpoint] = function () {};
+					Zotero.Server.Endpoints[endpoint].prototype = {
+						supportedMethods: ["POST"],
+						supportedDataTypes: ["multipart/form-data"],
+
+						init: function (options) {
+							called = true;
+							assert.isArray(options.data);
+							assert.equal(options.data.length, 1);
+							assert.equal(options.data[0].body, expected);
+							return 204;
+						}
+					};
+
+					let formData = new FormData();
+					formData.append("file", new Blob([raw]), "f.bin");
+
+					let req = await Zotero.HTTP.request(
+						"POST",
+						serverPath + endpoint,
+						{
+							headers: {
+								"Content-Type": "multipart/form-data"
+							},
+							body: formData
+						}
+					);
+
+					assert.ok(called);
+					assert.equal(req.status, 204);
+				});
+
 				it("should support an empty body", async function () {
 					var called = false;
 					var endpoint = "/test/" + Zotero.Utilities.randomString();

--- a/test/tests/server_localAPITest.js
+++ b/test/tests/server_localAPITest.js
@@ -85,7 +85,7 @@ describe("Local API Server", function () {
 		try {
 			let { response } = await Zotero.HTTP.request(
 				'POST',
-				apiRoot + '/authorize-local',
+				apiRoot + '/local/authorize',
 				{
 					headers: {
 						'Zotero-Allowed-Request': '1',
@@ -480,19 +480,19 @@ describe("Local API Server", function () {
 			writeAPIKey = await setupRememberedAPIKey();
 		});
 
-		// Reset the authorize-local rate limit between tests so a long sequence of
+		// Reset the local/authorize rate limit between tests so a long sequence of
 		// stubbed prompts can run without tripping the per-minute 429 throttle.
 		beforeEach(function () {
 			Zotero.Server.LocalAPI._resetAuthorizeRateLimit();
 		});
 
-		describe("POST /api/authorize-local", function () {
+		describe("POST /api/local/authorize", function () {
 			it("should return a key on allow", async function () {
 				let stub = sinon.stub(Zotero.Server.LocalAPI, '_promptForAuthorization')
 					.resolves({ allow: true, remember: false });
 				try {
 					let { response, status } = await Zotero.HTTP.request(
-						'POST', apiRoot + '/authorize-local',
+						'POST', apiRoot + '/local/authorize',
 						{
 							headers: {
 								'Zotero-Allowed-Request': '1',
@@ -517,7 +517,7 @@ describe("Local API Server", function () {
 					.resolves({ allow: true, remember: true });
 				try {
 					let { response } = await Zotero.HTTP.request(
-						'POST', apiRoot + '/authorize-local',
+						'POST', apiRoot + '/local/authorize',
 						{
 							headers: {
 								'Zotero-Allowed-Request': '1',
@@ -539,7 +539,7 @@ describe("Local API Server", function () {
 					.resolves({ allow: false, remember: false });
 				try {
 					let { response, status } = await Zotero.HTTP.request(
-						'POST', apiRoot + '/authorize-local',
+						'POST', apiRoot + '/local/authorize',
 						{
 							headers: {
 								'Zotero-Allowed-Request': '1',
@@ -560,7 +560,7 @@ describe("Local API Server", function () {
 
 			it("should require appName", async function () {
 				let { status } = await Zotero.HTTP.request(
-					'POST', apiRoot + '/authorize-local',
+					'POST', apiRoot + '/local/authorize',
 					{
 						headers: {
 							'Zotero-Allowed-Request': '1',
@@ -583,7 +583,7 @@ describe("Local API Server", function () {
 					});
 				try {
 					await Zotero.HTTP.request(
-						'POST', apiRoot + '/authorize-local',
+						'POST', apiRoot + '/local/authorize',
 						{
 							headers: {
 								'Zotero-Allowed-Request': '1',
@@ -607,7 +607,7 @@ describe("Local API Server", function () {
 				try {
 					for (let i = 0; i < 5; i++) {
 						await Zotero.HTTP.request(
-							'POST', apiRoot + '/authorize-local',
+							'POST', apiRoot + '/local/authorize',
 							{
 								headers: {
 									'Zotero-Allowed-Request': '1',
@@ -620,7 +620,7 @@ describe("Local API Server", function () {
 						);
 					}
 					let xhr = await Zotero.HTTP.request(
-						'POST', apiRoot + '/authorize-local',
+						'POST', apiRoot + '/local/authorize',
 						{
 							headers: {
 								'Zotero-Allowed-Request': '1',
@@ -645,7 +645,7 @@ describe("Local API Server", function () {
 				// 5 bad-appName requests fail before the prompt and don't consume slots
 				for (let i = 0; i < 5; i++) {
 					await Zotero.HTTP.request(
-						'POST', apiRoot + '/authorize-local',
+						'POST', apiRoot + '/local/authorize',
 						{
 							headers: {
 								'Zotero-Allowed-Request': '1',
@@ -662,7 +662,7 @@ describe("Local API Server", function () {
 					.resolves({ allow: false, remember: false });
 				try {
 					let { status } = await Zotero.HTTP.request(
-						'POST', apiRoot + '/authorize-local',
+						'POST', apiRoot + '/local/authorize',
 						{
 							headers: {
 								'Zotero-Allowed-Request': '1',
@@ -780,7 +780,7 @@ describe("Local API Server", function () {
 					.resolves({ allow: true, remember: false });
 				try {
 					let { response } = await Zotero.HTTP.request(
-						'POST', apiRoot + '/authorize-local',
+						'POST', apiRoot + '/local/authorize',
 						{
 							headers: {
 								'Zotero-Allowed-Request': '1',

--- a/test/tests/server_localAPITest.js
+++ b/test/tests/server_localAPITest.js
@@ -1695,11 +1695,11 @@ describe("Local API Server", function () {
 				assert.property(response, 'suffix');
 			});
 
-			it("should return params object when ?params=1", async function () {
+			it("should return params object when params=1 is in the body", async function () {
 				let { response } = await apiPost(
-					`/users/0/items/${attachment.key}/file?params=1`,
+					`/users/0/items/${attachment.key}/file`,
 					{
-						body: `md5=${'b'.repeat(32)}&filename=x.pdf&filesize=10&mtime=${Date.now()}`,
+						body: `md5=${'b'.repeat(32)}&filename=x.pdf&filesize=10&mtime=${Date.now()}&params=1`,
 						headers: {
 							'Content-Type': 'application/x-www-form-urlencoded',
 							'If-None-Match': '*',
@@ -1839,6 +1839,80 @@ describe("Local API Server", function () {
 				assert.equal(reloaded.attachmentSyncedHash, md5);
 				assert.equal(reloaded.attachmentSyncedModificationTime, mtime);
 				assert.equal(reloaded.attachmentFilename, 'uploaded.bin');
+			});
+
+			// Exercises the params=1 multipart upload form: each returned param as a form
+			// field, then the file bytes in a final `file` field. Uses real binary content
+			// to confirm it survives the multipart path.
+			it("should perform a params=1 multipart upload + register flow", async function () {
+				// Binary content spanning the byte range, ending in a newline byte to
+				// confirm the multipart parser doesn't trim/corrupt the file body
+				let raw = [0x25, 0x50, 0x44, 0x46, 0x00, 0x7f, 0x80, 0xff, 0xd0, 0x0a];
+				let bytes = Uint8Array.from(raw);
+				let tmpDir = Zotero.getTempDirectory().path;
+				let tmpPath = PathUtils.join(tmpDir, 'localapi-mp-upload-test.bin');
+				await IOUtils.write(tmpPath, bytes);
+				let md5 = await Zotero.Utilities.Internal.md5Async(tmpPath);
+				await IOUtils.remove(tmpPath);
+
+				let mtime = Date.now();
+
+				// Phase 1: authorize with params=1 in the form body
+				let { response: authResp } = await apiPost(
+					`/users/0/items/${attachment.key}/file`,
+					{
+						body: `md5=${md5}&filename=uploaded.bin&filesize=${bytes.length}`
+							+ `&mtime=${mtime}&params=1`,
+						headers: {
+							'Content-Type': 'application/x-www-form-urlencoded',
+							'If-None-Match': '*',
+						}
+					}
+				);
+				assert.isObject(authResp.params);
+				assert.isString(authResp.uploadKey);
+
+				// Phase 2: upload as multipart/form-data via FormData, with the returned
+				// params first, then the file part
+				let formData = new FormData();
+				for (let [key, val] of Object.entries(authResp.params)) {
+					formData.append(key, val);
+				}
+				formData.append('file', new Blob([bytes]), 'uploaded.bin');
+
+				let uploadXhr = await Zotero.HTTP.request('POST', authResp.url, {
+					headers: {
+						'Zotero-Allowed-Request': '1',
+						'Content-Type': 'multipart/form-data',
+					},
+					body: formData,
+					successCodes: [201],
+					responseType: 'text'
+				});
+				assert.equal(uploadXhr.status, 201);
+
+				// Phase 3: register
+				let { status } = await apiPost(
+					`/users/0/items/${attachment.key}/file`,
+					{
+						body: `upload=${authResp.uploadKey}`,
+						headers: {
+							'Content-Type': 'application/x-www-form-urlencoded',
+							'If-None-Match': '*',
+						},
+						successCodes: [204]
+					}
+				);
+				assert.equal(status, 204);
+
+				let reloaded = await Zotero.Items.getByLibraryAndKeyAsync(
+					Zotero.Libraries.userLibraryID, attachment.key);
+				assert.equal(reloaded.attachmentSyncedHash, md5);
+				assert.equal(reloaded.attachmentFilename, 'uploaded.bin');
+				// The stored file's bytes must match exactly
+				let storedPath = await reloaded.getFilePathAsync();
+				let stored = await IOUtils.read(storedPath);
+				assert.deepEqual(Array.from(stored), raw);
 			});
 
 			it("should reject registration without prior upload", async function () {

--- a/test/tests/server_localAPITest.js
+++ b/test/tests/server_localAPITest.js
@@ -880,6 +880,8 @@ describe("Local API Server", function () {
 				assert.equal(entry.data.title, 'New Book From API');
 				assert.match(entry.key, /^[23456789ABCDEFGHIJKLMNPQRSTUVWXYZ]{8}$/);
 				assert.equal(response.success['0'], entry.key);
+				// Top-level version and data.version report the same (local) version
+				assert.equal(entry.version, entry.data.version);
 				// Cleanup
 				let item = await Zotero.Items.getByLibraryAndKeyAsync(
 					Zotero.Libraries.userLibraryID, entry.key);

--- a/test/tests/server_localAPITest.js
+++ b/test/tests/server_localAPITest.js
@@ -325,11 +325,25 @@ describe("Local API Server", function () {
 		
 		describe("?since", function () {
 			it("should filter the results", async function () {
-				let { response: response1 } = await apiGet('/users/0/items?since=' + (Zotero.Libraries.userLibrary.libraryVersion + 1));
+				let version = Zotero.Libraries.userLibrary.clientVersion;
+				
+				let { response: response1 } = await apiGet('/users/0/items?since=' + version);
 				assert.isEmpty(response1);
 
 				let { response: response2 } = await apiGet('/users/0/items?since=0');
 				assert.lengthOf(response2, allItems.length);
+
+				let tempItem = await createDataObject('item');
+				let { response: response3 } = await apiGet('/users/0/items?since=' + version);
+				assert.lengthOf(response3, 1);
+				assert.equal(response3[0].key, tempItem.key);
+				assert.equal(response3[0].version, tempItem.clientVersion);
+				assert.equal(tempItem.clientVersion, version + 1);
+				
+				await tempItem.eraseTx();
+
+				let { response: response4 } = await apiGet('/users/0/items?since=' + version);
+				assert.lengthOf(response4, 0);
 			});
 		});
 

--- a/test/tests/server_localAPITest.js
+++ b/test/tests/server_localAPITest.js
@@ -1156,6 +1156,27 @@ describe("Local API Server", function () {
 				assert.equal(reloaded.getField('publisher'), '');
 				await item.eraseTx();
 			});
+
+			it("should accept If-Unmodified-Since-Version against the object version even after the library version advances", async function () {
+				let itemA = await createDataObject('item', { itemType: 'book' });
+				let versionA = itemA.clientVersion;
+				// Another write advances the library version past itemA's version
+				let itemB = await createDataObject('item', { itemType: 'book' });
+				assert.isAbove(itemB.clientVersion, versionA);
+
+				// itemA itself is unchanged, so a write with its version must succeed
+				let { status } = await apiPatch(`/users/0/items/${itemA.key}`, {
+					body: { publisher: 'Updated' },
+					headers: { 'If-Unmodified-Since-Version': String(versionA) },
+					successCodes: [204]
+				});
+				assert.equal(status, 204);
+				let reloaded = await Zotero.Items.getByLibraryAndKeyAsync(
+					Zotero.Libraries.userLibraryID, itemA.key);
+				assert.equal(reloaded.getField('publisher'), 'Updated');
+				await itemA.eraseTx();
+				await itemB.eraseTx();
+			});
 		});
 
 		describe("DELETE <userOrGroupPrefix>/items/<key>", function () {

--- a/test/tests/server_localAPITest.js
+++ b/test/tests/server_localAPITest.js
@@ -23,6 +23,85 @@ describe("Local API Server", function () {
 		});
 	}
 
+	// API key used by write tests; set up in the Write requests before() hook.
+	let writeAPIKey;
+
+	function apiRequest(method, endpoint, options = {}) {
+		let { body, headers, skipAPIKey, ...rest } = options;
+		let requestHeaders = {
+			'Zotero-Allowed-Request': '1',
+			...(headers || {})
+		};
+		if (!skipAPIKey && writeAPIKey
+				&& !requestHeaders['Zotero-API-Key']
+				&& !endpoint.includes('key=')) {
+			requestHeaders['Zotero-API-Key'] = writeAPIKey;
+		}
+		let requestBody = body;
+		if (body !== undefined && typeof body !== 'string'
+				&& !(body instanceof ArrayBuffer)
+				&& !ArrayBuffer.isView(body)) {
+			requestBody = JSON.stringify(body);
+			if (!requestHeaders['Content-Type']) {
+				requestHeaders['Content-Type'] = 'application/json';
+			}
+		}
+		return Zotero.HTTP.request(method, apiRoot + endpoint, {
+			headers: requestHeaders,
+			body: requestBody,
+			responseType: 'json',
+			...rest
+		});
+	}
+
+	function apiPost(endpoint, options = {}) {
+		return apiRequest('POST', endpoint, options);
+	}
+
+	function apiPut(endpoint, options = {}) {
+		return apiRequest('PUT', endpoint, options);
+	}
+
+	function apiPatch(endpoint, options = {}) {
+		return apiRequest('PATCH', endpoint, options);
+	}
+
+	function apiDelete(endpoint, options = {}) {
+		return apiRequest('DELETE', endpoint, options);
+	}
+
+	// Counter so each test generates a fresh write token (server caches them for 12h)
+	let writeTokenCounter = 0;
+	function newWriteToken() {
+		writeTokenCounter++;
+		return ('writeToken' + writeTokenCounter + 'x'.repeat(32))
+			.substring(0, 32);
+	}
+
+	// Stub the dialog and obtain a remembered API key directly via the endpoint
+	async function setupRememberedAPIKey(appName = 'Test Suite') {
+		let stub = sinon.stub(Zotero.Server.LocalAPI, '_promptForAuthorization')
+			.resolves({ allow: true, remember: true });
+		try {
+			let { response } = await Zotero.HTTP.request(
+				'POST',
+				apiRoot + '/authorize-local',
+				{
+					headers: {
+						'Zotero-Allowed-Request': '1',
+						'Content-Type': 'application/json',
+					},
+					body: JSON.stringify({ appName }),
+					responseType: 'json'
+				}
+			);
+			return response.key;
+		}
+		finally {
+			stub.restore();
+		}
+	}
+
 	before(async function () {
 		apiRoot = 'http://127.0.0.1:' + Zotero.Server.port + '/api';
 
@@ -388,6 +467,1451 @@ describe("Local API Server", function () {
 				}
 			);
 			assert.equal(response, "Not found");
+		});
+	});
+
+	// ===================================================================
+	// Write request tests
+	// ===================================================================
+
+	describe("Write requests", function () {
+		before(async function () {
+			Zotero.Server.LocalAPI._resetAuthorizeRateLimit();
+			writeAPIKey = await setupRememberedAPIKey();
+		});
+
+		// Reset the authorize-local rate limit between tests so a long sequence of
+		// stubbed prompts can run without tripping the per-minute 429 throttle.
+		beforeEach(function () {
+			Zotero.Server.LocalAPI._resetAuthorizeRateLimit();
+		});
+
+		describe("POST /api/authorize-local", function () {
+			it("should return a key on allow", async function () {
+				let stub = sinon.stub(Zotero.Server.LocalAPI, '_promptForAuthorization')
+					.resolves({ allow: true, remember: false });
+				try {
+					let { response, status } = await Zotero.HTTP.request(
+						'POST', apiRoot + '/authorize-local',
+						{
+							headers: {
+								'Zotero-Allowed-Request': '1',
+								'Content-Type': 'application/json',
+							},
+							body: JSON.stringify({ appName: 'AllowApp' }),
+							responseType: 'json'
+						}
+					);
+					assert.equal(status, 200);
+					assert.isString(response.key);
+					assert.lengthOf(response.key, 32);
+					assert.isFalse(response.remember);
+				}
+				finally {
+					stub.restore();
+				}
+			});
+
+			it("should mark a key as remembered when Always Allow is chosen", async function () {
+				let stub = sinon.stub(Zotero.Server.LocalAPI, '_promptForAuthorization')
+					.resolves({ allow: true, remember: true });
+				try {
+					let { response } = await Zotero.HTTP.request(
+						'POST', apiRoot + '/authorize-local',
+						{
+							headers: {
+								'Zotero-Allowed-Request': '1',
+								'Content-Type': 'application/json',
+							},
+							body: JSON.stringify({ appName: 'RememberApp' }),
+							responseType: 'json'
+						}
+					);
+					assert.isTrue(response.remember);
+				}
+				finally {
+					stub.restore();
+				}
+			});
+
+			it("should return 403 on deny", async function () {
+				let stub = sinon.stub(Zotero.Server.LocalAPI, '_promptForAuthorization')
+					.resolves({ allow: false, remember: false });
+				try {
+					let { response, status } = await Zotero.HTTP.request(
+						'POST', apiRoot + '/authorize-local',
+						{
+							headers: {
+								'Zotero-Allowed-Request': '1',
+								'Content-Type': 'application/json',
+							},
+							body: JSON.stringify({ appName: 'DeniedApp' }),
+							responseType: 'json',
+							successCodes: [403]
+						}
+					);
+					assert.equal(status, 403);
+					assert.isTrue(response.denied);
+				}
+				finally {
+					stub.restore();
+				}
+			});
+
+			it("should require appName", async function () {
+				let { status } = await Zotero.HTTP.request(
+					'POST', apiRoot + '/authorize-local',
+					{
+						headers: {
+							'Zotero-Allowed-Request': '1',
+							'Content-Type': 'application/json',
+						},
+						body: JSON.stringify({}),
+						responseType: 'text',
+						successCodes: [400]
+					}
+				);
+				assert.equal(status, 400);
+			});
+
+			it("should pass appName into the prompt", async function () {
+				let captured;
+				let stub = sinon.stub(Zotero.Server.LocalAPI, '_promptForAuthorization')
+					.callsFake(async (appName) => {
+						captured = appName;
+						return { allow: false };
+					});
+				try {
+					await Zotero.HTTP.request(
+						'POST', apiRoot + '/authorize-local',
+						{
+							headers: {
+								'Zotero-Allowed-Request': '1',
+								'Content-Type': 'application/json',
+							},
+							body: JSON.stringify({ appName: 'MyTestApp 1.0' }),
+							responseType: 'text',
+							successCodes: [403]
+						}
+					);
+				}
+				finally {
+					stub.restore();
+				}
+				assert.equal(captured, 'MyTestApp 1.0');
+			});
+
+			it("should rate-limit after 5 confirmation-requiring requests in a minute", async function () {
+				let stub = sinon.stub(Zotero.Server.LocalAPI, '_promptForAuthorization')
+					.resolves({ allow: false, remember: false });
+				try {
+					for (let i = 0; i < 5; i++) {
+						await Zotero.HTTP.request(
+							'POST', apiRoot + '/authorize-local',
+							{
+								headers: {
+									'Zotero-Allowed-Request': '1',
+									'Content-Type': 'application/json',
+								},
+								body: JSON.stringify({ appName: 'Throttle ' + i }),
+								responseType: 'text',
+								successCodes: [403]
+							}
+						);
+					}
+					let xhr = await Zotero.HTTP.request(
+						'POST', apiRoot + '/authorize-local',
+						{
+							headers: {
+								'Zotero-Allowed-Request': '1',
+								'Content-Type': 'application/json',
+							},
+							body: JSON.stringify({ appName: 'Throttle 6' }),
+							responseType: 'text',
+							successCodes: [429]
+						}
+					);
+					assert.equal(xhr.status, 429);
+					let retryAfter = parseInt(xhr.getResponseHeader('Retry-After'));
+					assert.isAbove(retryAfter, 0);
+					assert.isAtMost(retryAfter, 60);
+				}
+				finally {
+					stub.restore();
+				}
+			});
+
+			it("should not count rejected (pre-prompt) requests against the rate limit", async function () {
+				// 5 bad-appName requests fail before the prompt and don't consume slots
+				for (let i = 0; i < 5; i++) {
+					await Zotero.HTTP.request(
+						'POST', apiRoot + '/authorize-local',
+						{
+							headers: {
+								'Zotero-Allowed-Request': '1',
+								'Content-Type': 'application/json',
+							},
+							body: JSON.stringify({}),
+							responseType: 'text',
+							successCodes: [400]
+						}
+					);
+				}
+				// A subsequent valid request still goes through
+				let stub = sinon.stub(Zotero.Server.LocalAPI, '_promptForAuthorization')
+					.resolves({ allow: false, remember: false });
+				try {
+					let { status } = await Zotero.HTTP.request(
+						'POST', apiRoot + '/authorize-local',
+						{
+							headers: {
+								'Zotero-Allowed-Request': '1',
+								'Content-Type': 'application/json',
+							},
+							body: JSON.stringify({ appName: 'AfterBadReqs' }),
+							responseType: 'json',
+							successCodes: [403]
+						}
+					);
+					assert.equal(status, 403);
+				}
+				finally {
+					stub.restore();
+				}
+			});
+		});
+
+		describe("Authorization management", function () {
+			it("should report a count of remembered authorizations", async function () {
+				let before = await Zotero.Server.LocalAPI.getAuthorizationCount();
+				await setupRememberedAPIKey('CountedApp');
+				let after = await Zotero.Server.LocalAPI.getAuthorizationCount();
+				assert.equal(after, before + 1);
+			});
+
+			it("should drop every stored key when cleared", async function () {
+				await setupRememberedAPIKey('ToClearApp');
+				assert.isAbove(await Zotero.Server.LocalAPI.getAuthorizationCount(), 0);
+				await Zotero.Server.LocalAPI.clearAuthorizations();
+				assert.equal(await Zotero.Server.LocalAPI.getAuthorizationCount(), 0);
+
+				// Previously-issued keys must no longer authenticate writes
+				let { status } = await apiPost('/users/0/items', {
+					body: [{ itemType: 'book' }],
+					headers: {
+						'Zotero-Write-Token': newWriteToken(),
+						'Zotero-API-Key': writeAPIKey,
+					},
+					skipAPIKey: true,
+					successCodes: [401],
+					responseType: 'text'
+				});
+				assert.equal(status, 401);
+
+				// Restore the suite-wide key so later tests still work
+				writeAPIKey = await setupRememberedAPIKey('Test Suite');
+			});
+		});
+
+		describe("Authentication", function () {
+			it("should reject write requests with no API key (401)", async function () {
+				let { status } = await apiPost('/users/0/items', {
+					body: [{ itemType: 'book' }],
+					headers: { 'Zotero-Write-Token': newWriteToken() },
+					skipAPIKey: true,
+					successCodes: [401],
+					responseType: 'text'
+				});
+				assert.equal(status, 401);
+			});
+
+			it("should reject write requests with an unknown API key (401)", async function () {
+				let { status } = await apiPost('/users/0/items', {
+					body: [{ itemType: 'book' }],
+					headers: {
+						'Zotero-Write-Token': newWriteToken(),
+						'Zotero-API-Key': 'not-a-real-key-at-all',
+					},
+					skipAPIKey: true,
+					successCodes: [401],
+					responseType: 'text'
+				});
+				assert.equal(status, 401);
+			});
+
+			it("should accept the API key via ?key= query parameter", async function () {
+				let { status, response } = await apiPost(
+					`/users/0/items?key=${encodeURIComponent(writeAPIKey)}`,
+					{
+						body: [{ itemType: 'book', title: 'QueryKey Item' }],
+						headers: { 'Zotero-Write-Token': newWriteToken() },
+						skipAPIKey: true,
+					}
+				);
+				assert.equal(status, 200);
+				let key = response.successful['0'].key;
+				let item = await Zotero.Items.getByLibraryAndKeyAsync(
+					Zotero.Libraries.userLibraryID, key);
+				if (item) await item.eraseTx();
+			});
+
+			it("should consume a single-use API key after one write", async function () {
+				let oneShot;
+				let stub = sinon.stub(Zotero.Server.LocalAPI, '_promptForAuthorization')
+					.resolves({ allow: true, remember: false });
+				try {
+					let { response } = await Zotero.HTTP.request(
+						'POST', apiRoot + '/authorize-local',
+						{
+							headers: {
+								'Zotero-Allowed-Request': '1',
+								'Content-Type': 'application/json',
+							},
+							body: JSON.stringify({ appName: 'OneShotApp' }),
+							responseType: 'json'
+						}
+					);
+					oneShot = response.key;
+				}
+				finally {
+					stub.restore();
+				}
+
+				let { status, response } = await apiPost('/users/0/items', {
+					body: [{ itemType: 'book' }],
+					headers: {
+						'Zotero-Write-Token': newWriteToken(),
+						'Zotero-API-Key': oneShot,
+					},
+					skipAPIKey: true,
+				});
+				assert.equal(status, 200);
+				let key = response.successful['0'].key;
+				let item = await Zotero.Items.getByLibraryAndKeyAsync(
+					Zotero.Libraries.userLibraryID, key);
+				if (item) await item.eraseTx();
+
+				// Second use must be rejected
+				let { status: status2 } = await apiPost('/users/0/items', {
+					body: [{ itemType: 'book' }],
+					headers: {
+						'Zotero-Write-Token': newWriteToken(),
+						'Zotero-API-Key': oneShot,
+					},
+					skipAPIKey: true,
+					successCodes: [401],
+					responseType: 'text'
+				});
+				assert.equal(status2, 401);
+			});
+
+			it("should allow remembered keys to be reused", async function () {
+				// Use the suite key twice -- it's marked remember:true
+				let first = await apiPost('/users/0/items', {
+					body: [{ itemType: 'book' }],
+					headers: { 'Zotero-Write-Token': newWriteToken() }
+				});
+				let second = await apiPost('/users/0/items', {
+					body: [{ itemType: 'book' }],
+					headers: { 'Zotero-Write-Token': newWriteToken() }
+				});
+				assert.equal(first.status, 200);
+				assert.equal(second.status, 200);
+				for (let resp of [first, second]) {
+					let key = resp.response.successful['0'].key;
+					let item = await Zotero.Items.getByLibraryAndKeyAsync(
+						Zotero.Libraries.userLibraryID, key);
+					if (item) await item.eraseTx();
+				}
+			});
+
+			it("should not require API key for GET requests", async function () {
+				let { status } = await apiGet('/users/0/items');
+				assert.equal(status, 200);
+			});
+
+			it("should persist remembered keys to <profileDir>/localAPIKeys.json", async function () {
+				let path = PathUtils.join(Zotero.Profile.dir, 'localAPIKeys.json');
+				assert.isTrue(await IOUtils.exists(path));
+				let text = await IOUtils.readUTF8(path);
+				let json = JSON.parse(text);
+				assert.isArray(json.keys);
+				assert.isTrue(json.keys.some(k => k.key === writeAPIKey && k.remember));
+			});
+		});
+
+		describe("POST <userOrGroupPrefix>/items", function () {
+			it("should create a single item", async function () {
+				let { response } = await apiPost('/users/0/items', {
+					body: [{
+						itemType: 'book',
+						title: 'New Book From API',
+					}],
+					headers: { 'Zotero-Write-Token': newWriteToken() }
+				});
+				assert.isObject(response);
+				assert.isObject(response.successful);
+				assert.isObject(response.success);
+				assert.isObject(response.unchanged);
+				assert.isObject(response.failed);
+				assert.isEmpty(Object.keys(response.failed));
+				assert.lengthOf(Object.keys(response.successful), 1);
+				let entry = response.successful['0'];
+				assert.equal(entry.data.itemType, 'book');
+				assert.equal(entry.data.title, 'New Book From API');
+				assert.match(entry.key, /^[23456789ABCDEFGHIJKLMNPQRSTUVWXYZ]{8}$/);
+				assert.equal(response.success['0'], entry.key);
+				// Cleanup
+				let item = await Zotero.Items.getByLibraryAndKeyAsync(
+					Zotero.Libraries.userLibraryID, entry.key);
+				if (item) await item.eraseTx();
+			});
+
+			it("should create multiple items in one request", async function () {
+				let { response } = await apiPost('/users/0/items', {
+					body: [
+						{ itemType: 'book', title: 'Book A' },
+						{ itemType: 'journalArticle', title: 'Article B' }
+					],
+					headers: { 'Zotero-Write-Token': newWriteToken() }
+				});
+				assert.lengthOf(Object.keys(response.successful), 2);
+				assert.equal(response.successful['0'].data.title, 'Book A');
+				assert.equal(response.successful['1'].data.itemType, 'journalArticle');
+				// Cleanup
+				for (let i of ['0', '1']) {
+					let key = response.successful[i].key;
+					let item = await Zotero.Items.getByLibraryAndKeyAsync(
+						Zotero.Libraries.userLibraryID, key);
+					if (item) await item.eraseTx();
+				}
+			});
+
+			it("should report failed items in 'failed'", async function () {
+				let { response } = await apiPost('/users/0/items', {
+					body: [
+						{ itemType: 'book', title: 'Valid Book' },
+						{ itemType: 'noSuchType', title: 'Invalid' },
+					],
+					headers: { 'Zotero-Write-Token': newWriteToken() }
+				});
+				assert.lengthOf(Object.keys(response.successful), 1);
+				assert.lengthOf(Object.keys(response.failed), 1);
+				let failure = response.failed['1'];
+				assert.equal(failure.code, 400);
+				assert.include(failure.message.toLowerCase(), 'itemtype');
+				// Cleanup
+				let key = response.successful['0'].key;
+				let item = await Zotero.Items.getByLibraryAndKeyAsync(
+					Zotero.Libraries.userLibraryID, key);
+				if (item) await item.eraseTx();
+			});
+
+			it("should reject non-array body", async function () {
+				let { status } = await apiPost('/users/0/items', {
+					body: { itemType: 'book' },
+					headers: { 'Zotero-Write-Token': newWriteToken() },
+					successCodes: [400],
+					responseType: 'text'
+				});
+				assert.equal(status, 400);
+			});
+
+			it("should reject batches over 50 items with 413", async function () {
+				let body = [];
+				for (let i = 0; i < 51; i++) {
+					body.push({ itemType: 'book', title: 'Book ' + i });
+				}
+				let { status } = await apiPost('/users/0/items', {
+					body,
+					headers: { 'Zotero-Write-Token': newWriteToken() },
+					successCodes: [413],
+					responseType: 'text'
+				});
+				assert.equal(status, 413);
+			});
+
+			it("should reject duplicate write tokens with 412", async function () {
+				let token = newWriteToken();
+				await apiPost('/users/0/items', {
+					body: [{ itemType: 'book', title: 'First with token' }],
+					headers: { 'Zotero-Write-Token': token }
+				});
+				let { status } = await apiPost('/users/0/items', {
+					body: [{ itemType: 'book', title: 'Second with token' }],
+					headers: { 'Zotero-Write-Token': token },
+					successCodes: [412],
+					responseType: 'text'
+				});
+				assert.equal(status, 412);
+			});
+
+			it("should accept write tokens of 5-32 chars", async function () {
+				let { status } = await apiPost('/users/0/items', {
+					body: [{ itemType: 'book', title: 'Short token' }],
+					headers: { 'Zotero-Write-Token': 'short' }
+				});
+				assert.equal(status, 200);
+			});
+
+			it("should reject write tokens shorter than 5 chars with 400", async function () {
+				let { status } = await apiPost('/users/0/items', {
+					body: [{ itemType: 'book' }],
+					headers: { 'Zotero-Write-Token': 'abcd' },
+					successCodes: [400],
+					responseType: 'text'
+				});
+				assert.equal(status, 400);
+			});
+
+			it("should update an existing item with key+version", async function () {
+				let item = await createDataObject('item', { itemType: 'book', setTitle: true });
+				let { response } = await apiPost('/users/0/items', {
+					body: [{
+						key: item.key,
+						version: item.clientVersion,
+						itemType: 'book',
+						title: 'Updated Title',
+					}],
+					headers: { 'Zotero-Write-Token': newWriteToken() }
+				});
+				assert.lengthOf(Object.keys(response.successful), 1);
+				assert.equal(response.successful['0'].data.title, 'Updated Title');
+				let reloaded = await Zotero.Items.getByLibraryAndKeyAsync(
+					Zotero.Libraries.userLibraryID, item.key);
+				assert.equal(reloaded.getField('title'), 'Updated Title');
+				await item.eraseTx();
+			});
+
+			it("should fail an object with stale version", async function () {
+				let item = await createDataObject('item', { itemType: 'book', setTitle: true });
+				let { response } = await apiPost('/users/0/items', {
+					body: [{
+						key: item.key,
+						version: item.clientVersion - 5,
+						itemType: 'book',
+						title: 'Stale Update',
+					}],
+					headers: { 'Zotero-Write-Token': newWriteToken() }
+				});
+				assert.lengthOf(Object.keys(response.failed), 1);
+				assert.equal(response.failed['0'].code, 412);
+				await item.eraseTx();
+			});
+
+			it("should return 412 on stale If-Unmodified-Since-Version", async function () {
+				let staleVersion = Zotero.Libraries.userLibrary.clientVersion;
+				// Bump the library by creating a sentinel item
+				let sentinel = await createDataObject('item');
+				let { status } = await apiPost('/users/0/items', {
+					body: [{ itemType: 'book' }],
+					headers: {
+						'Zotero-Write-Token': newWriteToken(),
+						'If-Unmodified-Since-Version': String(staleVersion)
+					},
+					successCodes: [412],
+					responseType: 'text'
+				});
+				assert.equal(status, 412);
+				await sentinel.eraseTx();
+			});
+
+			it("should include Last-Modified-Version response header", async function () {
+				let xhr = await apiPost('/users/0/items', {
+					body: [{ itemType: 'book' }],
+					headers: { 'Zotero-Write-Token': newWriteToken() }
+				});
+				let header = xhr.getResponseHeader('Last-Modified-Version');
+				assert.isNotEmpty(header);
+				assert.equal(
+					parseInt(header),
+					Zotero.Libraries.userLibrary.clientVersion);
+				let key = xhr.response.successful['0'].key;
+				let item = await Zotero.Items.getByLibraryAndKeyAsync(
+					Zotero.Libraries.userLibraryID, key);
+				if (item) await item.eraseTx();
+			});
+		});
+
+		describe("PUT <userOrGroupPrefix>/items/<key>", function () {
+			it("should fully replace an item's fields", async function () {
+				let item = await createDataObject('item', {
+					itemType: 'book',
+					setTitle: true,
+				});
+				item.setField('publisher', 'Original Pub');
+				await item.saveTx();
+
+				let { status } = await apiPut(`/users/0/items/${item.key}`, {
+					body: {
+						key: item.key,
+						version: item.clientVersion,
+						itemType: 'book',
+						title: 'New Title After PUT',
+					},
+					successCodes: [204]
+				});
+				assert.equal(status, 204);
+
+				let reloaded = await Zotero.Items.getByLibraryAndKeyAsync(
+					Zotero.Libraries.userLibraryID, item.key);
+				assert.equal(reloaded.getField('title'), 'New Title After PUT');
+				// PUT should clear unspecified fields
+				assert.equal(reloaded.getField('publisher'), '');
+				await item.eraseTx();
+			});
+
+			it("should reject without version or If-Unmodified-Since-Version", async function () {
+				let item = await createDataObject('item');
+				let { status } = await apiPut(`/users/0/items/${item.key}`, {
+					body: { itemType: 'book', title: 'x' },
+					successCodes: [428],
+					responseType: 'text'
+				});
+				assert.equal(status, 428);
+				await item.eraseTx();
+			});
+
+			it("should return 412 on stale version", async function () {
+				let item = await createDataObject('item');
+				let { status } = await apiPut(`/users/0/items/${item.key}`, {
+					body: {
+						itemType: 'book',
+						title: 'x',
+						version: item.clientVersion - 1,
+					},
+					successCodes: [412],
+					responseType: 'text'
+				});
+				assert.equal(status, 412);
+				await item.eraseTx();
+			});
+
+			it("should reject invalid key with 400", async function () {
+				let { status } = await apiPut('/users/0/items/badkey!!', {
+					body: { itemType: 'book' },
+					successCodes: [400],
+					responseType: 'text'
+				});
+				assert.equal(status, 400);
+			});
+		});
+
+		describe("PATCH <userOrGroupPrefix>/items/<key>", function () {
+			it("should leave unspecified fields untouched", async function () {
+				let item = await createDataObject('item', {
+					itemType: 'book',
+					setTitle: true,
+				});
+				item.setField('publisher', 'Keep Me');
+				await item.saveTx();
+				let savedTitle = item.getField('title');
+
+				let { status } = await apiPatch(`/users/0/items/${item.key}`, {
+					body: {
+						publisher: 'New Publisher',
+						version: item.clientVersion,
+					},
+					successCodes: [204]
+				});
+				assert.equal(status, 204);
+
+				let reloaded = await Zotero.Items.getByLibraryAndKeyAsync(
+					Zotero.Libraries.userLibraryID, item.key);
+				assert.equal(reloaded.getField('title'), savedTitle);
+				assert.equal(reloaded.getField('publisher'), 'New Publisher');
+				await item.eraseTx();
+			});
+
+			it("should clear a field when explicitly set to ''", async function () {
+				let item = await createDataObject('item', { itemType: 'book' });
+				item.setField('publisher', 'Will Be Cleared');
+				await item.saveTx();
+				let { status } = await apiPatch(`/users/0/items/${item.key}`, {
+					body: { publisher: '', version: item.clientVersion },
+					successCodes: [204]
+				});
+				assert.equal(status, 204);
+				let reloaded = await Zotero.Items.getByLibraryAndKeyAsync(
+					Zotero.Libraries.userLibraryID, item.key);
+				assert.equal(reloaded.getField('publisher'), '');
+				await item.eraseTx();
+			});
+		});
+
+		describe("DELETE <userOrGroupPrefix>/items/<key>", function () {
+			it("should delete a single item", async function () {
+				let item = await createDataObject('item');
+				let { status } = await apiDelete(`/users/0/items/${item.key}`, {
+					headers: {
+						'If-Unmodified-Since-Version': String(item.clientVersion),
+					},
+					successCodes: [204]
+				});
+				assert.equal(status, 204);
+				let reloaded = await Zotero.Items.getByLibraryAndKeyAsync(
+					Zotero.Libraries.userLibraryID, item.key);
+				assert.isFalse(!!reloaded);
+			});
+
+			it("should require If-Unmodified-Since-Version (428)", async function () {
+				let item = await createDataObject('item');
+				let { status } = await apiDelete(`/users/0/items/${item.key}`, {
+					successCodes: [428],
+					responseType: 'text'
+				});
+				assert.equal(status, 428);
+				await item.eraseTx();
+			});
+
+			it("should return 412 on stale If-Unmodified-Since-Version", async function () {
+				let item = await createDataObject('item');
+				let { status } = await apiDelete(`/users/0/items/${item.key}`, {
+					headers: {
+						'If-Unmodified-Since-Version': String(item.clientVersion - 1),
+					},
+					successCodes: [412],
+					responseType: 'text'
+				});
+				assert.equal(status, 412);
+				await item.eraseTx();
+			});
+
+			it("should return 404 for unknown key", async function () {
+				let { status } = await apiDelete('/users/0/items/ABCDEFGH', {
+					headers: { 'If-Unmodified-Since-Version': '999' },
+					successCodes: [404],
+					responseType: 'text'
+				});
+				assert.equal(status, 404);
+			});
+		});
+
+		describe("DELETE <userOrGroupPrefix>/items?itemKey=", function () {
+			it("should delete multiple items", async function () {
+				let item1 = await createDataObject('item');
+				let item2 = await createDataObject('item');
+				let { status } = await apiDelete(
+					`/users/0/items?itemKey=${item1.key},${item2.key}`,
+					{
+						headers: {
+							'If-Unmodified-Since-Version':
+								String(Zotero.Libraries.userLibrary.clientVersion),
+						},
+						successCodes: [204]
+					}
+				);
+				assert.equal(status, 204);
+				assert.isFalse(!!(await Zotero.Items.getByLibraryAndKeyAsync(
+					Zotero.Libraries.userLibraryID, item1.key)));
+				assert.isFalse(!!(await Zotero.Items.getByLibraryAndKeyAsync(
+					Zotero.Libraries.userLibraryID, item2.key)));
+			});
+
+			it("should ignore unknown keys mixed in", async function () {
+				let item = await createDataObject('item');
+				let { status } = await apiDelete(
+					`/users/0/items?itemKey=${item.key},ZZZZZZZZ`,
+					{
+						headers: {
+							'If-Unmodified-Since-Version':
+								String(Zotero.Libraries.userLibrary.clientVersion),
+						},
+						successCodes: [204]
+					}
+				);
+				assert.equal(status, 204);
+			});
+
+			it("should reject batches over 50 keys with 413", async function () {
+				let keys = [];
+				for (let i = 0; i < 51; i++) {
+					keys.push("AAAAAAA" + (i % 9 + 1));
+				}
+				let { status } = await apiDelete(
+					'/users/0/items?itemKey=' + keys.join(','),
+					{
+						headers: {
+							'If-Unmodified-Since-Version':
+								String(Zotero.Libraries.userLibrary.clientVersion),
+						},
+						successCodes: [413],
+						responseType: 'text'
+					}
+				);
+				assert.equal(status, 413);
+			});
+		});
+
+		describe("POST <userOrGroupPrefix>/collections", function () {
+			it("should create a collection", async function () {
+				let { response } = await apiPost('/users/0/collections', {
+					body: [{ name: 'New Test Collection' }],
+					headers: { 'Zotero-Write-Token': newWriteToken() }
+				});
+				assert.lengthOf(Object.keys(response.successful), 1);
+				let key = response.successful['0'].key;
+				let col = Zotero.Collections.getByLibraryAndKey(
+					Zotero.Libraries.userLibraryID, key);
+				assert.equal(col.name, 'New Test Collection');
+				await col.eraseTx();
+			});
+
+			it("should set parentCollection when provided", async function () {
+				let parent = await createDataObject('collection');
+				let { response } = await apiPost('/users/0/collections', {
+					body: [{ name: 'Child', parentCollection: parent.key }],
+					headers: { 'Zotero-Write-Token': newWriteToken() }
+				});
+				let key = response.successful['0'].key;
+				let child = Zotero.Collections.getByLibraryAndKey(
+					Zotero.Libraries.userLibraryID, key);
+				assert.equal(child.parentKey, parent.key);
+				await child.eraseTx();
+				await parent.eraseTx();
+			});
+		});
+
+		describe("PUT/PATCH/DELETE <userOrGroupPrefix>/collections/<key>", function () {
+			it("should update a collection via PUT", async function () {
+				let col = await createDataObject('collection', { name: 'Before' });
+				let { status } = await apiPut(`/users/0/collections/${col.key}`, {
+					body: {
+						version: col.clientVersion,
+						name: 'After PUT',
+					},
+					successCodes: [204]
+				});
+				assert.equal(status, 204);
+				let reloaded = Zotero.Collections.getByLibraryAndKey(
+					Zotero.Libraries.userLibraryID, col.key);
+				assert.equal(reloaded.name, 'After PUT');
+				await col.eraseTx();
+			});
+
+			it("should patch a collection's name", async function () {
+				let col = await createDataObject('collection', { name: 'Before' });
+				let { status } = await apiPatch(`/users/0/collections/${col.key}`, {
+					body: { name: 'After PATCH', version: col.clientVersion },
+					successCodes: [204]
+				});
+				assert.equal(status, 204);
+				let reloaded = Zotero.Collections.getByLibraryAndKey(
+					Zotero.Libraries.userLibraryID, col.key);
+				assert.equal(reloaded.name, 'After PATCH');
+				await col.eraseTx();
+			});
+
+			it("should delete a collection", async function () {
+				let col = await createDataObject('collection');
+				let { status } = await apiDelete(`/users/0/collections/${col.key}`, {
+					headers: {
+						'If-Unmodified-Since-Version': String(col.clientVersion),
+					},
+					successCodes: [204]
+				});
+				assert.equal(status, 204);
+				let reloaded = Zotero.Collections.getByLibraryAndKey(
+					Zotero.Libraries.userLibraryID, col.key);
+				assert.isFalse(!!reloaded);
+			});
+		});
+
+		describe("POST/PUT/DELETE <userOrGroupPrefix>/searches", function () {
+			it("should create a saved search", async function () {
+				let { response } = await apiPost('/users/0/searches', {
+					body: [{
+						name: 'My Saved Search',
+						conditions: [
+							{ condition: 'title', operator: 'contains', value: 'foo' }
+						]
+					}],
+					headers: { 'Zotero-Write-Token': newWriteToken() }
+				});
+				assert.lengthOf(Object.keys(response.successful), 1);
+				let key = response.successful['0'].key;
+				let search = Zotero.Searches.getByLibraryAndKey(
+					Zotero.Libraries.userLibraryID, key);
+				assert.equal(search.name, 'My Saved Search');
+				await search.eraseTx();
+			});
+
+			it("should delete a search", async function () {
+				let search = await createDataObject('search', { name: 'To Delete' });
+				let { status } = await apiDelete(`/users/0/searches/${search.key}`, {
+					headers: {
+						'If-Unmodified-Since-Version': String(search.clientVersion),
+					},
+					successCodes: [204]
+				});
+				assert.equal(status, 204);
+				let reloaded = Zotero.Searches.getByLibraryAndKey(
+					Zotero.Libraries.userLibraryID, search.key);
+				assert.isFalse(!!reloaded);
+			});
+		});
+
+		describe("DELETE <userOrGroupPrefix>/tags", function () {
+			it("should remove tags from the library", async function () {
+				let item = await createDataObject('item');
+				item.setTags(['tagToDelete', 'tagToKeep']);
+				await item.saveTx();
+				assert.isAtLeast(Zotero.Tags.getID('tagToDelete'), 1);
+
+				let { status } = await apiDelete('/users/0/tags?tag=tagToDelete', {
+					headers: {
+						'If-Unmodified-Since-Version':
+							String(Zotero.Libraries.userLibrary.clientVersion),
+					},
+					successCodes: [204]
+				});
+				assert.equal(status, 204);
+				let reloaded = await Zotero.Items.getByLibraryAndKeyAsync(
+					Zotero.Libraries.userLibraryID, item.key);
+				assert.notInclude(reloaded.getTags().map(t => t.tag), 'tagToDelete');
+				assert.include(reloaded.getTags().map(t => t.tag), 'tagToKeep');
+				await item.eraseTx();
+			});
+
+			it("should split tag names on ||", async function () {
+				let item = await createDataObject('item');
+				item.setTags(['multi1', 'multi2', 'keep']);
+				await item.saveTx();
+				let { status } = await apiDelete('/users/0/tags?tag=multi1||multi2', {
+					headers: {
+						'If-Unmodified-Since-Version':
+							String(Zotero.Libraries.userLibrary.clientVersion),
+					},
+					successCodes: [204]
+				});
+				assert.equal(status, 204);
+				let reloaded = await Zotero.Items.getByLibraryAndKeyAsync(
+					Zotero.Libraries.userLibraryID, item.key);
+				let tags = reloaded.getTags().map(t => t.tag);
+				assert.notInclude(tags, 'multi1');
+				assert.notInclude(tags, 'multi2');
+				assert.include(tags, 'keep');
+				await item.eraseTx();
+			});
+
+			it("should require If-Unmodified-Since-Version", async function () {
+				let { status } = await apiDelete('/users/0/tags?tag=anything', {
+					successCodes: [428],
+					responseType: 'text'
+				});
+				assert.equal(status, 428);
+			});
+		});
+
+		describe("PUT <userOrGroupPrefix>/items/<key>/fulltext", function () {
+			let parent;
+			let attachment;
+
+			beforeEach(async function () {
+				parent = await createDataObject('item');
+				attachment = await importPDFAttachment(parent);
+			});
+
+			afterEach(async function () {
+				if (attachment) await attachment.eraseTx();
+				if (parent) await parent.eraseTx();
+			});
+
+			it("should set fulltext content for an attachment", async function () {
+				let beforeVersion = Zotero.Libraries.userLibrary.clientVersion;
+				let xhr = await apiPut(
+					`/users/0/items/${attachment.key}/fulltext`,
+					{
+						body: {
+							content: 'Hello, fulltext.',
+							indexedPages: 1,
+							totalPages: 1,
+						}
+					}
+				);
+				assert.equal(xhr.status, 204);
+				let lastModified = parseInt(xhr.getResponseHeader('Last-Modified-Version'));
+				assert.isAbove(lastModified, beforeVersion);
+
+				let { response } = await apiGet(`/users/0/items/${attachment.key}/fulltext`);
+				assert.equal(response.content, 'Hello, fulltext.');
+				assert.equal(response.indexedPages, 1);
+				assert.equal(response.totalPages, 1);
+			});
+
+			it("should accept char-based stats", async function () {
+				let { status } = await apiPut(
+					`/users/0/items/${attachment.key}/fulltext`,
+					{
+						body: {
+							content: 'Char-counted content.',
+							indexedChars: 21,
+							totalChars: 21,
+						}
+					}
+				);
+				assert.equal(status, 204);
+				let { response } = await apiGet(`/users/0/items/${attachment.key}/fulltext`);
+				assert.equal(response.content, 'Char-counted content.');
+				assert.equal(response.indexedChars, 21);
+				assert.equal(response.totalChars, 21);
+			});
+
+			it("should reject a body without 'content'", async function () {
+				let { status } = await apiPut(
+					`/users/0/items/${attachment.key}/fulltext`,
+					{
+						body: { indexedPages: 1, totalPages: 1 },
+						successCodes: [400],
+						responseType: 'text'
+					}
+				);
+				assert.equal(status, 400);
+			});
+
+			it("should reject non-integer stats", async function () {
+				let { status } = await apiPut(
+					`/users/0/items/${attachment.key}/fulltext`,
+					{
+						body: { content: 'x', indexedPages: '1' },
+						successCodes: [400],
+						responseType: 'text'
+					}
+				);
+				assert.equal(status, 400);
+			});
+
+			it("should return 404 for unknown item key", async function () {
+				let { status } = await apiPut(
+					`/users/0/items/AAAAAAAA/fulltext`,
+					{
+						body: { content: 'x' },
+						successCodes: [404],
+						responseType: 'text'
+					}
+				);
+				assert.equal(status, 404);
+			});
+
+			it("should reject a non-attachment item", async function () {
+				let regularItem = await createDataObject('item');
+				try {
+					let { status } = await apiPut(
+						`/users/0/items/${regularItem.key}/fulltext`,
+						{
+							body: { content: 'x' },
+							successCodes: [404],
+							responseType: 'text'
+						}
+					);
+					assert.equal(status, 404);
+				}
+				finally {
+					await regularItem.eraseTx();
+				}
+			});
+		});
+
+		describe("POST <userOrGroupPrefix>/fulltext", function () {
+			let parent;
+			let a1;
+			let a2;
+
+			beforeEach(async function () {
+				parent = await createDataObject('item');
+				a1 = await importPDFAttachment(parent);
+				a2 = await importPDFAttachment(parent);
+			});
+
+			afterEach(async function () {
+				for (let item of [a1, a2, parent]) {
+					if (item) await item.eraseTx();
+				}
+			});
+
+			function iusvHeader() {
+				return { 'If-Unmodified-Since-Version': String(Zotero.Libraries.userLibrary.clientVersion) };
+			}
+
+			it("should write multiple items and return a write report", async function () {
+				let { status, response } = await apiPost('/users/0/fulltext', {
+					headers: iusvHeader(),
+					body: [
+						{ key: a1.key, content: 'one', indexedPages: 1, totalPages: 1 },
+						{ key: a2.key, content: 'two', indexedPages: 1, totalPages: 1 },
+					]
+				});
+				assert.equal(status, 200);
+				assert.deepEqual(response.successful['0'], { key: a1.key });
+				assert.deepEqual(response.successful['1'], { key: a2.key });
+				assert.equal(response.success['0'], a1.key);
+				assert.equal(response.success['1'], a2.key);
+				assert.isEmpty(Object.keys(response.failed));
+
+				let { response: r1 } = await apiGet(`/users/0/items/${a1.key}/fulltext`);
+				assert.equal(r1.content, 'one');
+				let { response: r2 } = await apiGet(`/users/0/items/${a2.key}/fulltext`);
+				assert.equal(r2.content, 'two');
+			});
+
+			it("should report per-item failures while applying the rest", async function () {
+				let regularItem = await createDataObject('item');
+				try {
+					let { status, response } = await apiPost('/users/0/fulltext', {
+						headers: iusvHeader(),
+						body: [
+							{ key: a1.key, content: 'ok' },
+							{ key: 'AAAAAAAA', content: 'missing' },
+							{ key: regularItem.key, content: 'not-attach' },
+						]
+					});
+					assert.equal(status, 200);
+					assert.property(response.successful, '0');
+					assert.notProperty(response.successful, '1');
+					assert.notProperty(response.successful, '2');
+					assert.equal(response.failed['1'].code, 404);
+					assert.equal(response.failed['2'].code, 404);
+				}
+				finally {
+					await regularItem.eraseTx();
+				}
+			});
+
+			it("should require If-Unmodified-Since-Version (428)", async function () {
+				let { status } = await apiPost('/users/0/fulltext', {
+					body: [{ key: a1.key, content: 'x' }],
+					successCodes: [428],
+					responseType: 'text'
+				});
+				assert.equal(status, 428);
+			});
+
+			it("should reject non-array body with 400", async function () {
+				let { status } = await apiPost('/users/0/fulltext', {
+					headers: iusvHeader(),
+					body: { key: a1.key, content: 'x' },
+					successCodes: [400],
+					responseType: 'text'
+				});
+				assert.equal(status, 400);
+			});
+
+			it("should reject batches over 10 with 413", async function () {
+				let big = [];
+				for (let i = 0; i < 11; i++) {
+					big.push({ key: a1.key, content: 'x' });
+				}
+				let { status } = await apiPost('/users/0/fulltext', {
+					headers: iusvHeader(),
+					body: big,
+					successCodes: [413],
+					responseType: 'text'
+				});
+				assert.equal(status, 413);
+			});
+
+			it("should reject an entry missing 'key'", async function () {
+				let { status, response } = await apiPost('/users/0/fulltext', {
+					headers: iusvHeader(),
+					body: [{ content: 'x' }]
+				});
+				assert.equal(status, 200);
+				assert.equal(response.failed['0'].code, 400);
+			});
+		});
+
+		describe("File uploads", function () {
+			let attachment;
+
+			beforeEach(async function () {
+				let parent = await createDataObject('item');
+				attachment = await Zotero.Attachments.importFromFile({
+					file: OS.Path.join(getTestDataDirectory().path, 'test.pdf'),
+					parentItemID: parent.id,
+				});
+			});
+
+			afterEach(async function () {
+				if (attachment) {
+					let parent = Zotero.Items.get(attachment.parentItemID);
+					await attachment.eraseTx();
+					if (parent) await parent.eraseTx();
+				}
+			});
+
+			it("should return {exists:1} when MD5 matches local file", async function () {
+				let path = await attachment.getFilePathAsync();
+				let md5 = await Zotero.Utilities.Internal.md5Async(path);
+				let stat = await IOUtils.stat(path);
+
+				let { response } = await apiPost(
+					`/users/0/items/${attachment.key}/file`,
+					{
+						body: `md5=${md5}&filename=${encodeURIComponent(attachment.attachmentFilename)}&filesize=${stat.size}&mtime=${stat.lastModified}`,
+						headers: {
+							'Content-Type': 'application/x-www-form-urlencoded',
+							'If-None-Match': '*',
+						}
+					}
+				);
+				assert.equal(response.exists, 1);
+			});
+
+			it("should authorize a new upload when MD5 differs", async function () {
+				let newMD5 = 'a'.repeat(32);
+				let { response } = await apiPost(
+					`/users/0/items/${attachment.key}/file`,
+					{
+						body: `md5=${newMD5}&filename=newfile.pdf&filesize=10&mtime=${Date.now()}`,
+						headers: {
+							'Content-Type': 'application/x-www-form-urlencoded',
+							'If-None-Match': '*',
+						}
+					}
+				);
+				assert.isString(response.url);
+				assert.isString(response.uploadKey);
+				assert.include(response.url, '/api/local/uploads/');
+				assert.property(response, 'prefix');
+				assert.property(response, 'suffix');
+			});
+
+			it("should return params object when ?params=1", async function () {
+				let { response } = await apiPost(
+					`/users/0/items/${attachment.key}/file?params=1`,
+					{
+						body: `md5=${'b'.repeat(32)}&filename=x.pdf&filesize=10&mtime=${Date.now()}`,
+						headers: {
+							'Content-Type': 'application/x-www-form-urlencoded',
+							'If-None-Match': '*',
+						}
+					}
+				);
+				assert.isObject(response.params);
+				assert.isString(response.uploadKey);
+			});
+
+			it("should reject mtime in seconds with 400", async function () {
+				let { status } = await apiPost(
+					`/users/0/items/${attachment.key}/file`,
+					{
+						body: `md5=${'c'.repeat(32)}&filename=x.pdf&filesize=10&mtime=1000`,
+						headers: {
+							'Content-Type': 'application/x-www-form-urlencoded',
+							'If-None-Match': '*',
+						},
+						successCodes: [400],
+						responseType: 'text'
+					}
+				);
+				assert.equal(status, 400);
+			});
+
+			it("should require If-Match or If-None-Match with 428", async function () {
+				let { status } = await apiPost(
+					`/users/0/items/${attachment.key}/file`,
+					{
+						body: `md5=${'d'.repeat(32)}&filename=x.pdf&filesize=10&mtime=${Date.now()}`,
+						headers: {
+							'Content-Type': 'application/x-www-form-urlencoded',
+						},
+						successCodes: [428],
+						responseType: 'text'
+					}
+				);
+				assert.equal(status, 428);
+			});
+
+			it("should reject bad MD5 with 400", async function () {
+				let { status } = await apiPost(
+					`/users/0/items/${attachment.key}/file`,
+					{
+						body: `md5=not-a-real-md5&filename=x.pdf&filesize=10&mtime=${Date.now()}`,
+						headers: {
+							'Content-Type': 'application/x-www-form-urlencoded',
+							'If-None-Match': '*',
+						},
+						successCodes: [400],
+						responseType: 'text'
+					}
+				);
+				assert.equal(status, 400);
+			});
+
+			it("should perform a full upload + register flow", async function () {
+				// Generate new file content with a known MD5
+				let content = "Local API upload test content " + Date.now();
+				let encoder = new TextEncoder();
+				let bytes = encoder.encode(content);
+				// Compute the MD5 we will claim
+				let tmpDir = Zotero.getTempDirectory().path;
+				let tmpPath = PathUtils.join(tmpDir, 'localapi-upload-test.bin');
+				await IOUtils.write(tmpPath, bytes);
+				let md5 = await Zotero.Utilities.Internal.md5Async(tmpPath);
+				await IOUtils.remove(tmpPath);
+
+				let mtime = Date.now();
+
+				// Phase 1: authorize
+				let { response: authResp } = await apiPost(
+					`/users/0/items/${attachment.key}/file`,
+					{
+						body: `md5=${md5}&filename=uploaded.bin&filesize=${bytes.length}&mtime=${mtime}`,
+						headers: {
+							'Content-Type': 'application/x-www-form-urlencoded',
+							'If-None-Match': '*',
+						}
+					}
+				);
+				assert.isString(authResp.uploadKey);
+				let uploadKey = authResp.uploadKey;
+
+				// Phase 2: upload bytes to local receiver
+				let uploadXhr = await Zotero.HTTP.request(
+					'POST', authResp.url,
+					{
+						headers: {
+							'Zotero-Allowed-Request': '1',
+							'Content-Type': 'application/octet-stream',
+						},
+						body: content,
+						successCodes: [201],
+						responseType: 'text'
+					}
+				);
+				assert.equal(uploadXhr.status, 201);
+
+				// Phase 3: register
+				let { status } = await apiPost(
+					`/users/0/items/${attachment.key}/file`,
+					{
+						body: `upload=${uploadKey}`,
+						headers: {
+							'Content-Type': 'application/x-www-form-urlencoded',
+							'If-None-Match': '*',
+						},
+						successCodes: [204]
+					}
+				);
+				assert.equal(status, 204);
+
+				// Verify attachment metadata was updated
+				let reloaded = await Zotero.Items.getByLibraryAndKeyAsync(
+					Zotero.Libraries.userLibraryID, attachment.key);
+				assert.equal(reloaded.attachmentSyncedHash, md5);
+				assert.equal(reloaded.attachmentSyncedModificationTime, mtime);
+				assert.equal(reloaded.attachmentFilename, 'uploaded.bin');
+			});
+
+			it("should reject registration without prior upload", async function () {
+				// Authorize but never upload, then try to register
+				let { response: authResp } = await apiPost(
+					`/users/0/items/${attachment.key}/file`,
+					{
+						body: `md5=${'e'.repeat(32)}&filename=x.bin&filesize=5&mtime=${Date.now()}`,
+						headers: {
+							'Content-Type': 'application/x-www-form-urlencoded',
+							'If-None-Match': '*',
+						}
+					}
+				);
+				let { status } = await apiPost(
+					`/users/0/items/${attachment.key}/file`,
+					{
+						body: `upload=${authResp.uploadKey}`,
+						headers: {
+							'Content-Type': 'application/x-www-form-urlencoded',
+							'If-None-Match': '*',
+						},
+						successCodes: [400],
+						responseType: 'text'
+					}
+				);
+				assert.equal(status, 400);
+			});
+
+			it("should reject upload-receiver with mismatched MD5", async function () {
+				// Authorize with one MD5, then upload different content
+				let claimedMD5 = 'a'.repeat(32);
+				let { response: authResp } = await apiPost(
+					`/users/0/items/${attachment.key}/file`,
+					{
+						body: `md5=${claimedMD5}&filename=mm.bin&filesize=10&mtime=${Date.now()}`,
+						headers: {
+							'Content-Type': 'application/x-www-form-urlencoded',
+							'If-None-Match': '*',
+						}
+					}
+				);
+				let { status } = await Zotero.HTTP.request(
+					'POST', authResp.url,
+					{
+						headers: {
+							'Zotero-Allowed-Request': '1',
+							'Content-Type': 'application/octet-stream',
+						},
+						body: 'wrong content',
+						successCodes: [400],
+						responseType: 'text'
+					}
+				);
+				assert.equal(status, 400);
+			});
+
+			it("should return 404 when upload key is unknown", async function () {
+				let { status } = await Zotero.HTTP.request(
+					'POST', apiRoot + '/local/uploads/badkey999',
+					{
+						headers: {
+							'Zotero-Allowed-Request': '1',
+							'Content-Type': 'application/octet-stream',
+						},
+						body: 'whatever',
+						successCodes: [404],
+						responseType: 'text'
+					}
+				);
+				assert.equal(status, 404);
+			});
+
+			it("should reject PATCH partial upload with 405", async function () {
+				let { status } = await apiPatch(
+					`/users/0/items/${attachment.key}/file?algorithm=xdelta&upload=foo`,
+					{
+						headers: {
+							'Content-Type': 'application/octet-stream',
+						},
+						body: 'diff',
+						successCodes: [405],
+						responseType: 'text'
+					}
+				);
+				assert.equal(status, 405);
+			});
+		});
+
+		describe("Method restrictions", function () {
+			it("should reject POST to /items/top with 400 or 405", async function () {
+				let { status } = await apiPost('/users/0/items/top', {
+					body: [{ itemType: 'book' }],
+					headers: { 'Zotero-Write-Token': newWriteToken() },
+					successCodes: [400, 405],
+					responseType: 'text'
+				});
+				assert.oneOf(status, [400, 405]);
+			});
+
+			it("should reject DELETE to /items/trash with 400 or 405", async function () {
+				let { status } = await apiDelete(
+					'/users/0/items/trash?itemKey=ABCDEFGH',
+					{
+						headers: { 'If-Unmodified-Since-Version': '0' },
+						successCodes: [400, 405],
+						responseType: 'text'
+					}
+				);
+				assert.oneOf(status, [400, 405]);
+			});
 		});
 	});
 });

--- a/test/tests/server_localAPITest.js
+++ b/test/tests/server_localAPITest.js
@@ -1738,6 +1738,25 @@ describe("Local API Server", function () {
 				assert.equal(status, 400);
 			});
 
+			it("should reject a filename containing path separators with 400", async function () {
+				for (let filename of ['../escape.txt', 'sub/escape.txt', '..\\escape.txt', '..']) {
+					let { status } = await apiPost(
+						`/users/0/items/${attachment.key}/file`,
+						{
+							body: `md5=${'a'.repeat(32)}&filename=${encodeURIComponent(filename)}`
+								+ `&filesize=10&mtime=${Date.now()}`,
+							headers: {
+								'Content-Type': 'application/x-www-form-urlencoded',
+								'If-None-Match': '*',
+							},
+							successCodes: [400],
+							responseType: 'text'
+						}
+					);
+					assert.equal(status, 400, `expected 400 for filename '${filename}'`);
+				}
+			});
+
 			it("should perform a full upload + register flow", async function () {
 				// Generate new file content with a known MD5
 				let content = "Local API upload test content " + Date.now();

--- a/test/tests/server_localAPITest.js
+++ b/test/tests/server_localAPITest.js
@@ -2,7 +2,8 @@
 
 describe("Local API Server", function () {
 	let apiRoot;
-	
+	let serverID;
+
 	let collection;
 	let subcollection;
 	let collectionItem1;
@@ -27,7 +28,7 @@ describe("Local API Server", function () {
 	let writeAPIKey;
 
 	function apiRequest(method, endpoint, options = {}) {
-		let { body, headers, skipAPIKey, ...rest } = options;
+		let { body, headers, skipAPIKey, skipServerID, ...rest } = options;
 		let requestHeaders = {
 			'Zotero-Allowed-Request': '1',
 			...(headers || {})
@@ -36,6 +37,9 @@ describe("Local API Server", function () {
 				&& !requestHeaders['Zotero-API-Key']
 				&& !endpoint.includes('key=')) {
 			requestHeaders['Zotero-API-Key'] = writeAPIKey;
+		}
+		if (!skipServerID && serverID && !requestHeaders['Zotero-Server-ID']) {
+			requestHeaders['Zotero-Server-ID'] = serverID;
 		}
 		let requestBody = body;
 		if (body !== undefined && typeof body !== 'string'
@@ -78,23 +82,28 @@ describe("Local API Server", function () {
 			.substring(0, 32);
 	}
 
+	function authorizePost(body, { responseType = 'json', successCodes } = {}) {
+		let options = {
+			headers: {
+				'Zotero-Allowed-Request': '1',
+				'Content-Type': 'application/json',
+				'Zotero-Server-ID': serverID,
+			},
+			body: typeof body === 'string' ? body : JSON.stringify(body),
+			responseType
+		};
+		if (successCodes) {
+			options.successCodes = successCodes;
+		}
+		return Zotero.HTTP.request('POST', apiRoot + '/local/authorize', options);
+	}
+
 	// Stub the dialog and obtain a remembered API key directly via the endpoint
 	async function setupRememberedAPIKey(appName = 'Test Suite') {
 		let stub = sinon.stub(Zotero.Server.LocalAPI, '_promptForAuthorization')
 			.resolves({ allow: true, remember: true });
 		try {
-			let { response } = await Zotero.HTTP.request(
-				'POST',
-				apiRoot + '/local/authorize',
-				{
-					headers: {
-						'Zotero-Allowed-Request': '1',
-						'Content-Type': 'application/json',
-					},
-					body: JSON.stringify({ appName }),
-					responseType: 'json'
-				}
-			);
+			let { response } = await authorizePost({ appName });
 			return response.key;
 		}
 		finally {
@@ -104,6 +113,9 @@ describe("Local API Server", function () {
 
 	before(async function () {
 		apiRoot = 'http://127.0.0.1:' + Zotero.Server.port + '/api';
+
+		// Pref pinned in runtests.sh so it survives resets
+		serverID = Zotero.Prefs.get('httpServer.localAPI.serverID');
 
 		await resetDB({
 			thisArg: this
@@ -164,6 +176,78 @@ describe("Local API Server", function () {
 		});
 	});
 	
+	describe("Zotero-Server-ID", function () {
+		it("should return the server ID in a response header", async function () {
+			let xhr = await apiGet('/users/0/items');
+			assert.equal(xhr.getResponseHeader('Zotero-Server-ID'), serverID);
+		});
+
+		it("should accept a read with a matching server ID", async function () {
+			let xhr = await apiGet('/users/0/items', {
+				headers: {
+					'Zotero-Allowed-Request': '1',
+					'Zotero-Server-ID': serverID,
+				}
+			});
+			assert.equal(xhr.status, 200);
+		});
+
+		it("should accept a read with no server ID", async function () {
+			// apiGet() doesn't send the header
+			let xhr = await apiGet('/users/0/items');
+			assert.equal(xhr.status, 200);
+		});
+
+		it("should reject a read with a mismatched server ID with 412", async function () {
+			let xhr = await apiGet('/users/0/items', {
+				headers: {
+					'Zotero-Allowed-Request': '1',
+					'Zotero-Server-ID': 'wrongServerID',
+				},
+				responseType: 'text',
+				successCodes: [412]
+			});
+			assert.equal(xhr.status, 412);
+			// The rejection still carries the real server ID, so a client with a
+			// stale ID can recover
+			assert.equal(xhr.getResponseHeader('Zotero-Server-ID'), serverID);
+		});
+
+		it("should require a server ID on writes with 428", async function () {
+			let xhr = await apiPost('/users/0/items', {
+				body: [],
+				skipServerID: true,
+				skipAPIKey: true,
+				responseType: 'text',
+				successCodes: [428]
+			});
+			assert.equal(xhr.status, 428);
+		});
+
+		it("should reject a write with a mismatched server ID with 412", async function () {
+			let xhr = await apiPost('/users/0/items', {
+				body: [],
+				headers: { 'Zotero-Server-ID': 'wrongServerID' },
+				skipAPIKey: true,
+				responseType: 'text',
+				successCodes: [412]
+			});
+			assert.equal(xhr.status, 412);
+		});
+
+		it("should validate the server ID before the API key on writes", async function () {
+			// A valid server ID but no API key passes the server-ID check and
+			// then fails authentication with 401
+			let xhr = await apiPost('/users/0/items', {
+				body: [],
+				skipAPIKey: true,
+				responseType: 'text',
+				successCodes: [401]
+			});
+			assert.equal(xhr.status, 401);
+		});
+	});
+
 	describe("<userOrGroupPrefix>/collections", function () {
 		it("should return all collections", async function () {
 			let { response } = await apiGet('/users/0/collections');
@@ -491,17 +575,7 @@ describe("Local API Server", function () {
 				let stub = sinon.stub(Zotero.Server.LocalAPI, '_promptForAuthorization')
 					.resolves({ allow: true, remember: false });
 				try {
-					let { response, status } = await Zotero.HTTP.request(
-						'POST', apiRoot + '/local/authorize',
-						{
-							headers: {
-								'Zotero-Allowed-Request': '1',
-								'Content-Type': 'application/json',
-							},
-							body: JSON.stringify({ appName: 'AllowApp' }),
-							responseType: 'json'
-						}
-					);
+					let { response, status } = await authorizePost({ appName: 'AllowApp' });
 					assert.equal(status, 200);
 					assert.isString(response.key);
 					assert.lengthOf(response.key, 32);
@@ -516,17 +590,7 @@ describe("Local API Server", function () {
 				let stub = sinon.stub(Zotero.Server.LocalAPI, '_promptForAuthorization')
 					.resolves({ allow: true, remember: true });
 				try {
-					let { response } = await Zotero.HTTP.request(
-						'POST', apiRoot + '/local/authorize',
-						{
-							headers: {
-								'Zotero-Allowed-Request': '1',
-								'Content-Type': 'application/json',
-							},
-							body: JSON.stringify({ appName: 'RememberApp' }),
-							responseType: 'json'
-						}
-					);
+					let { response } = await authorizePost({ appName: 'RememberApp' });
 					assert.isTrue(response.remember);
 				}
 				finally {
@@ -538,18 +602,8 @@ describe("Local API Server", function () {
 				let stub = sinon.stub(Zotero.Server.LocalAPI, '_promptForAuthorization')
 					.resolves({ allow: false, remember: false });
 				try {
-					let { response, status } = await Zotero.HTTP.request(
-						'POST', apiRoot + '/local/authorize',
-						{
-							headers: {
-								'Zotero-Allowed-Request': '1',
-								'Content-Type': 'application/json',
-							},
-							body: JSON.stringify({ appName: 'DeniedApp' }),
-							responseType: 'json',
-							successCodes: [403]
-						}
-					);
+					let { response, status } = await authorizePost(
+						{ appName: 'DeniedApp' }, { successCodes: [403] });
 					assert.equal(status, 403);
 					assert.isTrue(response.denied);
 				}
@@ -559,18 +613,8 @@ describe("Local API Server", function () {
 			});
 
 			it("should require appName", async function () {
-				let { status } = await Zotero.HTTP.request(
-					'POST', apiRoot + '/local/authorize',
-					{
-						headers: {
-							'Zotero-Allowed-Request': '1',
-							'Content-Type': 'application/json',
-						},
-						body: JSON.stringify({}),
-						responseType: 'text',
-						successCodes: [400]
-					}
-				);
+				let { status } = await authorizePost(
+					{}, { responseType: 'text', successCodes: [400] });
 				assert.equal(status, 400);
 			});
 
@@ -582,18 +626,8 @@ describe("Local API Server", function () {
 						return { allow: false };
 					});
 				try {
-					await Zotero.HTTP.request(
-						'POST', apiRoot + '/local/authorize',
-						{
-							headers: {
-								'Zotero-Allowed-Request': '1',
-								'Content-Type': 'application/json',
-							},
-							body: JSON.stringify({ appName: 'MyTestApp 1.0' }),
-							responseType: 'text',
-							successCodes: [403]
-						}
-					);
+					await authorizePost(
+						{ appName: 'MyTestApp 1.0' }, { responseType: 'text', successCodes: [403] });
 				}
 				finally {
 					stub.restore();
@@ -606,31 +640,11 @@ describe("Local API Server", function () {
 					.resolves({ allow: false, remember: false });
 				try {
 					for (let i = 0; i < 5; i++) {
-						await Zotero.HTTP.request(
-							'POST', apiRoot + '/local/authorize',
-							{
-								headers: {
-									'Zotero-Allowed-Request': '1',
-									'Content-Type': 'application/json',
-								},
-								body: JSON.stringify({ appName: 'Throttle ' + i }),
-								responseType: 'text',
-								successCodes: [403]
-							}
-						);
+						await authorizePost(
+							{ appName: 'Throttle ' + i }, { responseType: 'text', successCodes: [403] });
 					}
-					let xhr = await Zotero.HTTP.request(
-						'POST', apiRoot + '/local/authorize',
-						{
-							headers: {
-								'Zotero-Allowed-Request': '1',
-								'Content-Type': 'application/json',
-							},
-							body: JSON.stringify({ appName: 'Throttle 6' }),
-							responseType: 'text',
-							successCodes: [429]
-						}
-					);
+					let xhr = await authorizePost(
+						{ appName: 'Throttle 6' }, { responseType: 'text', successCodes: [429] });
 					assert.equal(xhr.status, 429);
 					let retryAfter = parseInt(xhr.getResponseHeader('Retry-After'));
 					assert.isAbove(retryAfter, 0);
@@ -644,35 +658,15 @@ describe("Local API Server", function () {
 			it("should not count rejected (pre-prompt) requests against the rate limit", async function () {
 				// 5 bad-appName requests fail before the prompt and don't consume slots
 				for (let i = 0; i < 5; i++) {
-					await Zotero.HTTP.request(
-						'POST', apiRoot + '/local/authorize',
-						{
-							headers: {
-								'Zotero-Allowed-Request': '1',
-								'Content-Type': 'application/json',
-							},
-							body: JSON.stringify({}),
-							responseType: 'text',
-							successCodes: [400]
-						}
-					);
+					await authorizePost(
+						{}, { responseType: 'text', successCodes: [400] });
 				}
 				// A subsequent valid request still goes through
 				let stub = sinon.stub(Zotero.Server.LocalAPI, '_promptForAuthorization')
 					.resolves({ allow: false, remember: false });
 				try {
-					let { status } = await Zotero.HTTP.request(
-						'POST', apiRoot + '/local/authorize',
-						{
-							headers: {
-								'Zotero-Allowed-Request': '1',
-								'Content-Type': 'application/json',
-							},
-							body: JSON.stringify({ appName: 'AfterBadReqs' }),
-							responseType: 'json',
-							successCodes: [403]
-						}
-					);
+					let { status } = await authorizePost(
+						{ appName: 'AfterBadReqs' }, { successCodes: [403] });
 					assert.equal(status, 403);
 				}
 				finally {
@@ -779,17 +773,7 @@ describe("Local API Server", function () {
 				let stub = sinon.stub(Zotero.Server.LocalAPI, '_promptForAuthorization')
 					.resolves({ allow: true, remember: false });
 				try {
-					let { response } = await Zotero.HTTP.request(
-						'POST', apiRoot + '/local/authorize',
-						{
-							headers: {
-								'Zotero-Allowed-Request': '1',
-								'Content-Type': 'application/json',
-							},
-							body: JSON.stringify({ appName: 'OneShotApp' }),
-							responseType: 'json'
-						}
-					);
+					let { response } = await authorizePost({ appName: 'OneShotApp' });
 					oneShot = response.key;
 				}
 				finally {
@@ -1834,6 +1818,7 @@ describe("Local API Server", function () {
 						headers: {
 							'Zotero-Allowed-Request': '1',
 							'Content-Type': 'application/octet-stream',
+							'Zotero-Server-ID': serverID,
 						},
 						body: content,
 						successCodes: [201],
@@ -1907,6 +1892,7 @@ describe("Local API Server", function () {
 					headers: {
 						'Zotero-Allowed-Request': '1',
 						'Content-Type': 'multipart/form-data',
+						'Zotero-Server-ID': serverID,
 					},
 					body: formData,
 					successCodes: [201],
@@ -1984,6 +1970,7 @@ describe("Local API Server", function () {
 						headers: {
 							'Zotero-Allowed-Request': '1',
 							'Content-Type': 'application/octet-stream',
+							'Zotero-Server-ID': serverID,
 						},
 						body: 'wrong content',
 						successCodes: [400],
@@ -2000,6 +1987,7 @@ describe("Local API Server", function () {
 						headers: {
 							'Zotero-Allowed-Request': '1',
 							'Content-Type': 'application/octet-stream',
+							'Zotero-Server-ID': serverID,
 						},
 						body: 'whatever',
 						successCodes: [404],

--- a/test/tests/server_localAPITest.js
+++ b/test/tests/server_localAPITest.js
@@ -114,12 +114,12 @@ describe("Local API Server", function () {
 	before(async function () {
 		apiRoot = 'http://127.0.0.1:' + Zotero.Server.port + '/api';
 
-		// Pref pinned in runtests.sh so it survives resets
-		serverID = Zotero.Prefs.get('httpServer.localAPI.serverID');
-
 		await resetDB({
 			thisArg: this
 		});
+
+		// Regenerated in the settings table on reset, so read it back afterward
+		serverID = Zotero.Server.LocalAPI.getServerID();
 
 		collection = await createDataObject('collection', { setTitle: true });
 		subcollection = await createDataObject('collection', { setTitle: true, parentID: collection.id });

--- a/test/tests/server_localAPITest.js
+++ b/test/tests/server_localAPITest.js
@@ -755,6 +755,25 @@ describe("Local API Server", function () {
 				if (item) await item.eraseTx();
 			});
 
+			it("should accept the API key via Authorization: Bearer header", async function () {
+				let { status, response } = await apiPost(
+					`/users/0/items`,
+					{
+						body: [{ itemType: 'book', title: 'BearerKey Item' }],
+						headers: {
+							'Zotero-Write-Token': newWriteToken(),
+							'Authorization': `Bearer ${writeAPIKey}`,
+						},
+						skipAPIKey: true,
+					}
+				);
+				assert.equal(status, 200);
+				let key = response.successful['0'].key;
+				let item = await Zotero.Items.getByLibraryAndKeyAsync(
+					Zotero.Libraries.userLibraryID, key);
+				if (item) await item.eraseTx();
+			});
+
 			it("should consume a single-use API key after one write", async function () {
 				let oneShot;
 				let stub = sinon.stub(Zotero.Server.LocalAPI, '_promptForAuthorization')

--- a/test/tests/server_localAPITest.js
+++ b/test/tests/server_localAPITest.js
@@ -542,7 +542,38 @@ describe("Local API Server", function () {
 		});
 	});
 
+	describe("/users/<userID>/groups", function () {
+		it("should omit Last-Modified-Version", async function () {
+			let group = await getGroup();
+			let xhr = await apiGet('/users/0/groups');
+			assert.isNull(xhr.getResponseHeader('Last-Modified-Version'));
+			assert.include(xhr.response.map(g => g.id), group.id);
+		});
+
+		it("should map group IDs to metadata versions with ?format=versions", async function () {
+			let group = await getGroup();
+			let { response } = await apiGet('/users/0/groups?format=versions');
+			assert.propertyVal(response, String(group.id), group.version);
+		});
+	});
+
 	describe("/groups/<groupID>", function () {
+		it("should report the synced group version at the top level, in data, and in Last-Modified-Version", async function () {
+			let group = await getGroup();
+			// Changing the group library's contents doesn't affect the group metadata version
+			let item = await createDataObject('item', { libraryID: group.libraryID });
+			let xhr = await apiGet(`/groups/${group.groupID}`);
+			let response = xhr.response;
+			assert.notEqual(group.version, group.clientVersion);
+			assert.equal(response.version, group.version);
+			assert.equal(response.data.version, group.version);
+			assert.equal(
+				parseInt(xhr.getResponseHeader('Last-Modified-Version')),
+				group.version
+			);
+			await item.eraseTx();
+		});
+
 		it("should return 404 for unknown group", async function () {
 			let { response } = await apiGet(
 				'/groups/99999999999',

--- a/test/tests/server_localAPITest.js
+++ b/test/tests/server_localAPITest.js
@@ -1208,16 +1208,22 @@ describe("Local API Server", function () {
 		describe("DELETE <userOrGroupPrefix>/items/<key>", function () {
 			it("should delete a single item", async function () {
 				let item = await createDataObject('item');
-				let { status } = await apiDelete(`/users/0/items/${item.key}`, {
+				let versionBefore = Zotero.Libraries.userLibrary.clientVersion;
+				let xhr = await apiDelete(`/users/0/items/${item.key}`, {
 					headers: {
 						'If-Unmodified-Since-Version': String(item.clientVersion),
 					},
 					successCodes: [204]
 				});
-				assert.equal(status, 204);
+				assert.equal(xhr.status, 204);
 				let reloaded = await Zotero.Items.getByLibraryAndKeyAsync(
 					Zotero.Libraries.userLibraryID, item.key);
 				assert.isFalse(!!reloaded);
+				// The deletion advances the library version
+				assert.isAbove(
+					parseInt(xhr.getResponseHeader('Last-Modified-Version')),
+					versionBefore
+				);
 			});
 
 			it("should require If-Unmodified-Since-Version (428)", async function () {
@@ -1423,19 +1429,26 @@ describe("Local API Server", function () {
 				item.setTags(['tagToDelete', 'tagToKeep']);
 				await item.saveTx();
 				assert.isAtLeast(Zotero.Tags.getID('tagToDelete'), 1);
+				let itemVersionBefore = item.clientVersion;
 
-				let { status } = await apiDelete('/users/0/tags?tag=tagToDelete', {
+				let xhr = await apiDelete('/users/0/tags?tag=tagToDelete', {
 					headers: {
 						'If-Unmodified-Since-Version':
 							String(Zotero.Libraries.userLibrary.clientVersion),
 					},
 					successCodes: [204]
 				});
-				assert.equal(status, 204);
+				assert.equal(xhr.status, 204);
 				let reloaded = await Zotero.Items.getByLibraryAndKeyAsync(
 					Zotero.Libraries.userLibraryID, item.key);
 				assert.notInclude(reloaded.getTags().map(t => t.tag), 'tagToDelete');
 				assert.include(reloaded.getTags().map(t => t.tag), 'tagToKeep');
+				// The tag deletion advances the modified items' versions
+				assert.isAbove(reloaded.clientVersion, itemVersionBefore);
+				assert.equal(
+					parseInt(xhr.getResponseHeader('Last-Modified-Version')),
+					reloaded.clientVersion
+				);
 				await item.eraseTx();
 			});
 

--- a/test/tests/server_localAPITest.js
+++ b/test/tests/server_localAPITest.js
@@ -1004,6 +1004,46 @@ describe("Local API Server", function () {
 				await item.eraseTx();
 			});
 
+			it("should fail a keyed object without version or If-Unmodified-Since-Version with 428", async function () {
+				let item = await createDataObject('item', { itemType: 'book', setTitle: true });
+				let title = item.getField('title');
+				let { response } = await apiPost('/users/0/items', {
+					body: [{
+						key: item.key,
+						itemType: 'book',
+						title: 'No Precondition',
+					}],
+					headers: { 'Zotero-Write-Token': newWriteToken() }
+				});
+				assert.lengthOf(Object.keys(response.failed), 1);
+				assert.equal(response.failed['0'].code, 428);
+				let reloaded = await Zotero.Items.getByLibraryAndKeyAsync(
+					Zotero.Libraries.userLibraryID, item.key);
+				assert.equal(reloaded.getField('title'), title);
+				await item.eraseTx();
+			});
+
+			it("should allow a keyed object without version when If-Unmodified-Since-Version is provided", async function () {
+				let item = await createDataObject('item', { itemType: 'book', setTitle: true });
+				let { response } = await apiPost('/users/0/items', {
+					body: [{
+						key: item.key,
+						itemType: 'book',
+						title: 'Updated Via Header',
+					}],
+					headers: {
+						'Zotero-Write-Token': newWriteToken(),
+						'If-Unmodified-Since-Version':
+							String(Zotero.Libraries.userLibrary.clientVersion),
+					}
+				});
+				assert.lengthOf(Object.keys(response.successful), 1);
+				let reloaded = await Zotero.Items.getByLibraryAndKeyAsync(
+					Zotero.Libraries.userLibraryID, item.key);
+				assert.equal(reloaded.getField('title'), 'Updated Via Header');
+				await item.eraseTx();
+			});
+
 			it("should return 412 on stale If-Unmodified-Since-Version", async function () {
 				let staleVersion = Zotero.Libraries.userLibrary.clientVersion;
 				// Bump the library by creating a sentinel item

--- a/test/tests/server_localAPITest.js
+++ b/test/tests/server_localAPITest.js
@@ -435,9 +435,10 @@ describe("Local API Server", function () {
 			});
 
 			describe("=versions", function () {
-				it("should output a JSON object mapping keys to versions", async function () {
+				it("should output a JSON object mapping keys to local versions", async function () {
 					let { response } = await apiGet('/users/0/items?format=versions');
-					assert.propertyVal(response, collectionItem1.key, collectionItem1.version);
+					assert.isAbove(collectionItem1.clientVersion, 0);
+					assert.propertyVal(response, collectionItem1.key, collectionItem1.clientVersion);
 				});
 			});
 		});

--- a/test/tests/server_localAPITest.js
+++ b/test/tests/server_localAPITest.js
@@ -550,6 +550,13 @@ describe("Local API Server", function () {
 			assert.include(xhr.response.map(g => g.id), group.id);
 		});
 
+		it("should ignore ?since", async function () {
+			let group = await getGroup();
+			let { response: all } = await apiGet('/users/0/groups');
+			let { response: since } = await apiGet(`/users/0/groups?since=${group.version + 1}`);
+			assert.sameDeepMembers(since, all);
+		});
+
 		it("should map group IDs to metadata versions with ?format=versions", async function () {
 			let group = await getGroup();
 			let { response } = await apiGet('/users/0/groups?format=versions');

--- a/test/tests/server_localAPITest.js
+++ b/test/tests/server_localAPITest.js
@@ -1849,6 +1849,115 @@ describe("Local API Server", function () {
 				assert.equal(reloaded.attachmentFilename, 'uploaded.bin');
 			});
 
+			it("shouldn't modify the existing file until registration succeeds", async function () {
+				let path = await attachment.getFilePathAsync();
+				let originalContents = await IOUtils.read(path);
+
+				let content = "Replacement content for staged upload test";
+				let bytes = new TextEncoder().encode(content);
+				let tmpPath = PathUtils.join(Zotero.getTempDirectory().path, 'localapi-staged-test.bin');
+				await IOUtils.write(tmpPath, bytes);
+				let md5 = await Zotero.Utilities.Internal.md5Async(tmpPath);
+				await IOUtils.remove(tmpPath);
+
+				// Authorize and upload with the existing filename
+				let { response: authResp } = await apiPost(
+					`/users/0/items/${attachment.key}/file`,
+					{
+						body: `md5=${md5}&filename=${encodeURIComponent(attachment.attachmentFilename)}`
+							+ `&filesize=${bytes.length}&mtime=${Date.now()}`,
+						headers: {
+							'Content-Type': 'application/x-www-form-urlencoded',
+							'If-None-Match': '*',
+						}
+					}
+				);
+				await Zotero.HTTP.request('POST', authResp.url, {
+					headers: {
+						'Zotero-Allowed-Request': '1',
+						'Content-Type': 'application/octet-stream',
+						'Zotero-Server-ID': serverID,
+					},
+					body: content,
+					successCodes: [201],
+					responseType: 'text'
+				});
+
+				// The bytes have been received but not registered, so the existing file
+				// must be untouched
+				assert.deepEqual(await IOUtils.read(path), originalContents);
+
+				// Register, after which the file is replaced
+				await apiPost(
+					`/users/0/items/${attachment.key}/file`,
+					{
+						body: `upload=${authResp.uploadKey}`,
+						headers: {
+							'Content-Type': 'application/x-www-form-urlencoded',
+							'If-None-Match': '*',
+						},
+						successCodes: [204]
+					}
+				);
+				assert.equal(
+					await Zotero.Utilities.Internal.md5Async(await attachment.getFilePathAsync()),
+					md5
+				);
+			});
+
+			it("shouldn't modify the existing file when registration fails with 412", async function () {
+				let path = await attachment.getFilePathAsync();
+				let originalContents = await IOUtils.read(path);
+
+				let content = "Content that must never be registered";
+				let bytes = new TextEncoder().encode(content);
+				let tmpPath = PathUtils.join(Zotero.getTempDirectory().path, 'localapi-staged-412-test.bin');
+				await IOUtils.write(tmpPath, bytes);
+				let md5 = await Zotero.Utilities.Internal.md5Async(tmpPath);
+				await IOUtils.remove(tmpPath);
+
+				let { response: authResp } = await apiPost(
+					`/users/0/items/${attachment.key}/file`,
+					{
+						body: `md5=${md5}&filename=${encodeURIComponent(attachment.attachmentFilename)}`
+							+ `&filesize=${bytes.length}&mtime=${Date.now()}`,
+						headers: {
+							'Content-Type': 'application/x-www-form-urlencoded',
+							'If-None-Match': '*',
+						}
+					}
+				);
+				await Zotero.HTTP.request('POST', authResp.url, {
+					headers: {
+						'Zotero-Allowed-Request': '1',
+						'Content-Type': 'application/octet-stream',
+						'Zotero-Server-ID': serverID,
+					},
+					body: content,
+					successCodes: [201],
+					responseType: 'text'
+				});
+
+				// Another client registers a file for this attachment in the meantime
+				attachment.attachmentSyncedHash = 'f'.repeat(32);
+				await attachment.saveTx();
+
+				let { status } = await apiPost(
+					`/users/0/items/${attachment.key}/file`,
+					{
+						body: `upload=${authResp.uploadKey}`,
+						headers: {
+							'Content-Type': 'application/x-www-form-urlencoded',
+							'If-None-Match': '*',
+						},
+						successCodes: [412],
+						responseType: 'text'
+					}
+				);
+				assert.equal(status, 412);
+				assert.deepEqual(await IOUtils.read(path), originalContents);
+			});
+
 			// Exercises the params=1 multipart upload form: each returned param as a form
 			// field, then the file bytes in a final `file` field. Uses real binary content
 			// to confirm it survives the multipart path.


### PR DESCRIPTION
I haven't run the entire test suite locally, so we'll see what happens on CI, but this is intended to be a relatively unobtrusive set of changes to track a monotonically increasing library/data object version number.

When the local API is enabled, modifying a data object (item, collection, or search) increments the library's `clientVersion` (once per transaction), then sets the data object's `clientVersion` to the same value.

Also updated `toResponseJSON()` to return local storage properties as well as versions.

Closes #5011 (option C)