### PR TITLE
Define "snapshot" the same way everywhere

### DIFF
--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -2485,10 +2485,8 @@ Zotero.Item.prototype.isEmbeddedImageAttachment = function() {
  * @return {Boolean} - Returns true if item is a snapshot
  */
 Zotero.Item.prototype.isSnapshotAttachment = function () {
-	return this.attachmentLinkMode == Zotero.Attachments.LINK_MODE_IMPORTED_URL
-		&& this.attachmentContentType == 'text/html';
+	return this.isFileAttachment() && this.attachmentContentType == 'text/html';
 };
-
 
 
 /**
@@ -4600,6 +4598,14 @@ Zotero.Item.prototype.getItemTypeIconName = function (skipLinkMode = false) {
 				itemType += 'EPUB';
 			}
 		}
+		else if (this.isSnapshotAttachment()) {
+			if (!skipLinkMode && linkMode == Zotero.Attachments.LINK_MODE_LINKED_FILE) {
+				itemType += 'WebLink';
+			}
+			else {
+				itemType += 'Snapshot';
+			}
+		}
 		else if (this.isImageAttachment()) {
 			itemType += linkMode == (!skipLinkMode && Zotero.Attachments.LINK_MODE_LINKED_FILE) ? 'ImageLink' : 'Image';
 		}
@@ -4611,9 +4617,6 @@ Zotero.Item.prototype.getItemTypeIconName = function (skipLinkMode = false) {
 		}
 		else if (!skipLinkMode && linkMode == Zotero.Attachments.LINK_MODE_LINKED_FILE) {
 			itemType += "Link";
-		}
-		else if (linkMode == Zotero.Attachments.LINK_MODE_IMPORTED_URL) {
-			itemType += "Snapshot";
 		}
 		else if (linkMode == Zotero.Attachments.LINK_MODE_LINKED_URL) {
 			itemType += "WebLink";

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -3208,16 +3208,16 @@ Zotero.defineProperty(Zotero.Item.prototype, 'attachmentReaderType', {
 		if (!this.isFileAttachment()) {
 			return undefined;
 		}
-		switch (this.attachmentContentType) {
-			case 'application/pdf':
-				return 'pdf';
-			case 'application/epub+zip':
-				return 'epub';
-			case 'text/html':
-				return 'snapshot';
-			default:
-				return undefined;
+		if (this.isPDFAttachment()) {
+			return 'pdf';
 		}
+		else if (this.isEPUBAttachment()) {
+			return 'epub';
+		}
+		else if (this.isSnapshotAttachment()) {
+			return 'snapshot';
+		}
+		return undefined;
 	}
 });
 


### PR DESCRIPTION
Before this PR:
- All HTML attachments, whether imported via the Connector or from disk, could be opened as snapshots in the reader
- All HTML attachments' `attachmentReaderType` was `'snapshot'`

But:
- HTML attachments imported from disk wouldn't satisfy `isSnapshotAttachment()`, so some snapshot functionality (like Add Note from Annotations) wouldn't work
- HTML attachments imported from disk had a generic document icon, not a snapshot icon

This PR makes `isSnapshotAttachment()` use the same conditions as `attachmentReaderType` and rewrites `attachmentReaderType` to use the `is*Attachment()` methods instead of duplicating their logic.

Caveat: We don't currently have an icon for a "linked snapshot," so this uses the web link icon.