### PR TITLE
Click on itemBox label focus edits

### DIFF
--- a/chrome/content/zotero/elements/attachmentBox.js
+++ b/chrome/content/zotero/elements/attachmentBox.js
@@ -700,7 +700,7 @@
 			
 			let labelWrapper = event.target.closest(".meta-label");
 			if (labelWrapper.nextSibling.contains(document.activeElement)) {
-				document.activeElement.blur();
+				ZoteroPane.itemsView.focus();
 			}
 			else if (!labelWrapper.nextSibling.firstChild.readOnly) {
 				labelWrapper.nextSibling.firstChild.focus();

--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -1681,7 +1681,7 @@
 					if (labelWrapper.nextSibling.contains(document.activeElement)) {
 						// click on label when value field is already focused
 						// will refocus itemTree in library tab or reader content in reader tab
-						if (Zotero_Tabs.selectedIndex === 0) {
+						if (Zotero_Tabs.selectedType === "library") {
 							ZoteroPane.itemsView.focus();
 						}
 						else {

--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -1679,7 +1679,15 @@
 					
 					let labelWrapper = label.closest(".meta-label");
 					if (labelWrapper.nextSibling.contains(document.activeElement)) {
-						document.activeElement.blur();
+						// click on label when value field is already focused
+						// will refocus itemTree in library tab or reader content in reader tab
+						if (Zotero_Tabs.selectedIndex === 0) {
+							ZoteroPane.itemsView.focus();
+						}
+						else {
+							let reader = Zotero.Reader.getByTabID(Zotero_Tabs.selectedID);
+							reader.focus();
+						}
 					}
 					else {
 						let valueField = labelWrapper.nextSibling.firstChild;


### PR DESCRIPTION
Click on a label of a focused field in itemBox or attachmentBox will refocus itemTree or the reader content, depending on the tab. That way focus is not lost.

Fixes: #5063