### PR TITLE
Connector server support to adding a note

### DIFF
--- a/chrome/content/zotero/xpcom/connector/server_connector.js
+++ b/chrome/content/zotero/xpcom/connector/server_connector.js
@@ -160,6 +160,7 @@ Zotero.Server.Connector.SaveSession = function (id, action, requestData) {
 	
 	this._progressItems = {};
 	this._orderedProgressItems = [];
+	this._userAddedNotes = {};
 };
 
 
@@ -252,10 +253,11 @@ Zotero.Server.Connector.SaveSession.prototype.remove = function () {
 /**
  * Change the target data for this session and update any items that have already been saved
  */
-Zotero.Server.Connector.SaveSession.prototype.update = async function (targetID, tags) {
+Zotero.Server.Connector.SaveSession.prototype.update = async function (targetID, tags, note) {
 	var previousTargetID = this._currentTargetID;
 	this._currentTargetID = targetID;
 	this._currentTags = tags || "";
+	this._currentNote = note || "";
 	
 	// Select new destination in collections pane
 	var zp = Zotero.getActiveZoteroPane();
@@ -340,6 +342,14 @@ Zotero.Server.Connector.SaveSession.prototype._updateItems = Zotero.serial(async
 			// Replace item in session
 			this._items.delete(item);
 			this._items.add(newItem);
+			// Update cache of user-added note items, since IDs are different in a new library
+			if (this._currentNote) {
+				delete this._userAddedNotes[item.id];
+				let userNote = Zotero.Items.get(newItem.getNotes()).find(note => note.getNote() == this._currentNote);
+				if (userNote) {
+					this._userAddedNotes[newItem.id] = userNote.id;
+				}
+			}
 		}
 		
 		// If the item is now a child item (e.g., from Retrieve Metadata), update the
@@ -357,6 +367,28 @@ Zotero.Server.Connector.SaveSession.prototype._updateItems = Zotero.serial(async
 		item.setTags(originalTags.concat(tags));
 		item.setCollections(collection ? [collection.id] : []);
 		await item.saveTx();
+
+		// If a note is passed, add it as a child item
+		if (this._currentNote) {
+			// If the note item already exists, update it. Otherwise, create a new one.
+			let existingItemNoteID = this._userAddedNotes[item.id];
+			let noteItem = existingItemNoteID && Zotero.Items.get(existingItemNoteID);
+			if (!noteItem) {
+				noteItem = new Zotero.Item('note');
+			}
+			noteItem.setNote(this._currentNote);
+			noteItem.parentID = item.id;
+			noteItem.libraryID = item.libraryID;
+			await noteItem.saveTx();
+			// Record which of the notes (there could be multiple) is added by the user
+			this._userAddedNotes[item.id] = noteItem.id;
+		}
+		// If the note was typed and then erased, delete it
+		else if (this._userAddedNotes[item.id]) {
+			let noteItem = Zotero.Items.get(this._userAddedNotes[item.id]);
+			await noteItem.eraseTx();
+			delete this._userAddedNotes[item.id];
+		}
 	}
 	
 	this._updateRecents();
@@ -1249,6 +1281,7 @@ Zotero.Server.Connector.SaveSnapshot.prototype = {
  *		sessionID - A session ID previously passed to /saveItems
  *		target - A treeViewID (L1, C23, etc.) for the library or collection to save to
  *		tags - A string of tags separated by commas
+ *		note - A string to turn into a child note
  *
  * Returns:
  *		200 response on successful change
@@ -1277,6 +1310,7 @@ Zotero.Server.Connector.UpdateSession.prototype = {
 		// Parse treeViewID
 		var [type, id] = [data.target[0], parseInt(data.target.substr(1))];
 		var tags = data.tags;
+		let note = data.note;
 		
 		if (type == 'C') {
 			let collection = await Zotero.Collections.getAsync(id);
@@ -1285,7 +1319,7 @@ Zotero.Server.Connector.UpdateSession.prototype = {
 			}
 		}
 		
-		await session.update(data.target, tags);
+		await session.update(data.target, tags, note);
 		
 		return [200, "application/json", JSON.stringify({})];
 	}
@@ -1701,7 +1735,8 @@ Zotero.Server.Connector.Ping.prototype = {
 					automaticSnapshots: Zotero.Prefs.get('automaticSnapshots'),
 					googleDocsAddNoteEnabled: true,
 					translatorsHash,
-					sortedTranslatorHash
+					sortedTranslatorHash,
+					canUserAddNote: true
 				}
 			};
 			if (Zotero.QuickCopy.hasSiteSettings()) {

--- a/test/tests/server_connectorTest.js
+++ b/test/tests/server_connectorTest.js
@@ -1490,7 +1490,7 @@ describe("Connector Server", function () {
 	});
 	
 	describe("/connector/updateSession", function () {
-		it("should update collections and tags of item saved via /saveItems", async function () {
+		it("should update collections, tags, and note of item saved via /saveItems", async function () {
 			var collection1 = await createDataObject('collection');
 			var collection2 = await createDataObject('collection');
 			await select(win, collection2);
@@ -1561,7 +1561,8 @@ describe("Connector Server", function () {
 					body: JSON.stringify({
 						sessionID,
 						target: collection1.treeViewID,
-						tags: "A, B"
+						tags: "A, B",
+						note: "Test note"
 					})
 				}
 			);
@@ -1570,6 +1571,8 @@ describe("Connector Server", function () {
 			assert.isTrue(collection1.hasItem(item.id));
 			assert.isTrue(item.hasTag("A"));
 			assert.isTrue(item.hasTag("B"));
+			let note = Zotero.Items.get(item.getNotes())[0];
+			assert.equal(note.getNote(), "Test note");
 		});
 		
 		it("should update collections and tags of PDF saved via /saveSnapshot", async function () {
@@ -1628,7 +1631,7 @@ describe("Connector Server", function () {
 			assert.isTrue(item.hasTag("B"));
 		});
 		
-		it("should update collections and tags of webpage saved via /saveSnapshot", async function () {
+		it("should update collections, tags, and note of webpage saved via /saveSnapshot", async function () {
 			var sessionID = Zotero.Utilities.randomString();
 			
 			var collection1 = await createDataObject('collection');
@@ -1673,7 +1676,8 @@ describe("Connector Server", function () {
 					body: JSON.stringify({
 						sessionID,
 						target: collection1.treeViewID,
-						tags: "A, B"
+						tags: "A, B",
+						note: "Test note"
 					})
 				}
 			);
@@ -1682,6 +1686,8 @@ describe("Connector Server", function () {
 			assert.isTrue(collection1.hasItem(item.id));
 			assert.isTrue(item.hasTag("A"));
 			assert.isTrue(item.hasTag("B"));
+			let note = Zotero.Items.get(item.getNotes())[0];
+			assert.equal(note.getNote(), "Test note");
 		});
 		
 		it("should move item saved via /saveItems to another library", async function () {
@@ -1731,6 +1737,23 @@ describe("Connector Server", function () {
 			
 			var ids1 = await waitForItemEvent('add');
 			var item1 = Zotero.Items.get(ids1[0]);
+
+			// Add a note
+			await Zotero.HTTP.request(
+				'POST',
+				connectorServerPath + "/connector/updateSession",
+				{
+					headers: {
+						"Content-Type": "application/json"
+					},
+					body: JSON.stringify({
+						sessionID,
+						target: "L" + Zotero.Libraries.userLibraryID,
+						note: "Test note"
+					})
+				}
+			);
+
 			// Attachment
 			await waitForItemEvent('add');
 			
@@ -1770,6 +1793,10 @@ describe("Connector Server", function () {
 			assert.isFalse(Zotero.Items.exists(item1.id));
 			assert.equal(item2.libraryID, group.libraryID);
 			assert.equal(item2.numAttachments(), 0);
+			// Make sure the child note remains
+			assert.equal(item2.getNotes().length, 1);
+			let note = Zotero.Items.get(item2.getNotes())[0];
+			assert.equal(note.getNote(), "Test note");
 			
 			// Move back to My Library and resave attachment
 			reqPromise = Zotero.HTTP.request(
@@ -1781,7 +1808,8 @@ describe("Connector Server", function () {
 					},
 					body: JSON.stringify({
 						sessionID,
-						target: Zotero.Libraries.userLibrary.treeViewID
+						target: Zotero.Libraries.userLibrary.treeViewID,
+						note: "Test note"
 					})
 				}
 			);
@@ -1796,6 +1824,10 @@ describe("Connector Server", function () {
 			assert.isFalse(Zotero.Items.exists(item2.id));
 			assert.equal(item3.libraryID, Zotero.Libraries.userLibraryID);
 			assert.equal(item3.numAttachments(), 1);
+			// Make sure the child note remains
+			assert.equal(item3.getNotes().length, 1);
+			let noteTwo = Zotero.Items.get(item3.getNotes())[0];
+			assert.equal(noteTwo.getNote(), "Test note");
 			
 			addItemsSpy.restore();
 		});
@@ -2414,6 +2446,74 @@ describe("Connector Server", function () {
 			assert.isTrue(await OS.File.exists(path));
 			let contents = await Zotero.File.getContentsAsync(path);
 			assert.equal(contents, '<html><head><title>Title</title><body>Body');
+		});
+
+		it("should delete added child note if its content is erased", async function () {
+			let collection = await createDataObject('collection');
+			await select(win, collection);
+			
+			let sessionID = Zotero.Utilities.randomString();
+			let payload = {
+				sessionID,
+				items: [
+					{
+						itemType: "newspaperArticle",
+						title: "Note Test",
+						creators: [
+							{ firstName: "First", lastName: "Last", creatorType: "author" }
+						],
+						attachments: []
+					}
+				],
+				uri: "http://example.com"
+			};
+			
+			let promise = waitForItemEvent('add');
+			// Create item
+			await Zotero.HTTP.request(
+				'POST',
+				connectorServerPath + "/connector/saveItems",
+				{
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify(payload)
+				}
+			);
+			let ids = await promise;
+			let item = Zotero.Items.get(ids[0]);
+			
+			// Add a note
+			await Zotero.HTTP.request(
+				'POST',
+				connectorServerPath + "/connector/updateSession",
+				{
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						sessionID,
+						target: collection.treeViewID,
+						note: "Test note"
+					})
+				}
+			);
+			let notes = Zotero.Items.get(item.getNotes());
+			assert.isNotEmpty(notes);
+			assert.equal(notes[0].getNote(), "Test note");
+			
+			// Erase the note
+			await Zotero.HTTP.request(
+				'POST',
+				connectorServerPath + "/connector/updateSession",
+				{
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						sessionID,
+						target: collection.treeViewID,
+						note: ""
+					})
+				}
+			);
+			// Make sure the child note is removed
+			notes = Zotero.Items.get(item.getNotes());
+			assert.equal(notes.length, 0);
 		});
 	});
 	


### PR DESCRIPTION
- pass `canUserAddNote` flag in ping response to tell the connector that it should display a note field
- when the connector sends a note, create a child note item if it does not yet exist and set its content. If the child item for user-added notes is already created, update it
- if the connector sends an empty note, user-added child note item is deleted
- record child notes added by the user in `_userAddedNotes` cache to distinguish between user added notes and
notes added by the connector automatically
- if the target library changes, child note items are moved to the new library as well.` _userAddedNotes`
will be updated to reflect new `itemID`s
- if there are multiple toplevel items being added, the note is added to all of them