### PR TITLE
Trim editableText from itemBox on blur

### DIFF
--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -2206,6 +2206,8 @@
 				textbox.setAttribute("min-lines", 1);
 			}
 			var value = textbox.value.trim();
+			// Remove trailing whitespaces from editable-text in case itemBox is not refreshed
+			textbox.value = value;
 			
 			var [field, creatorIndex, creatorField] = fieldName.split('-');
 			


### PR DESCRIPTION
So that whitespaces are removed even if the itemBox does not refresh.

Fixes: #5080