### PR TITLE
Fix broken browser window on print + remove many Mozilla files

### DIFF
--- a/app/build.sh
+++ b/app/build.sh
@@ -232,6 +232,47 @@ elif [ $BUILD_LINUX == 1 ]; then
 fi
 set -e
 cd $omni_dir
+
+# Remove Firefox files that we don't need
+rm actors/AboutLogins{Parent,Child}.sys.mjs
+rm actors/AboutMessagePreview{Parent,Child}.sys.mjs
+rm actors/AboutNewTab{Parent,Child}.sys.mjs
+rm actors/AboutPocket{Parent,Child}.sys.mjs
+rm actors/AboutPrivateBrowsing{Parent,Child}.sys.mjs
+rm actors/AboutProtections{Parent,Child}.sys.mjs
+rm actors/AboutReader{Parent,Child}.sys.mjs
+rm actors/AboutTabCrashed{Parent,Child}.sys.mjs
+rm actors/AboutWelcome{Parent,Child}.sys.mjs
+rm actors/ASRouter{Parent,Child}.sys.mjs
+rm actors/BackupUI{Parent,Child}.sys.mjs
+rm actors/BlockedSite{Parent,Child}.sys.mjs
+rm actors/BrowserProcessChild.sys.mjs
+rm actors/BrowserTabChild.sys.mjs
+rm actors/ClickHandler{Parent,Child}.sys.mjs
+rm actors/ContentSearch{Parent,Child}.sys.mjs
+rm actors/DecoderDoctor{Parent,Child}.sys.mjs
+rm actors/DOMFullscreen{Parent,Child}.sys.mjs
+rm actors/EncryptedMedia{Parent,Child}.sys.mjs
+rm actors/FormValidation{Parent,Child}.sys.mjs
+rm actors/LinkHandler{Parent,Child}.sys.mjs
+rm actors/MigrationWizard{Parent,Child}.sys.mjs
+rm actors/PageData{Parent,Child}.sys.mjs # Not our PageData actor
+rm actors/PageInfoChild.sys.mjs
+rm actors/PageStyle{Parent,Child}.sys.mjs
+rm actors/Plugin{Parent,Child}.sys.mjs # GMP plugins, which we remove
+rm actors/PointerLock{Parent,Child}.sys.mjs
+rm actors/RFPHelper{Parent,Child}.sys.mjs
+rm actors/ScreenshotsComponentChild.sys.mjs
+rm actors/SearchSERPTelemetry{Parent,Child}.sys.mjs
+rm actors/ShoppingSidebar{Parent,Child}.sys.mjs
+rm actors/SpeechDispatcher{Parent,Child}.sys.mjs
+rm actors/WebRTC{Parent,Child}.sys.mjs
+
+mv chrome/browser/content/browser/license.html chrome/browser_license.html
+rm -r chrome/browser # We want Firefox, just not the browser part
+
+rm modules/SearchSERPTelemetry.sys.mjs
+
 # Move some Firefox files that would be overwritten out of the way
 mv chrome.manifest chrome.manifest-fx
 mv defaults defaults-fx
@@ -292,9 +333,6 @@ elif [ $BUILD_LINUX == 1 ]; then
 	# https://bugzilla.mozilla.org/show_bug.cgi?id=1747208
 	perl -pi -e 's/pref\("general\.autoScroll", false\);/pref\("general.autoScroll", true);/' $prefs_file
 fi
-
-# Clear list of built-in add-ons
-echo '{"dictionaries": {"en-US": "dictionaries/en-US.dic"}, "system": []}' > chrome/browser/content/browser/built_in_addons.json
 
 # chrome.manifest
 mv chrome.manifest zotero.manifest
@@ -378,9 +416,6 @@ export CALLDIR && perl -pi -e 'BEGIN { local $/; open $fh, "$ENV{CALLDIR}/assets
 
 # Don't try to initialize Places, since we've removed its files
 replace_line 'this._placesInitialized = true;' 'if (true) return; this._placesInitialized = true;' modules/BrowserGlue.sys.mjs
