### PR TITLE
Do not switch to library tab while changing target collection in connector

### DIFF
--- a/chrome/content/zotero/advancedSearch.js
+++ b/chrome/content/zotero/advancedSearch.js
@@ -197,7 +197,7 @@ var ZoteroAdvancedSearch = new function() {
 			return;
 		}
 		
-		lastWin.ZoteroPane.selectItems(items.map(item => item.id), { inLibraryRoot: false });
+		lastWin.ZoteroPane.selectItems(items.map(item => item.id));
 		lastWin.focus();
 	}
 }

--- a/chrome/content/zotero/advancedSearch.js
+++ b/chrome/content/zotero/advancedSearch.js
@@ -197,7 +197,7 @@ var ZoteroAdvancedSearch = new function() {
 			return;
 		}
 		
-		lastWin.ZoteroPane.selectItems(items.map(item => item.id), false);
+		lastWin.ZoteroPane.selectItems(items.map(item => item.id), { inLibraryRoot: false });
 		lastWin.focus();
 	}
 }

--- a/chrome/content/zotero/progressQueueDialog.jsx
+++ b/chrome/content/zotero/progressQueueDialog.jsx
@@ -62,7 +62,7 @@ async function _handleActivate(event, indices) {
 		
 		let win = Services.wm.getMostRecentWindow("navigator:browser");
 		if (win) {
-			win.ZoteroPane.selectItem(itemID, { inLibraryRoot: true });
+			win.ZoteroPane.selectItem(itemID, { inLibraryRoot: false });
 			win.focus();
 		}
 	}

--- a/chrome/content/zotero/progressQueueDialog.jsx
+++ b/chrome/content/zotero/progressQueueDialog.jsx
@@ -62,7 +62,7 @@ async function _handleActivate(event, indices) {
 		
 		let win = Services.wm.getMostRecentWindow("navigator:browser");
 		if (win) {
-			win.ZoteroPane.selectItem(itemID, { inLibraryRoot: false });
+			win.ZoteroPane.selectItem(itemID);
 			win.focus();
 		}
 	}

--- a/chrome/content/zotero/progressQueueDialog.jsx
+++ b/chrome/content/zotero/progressQueueDialog.jsx
@@ -62,7 +62,7 @@ async function _handleActivate(event, indices) {
 		
 		let win = Services.wm.getMostRecentWindow("navigator:browser");
 		if (win) {
-			win.ZoteroPane.selectItem(itemID, false, true);
+			win.ZoteroPane.selectItem(itemID, { inLibraryRoot: true });
 			win.focus();
 		}
 	}

--- a/chrome/content/zotero/xpcom/connector/server_connector.js
+++ b/chrome/content/zotero/xpcom/connector/server_connector.js
@@ -305,7 +305,7 @@ Zotero.Server.Connector.SaveSession.prototype.update = async function (targetID,
 		item = item.isTopLevelItem() ? item : item.parentItem;
 		// Don't select if in trash
 		if (!item.deleted) {
-			await zp.selectItem(item.id);
+			await zp.selectItem(item.id, { noTabSwitch: true });
 		}
 	}
 };

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -2989,15 +2989,21 @@ var ZoteroPane = new function()
 	};
 
 
-	this.selectItem = async function (itemID, inLibraryRoot) {
+	this.selectItem = async function (itemID, options) {
 		if (!itemID) {
 			return false;
 		}
-		return this.selectItems([itemID], inLibraryRoot);
+		return this.selectItems([itemID], options);
 	};
 	
 	
-	this.selectItems = async function (itemIDs, inLibraryRoot) {
+	this.selectItems = async function (itemIDs, options = {}) {
+		if (typeof options == "boolean") {
+			Zotero.warn("ZoteroPane.selectItems() with inLibraryRoot boolean param is deprecated."
+				+ " -- New usage: ZoteroPane.selectItems(itemIDs, { inLibraryRoot, noTabSwitch })");
+			options = { inLibraryRoot: options };
+		}
+		let { inLibraryRoot, noTabSwitch } = options;
 		if (!itemIDs.length) {
 			return false;
 		}
@@ -3023,7 +3029,10 @@ var ZoteroPane = new function()
 			document.getElementById(ZoteroPane.itemsView.id).focus();
 		}
 		
-		Zotero_Tabs.select('zotero-pane', false, { focusElementID: ZoteroPane.itemsView.id });
+		if (!noTabSwitch) {
+			Zotero_Tabs.select('zotero-pane', false, { focusElementID: ZoteroPane.itemsView.id });
+		}
+		return true;
 	};
 	
 	

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -2999,8 +2999,7 @@ var ZoteroPane = new function()
 	
 	this.selectItems = async function (itemIDs, options = {}) {
 		if (typeof options == "boolean") {
-			Zotero.warn("ZoteroPane.selectItems() with inLibraryRoot boolean param is deprecated."
-				+ " -- New usage: ZoteroPane.selectItems(itemIDs, { inLibraryRoot, noTabSwitch })");
+			Zotero.warn("ZoteroPane.selectItems() now takes an 'options' object -- update your code");
 			options = { inLibraryRoot: options };
 		}
 		let { inLibraryRoot, noTabSwitch } = options;


### PR DESCRIPTION
Deprecate inLibraryRoot as an independent boolean param in `ZoteroPane.selectItems` to instead have a composite options param `{ inLibraryRoot, noTabSwitch }`.

Fixes: #4262

https://github.com/user-attachments/assets/2606faf1-f951-4719-be66-330307f8eb63

