### PR TITLE
Info box: Add "Migrate Fields…" action

### DIFF
--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -710,6 +710,14 @@
 
 				this.addDynamicRow(rowLabel, rowData);
 				
+				if (this.editable && fieldID && fieldName === 'extra' && this.item.canMigrateExtraFields()) {
+					let migrateFields = document.createXULElement('label', { is: 'zotero-text-link' });
+					document.l10n.setAttributes(migrateFields, 'migrate-fields');
+					migrateFields.classList.add('row-action');
+					migrateFields.addEventListener('click', () => this.handleMigrateFields());
+					this._infoTable.append(migrateFields);
+				}
+
 				let button, popup;
 				// In field merge mode, add a button to switch field versions
 				if (this.mode == 'fieldmerge' && typeof this._fieldAlternatives[fieldName] != 'undefined') {
@@ -2672,6 +2680,19 @@
 			}
 			else {
 				popup.openPopup(event.target);
+			}
+		}
+		
+		handleMigrateFields() {
+			if (
+				!Services.prompt.confirm(null,
+					Zotero.ftl.formatValueSync('migrate-fields-dialog-title'),
+					Zotero.ftl.formatValueSync('migrate-fields-dialog-description'))
+			) {
+				return;
+			}
+			if (this.item.migrateExtraFields()) {
+				this.item.saveTx();
 			}
 		}
 

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -5713,14 +5713,7 @@ Zotero.Item.prototype.migrateExtraFields = function () {
 		var { itemType, fields, creators, extra } = Zotero.Utilities.Internal.extractExtraFields(
 			originalExtra,
 			this,
-			[
-				// Skip 'publisher-place' and 'event-place' for now, since the mappings will be changed
-				// https://github.com/citation-style-language/zotero-bits/issues/6
-				'place',
-				// Skip 'issued' for now, since we don't support date ranges in Date
-				// https://github.com/zotero/zotero/issues/3030
-				'date'
-			]
+			Zotero.Items.MIGRATE_EXTRA_FIELDS_SKIP_FIELDS,
 		);
 		if (itemType) {
 			let originalType = this.itemTypeID;
@@ -5773,6 +5766,24 @@ Zotero.Item.prototype.migrateExtraFields = function () {
 	
 	return true;
 }
+
+
+Zotero.Item.prototype.canMigrateExtraFields = function () {
+	try {
+		let originalExtra = this.getField('extra');
+		let { itemType, fields, creators, extra } = Zotero.Utilities.Internal.extractExtraFields(
+			originalExtra,
+			this,
+			Zotero.Items.MIGRATE_EXTRA_FIELDS_SKIP_FIELDS,
+		);
+		return !!(itemType || fields.size || creators.length || extra !== originalExtra);
+	}
+	catch (e) {
+		Zotero.logError(e);
+		return false;
+	}
+};
+
 
 
 /**

--- a/chrome/content/zotero/xpcom/data/items.js
+++ b/chrome/content/zotero/xpcom/data/items.js
@@ -2145,6 +2145,13 @@ Zotero.Items = function() {
 	};
 	
 	
+	this.MIGRATE_EXTRA_FIELDS_SKIP_FIELDS = Object.freeze([
+		// Skip 'publisher-place' and 'event-place' for now, since the mappings will be changed
+		// https://github.com/citation-style-language/zotero-bits/issues/6
+		'place'
+	]);
+	
+	
 	Zotero.DataObjects.call(this);
 	
 	return this;

--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -1043,33 +1043,7 @@ Zotero.Utilities.Internal = {
 		var fields = new Map();
 		var creators = [];
 		additionalFields = new Set(additionalFields);
-		
-		//
-		// Build `Map`s of normalized types/fields, including CSL variables, to built-in types/fields
-		//
-		
-		// For fields we use arrays, because there can be multiple possibilities
-		//
-		// Built-in fields
-		var fieldNames = new Map(Zotero.ItemFields.getAll().map(x => [this._normalizeExtraKey(x.name), [x.name]]));
-		// CSL fields
-		for (let map of [Zotero.Schema.CSL_TEXT_MAPPINGS, Zotero.Schema.CSL_DATE_MAPPINGS]) {
-			for (let cslVar in map) {
-				let normalized = this._normalizeExtraKey(cslVar);
-				let existing = fieldNames.get(normalized) || [];
-				// Text fields are one-to-many; date fields are one-to-one
-				let additional = Array.isArray(map[cslVar]) ? map[cslVar] : [map[cslVar]];
-				fieldNames.set(normalized, new Set([...existing, ...additional]));
-			}
-		}
-		
-		// Built-in creator types
-		var creatorTypes = new Map(Zotero.CreatorTypes.getAll().map(x => [this._normalizeExtraKey(x.name), x.name]));
-		// CSL types
-		for (let i in Zotero.Schema.CSL_NAME_MAPPINGS) {
-			let cslType = Zotero.Schema.CSL_NAME_MAPPINGS[i];
-			creatorTypes.set(cslType.toLowerCase(), i);
-		}
+		var { fieldNames, creatorTypes } = this.EXTRA_FIELD_MAPPINGS;
 		
 		// Process Extra lines
 		var skipKeys = new Set();
@@ -1102,7 +1076,7 @@ Zotero.Utilities.Internal = {
 					|| key != 'type'
 					|| skipKeys.has(key)
 					// 1) Ignore 'type: note', 'type: attachment', 'type: annotation'
-					// 2) Ignore 'article' until we have a Preprint item type
+					// 2) Ignore 'article' until we have a Preprint item type (TODO: revisit this)
 					//    (https://github.com/zotero/translators/pull/2248#discussion_r546428184)
 					|| ['note', 'attachment', 'annotation', 'article'].includes(value)
 					// Ignore numeric values
@@ -1159,6 +1133,20 @@ Zotero.Utilities.Internal = {
 								|| additionalFields.has(possibleField)) {
 							return true;
 						}
+					}
+					// Skip date values that look roughly like date ranges and era notations,
+					// which the Zotero date parser doesn't support
+					if (possibleField === 'date' && (
+						value.startsWith('-')
+							|| /BCE?|AD/i.test(value)
+							// This is really rough, because citeproc.js has complicated rules
+							// for matching ranges, but we'll assume it's a range (and not a
+							// slash-separated date) if there's a single slash in the string,
+							// with at least one four-digit number somewhere before it and one
+							// immediately after it
+							|| value.split('/').length === 2 && /\d{4}.*\s*\/\s*\d{4}/.test(value)
+					)) {
+						return true;
 					}
 					fields.set(possibleField, value);
 					added = true;
@@ -3314,6 +3302,42 @@ Zotero.Utilities.Internal.onDragItems = function (event, itemIDs, dragImage) {
 		Zotero.logError(e + " with '" + format.id + "'");
 	}
 };
+
+ChromeUtils.defineLazyGetter(Zotero.Utilities.Internal, 'EXTRA_FIELD_MAPPINGS', () => {
+	//
+	// Build `Map`s of normalized types/fields, including CSL variables, to built-in types/fields
+	//
+
+	// For fields we use arrays, because there can be multiple possibilities
+	//
+	// Built-in fields
+	var fieldNames = new Map(Zotero.ItemFields.getAll()
+		.map(x => [Zotero.Utilities.Internal._normalizeExtraKey(x.name), [x.name]]));
+	// CSL fields
+	for (let map of [Zotero.Schema.CSL_TEXT_MAPPINGS, Zotero.Schema.CSL_DATE_MAPPINGS]) {
+		for (let cslVar in map) {
+			let normalized = Zotero.Utilities.Internal._normalizeExtraKey(cslVar);
+			let existing = fieldNames.get(normalized) || [];
+			// Text fields are one-to-many; date fields are one-to-one
+			let additional = Array.isArray(map[cslVar]) ? map[cslVar] : [map[cslVar]];
+			fieldNames.set(normalized, new Set([...existing, ...additional]));
+		}
+	}
+
+	// Built-in creator types
+	var creatorTypes = new Map(Zotero.CreatorTypes.getAll()
+		.map(x => [Zotero.Utilities.Internal._normalizeExtraKey(x.name), x.name]));
+	// CSL types
+	for (let i in Zotero.Schema.CSL_NAME_MAPPINGS) {
+		let cslType = Zotero.Schema.CSL_NAME_MAPPINGS[i];
+		creatorTypes.set(cslType.toLowerCase(), i);
+	}
+
+	return {
+		fieldNames,
+		creatorTypes
+	};
+});
 
 if (typeof process === 'object' && process + '' === '[object process]') {
 	module.exports = Zotero.Utilities.Internal;

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -160,6 +160,12 @@ itembox-button-options =
 itembox-button-merge =
     .aria-label = Select version of { $field } field
 
+migrate-fields = Migrate Fields…
+migrate-fields-dialog-title = Migrate Fields from Extra
+migrate-fields-dialog-description = Are you sure you want to migrate fields from Extra?
+    
+    Items with migrated fields may no longer sync with previous versions of { -app-name }.
+
 create-parent-intro = Enter a DOI, ISBN, PMID, arXiv ID, or ADS Bibcode to identify this file:
 
 reader-use-dark-mode-for-content =

--- a/scss/abstracts/_mixins.scss
+++ b/scss/abstracts/_mixins.scss
@@ -227,6 +227,13 @@
 			border-radius: 2px;
 		}
 	}
+	
+	label.row-action {
+		grid-column: 2;
+		font-size: 0.9em;
+		margin: 0;
+		padding: 0 var(--editable-text-padding-inline);
+	}
 }
 
 /* Hide icons on macOS. We use :is() to work around weird behavior in Fx101 where a regular child

--- a/test/tests/utilities_internalTest.js
+++ b/test/tests/utilities_internalTest.js
@@ -328,6 +328,36 @@ describe("Zotero.Utilities.Internal", function () {
 			assert.equal(fields.size, 0);
 			assert.strictEqual(extra, str);
 		});
+
+		it("should not extract a date field containing a simple range", function () {
+			var str = 'Date: 2020/2024';
+			var { fields, extra } = Zotero.Utilities.Internal.extractExtraFields(str);
+			assert.equal(fields.size, 0);
+			assert.equal(extra, 'Date: 2020/2024');
+		});
+
+		it("should not extract a date field containing a complicated range", function () {
+			var str = 'Date: 1985-08-01 / 2000-11-11';
+			var { fields, extra } = Zotero.Utilities.Internal.extractExtraFields(str);
+			assert.equal(fields.size, 0);
+			assert.equal(extra, 'Date: 1985-08-01 / 2000-11-11');
+		});
+
+		it("should extract a slash-separated date field with two parts", function () {
+			var str = 'Date: 2024/01';
+			var { fields, extra } = Zotero.Utilities.Internal.extractExtraFields(str);
+			assert.equal(fields.size, 1);
+			assert.equal(fields.get('date'), '2024/01');
+			assert.strictEqual(extra, '');
+		});
+
+		it("should extract a slash-separated date field with three parts", function () {
+			var str = 'Date: 01/10/2025';
+			var { fields, extra } = Zotero.Utilities.Internal.extractExtraFields(str);
+			assert.equal(fields.size, 1);
+			assert.equal(fields.get('date'), '01/10/2025');
+			assert.strictEqual(extra, '');
+		});
 	});
 	
 	describe("#combineExtraFields", function () {


### PR DESCRIPTION
And:

- Don't skip all date fields when migrating, but do skip (in `extractExtraFields()`) when they look kinda like citeproc.js ranges or dates with era notations (this is rough)
- Compute `extractExtraFields()` mappings once, lazily
- Add TODO for preprint migration