### PR TITLE
Update eslint ecmaVersion to es2022

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -61,7 +61,7 @@ export default [
 			},
 			
 			parser: babelParser,
-			ecmaVersion: 2018,
+			ecmaVersion: 2022,
 			sourceType: "module",
 			
 			parserOptions: {


### PR DESCRIPTION
Current firefox version supports all features of es2022
Fix errors with features like WeakRef