### PR TITLE
Add JXA bridge and macOS Vision interface

### DIFF
--- a/chrome/content/zotero/jxa.mjs
+++ b/chrome/content/zotero/jxa.mjs
@@ -1,0 +1,83 @@
+var { Subprocess } = ChromeUtils.import("resource://gre/modules/Subprocess.jsm");
+var { Zotero } = ChromeUtils.importESModule("chrome://zotero/content/zotero.mjs");
+
+/**
+ * Run a JavaScript function with osascript (JXA), giving it access to an Objective-C bridge.
+ *
+ * @param {Function} fn The function. The function will be called with the
+ * 		arguments passed in args, but it won't have access to closures or any
+ * 		Zotero objects/APIs.
+ *
+ * 		Your function should return something that can be JSON-serialized.
+ *
+ * 		For more information on JXA and its capabilities, see:
+ * 		https://developer.apple.com/library/archive/releasenotes/InterapplicationCommunication/RN-JavaScriptForAutomation/Articles/OSX10-10.html
+ * @param args The arguments to pass to fn. ArrayBuffer and TypedArray (Uint8Array, etc.)
+ * 		arguments will be serialized as bytes over stdin; all other arguments are
+ * 		JSON-serialized.
+ * @returns {Promise<any>}
+ */
+export async function runJXA(fn, ...args) {
+	let toWrite = [];
+	let argsString = args.map((arg) => {
+		if (typeof arg === 'object' && (arg.constructor.name === 'ArrayBuffer' || 'BYTES_PER_ELEMENT' in arg.constructor)) {
+			toWrite.push(arg);
+			return `READ_STDIN(${arg.byteLength})`;
+		}
+		return JSON.stringify(arg);
+	}).join(', ');
+
+	let sourceCodeWrapped = `
+		// Please don't pass nil into a call-by-reference argument or it won't be nil anymore
+		const nil = $();
+		
+		let fn = ${fn.toString()};
+		let json;
+		try {
+			const READ_STDIN = (numBytes) => {
+				let stdin = $.NSFileHandle.fileHandleWithStandardInput;
+				return stdin.readDataOfLength(numBytes);
+			};
+			json = fn(${argsString});
+		}
+		catch (e) {
+			json = { __jxa_error: e.message };
+		}
+		JSON.stringify(json)
+	`;
+	
+	let proc = await Subprocess.call({
+		command: '/usr/bin/osascript',
+		arguments: [
+			'-l',
+			'JavaScript',
+			'-e',
+			sourceCodeWrapped,
+		]
+	});
+	for (let arg of toWrite) {
+		await proc.stdin.write(arg);
+	}
+	await proc.stdin.close();
+
+	let result = '';
+	let str;
+	while ((str = await proc.stdout.readString())) {
+		result += str;
+	}
+	
+	// Remove the final trailing newline added by osascript
+	result = result.replace(/\n$/, '');
+	let newlineIndex;
+	while ((newlineIndex = result.indexOf('\n')) !== -1) {
+		let logOutput = result.substring(0, newlineIndex);
+		Zotero.debug(logOutput);
+		result = result.substring(newlineIndex);
+	}
+	
+	let json = JSON.parse(result);
+	if (typeof json === 'object' && '__jxa_error' in json) {
+		throw new Error(json.__jxa_error);
+	}
+	return json;
+}

--- a/chrome/content/zotero/vision.mjs
+++ b/chrome/content/zotero/vision.mjs
@@ -33,6 +33,7 @@ export function recognizeTextInImage(imageBytes) {
 				observations = request.results.js;
 			}
 		});
