### PR TITLE
Fix broken QF cancellation from editor instance

### DIFF
--- a/chrome/content/zotero/xpcom/editorInstance.js
+++ b/chrome/content/zotero/xpcom/editorInstance.js
@@ -1150,6 +1150,14 @@ class EditorInstance {
 			},
 
 			/**
+			 * Cancel changes to the citation
+			 */
+			cancel: function () {
+				this.citation.citationItems = [];
+				return this.accept();
+			},
+
+			/**
 			 * Get a list of items used in the current document
 			 * @return {Promise} A promise resolved by the items
 			 */


### PR DESCRIPTION
Define missing `cancel` method on `io` object passed from the editor instance to quickFormat dialog. Without this, Escape keypresses throws an error because `io.cancel` is undefined.

Followup to #4859

For reference, this is how the original error can be reproduced on current `main`:


https://github.com/user-attachments/assets/e0e3b0a3-72b9-4939-9c2c-95a99f48eaa2