-
-# Prevent color scheme getting reset to 'light' during printing
-replace_line 'new LightweightThemeConsumer\(document\);' '\/\/new LightweightThemeConsumer\(document\);'  chrome/browser/content/browser/browser-init.js
 
 # Move test files to root directory
 if [ $include_tests -eq 1 ]; then

--- a/app/scripts/fetch_xulrunner
+++ b/app/scripts/fetch_xulrunner
@@ -90,6 +90,17 @@ function modify_omni {
 	unzip omni.ja
 	rm omni.ja
 	
+	rm -r chrome/pdfjs
+	
+	rm -r modules/narrate
+	rm -r modules/translation
+	
+	rm actors/AboutTranslations{Parent,Child}.sys.mjs
+	rm actors/CookieBanner{Parent,Child}.sys.mjs
+	rm actors/PictureInPictureChild.sys.mjs
+	rm actors/ThumbnailsChild.sys.mjs
+	rm actors/Translations{Engine,}{Parent,Child}.sys.mjs
+	
 	replace_line 'BROWSER_CHROME_URL:.+' 'BROWSER_CHROME_URL: "chrome:\/\/zotero\/content\/zoteroPane.xhtml",' modules/AppConstants.sys.mjs
 	
 	# https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/internals/preferences.html

--- a/chrome/content/zotero/browserWindowShim.js
+++ b/chrome/content/zotero/browserWindowShim.js
@@ -1,0 +1,220 @@
+// Try our very hardest to look like a browser window so Firefox doesn't make its own
+// We're faking it like Thunderbird does in a couple places:
+//   https://searchfox.org/comm-esr128/rev/c0882dde78e3fb440d2c0bb730e9ac5377762cbf/mail/base/content/mailWindow.js
+//   https://searchfox.org/comm-esr128/rev/c0882dde78e3fb440d2c0bb730e9ac5377762cbf/mail/components/extensions/extensionPopup.js
+// But we can try a little less hard because our browsers will never be visible
+
+
+var { AppConstants } = ChromeUtils.importESModule(
+	"resource://gre/modules/AppConstants.sys.mjs"
+);
+var { XPCOMUtils } = ChromeUtils.importESModule(
+	"resource://gre/modules/XPCOMUtils.sys.mjs"
+);
+
+// In case PrintUtils isn't already loaded:
+XPCOMUtils.defineLazyScriptGetter(
+	window,
+	"PrintUtils",
+	"chrome://global/content/printUtils.js"
+);
+
+class nsBrowserAccess {
+	QueryInterface = ChromeUtils.generateQI(["nsIBrowserDOMWindow"]);
+
+	_openURIInNewTab() {
+		// Callers pass this method all kinds of crazy arguments,
+		// but it seems like we don't need anything complicated:
+		let browser = document.createXULElement('browser');
+		browser.hidden = true;
+		document.documentElement.appendChild(browser);
+		return browser;
+	}
+
+	createContentWindow(
+		aURI,
+		aOpenWindowInfo,
+		aWhere,
+		aFlags,
+		aTriggeringPrincipal,
+		aCsp
+	) {
+		return this.getContentWindowOrOpenURI(
+			null,
+			aOpenWindowInfo,
+			aWhere,
+			aFlags,
+			aTriggeringPrincipal,
+			aCsp,
+			true
+		);
+	}
+
+	createContentWindowInFrame(aURI, aParams, aWhere, aFlags, aName) {
+		// Passing a null-URI to only create the content window,
+		// and pass true for aSkipLoad to prevent loading of
+		// about:blank
+		return this.getContentWindowOrOpenURIInFrame(
+			null,
+			aParams,
+			aWhere,
+			aFlags,
+			aName,
+			true
+		);
+	}
+
+	openURI(aURI, aOpenWindowInfo, aWhere, aFlags, aTriggeringPrincipal, aCsp) {
+		if (!aURI) {
+			throw Components.Exception(
+				"openURI should only be called with a valid URI",
+				Cr.NS_ERROR_FAILURE
+			);
+		}
+		return this.getContentWindowOrOpenURI(
+			aURI,
+			aOpenWindowInfo,
+			aWhere,
+			aFlags,
+			aTriggeringPrincipal,
+			aCsp,
+			false
+		);
+	}
+
+	openURIInFrame(aURI, aParams, aWhere, aFlags, aName) {
+		return this.getContentWindowOrOpenURIInFrame(
+			aURI,
+			aParams,
+			aWhere,
+			aFlags,
+			aName,
+			false
+		);
+	}
+
+	getContentWindowOrOpenURI(
+		aURI,
+		aOpenWindowInfo,
+		aWhere,
+		aFlags,
+		aTriggeringPrincipal,
+		aCsp,
+		aSkipLoad
+	) {
+		if (aWhere == Ci.nsIBrowserDOMWindow.OPEN_PRINT_BROWSER) {
+			const browser =
+				PrintUtils.handleStaticCloneCreatedForPrint(aOpenWindowInfo);
+			return browser ? browser.browsingContext : null;
+		}
+
+		const isExternal = !!(aFlags & Ci.nsIBrowserDOMWindow.OPEN_EXTERNAL);
+
+		if (aOpenWindowInfo && isExternal) {
+			throw Components.Exception(
+				"nsBrowserAccess.openURI did not expect aOpenWindowInfo to be " +
+				"passed if the context is OPEN_EXTERNAL.",
+				Cr.NS_ERROR_FAILURE
+			);
+		}
+
+		if (isExternal && aURI && aURI.schemeIs("chrome")) {
+			Services.console.logStringMessage(
+				"use -chrome command-line option to load external chrome urls\n"
+			);
+			return null;
+		}
+
+		const ReferrerInfo = Components.Constructor(
+			"@mozilla.org/referrer-info;1",
+			"nsIReferrerInfo",
+			"init"
+		);
+
+		let referrerInfo;
+		if (aFlags & Ci.nsIBrowserDOMWindow.OPEN_NO_REFERRER) {
+			referrerInfo = new ReferrerInfo(Ci.nsIReferrerInfo.EMPTY, false, null);
+		} else if (
+			aOpenWindowInfo &&
+			aOpenWindowInfo.parent &&
+			aOpenWindowInfo.parent.window
+		) {
+			referrerInfo = new ReferrerInfo(
+				aOpenWindowInfo.parent.window.document.referrerInfo.referrerPolicy,
+				true,
+				Services.io.newURI(aOpenWindowInfo.parent.window.location.href)
+			);
+		} else {
+			referrerInfo = new ReferrerInfo(Ci.nsIReferrerInfo.EMPTY, true, null);
+		}
+
+		if (aWhere != Ci.nsIBrowserDOMWindow.OPEN_NEWTAB) {
+			Services.console.logStringMessage(
+				"Opening a URI in something other than a new tab is not supported, opening in new tab instead"
+			);
+		}
+
+		const browser = this._openURIInNewTab(
+			aURI,
+			referrerInfo,
+			isExternal,
+			aOpenWindowInfo,
+			aTriggeringPrincipal,
+			aCsp,
+			aSkipLoad,
+			aOpenWindowInfo?.openerBrowser?.getAttribute("messagemanagergroup")
+		);
+
+		return browser ? browser.browsingContext : null;
+	}
+
+	getContentWindowOrOpenURIInFrame(
+		aURI,
+		aParams,
+		aWhere,
+		aFlags,
+		aName,
+		aSkipLoad
+	) {
+		if (aWhere == Ci.nsIBrowserDOMWindow.OPEN_PRINT_BROWSER) {
+			return PrintUtils.handleStaticCloneCreatedForPrint(
+				aParams.openWindowInfo
+			);
+		}
+
+		if (aWhere != Ci.nsIBrowserDOMWindow.OPEN_NEWTAB) {
+			Services.console.logStringMessage(
+				"Error: openURIInFrame can only open in new tabs or print"
+			);
+			return null;
+		}
+
+		const isExternal = !!(aFlags & Ci.nsIBrowserDOMWindow.OPEN_EXTERNAL);
+
+		return this._openURIInNewTab(
+			aURI,
+			aParams.referrerInfo,
+			isExternal,
+			aParams.openWindowInfo,
+			aParams.triggeringPrincipal,
+			aParams.csp,
+			aSkipLoad,
+			aParams.openerBrowser?.getAttribute("messagemanagergroup")
+		);
+	}
+
+	canClose() {
+		return true;
+	}
+
+	get tabCount() {
+		return 1;
+	}
+}
+
+window.addEventListener("DOMContentLoaded", () => {
+	window.docShell.treeOwner
+		.QueryInterface(Ci.nsIInterfaceRequestor)
+		.getInterface(Ci.nsIAppWindow).XULBrowserWindow = window.XULBrowserWindow;
+	window.browserDOMWindow = new nsBrowserAccess();
+});

--- a/chrome/content/zotero/reader.xhtml
+++ b/chrome/content/zotero/reader.xhtml
@@ -34,6 +34,7 @@
 		Services.scriptloader.loadSubScript("chrome://zotero/content/include.js", this);
 		Services.scriptloader.loadSubScript("resource://zotero/require.js", this);
 		Services.scriptloader.loadSubScript("chrome://zotero/content/platformKeys.js", this);
+		Services.scriptloader.loadSubScript("chrome://zotero/content/browserWindowShim.js", this);
 
 		// Mozilla scripts
 		Services.scriptloader.loadSubScript("chrome://global/content/globalOverlay.js", this);

--- a/chrome/content/zotero/standalone/basicViewer.xhtml
+++ b/chrome/content/zotero/standalone/basicViewer.xhtml
@@ -58,6 +58,7 @@
 		Services.scriptloader.loadSubScript("chrome://zotero/content/platformKeys.js", this);
 		Services.scriptloader.loadSubScript("chrome://zotero/content/editMenuOverlay.js", this);
 		Services.scriptloader.loadSubScript("chrome://zotero/content/include.js", this);
+		Services.scriptloader.loadSubScript("chrome://zotero/content/browserWindowShim.js", this);
 		
 		// Mozilla scripts
 		Services.scriptloader.loadSubScript("chrome://global/content/globalOverlay.js", this);

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -64,6 +64,7 @@
 		Services.scriptloader.loadSubScript("chrome://zotero/content/titlebar.js", this);
 		Services.scriptloader.loadSubScript("chrome://zotero/content/platformKeys.js", this);
 		Services.scriptloader.loadSubScript("chrome://zotero/content/editMenuOverlay.js", this);
+		Services.scriptloader.loadSubScript("chrome://zotero/content/browserWindowShim.js", this);
 		
 		// Mozilla scripts
 		Services.scriptloader.loadSubScript("chrome://global/content/globalOverlay.js", this);

--- a/test/content/support.js
+++ b/test/content/support.js
@@ -81,27 +81,6 @@ function loadWindow(winurl, argument) {
 }
 
 /**
- * Open a browser window and return a promise for the window
- *
- * @return {Promise<ChromeWindow>}
- */
-function loadBrowserWindow() {
-	var win = window.openDialog("chrome://browser/content/browser.xhtml", "", "all,height=700,width=1000");
-	return waitForDOMEvent(win, "load").then(function() {
-		return new Zotero.Promise((resolve) => {
-			if (!browserWindowInitialized) {
-				setTimeout(function () {
-					browserWindowInitialized = true;
-					resolve(win);
-				}, 1000);
-				return;
-			}
-			resolve(win);
-		});
-	});
-}
-
-/**
  * Open a Zotero window and return a promise for the window
  *
  * @return {Promise<ChromeWindow>}

--- a/test/tests/feedReaderTest.js
+++ b/test/tests/feedReaderTest.js
@@ -40,7 +40,7 @@ describe("Zotero.FeedReader", function () {
 	
 	before(async function() {
 		// Browser window is needed as parent window to load the feed reader scripts.
-		win = await loadBrowserWindow();
+		win = await loadZoteroWindow();
 	});
 
 	after(async function() {

--- a/test/tests/feedTest.js
+++ b/test/tests/feedTest.js
@@ -315,7 +315,7 @@ describe("Zotero.Feed", function() {
 		
 		before(async function() {
 			// Browser window is needed as parent window to load the feed reader scripts.
-			win = await loadBrowserWindow();
+			win = await loadZoteroWindow();
 			scheduleNextFeedCheck = sinon.stub(Zotero.Feeds, 'scheduleNextFeedCheck').resolves();
 		});
 		

--- a/test/tests/fulltextTest.js
+++ b/test/tests/fulltextTest.js
@@ -1,17 +1,4 @@
 describe("Zotero.FullText", function () {
-	var win;
-	
-	before(function* () {
-		// Hidden browser, which requires a browser window, needed for charset detection
-		// (until we figure out a better way)
-		win = yield loadBrowserWindow();
-	});
-	after(function () {
-		if (win) {
-			win.close();
-		}
-	});
-	
 	describe("Indexing", function () {
 		beforeEach(function () {
 			Zotero.Prefs.clear('fulltext.textMaxLength');

--- a/test/tests/searchTest.js
+++ b/test/tests/searchTest.js
@@ -123,7 +123,6 @@ describe("Zotero.Search", function() {
 	});
 
 	describe("#search()", function () {
-		var win;
 		var userLibraryID;
 		var fooItem;
 		var foobarItem;
@@ -138,9 +137,6 @@ describe("Zotero.Search", function() {
 				skipBundledFiles: true
 			});
 			
-			// Hidden browser, which requires a browser window, needed for charset detection
-			// (until we figure out a better way)
-			win = await loadBrowserWindow();
 			fooItem = await importFileAttachment("search/foo.html");
 			foobarItem = await importFileAttachment("search/foobar.html");
 			bazItem = await importFileAttachment("search/baz.pdf");
@@ -153,9 +149,6 @@ describe("Zotero.Search", function() {
 		});
 
 		after(function* () {
-			if (win) {
-				win.close();
-			}
 			yield fooItem.eraseTx();
 			yield foobarItem.eraseTx();
 			yield bazItem.eraseTx();

--- a/test/tests/storageLocalTest.js
+++ b/test/tests/storageLocalTest.js
@@ -590,7 +590,7 @@ describe("Zotero.Sync.Storage.Local", function () {
 		var win;
 		
 		before(function* () {
-			win = yield loadBrowserWindow();
+			win = yield loadZoteroWindow();
 		});
 		
 		after(function () {

--- a/test/tests/translateTest.js
+++ b/test/tests/translateTest.js
@@ -151,7 +151,6 @@ function setupAsyncEndpoints() {
 }
 
 describe("Zotero.Translate", function() {
-	let win;
 	let serverURL
 	let htmlURL;
 	
@@ -164,10 +163,6 @@ describe("Zotero.Translate", function() {
 		yield Zotero.Translators.init();
 		
 		setupAttachmentEndpoints();
-		win = yield loadBrowserWindow();
-	});
-	after(function () {
-		win.close();
 	});
 
 	describe("Zotero.Item", function() {


### PR DESCRIPTION
This removes a bunch of Mozilla files that we didn't need - mostly actors, which don't usually break things when removed, but some modules, too. We now remove the entire `browser/chrome/browser/` directory! 362.7 MB -> 354.6 MB! 🎉🎉🎉 Yes, you read that right, a full 2.23% reduction.

But the biggest improvement here is that we no longer show a broken browser window when printing. Turns out all we needed was to set `window.browserDOMWindow` to something implementing `nsIBrowserDOMWindow`. The weird part is that the methods we implement are apparently never actually called(???) - we just need to convince Firefox that a browser window of some kind is already open.

Closes #5048
