### PR TITLE
macOS: Unescape dragged path when NSURL doesn't

### DIFF
--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -2097,6 +2097,16 @@ Zotero.DragDrop = {
 						continue;
 					}
 					file.QueryInterface(Components.interfaces.nsIFile);
+					if (Zotero.isMac && /%[0-9A-F]{2}/.test(file.path) && !file.exists()) {
+						// On macOS, Firefox reads a file URL from `public.file-url`,
+						// constructs an NSURL from it, then gets its unescaped path using
+						// stringByReplacingPercentEscapesUsingEncoding:
+						//   https://searchfox.org/mozilla-central/rev/fcfb558f/widget/cocoa/nsCocoaUtils.mm#1668-1673
+						// But that function uses a strict URI parser that chokes on things
+						// like errant brackets in the file path, and when it chokes, the
+						// URI is left escaped. Unescape it ourselves.
+						file = Zotero.File.pathToFile(decodeURIComponent(file.path));
+					}
 					// Don't allow folder drag
 					if (file.isDirectory()) {
 						continue;


### PR DESCRIPTION
Works around a bug that I discovered when looking into https://forums.zotero.org/discussion/122122/i-have-imported-the-meta-data-bib-from-calibre-and-want-to-import-the-epub-files-as-well.

When you drag an ebook with brackets in its path from Calibre, the brackets don't get escaped in the file URI, which technically makes it invalid. Most URI parsers (including the JS `URL` class and whatever Finder uses when you paste a file URI) are fine with that - the restriction on brackets pretty obscure, and `Services.io.newFileURI()` even creates these apparently invalid URIs. The one used by Apple's `NSURL path` is strict, though, and fails when the path contains unescaped brackets. That causes us to receive an `nsIFile` with URL-encoded characters in its path, which makes the drag fail.

I [reported](https://bugs.launchpad.net/calibre/+bug/2099939) the invalid URI construction to Calibre, but for now, this PR implements a small workaround. (I would also report to Mozilla, but I don't think this affects Firefox - Mozilla code now reads [`text/uri-list`](https://searchfox.org/mozilla-central/rev/fcfb558f8946f3648d962576125af46bf6e2910a/toolkit/mozapps/extensions/content/drag-drop-addon-installer.js#45-62) first.)