### PR TITLE
Fix navigating to collections via "Libraries and Collections" section of trashed items

### DIFF
--- a/chrome/content/zotero/elements/librariesCollectionsBox.js
+++ b/chrome/content/zotero/elements/librariesCollectionsBox.js
@@ -157,7 +157,12 @@ import { getCSSIcon } from 'components/icons';
 			if (!disableClicky) {
 				box.addEventListener('click', async () => {
 					await ZoteroPane.collectionsView.selectByID(obj.treeViewID);
-					await ZoteroPane.selectItem(contextItem.id);
+					// Do not try to view deleted items in a collection.
+					// They do not appear outside of trash, and selecting a deleted item
+					// will re-open trash in collectionTree.
+					if (!contextItem.deleted) {
+						await ZoteroPane.selectItem(contextItem.id);
+					}
 				});
 			}
 


### PR DESCRIPTION
After navigating to a collection from "Libraries and Collections" section of an item in the trash, do not try to select that item. Deleted item will not appear in the actual collection and trying to select it will just re-select the trash.

Fixes: #5060


https://github.com/user-attachments/assets/64ab78ae-412e-4bc5-8cf4-e571df3652c0

