### PR TITLE
Sort strings naturally or alphabetically

### DIFF
--- a/chrome/content/zotero/xpcom/intl.js
+++ b/chrome/content/zotero/xpcom/intl.js
@@ -249,7 +249,7 @@ Zotero.Intl = new function () {
 			// passing manually?
 			let locales = Services.locale.appLocalesAsBCP47;
 			var collator = new Intl.Collator(locales, {
-				numeric: true,
+				numeric:  Zotero.Prefs.get('sortCollectionsNaturally'),
 				sensitivity: 'base'
 			});
 		}
@@ -260,7 +260,7 @@ Zotero.Intl = new function () {
 			try {
 				Zotero.logError("Falling back to en-US sorting");
 				collator = new Intl.Collator(['en-US'], {
-					numeric: true,
+					numeric: Zotero.Prefs.get('sortCollectionsNaturally'),
 					sensitivity: 'base'
 				});
 			}

--- a/chrome/content/zotero/xpcom/intl.js
+++ b/chrome/content/zotero/xpcom/intl.js
@@ -249,7 +249,7 @@ Zotero.Intl = new function () {
 			// passing manually?
 			let locales = Services.locale.appLocalesAsBCP47;
 			var collator = new Intl.Collator(locales, {
-				numeric:  Zotero.Prefs.get('sortCollectionsNaturally'),
+				numeric:  Zotero.Prefs.get('naturalSorting'),
 				sensitivity: 'base'
 			});
 		}
@@ -260,7 +260,7 @@ Zotero.Intl = new function () {
 			try {
 				Zotero.logError("Falling back to en-US sorting");
 				collator = new Intl.Collator(['en-US'], {
-					numeric: Zotero.Prefs.get('sortCollectionsNaturally'),
+					numeric: Zotero.Prefs.get('naturalSorting'),
 					sensitivity: 'base'
 				});
 			}

--- a/chrome/content/zotero/xpcom/intl.js
+++ b/chrome/content/zotero/xpcom/intl.js
@@ -244,12 +244,14 @@ Zotero.Intl = new function () {
 	}
 
 	function getLocaleCollation() {
+		var naturalSorting = Zotero.Prefs.get('naturalSorting');
+		
 		try {
 			// DEBUG: Is this necessary, or will Intl.Collator just default to the same locales we're
 			// passing manually?
 			let locales = Services.locale.appLocalesAsBCP47;
 			var collator = new Intl.Collator(locales, {
-				numeric:  Zotero.Prefs.get('naturalSorting'),
+				numeric:  naturalSorting,
 				sensitivity: 'base'
 			});
 		}
@@ -260,7 +262,7 @@ Zotero.Intl = new function () {
 			try {
 				Zotero.logError("Falling back to en-US sorting");
 				collator = new Intl.Collator(['en-US'], {
-					numeric: Zotero.Prefs.get('naturalSorting'),
+					numeric: naturalSorting,
 					sensitivity: 'base'
 				});
 			}

--- a/defaults/preferences/zotero.js
+++ b/defaults/preferences/zotero.js
@@ -41,6 +41,7 @@ pref("extensions.zotero.launchNonNativeFiles", false);
 pref("extensions.zotero.sortNotesChronologically", false);
 pref("extensions.zotero.sortNotesChronologically.reader", true);
 pref("extensions.zotero.sortAttachmentsChronologically", false);
+pref("extensions.zotero.sortCollectionsNaturally", true); // If false, use conventional alphabetic sorting.
 pref("extensions.zotero.showTrashWhenEmpty", true);
 pref("extensions.zotero.trashAutoEmptyDays", 30);
 pref("extensions.zotero.viewOnDoubleClick", true);

--- a/defaults/preferences/zotero.js
+++ b/defaults/preferences/zotero.js
@@ -38,10 +38,10 @@ pref("extensions.zotero.autoRenameFiles.fileTypes", "application/pdf,application
 pref("extensions.zotero.attachmentRenameTemplate", "{{ firstCreator suffix=\" - \" }}{{ year suffix=\" - \" }}{{ title truncate=\"100\" }}");
 pref("extensions.zotero.capitalizeTitles", false);
 pref("extensions.zotero.launchNonNativeFiles", false);
+pref("extensions.zotero.naturalSorting", true);
 pref("extensions.zotero.sortNotesChronologically", false);
 pref("extensions.zotero.sortNotesChronologically.reader", true);
 pref("extensions.zotero.sortAttachmentsChronologically", false);
-pref("extensions.zotero.sortCollectionsNaturally", true); // If false, use conventional alphabetic sorting.
 pref("extensions.zotero.showTrashWhenEmpty", true);
 pref("extensions.zotero.trashAutoEmptyDays", 30);
 pref("extensions.zotero.viewOnDoubleClick", true);


### PR DESCRIPTION
Define preference permitting alphabetical or natural sorting of collections. If true, use natural collection sorting matching the current behavior. If false, use conventional alphabetic sorting is used.

This pull request does not implement dynamic update of the tree. If changed, the preference is applied after restart.