### PR TITLE
Fix broken handling of closed main window on macOS

### DIFF
--- a/chrome/content/zotero/integration/addCitationDialog.js
+++ b/chrome/content/zotero/integration/addCitationDialog.js
@@ -853,23 +853,8 @@ var Zotero_Citation_Dialog = new function () {
 	}
 	
 	async function _showItemInLibrary(id) {
-		var pane = Zotero.getActiveZoteroPane();
-		// Open main window if it's not open (Mac)
-		if (!pane) {
-			let win = Zotero.openMainWindow();
-			await new Zotero.Promise((resolve) => {
-				let onOpen = function () {
-					win.removeEventListener('load', onOpen);
-					resolve();
-				};
-				win.addEventListener('load', onOpen);
-			});
-			pane = win.ZoteroPane;
-		}
+		var pane = await Zotero.getActiveZoteroPaneAsync();
 		pane.selectItem(id);
-		
-		// Pull window to foreground
-		Zotero.Utilities.Internal.activate(pane.document.defaultView);
 	}
 }
 

--- a/chrome/content/zotero/integration/quickFormat.js
+++ b/chrome/content/zotero/integration/quickFormat.js
@@ -2336,7 +2336,7 @@ var Zotero_QuickFormat = new function () {
 	this.showInLibrary = async function (itemID) {
 		let citationItem = JSON.parse(panelRefersToBubble?.dataset.citationItem || "{}");
 		var id = itemID || citationItem.id;
-		Zotero.Utilities.Internal.showInLibrary(id);
+		await Zotero.Utilities.Internal.showInLibrary(id);
 	}
 	
 	/**

--- a/chrome/content/zotero/xpcom/commandLineHandler.js
+++ b/chrome/content/zotero/xpcom/commandLineHandler.js
@@ -109,8 +109,8 @@ var ZoteroCommandLineHandler = {
 			Zotero.Integration.execCommand(agent, command, docId, templateVersion);
 		}
 		// Only open main window if we aren't handling an integration command
-		else if (!Zotero.getMainWindow()) {
-			Zotero.openMainWindow();
+		else {
+			Zotero.Utilities.Internal.activate(Zotero.getMainWindow());
 		}
 		
 		await Zotero.CommandLineIngester.ingest();

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -888,14 +888,11 @@ class ReaderInstance {
 		zp.exportPDF(this._item.id);
 	}
 
-	showInLibrary() {
-		let win = Zotero.getMainWindow();
-		if (win) {
-			let item = Zotero.Items.get(this._item.id);
-			let id = item.parentID || item.id;
-			win.ZoteroPane.selectItems([id]);
-			win.focus();
-		}
+	async showInLibrary() {
+		let zp = await Zotero.getActiveZoteroPaneAsync();
+		let item = Zotero.Items.get(this._item.id);
+		let id = item.parentID || item.id;
+		zp.selectItems([id]);
 	}
 
 	async _setState(state) {

--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -1743,19 +1743,7 @@ Zotero.Utilities.Internal = {
 	 * @param {Zotero.DataObject} - Data object (e.g., Zotero.Item) to select
 	 */
 	showInLibrary: async function (dataObject) {
-		var pane = Zotero.getActiveZoteroPane();
-		// Open main window if it's not open (Mac)
-		if (!pane) {
-			let win = Zotero.openMainWindow();
-			await new Zotero.Promise((resolve) => {
-				let onOpen = function () {
-					win.removeEventListener('load', onOpen);
-					resolve();
-				};
-				win.addEventListener('load', onOpen);
-			});
-			pane = win.ZoteroPane;
-		}
+		var pane = await Zotero.getActiveZoteroPaneAsync();
 		if (dataObject instanceof Zotero.Item) {
 			pane.selectItem(dataObject.id);
 		}
@@ -1763,8 +1751,6 @@ Zotero.Utilities.Internal = {
 			throw new Error("Unimplemented");
 		}
 		
-		// Pull window to foreground
-		Zotero.Utilities.Internal.activate(pane.document.defaultView);
 		pane.document.ownerGlobal.focus();
 	},
 	


### PR DESCRIPTION
This adds two utilities to the Zotero object: `getOrOpenMainWindow()` and `getOrOpenZoteroPane()`. The former reopens the main window if it's closed (or activates it if it's already open) and returns immediately, without waiting for anything to load. The latter waits for ZoteroPane to load fully, using a new promise that ZoteroPane resolves once it's *actually* loaded enough that methods like `selectItems()` will actually work.

The old routines in `addCitationDialog.js` and `quickFormat.js` were broken: `openMainWindow()` didn't return anything but they treated it like it returned the window, so they'd just throw.

Fixes #5057