### PR TITLE
Track changes in Style Editor and Scaffold

### DIFF
--- a/chrome/content/scaffold/scaffold.js
+++ b/chrome/content/scaffold/scaffold.js
@@ -30,6 +30,7 @@ var { ContentDOMReference } = ChromeUtils.import("resource://gre/modules/Content
 
 var { Zotero } = ChromeUtils.importESModule("chrome://zotero/content/zotero.mjs");
 var { FilePicker } = ChromeUtils.importESModule('chrome://zotero/content/modules/filePicker.mjs');
+var { DocumentManager } = ChromeUtils.importESModule("chrome://zotero/content/documentManager.mjs");
 
 var lazy = {};
 ChromeUtils.defineLazyGetter(lazy, 'shellPathPromise', () => {
@@ -63,6 +64,7 @@ var Scaffold = new function () {
 	var _translatorProvider = null;
 	var _lastModifiedTime = 0;
 	var _needRebuildTranslatorSuggestions = true;
+	var _docManager;
 
 	this.browser = () => _browser;
 	
@@ -83,7 +85,11 @@ var Scaffold = new function () {
 
 	this.onLoad = async function (e) {
 		if (e.target !== document) return;
+		
 		_browser = document.getElementById('browser');
+		_docManager = new DocumentManager(() => this.save());
+		_docManager.attach(window);
+		document.querySelector('#metadata-grid').addEventListener('command', () => _updateDocManagerState());
 
 		window.messageManager.addMessageListener('Scaffold:Load', ({ data }) => {
 			document.getElementById("browser-url").value = data.url;
@@ -311,7 +317,6 @@ var Scaffold = new function () {
 		monaco.languages.registerCodeLensProvider('javascript', this.createRunCodeLensProvider(monaco, editor));
 		monaco.languages.registerHoverProvider('javascript', this.createHoverProvider(monaco, editor));
 		monaco.languages.registerCompletionItemProvider('javascript', this.createCompletionProvider(monaco, editor));
-		model.onDidChangeContent(() => this.updateModelMarkers());
 
 		let tsLib = await Zotero.File.getContentsAsync(
 			PathUtils.join(Scaffold_Translators.getDirectory(), 'index.d.ts'));
@@ -320,10 +325,23 @@ var Scaffold = new function () {
 		// this would allow peeking:
 		//   monaco.editor.createModel(tsLib, 'typescript', monaco.Uri.parse(tsLibPath));
 		// but it doesn't currently seem to work
+
+		model.onDidChangeContent(() => this.updateModelMarkers());
+		model.onDidChangeContent(Zotero.Utilities.debounce(() => _updateDocManagerState(), 200));
 	};
 
 	this.initTestsEditor = function () {
 		let monaco = _editors.testsGlobal, editor = _editors.tests;
+
+		let model = editor.getModel();
+
+		model.updateOptions({
+			insertSpaces: false
+		});
+		editor.updateOptions({
+			links: false,
+			stickyScroll: { enabled: false }
+		});
 
 		monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
 			validate: true,
@@ -332,20 +350,10 @@ var Scaffold = new function () {
 			schemaValidation: 'error'
 		});
 
-		editor.getModel().updateOptions({
-			insertSpaces: false
-		});
-
-		editor.getModel().onDidChangeContent((_) => {
-			this.populateTests();
-		});
-
-		editor.updateOptions({
-			links: false,
-			stickyScroll: { enabled: false }
-		});
-
 		monaco.languages.registerCodeLensProvider('json', this.createTestCodeLensProvider(monaco, editor));
+
+		model.onDidChangeContent((_) => this.populateTests());
+		model.onDidChangeContent(() => _updateDocManagerState());
 	};
 
 	this.createRunCodeLensProvider = function (monaco, editor) {
@@ -614,22 +622,8 @@ var Scaffold = new function () {
 	};
 
 	this.newTranslator = async function (skipSavePrompt) {
-		if (!skipSavePrompt && _editors.code.getValue()) {
-			let ps = Services.prompt;
-			let buttonFlags = ps.BUTTON_POS_0 * ps.BUTTON_TITLE_IS_STRING
-				+ ps.BUTTON_POS_1 * ps.BUTTON_TITLE_IS_STRING;
-			let label = document.getElementById('textbox-label').value;
-			let index = ps.confirmEx(null,
-				"Scaffold",
-				`Do you want to save the changes you made to ${label}?`,
-				buttonFlags,
-				Zotero.getString('general.no'),
-				Zotero.getString('general.yes'),
-				null, null, {}
-			);
-			if (index == 1 && !await this.save()) {
-				return;
-			}
+		if (!skipSavePrompt && !(await _docManager.confirmClose())) {
+			return;
 		}
 
 		this.generateTranslatorID();
@@ -655,7 +649,9 @@ var Scaffold = new function () {
 
 		document.getElementById('textbox-label').focus();
 		_showTab('metadata');
+
 		_updateTitle();
+		_docManager.setClean();
 	};
 
 	/*
@@ -762,6 +758,7 @@ var Scaffold = new function () {
 		Zotero.Prefs.set('scaffold.lastTranslatorID', translator.translatorID);
 		
 		_updateTitle();
+		_docManager.setClean();
 		return true;
 	};
 
@@ -853,6 +850,7 @@ var Scaffold = new function () {
 
 		_lastModifiedTime = new Date().getTime();
 
+		_docManager.setClean();
 		await this.reloadTranslators();
 	};
 
@@ -930,7 +928,6 @@ var Scaffold = new function () {
 	// Add special keydown handling for the editors
 	this.addEditorKeydownHandlers = function (editor) {
 		let doc = editor.getDomNode().ownerDocument;
-		let tabbox = document.getElementById("left-tabbox");
 		// On shift-tab from the start of the first line, tab out of the editor.
 		// Use capturing listener, since Shift-Tab keydown events do not propagate to the document.
 		doc.addEventListener("keydown", (event) => {
@@ -2431,6 +2428,11 @@ var Scaffold = new function () {
 		}
 		
 		document.title = title;
+	}
+	
+	function _updateDocManagerState() {
+		let label = document.getElementById('textbox-label').value;
+		_docManager.setState(JSON.stringify(_getTranslatorFromPane()), { title: label });
 	}
 };
 

--- a/chrome/content/scaffold/scaffold.js
+++ b/chrome/content/scaffold/scaffold.js
@@ -87,7 +87,10 @@ var Scaffold = new function () {
 		if (e.target !== document) return;
 		
 		_browser = document.getElementById('browser');
-		_docManager = new DocumentManager(() => this.save());
+		_docManager = new DocumentManager({
+			editorName: 'Scaffold',
+			onSave: () => this.save(),
+		});
 		_docManager.attach(window);
 		document.querySelector('#metadata-grid').addEventListener('command', () => _updateDocManagerState());
 

--- a/chrome/content/scaffold/scaffold.xhtml
+++ b/chrome/content/scaffold/scaffold.xhtml
@@ -81,8 +81,6 @@
 	</script>
 
 	<commandset id="mainCommandSet">
-		<command id="cmd_close" oncommand="window.close();"/>
-
 		<command id="cmd_undo" oncommand="Scaffold.trigger('undo', 'cmd_undo')"/>
 		<command id="cmd_redo" oncommand="Scaffold.trigger('redo', 'cmd_redo')"/>
 		<command id="cmd_find" oncommand="Scaffold.trigger('actions.find', 'cmd_find')"/>
@@ -370,7 +368,7 @@
 				/>
 			<toolbarbutton class="titlebar-button titlebar-close"
 				titlebar-btn="close"
-				oncommand="window.close();"
+				command="cmd_close"
 				data-l10n-id="browser-window-close-button"
 				aria-hidden="true"
 				/>
@@ -548,6 +546,6 @@
 	</vbox>
 	
 	<keyset>
-		<key id="key_close" key="W" modifiers="accel" oncommand="window.close()"/>
+		<key id="key_close" key="W" modifiers="accel" command="cmd_close"/>
 	</keyset>
 </window>

--- a/chrome/content/zotero/documentManager.mjs
+++ b/chrome/content/zotero/documentManager.mjs
@@ -26,6 +26,8 @@
 var { Zotero } = ChromeUtils.importESModule("chrome://zotero/content/zotero.mjs");
 
 export class DocumentManager {
+	_editorName;
+	
 	_onSave;
 	
 	_currentState;
@@ -35,8 +37,13 @@ export class DocumentManager {
 	_metadata;
 	
 	_unloaded = false;
-	
-	constructor(onSave) {
+
+	/**
+	 * @param {string} editorName
+	 * @param {() => (Promise<void> | void)} onSave
+	 */
+	constructor({ editorName, onSave }) {
+		this._editorName = editorName;
 		this._onSave = onSave;
 	}
 	
@@ -125,8 +132,8 @@ export class DocumentManager {
 			+ ps.BUTTON_POS_1 * ps.BUTTON_TITLE_CANCEL
 			+ ps.BUTTON_POS_2 * ps.BUTTON_TITLE_DONT_SAVE;
 		let index = ps.confirmEx(null,
-			title,
-			description,
+			Zotero.isMac ? title : this._editorName,
+			Zotero.isMac ? description : title,
 			buttonFlags,
 			null,
 			null,

--- a/chrome/content/zotero/documentManager.mjs
+++ b/chrome/content/zotero/documentManager.mjs
@@ -1,0 +1,147 @@
+/*
+    ***** BEGIN LICENSE BLOCK *****
+    
+    Copyright © 2025 Corporation for Digital Scholarship
+                     Vienna, Virginia, USA
+                     https://www.zotero.org
+    
+    This file is part of Zotero.
+    
+    Zotero is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    
+    Zotero is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+    
+    You should have received a copy of the GNU Affero General Public License
+    along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
+    
+    ***** END LICENSE BLOCK *****
+*/
+
+var { Zotero } = ChromeUtils.importESModule("chrome://zotero/content/zotero.mjs");
+
+export class DocumentManager {
+	_onSave;
+	
+	_currentState;
+	
+	_cleanState;
+	
+	_metadata;
+	
+	_unloaded = false;
+	
+	constructor(onSave) {
+		this._onSave = onSave;
+	}
+	
+	attach(win) {
+		if (win.document.getElementById('cmd_close')) {
+			throw new Error('#cmd_close already exists in document');
+		}
+		
+		let commandset = win.document.createXULElement('commandset');
+		win.document.documentElement.append(commandset);
+
+		let closeCommand = win.document.createXULElement('command');
+		closeCommand.id = 'cmd_close';
+		closeCommand.addEventListener('command', async () => {
+			if (await this.confirmClose()) {
+				win.close();
+			}
+		});
+		commandset.append(closeCommand);
+		
+		this._observer = {
+			observe: async (cancelQuit) => {
+				// We can't await a promise before deciding whether to cancel the quit,
+				// so just cancel it
+				cancelQuit.data = 1;
+				
+				// Run through the save prompt routine, and if the user doesn't choose Cancel,
+				// quit for real
+				if (await this.confirmClose()) {
+					Zotero.Utilities.Internal.quit();
+				}
+			},
+			
+			QueryInterface: ChromeUtils.generateQI([
+				"nsIObserver",
+				"nsISupportsWeakReference",
+			]),
+		};
+		Services.obs.addObserver(this._observer, 'quit-application-requested', true);
+
+		win.addEventListener('close', (event) => {
+			event.preventDefault();
+			closeCommand.doCommand();
+		});
+
+		win.addEventListener('unload', () => {
+			this._observer = null;
+			this._unloaded = true;
+		});
+	}
+
+	/**
+	 * @param {any} state The current state.
+	 * @param {Object} metadata
+	 * @param {string} [metadata.title] The document title.
+	 */
+	setState(state, metadata) {
+		this._currentState = state;
+		this._metadata = metadata;
+	}
+
+	/**
+	 * Set the current state as the "clean" state. Call this after opening/saving.
+	 */
+	setClean() {
+		this._cleanState = this._currentState;
+	}
+	
+	async confirmClose() {
+		if (this._unloaded) {
+			return true;
+		}
+		if (this._currentState === this._cleanState) {
+			return true;
+		}
+
+		let title = this._metadata.title
+			? await Zotero.ftl.formatValue('document-manager-confirm-dialog-title', {
+				title: this._metadata.title
+			})
+			: await Zotero.ftl.formatValue('document-manager-confirm-dialog-title-new');
+		let description = await Zotero.ftl.formatValue('document-manager-confirm-dialog-description');
+
+		let ps = Services.prompt;
+		let buttonFlags = ps.BUTTON_POS_0 * ps.BUTTON_TITLE_SAVE
+			+ ps.BUTTON_POS_1 * ps.BUTTON_TITLE_CANCEL
+			+ ps.BUTTON_POS_2 * ps.BUTTON_TITLE_DONT_SAVE;
+		let index = ps.confirmEx(null,
+			title,
+			description,
+			buttonFlags,
+			null,
+			null,
+			null, null, {}
+		);
+
+		switch (index) {
+			case 0: // Save
+				await this._onSave();
+				return true;
+			case 1: // Cancel
+				return false;
+			case 2: // Don't Save
+			default:
+				return true;
+		}
+	}
+}

--- a/chrome/content/zotero/tools/csledit.js
+++ b/chrome/content/zotero/tools/csledit.js
@@ -28,7 +28,10 @@ var { DocumentManager } = ChromeUtils.importESModule("chrome://zotero/content/do
 
 var Zotero_CSL_Editor = new function () {
 	let monaco, editor;
-	var docManager = new DocumentManager(() => this.save());
+	var docManager = new DocumentManager({
+		editorName: 'Style Editor', // Tools -> Style Editor is not localized
+		onSave: () => this.save(),
+	});
 	var styleObject;
 
 	this.init = async function () {

--- a/chrome/content/zotero/tools/csledit.js
+++ b/chrome/content/zotero/tools/csledit.js
@@ -24,14 +24,14 @@
 */
 
 var { FilePicker } = ChromeUtils.importESModule('chrome://zotero/content/modules/filePicker.mjs');
+var { DocumentManager } = ChromeUtils.importESModule("chrome://zotero/content/documentManager.mjs");
 
 var Zotero_CSL_Editor = new function () {
 	let monaco, editor;
+	var docManager = new DocumentManager(() => this.save());
+	var styleObject;
 
-	this.init = init;
-	this.loadCSL = loadCSL;
-
-	async function init() {
+	this.init = async function () {
 		await Zotero.Schema.schemaUpdatePromise;
 
 		const isDarkMQL = window.matchMedia('(prefers-color-scheme: dark)');
@@ -77,6 +77,15 @@ var Zotero_CSL_Editor = new function () {
 		editor.getModel().onDidChangeContent(Zotero.Utilities.debounce(() => {
 			this.onStyleModified();
 		}, 250));
+		
+		editor.getModel().onDidChangeContent(() => {
+			docManager.setState(
+				editor.getModel().getVersionId(),
+				{ title: styleObject?.title || styleObject?.styleID }
+			);
+		});
+		
+		docManager.attach(window);
 
 		if (currentStyle) {
 			// Call asynchronously, see note in Zotero.Styles
@@ -87,9 +96,14 @@ var Zotero_CSL_Editor = new function () {
 			monaco.editor.setTheme(ev.matches ? 'vs-dark' : 'vs-light');
 			this.refresh();
 		});
-	}
+	};
 	
-	this.onStyleSelected = function (styleID) {
+	this.onStyleSelected = async function (styleID) {
+		if (styleObject && !(await docManager.confirmClose())) {
+			document.getElementById('zotero-csl-list').selectedIndex = -1;
+			return;
+		}
+
 		Zotero.Prefs.set('export.lastStyle', styleID);
 		let style = Zotero.Styles.get(styleID);
 		Zotero.Styles.updateLocaleList(
@@ -98,7 +112,7 @@ var Zotero_CSL_Editor = new function () {
 			Zotero.Prefs.get('export.lastLocale')
 		);
 		
-		loadCSL(style.styleID);
+		this.loadCSL(style.styleID);
 		this.refresh();
 	};
 	
@@ -128,14 +142,16 @@ var Zotero_CSL_Editor = new function () {
 		if (rv == fp.returnOK || rv == fp.returnReplace) {
 			let outputFile = fp.file;
 			Zotero.File.putContentsAsync(outputFile, style);
+			docManager.setClean();
 		}
 	};
 	
-	function loadCSL(cslID) {
+	this.loadCSL = function (cslID) {
 		var style = Zotero.Styles.get(cslID);
 		editor.setValue(style.getXML());
+		docManager.setClean();
 		document.getElementById('zotero-csl-list').value = cslID;
-	}
+	};
 	
 	this.loadStyleFromEditor = function () {
 		var styleObject;
@@ -164,7 +180,7 @@ var Zotero_CSL_Editor = new function () {
 			cslList.selectedIndex = -1;
 		}
 		
-		let styleObject = this.loadStyleFromEditor();
+		styleObject = this.loadStyleFromEditor();
 		
 		Zotero.Styles.updateLocaleList(
 			document.getElementById("locale-menu"),

--- a/chrome/content/zotero/tools/csledit.xhtml
+++ b/chrome/content/zotero/tools/csledit.xhtml
@@ -87,6 +87,6 @@
 	</vbox>
 	
 	<keyset>
-		<key id="key_close" key="W" modifiers="accel" oncommand="window.close()"/>
+		<key id="key_close" key="W" modifiers="accel" command="cmd_close"/>
 	</keyset>
 </window>

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -766,3 +766,7 @@ mac-word-plugin-install-remind-later-button =
     .label = { general-remind-me-later }
 mac-word-plugin-install-dont-ask-again-button =
     .label = { general-dont-ask-again }
+
+document-manager-confirm-dialog-title = Do you want to save the changes you made to { $title }?
+document-manager-confirm-dialog-title-new = Do you want to save this file?
+document-manager-confirm-dialog-description = Your changes will be lost if you don’t save them.


### PR DESCRIPTION
With new general-purpose `DocumentManager` class.

The two editors have a similar (lack of) document model - rather than storing the current style/translator and updating it after user interactions, they just rebuild it from scratch as needed based on the state of the UI. I wrote this to support that design, but it should still work just as well with a document-based model.