### PR TITLE
Return tags together with collections in /connector/getSelectedCollection

### DIFF
--- a/chrome/content/zotero/xpcom/server/saveSession.js
+++ b/chrome/content/zotero/xpcom/server/saveSession.js
@@ -169,7 +169,7 @@ Zotero.Server.Connector.SaveSession = class {
 	async update(targetID, tags, note) {
 		var previousTargetID = this._currentTargetID;
 		this._currentTargetID = targetID;
-		this._currentTags = tags || "";
+		this._currentTags = tags || [];
 		this._currentNote = note || "";
 		
 		// Select new destination in collections pane
@@ -206,8 +206,7 @@ Zotero.Server.Connector.SaveSession = class {
 		var { library, collection } = Zotero.Server.Connector.resolveTarget(this._currentTargetID);
 		var libraryID = library.libraryID;
 		
-		var tags = this._currentTags.trim();
-		tags = tags ? tags.split(/\s*,\s*/).filter(x => x) : [];
+		var tags = this._currentTags.map(tag => tag.trim()).filter(tag => tag);
 		
 		Zotero.debug("Updating items for connector save session " + this.id);
 		


### PR DESCRIPTION
It does not sound quite semantically correct, since tags don't have much to do with a selected collection but it is the endpoint called to fetch the info from the client when the connector popup appears, and it already returns not just the selected collections but all collections from all editable groups, so it felt more appropriate than adding a new tags-specific endpoint. Perhaps, `/connector/getSelectedCollection` could be renamed for something more general at some point?

Addresses: #1706
Needed for tags autocomplete in the connector: https://github.com/zotero/zotero-connectors/pull/529