### PR TITLE
Convert `customThemes` from a pref to a sync setting

### DIFF
--- a/chrome/content/zotero/xpcom/prefs.js
+++ b/chrome/content/zotero/xpcom/prefs.js
@@ -44,7 +44,7 @@ Zotero.Prefs = new function() {
 
 		// Process pref version updates
 		var fromVersion = this.get('prefVersion');
-		var toVersion = 13;
+		var toVersion = 14;
 		if (!fromVersion) {
 			this.set('prefVersion', toVersion);
 		}
@@ -148,6 +148,23 @@ Zotero.Prefs = new function() {
 					case 13:
 						Zotero.Prefs.clear('ui.popup.disable_autohide', true);
 						break;
+					// Convert from `reader.customThemes` pref to `readerCustomThemes` in sync settings
+					case 14: {
+						// Store the pref in a closure and clear it. Migrate to sync settings when ready.
+						// Try/Catch block to prevent migration from failing if the JSON is invalid
+						try {
+							let readerCustomThemes = JSON.parse(this.get('reader.customThemes') ?? '[]');
+							if (readerCustomThemes?.length) {
+								Zotero.initializationPromise.then(() => {
+									Zotero.SyncedSettings.set(Zotero.Libraries.userLibraryID, 'readerCustomThemes', readerCustomThemes);
+								});
+							}
+						}
+						finally {
+							this.clear('reader.customThemes');
+						}
+						break;
+					}
 				}
 			}
 			this.set('prefVersion', toVersion);

--- a/chrome/content/zotero/xpcom/prefs.js
+++ b/chrome/content/zotero/xpcom/prefs.js
@@ -148,10 +148,10 @@ Zotero.Prefs = new function() {
 					case 13:
 						Zotero.Prefs.clear('ui.popup.disable_autohide', true);
 						break;
-					// Convert from `reader.customThemes` pref to `readerCustomThemes` in sync settings
+					// Convert from `reader.customThemes` pref to `readerCustomThemes` synced setting
 					case 14: {
-						// Store the pref in a closure and clear it. Migrate to sync settings when ready.
-						// Try/Catch block to prevent migration from failing if the JSON is invalid
+						// Store the pref in a closure and clear it. Migrate to synced setting when ready.
+						// try/catch block to prevent migration from failing if the JSON is invalid
 						try {
 							let readerCustomThemes = JSON.parse(this.get('reader.customThemes') ?? '[]');
 							if (readerCustomThemes?.length) {

--- a/chrome/content/zotero/xpcom/syncedSettings.js
+++ b/chrome/content/zotero/xpcom/syncedSettings.js
@@ -223,7 +223,7 @@ Zotero.SyncedSettings = (function () {
 			}
 			
 			// Prevents a whole bunch of headache if you continue modifying the object after calling #set()
-			if (value instanceof Array) {
+			if (Array.isArray(value)) {
 				value = Array.from(value);
 			}
 			else if (typeof value == 'object') {

--- a/defaults/preferences/zotero.js
+++ b/defaults/preferences/zotero.js
@@ -224,7 +224,6 @@ pref("extensions.zotero.tabs.title.reader", "titleCreatorYear");
 
 // Reader
 pref("extensions.zotero.reader.textSelectionAnnotationMode", "highlight");
-pref("extensions.zotero.reader.customThemes", "[]");
 pref("extensions.zotero.reader.lightTheme", "");
 pref("extensions.zotero.reader.darkTheme", "dark");
 pref("extensions.zotero.reader.ebookFontFamily", "Georgia, serif");


### PR DESCRIPTION
Enables syncing custom themes, allowing the same custom themes to be used in the web library and mobile apps.  I've also included code to migrate existing pref to a synced setting.

I don't think we should sync the actual selected theme (and this PR doesn't do that)—users might prefer different themes on different devices—but it would be nice if the same custom themes were available across devices.

Depends on https://github.com/zotero/dataserver/pull/168