### PR TITLE
Apply macOS radio/checkbox normalization to import wizard

### DIFF
--- a/scss/components/_import-wizard.scss
+++ b/scss/components/_import-wizard.scss
@@ -1,4 +1,6 @@
 .import-wizard {
+	@include macOS-normalize-controls;
+	
 	min-width: 600px;
 	min-height: 400px;
 	font-size: 12px;
@@ -12,6 +14,7 @@
 	wizardpage {
 		display: flex;
 		flex-direction: column;
+		overflow: visible;
 
 		> div {
 			display: block;
@@ -27,10 +30,6 @@
 			outline:none;
 			text-decoration: $link-hover-decoration;
 		}
-	}
-
-	checkbox {
-		margin-left: 4px; // indent required for correct focus ring rendering
 	}
 
 	button {


### PR DESCRIPTION
And replace the left margin with `overflow: visible` so controls stay aligned.