### PR TITLE
Fix faulty siblings-of-type check in `setAutoAttachmentTitle()`

### DIFF
--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -2556,12 +2556,15 @@ Zotero.Item.prototype.numNonHTMLFileAttachments = function () {
 };
 
 
-Zotero.Item.prototype.numFileAttachmentsWithContentType = function (contentType) {
+Zotero.Item.prototype.getFileAttachmentsWithContentType = function (contentType) {
 	this._requireData('childItems');
-	return this.getAttachments()
-		.map(itemID => Zotero.Items.get(itemID))
-		.filter(item => item.isFileAttachment() && item.attachmentContentType == contentType)
-		.length;
+	return Zotero.Items.get(this.getAttachments())
+		.filter(item => item.isFileAttachment() && item.attachmentContentType == contentType);
+};
+
+
+Zotero.Item.prototype.numFileAttachmentsWithContentType = function (contentType) {
+	return this.getFileAttachmentsWithContentType(contentType).length;
 };
 
 
@@ -3969,7 +3972,8 @@ Zotero.Item.prototype.setAutoAttachmentTitle = function ({ ignoreAutoRenamePrefs
 	// If this is the only attachment of its type on the parent item and the
 	// file is being renamed, give it a default title ("PDF", "Webpage", etc.)
 	let isFirstOfType = this.parentItemID
-		&& this.parentItem.numFileAttachmentsWithContentType(this.attachmentContentType) <= 1;
+		&& this.parentItem.getFileAttachmentsWithContentType(this.attachmentContentType)
+			.every(item => item === this);
 	let isBeingRenamed = ignoreAutoRenamePrefs || Zotero.Attachments.shouldAutoRenameAttachment(this);
 	if (isFirstOfType && isBeingRenamed) {
 		let defaultTitle = this._getDefaultTitleForAttachmentContentType();

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -4517,7 +4517,7 @@ var ZoteroPane = new function()
 	/**
 	 * @param {Boolean} [link]
 	 * @param {Number} [parentItemID]
-	 * @param {nsIFile[]} [files] Used instead of showing a file picker - for tests
+	 * @param {String[]} [files] Used instead of showing a file picker - for tests
 	 * @returns {Promise<Zotero.Item[] | null>}
 	 */
 	this.addAttachmentFromDialog = async function (link, parentItemID, files = null) {

--- a/test/tests/zoteroPaneTest.js
+++ b/test/tests/zoteroPaneTest.js
@@ -1692,6 +1692,38 @@ describe("ZoteroPane", function() {
 			assert.equal(parentItem.getAttachments().length, 4);
 			assert.equal(epubAttachment.getField('title'), Zotero.getString('file-type-ebook'));
 		});
+
+		describe("Linked file renaming", function () {
+			before(() => {
+				Zotero.Prefs.set('autoRenameFiles.linked', true);
+			});
+
+			after(() => {
+				Zotero.Prefs.clear('autoRenameFiles.linked');
+			});
+
+			it("should only rename and change the title of the first PDF attachment", async function () {
+				let testFile = getTestDataDirectory();
+				testFile.append('test.pdf');
+
+				let tempDir = await getTempDirectory();
+				let copy1 = PathUtils.join(tempDir, 'copy1.pdf');
+				let copy2 = PathUtils.join(tempDir, 'copy2.pdf');
+
+				await IOUtils.copy(testFile.path, copy1);
+				await IOUtils.copy(testFile.path, copy2);
+
+				let parentItem = await createDataObject('item', { title: 'Foo' });
+
+				let [attachment1] = await zp.addAttachmentFromDialog(false, parentItem.id, [copy1]);
+				assert.equal(attachment1.getField('title'), Zotero.getString('file-type-pdf'));
+				assert.equal(attachment1.attachmentFilename, 'Foo.pdf');
+
+				let [attachment2] = await zp.addAttachmentFromDialog(false, parentItem.id, [copy2]);
+				assert.equal(attachment2.getField('title'), 'copy2');
+				assert.equal(attachment2.attachmentFilename, 'copy2.pdf');
+			});
+		});
 	});
 
 	describe("#createParentItemsFromSelected()", function () {


### PR DESCRIPTION
The `this.parentItem.numFileAttachmentsWithContentType(this.attachmentContentType) <= 1` thing was a very silly attempt to work around the fact that `setAutoAttachmentTitle()` can be called before the attachment is saved, so its parent item won't consider it one of its children. But the "workaround" actually just introduced an off-by-one error and didn't fix anything.

Stored files weren't affected because `importFromFile()` saves once before updating the title, but linked files were, because `_addToDB()` (called from various places including `linkFromFile()`) doesn't save until the very end.

Also fixed a JSDoc type and added a test.

Fixes #5044