### PR TITLE
Show banner when sync fails due to quota error

### DIFF
--- a/chrome/content/zotero/xpcom/storage/storageEngine.js
+++ b/chrome/content/zotero/xpcom/storage/storageEngine.js
@@ -134,9 +134,9 @@ Zotero.Sync.Storage.Engine.prototype.start = Zotero.Promise.coroutine(function* 
 	this.requestsRemaining = 0;
 	
 	// Clear over-quota flag on manual sync
-	if (!this.background && Zotero.Sync.Storage.Local.storageRemainingForLibrary.has(libraryID)) {
+	if (!this.background && Zotero.Sync.Storage.Local.lastQuotaErrorForLibrary.has(libraryID)) {
 		Zotero.debug("Clearing over-quota flag for " + this.library.name);
-		Zotero.Sync.Storage.Local.storageRemainingForLibrary.delete(libraryID)
+		Zotero.Sync.Storage.Local.lastQuotaErrorForLibrary.delete(libraryID);
 	}
 	
 	// Check for updated files to upload

--- a/chrome/content/zotero/xpcom/storage/storageLocal.js
+++ b/chrome/content/zotero/xpcom/storage/storageLocal.js
@@ -15,7 +15,9 @@ Zotero.Sync.Storage.Local = {
 	
 	lastFullFileCheck: {},
 	uploadCheckFiles: [],
-	storageRemainingForLibrary: new Map(),
+	
+	/** @type {Map<number, { remaining: number, userID: number }>} */
+	lastQuotaErrorForLibrary: new Map(),
 	
 	init: function () {
 		Zotero.Notifier.registerObserver(this, ['group'], 'storageLocal');
@@ -28,8 +30,8 @@ Zotero.Sync.Storage.Local = {
 				if (this.lastFullFileCheck[libraryID]) {
 					delete this.lastFullFileCheck[libraryID];
 				}
-				if (this.storageRemainingForLibrary.has(libraryID)) {
-					this.storageRemainingForLibrary.delete(libraryID);
+				if (this.lastQuotaErrorForLibrary.has(libraryID)) {
+					this.lastQuotaErrorForLibrary.delete(libraryID);
 				}
 			}
 		}

--- a/chrome/content/zotero/xpcom/sync/syncRunner.js
+++ b/chrome/content/zotero/xpcom/sync/syncRunner.js
@@ -1183,6 +1183,10 @@ Zotero.Sync.Runner_Module = function (options = {}) {
 						}, 1);
 					}
 					break;
+				case Zotero.Error.ERROR_ZFS_OVER_QUOTA: {
+					Zotero.getActiveZoteroPane()?.showQuotaErrorReminder(e);
+					break;
+				}
 			}
 		}
 		else if (e.name && e.name == 'ZoteroObjectUploadError') {

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -736,11 +736,9 @@ sync-reminder-setUp-message = Back up your library with { -app-name } syncing.
 sync-reminder-setUp-action = Set Up Syncing
 sync-reminder-autoSync-message = { -app-name } hasn’t synced in a while. Do you want to enable automatic syncing?
 sync-reminder-autoSync-action = { general-enable }
-sync-reminder-quotaError-message = { $libraryType ->
+sync-reminder-ownQuotaError-message = { $libraryType ->
    *[user] You have reached your Zotero Storage quota. Files you add may not sync.
-   [group] The owner of “{ $libraryName }” has reached their Zotero Storage quota. Files in the group may not sync.
+   [group] You have reached your Zotero Storage quota. Files added to “{ $libraryName }” may not sync.
 }
-sync-reminder-quotaError-action = { $libraryType ->
-    [user] Open Account Settings
-    *[group] Show Group
-}
+sync-reminder-ownQuotaError-action = Open Account Settings
+sync-reminder-groupOwnerQuotaError-message = The owner of “{ $libraryName }” has reached their Zotero Storage quota. Files in the group may not sync.

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -39,6 +39,7 @@ general-go-back = Go Back
 general-accept = Accept
 general-cancel = Cancel
 general-show-in-library = Show in Library
+general-enable = Enable
 
 citation-style-label = Citation Style:
 language-label = Language:
@@ -730,3 +731,16 @@ mac-word-plugin-install-remind-later-button =
     .label = { general-remind-me-later }
 mac-word-plugin-install-dont-ask-again-button =
     .label = { general-dont-ask-again }
+
+sync-reminder-setUp-message = Back up your library with { -app-name } syncing.
+sync-reminder-setUp-action = Set Up Syncing
+sync-reminder-autoSync-message = { -app-name } hasn’t synced in a while. Do you want to enable automatic syncing?
+sync-reminder-autoSync-action = { general-enable }
+sync-reminder-quotaError-message = { $libraryType ->
+   *[user] You have reached your Zotero Storage quota. Files you add may not sync.
+   [group] The owner of “{ $libraryName }” has reached their Zotero Storage quota. Files in the group may not sync.
+}
+sync-reminder-quotaError-action = { $libraryType ->
+    [user] Open Account Settings
+    *[group] Show Group
+}

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -1001,10 +1001,6 @@ sync.resetGroupFilesAndSync          = Reset Group Files and Sync
 sync.skipGroup                   = Skip Group
 sync.removeGroupsAndSync			= Remove Groups and Sync
 
-sync.reminder.setUp.message			= Back up your library with %S syncing.
-sync.reminder.setUp.action			= Set Up Syncing
-sync.reminder.autoSync.message       = %S hasn’t synced in a while. Do you want to enable automatic syncing?
-
 sync.error.usernameNotSet			= Username not set
 sync.error.usernameNotSet.text		= You must enter your zotero.org username and password in the Zotero preferences to sync with the Zotero server.
 sync.error.passwordNotSet			= Password not set

--- a/defaults/preferences/zotero.js
+++ b/defaults/preferences/zotero.js
@@ -176,8 +176,10 @@ pref("extensions.zotero.sync.reminder.setUp.enabled", true);
 pref("extensions.zotero.sync.reminder.setUp.lastDisplayed", 0);
 pref("extensions.zotero.sync.reminder.autoSync.enabled", true);
 pref("extensions.zotero.sync.reminder.autoSync.lastDisplayed", 0);
-pref("extensions.zotero.sync.reminder.quotaError.enabled", true);
-pref("extensions.zotero.sync.reminder.quotaError.lastDisplayed", 0);
+pref("extensions.zotero.sync.reminder.ownQuotaError.enabled", true);
+pref("extensions.zotero.sync.reminder.ownQuotaError.lastDisplayed", 0);
+pref("extensions.zotero.sync.reminder.groupOwnerQuotaError.enabled", true);
+pref("extensions.zotero.sync.reminder.groupOwnerQuotaError.lastDisplayed", 0);
 
 // Proxy
 pref("extensions.zotero.proxies.autoRecognize", true);

--- a/defaults/preferences/zotero.js
+++ b/defaults/preferences/zotero.js
@@ -176,6 +176,8 @@ pref("extensions.zotero.sync.reminder.setUp.enabled", true);
 pref("extensions.zotero.sync.reminder.setUp.lastDisplayed", 0);
 pref("extensions.zotero.sync.reminder.autoSync.enabled", true);
 pref("extensions.zotero.sync.reminder.autoSync.lastDisplayed", 0);
+pref("extensions.zotero.sync.reminder.quotaError.enabled", true);
+pref("extensions.zotero.sync.reminder.quotaError.lastDisplayed", 0);
 
 // Proxy
 pref("extensions.zotero.proxies.autoRecognize", true);

--- a/resource/config.js
+++ b/resource/config.js
@@ -31,7 +31,8 @@ var ZOTERO_CONFIG = {
 	GET_INVOLVED_URL: 'https://www.zotero.org/getinvolved',
 	DICTIONARIES_URL: 'https://download.zotero.org/dictionaries/',
 	PLUGINS_URL: 'https://www.zotero.org/support/plugins',
-	NEW_FEATURES_URL: 'https://www.zotero.org/blog/zotero-7/'
+	NEW_FEATURES_URL: 'https://www.zotero.org/blog/zotero-7/',
+	STORAGE_SETTINGS_URL: 'https://www.zotero.org/settings/storage'
 };
 
 if (typeof exports === 'object' && typeof module !== 'undefined') {

--- a/scss/components/_banners.scss
+++ b/scss/components/_banners.scss
@@ -34,6 +34,8 @@
 	
 	.message {
 		margin-inline-end: .8em;
+		overflow: hidden;
+		text-overflow: ellipsis;
 	}
 
 	.spacer {

--- a/test/tests/zfsTest.js
+++ b/test/tests/zfsTest.js
@@ -891,7 +891,7 @@ describe("Zotero.Sync.Storage.Mode.ZFS", function () {
 			await engine.start();
 			assert.equal(requests, Zotero.Prefs.get('sync.storage.maxUploads'));
 			
-			Zotero.Sync.Storage.Local.storageRemainingForLibrary.delete(items[0].libraryID);
+			Zotero.Sync.Storage.Local.lastQuotaErrorForLibrary.delete(items[0].libraryID);
 		});
 		
 		
@@ -911,7 +911,10 @@ describe("Zotero.Sync.Storage.Mode.ZFS", function () {
 				items.push(item);
 			}
 			
-			Zotero.Sync.Storage.Local.storageRemainingForLibrary.set(items[0].libraryID, 0);
+			Zotero.Sync.Storage.Local.lastQuotaErrorForLibrary.set(items[0].libraryID, {
+				remaining: 0,
+				userID: Zotero.Users.getCurrentUserID(),
+			});
 			
 			var spy = sinon.spy(engine.controller, 'uploadFile');
 			await engine.start()
@@ -919,7 +922,7 @@ describe("Zotero.Sync.Storage.Mode.ZFS", function () {
 			assert.equal(spy.callCount, Zotero.Prefs.get('sync.storage.maxUploads'));
 			spy.restore();
 			
-			Zotero.Sync.Storage.Local.storageRemainingForLibrary.delete(items[0].libraryID);
+			Zotero.Sync.Storage.Local.lastQuotaErrorForLibrary.delete(items[0].libraryID);
 		});
 	})
 	


### PR DESCRIPTION
This handles (6) in #2376.

Also:
- Move strings to Fluent
- Fix overflow when window is narrow

Simulate a quota error locally for testing:
```diff
--- a/chrome/content/zotero/xpcom/storage/zfs.js
+++ b/chrome/content/zotero/xpcom/storage/zfs.js
@@ -449,6 +449,21 @@ Zotero.Sync.Storage.Mode.ZFS.prototype = {
 						debug: true
 					}
 				);
+				// Don't merge me! Simulate a quota error for testing:
+				Object.defineProperty(req, 'status', { value: 413 });
+				let getResponseHeader = ((original, obj) => ((header) => {
+					if (header === 'Zotero-Storage-Usage') {
+						return 999;
+					}
+					if (header === 'Zotero-Storage-Quota') {
+						return 1000;
+					}
+					if (header === 'Zotero-Storage-UserID') {
+						return Zotero.Users.getCurrentUserID();
+					}
+					return original.call(obj, header);
+				}))(req.getResponseHeader, req);
+				Object.defineProperty(req, 'getResponseHeader', { value: getResponseHeader });
 			}
 			catch (e) {
 				if (e instanceof Zotero.HTTP.UnexpectedStatusException) {
```