+		request.automaticallyDetectsLanguage = true;
 		requestHandler.performRequestsError($.NSArray.arrayWithObjects(request), error);
 
 		if (!error.isNil()) {

--- a/chrome/content/zotero/vision.mjs
+++ b/chrome/content/zotero/vision.mjs
@@ -1,0 +1,84 @@
+var { runJXA } = ChromeUtils.importESModule('chrome://zotero/content/jxa.mjs');
+
+/**
+ * @typedef { string: string, boundingRect: Rect, chars: RecognizedChar[] | null } RecognizedText
+ * @typedef { char: string, rect: Rect } RecognizedChar
+ * @typedef { x: number, y: number } Point
+ * @typedef { bottomLeft: Point, bottomRight: Point, topLeft: Point, topRight: Point } Rect
+ */
+
+/**
+ * @param {ArrayBuffer | TypedArray} imageBytes Must be in a format that NSImage can read
+ * @returns {Promise<RecognizedText[]>} An array of recognized text segments
+ */
+export function recognizeTextInImage(imageBytes) {
+	return runJXA((imageBytes) => {
+		/* global ObjC, nil, $ */
+		
+		ObjC.import('Cocoa');
+		ObjC.import('Vision');
+		
+		let nsImage = $.NSImage.alloc.initWithData(imageBytes);
+		let nsImageRep = nsImage.representations.objectAtIndex(0);
+		let imageWidth = nsImageRep.pixelsWide;
+		let imageHeight = nsImageRep.pixelsHigh;
+		let cgImage = nsImage.CGImageForProposedRectContextHints(nil, $.NSGraphicsContext.current, nil);
+
+		let observations;
+		let error = $();
+
+		let requestHandler = $.VNImageRequestHandler.alloc.initWithCGImageOptions(cgImage, $.NSDictionary.alloc.init);
+		let request = $.VNRecognizeTextRequest.alloc.initWithCompletionHandler((request) => {
+			if (!request.results.isNil()) {
+				observations = request.results.js;
+			}
+		});
+		requestHandler.performRequestsError($.NSArray.arrayWithObjects(request), error);
+
+		if (!error.isNil()) {
+			throw new Error(error.localizedDescription);
+		}
+
+		function toIntegerPoint(point) {
+			return {
+				x: Math.floor(point.x * imageWidth),
+				y: Math.floor((1 - point.y) * imageHeight)
+			};
+		}
+
+		function toIntegerRect(rect) {
+			return {
+				bottomLeft: toIntegerPoint(rect.bottomLeft),
+				bottomRight: toIntegerPoint(rect.bottomRight),
+				topLeft: toIntegerPoint(rect.topLeft),
+				topRight: toIntegerPoint(rect.topRight),
+			};
+		}
+
+		return observations.map((obs) => {
+			let text = obs.topCandidates(1).firstObject;
+			let string = text.string;
+			let boundingRect = toIntegerRect(obs);
+			let chars = [];
+			for (let i = 0; i < string.length; i++) {
+				let range = $.NSMakeRange(i, 1);
+				let rect = text.boundingBoxForRangeError(range, $());
+				if (rect.isNil()) {
+					// There was an error calculating this rect,
+					// so we can't return character-level data
+					chars = null;
+					break;
+				}
+				chars.push({
+					char: string.substringWithRange(range).js,
+					rect: toIntegerRect(rect),
+				});
+			}
+			return {
+				string: string.js,
+				boundingRect,
+				chars,
+			};
+		});
+	}, imageBytes);
+}

--- a/chrome/content/zotero/vision.mjs
+++ b/chrome/content/zotero/vision.mjs
@@ -58,9 +58,11 @@ export function recognizeTextInImage(imageBytes) {
 
 		return observations.map((obs) => {
 			let text = obs.topCandidates(1).firstObject;
-			let string = text.string;
+			let string = text.string.js;
 			let boundingRect = toIntegerRect(obs);
 			let chars = [];
+			// TODO: Make sure we're counting characters the same way Vision does
+			// I can't get it to recognize any emoji to test this
 			for (let i = 0; i < string.length; i++) {
 				let range = $.NSMakeRange(i, 1);
 				let rect = text.boundingBoxForRangeError(range, $());
@@ -71,12 +73,12 @@ export function recognizeTextInImage(imageBytes) {
 					break;
 				}
 				chars.push({
-					char: string.substringWithRange(range).js,
+					char: string[i],
 					rect: toIntegerRect(rect),
 				});
 			}
 			return {
-				string: string.js,
+				string,
 				boundingRect,
 				chars,
 			};


### PR DESCRIPTION
Try out text recognition like this:

```js
var { recognizeTextInImage } = ChromeUtils.importESModule('chrome://zotero/content/vision.mjs');
var imageBytes = await fetch('https://ajellinek.s3.us-east-1.amazonaws.com/2025_02_05_17_31_09.png')
	.then(r => r.arrayBuffer());
await recognizeTextInImage(imageBytes)
```