### PR TITLE
Fix space before ellipsis in editable-text

### DIFF
--- a/app/scripts/fetch_xulrunner
+++ b/app/scripts/fetch_xulrunner
@@ -398,6 +398,12 @@ function modify_omni {
 	# Remove non-native text input styles
 	remove_between 'html\|input\:where\(' '^}' chrome/toolkit/skin/classic/global/global-shared.css
 	
+	# Provide a mechanism for non-UA stylesheets to override the overflow property
+	# of a text control's anonymous text node child
+	echo '::placeholder, ::-moz-text-control-editing-root, ::-moz-text-control-preview {
+		overflow: var(--moz-text-control-overflow);
+	}' >> chrome/toolkit/res/forms.css
+	
 	zip -qr9XD omni.ja *
 	mv omni.ja ..
 	cd ..

--- a/scss/elements/_editableText.scss
+++ b/scss/elements/_editableText.scss
@@ -112,6 +112,9 @@ editable-text {
 	&[nowrap] {
 		.input:not(:focus, :hover) {
 			text-overflow: ellipsis;
+			// Remove space before ellipsis by overriding UA style
+			// See fetch_xulrunner patch to chrome/toolkit/res/forms.css
+			--moz-text-control-overflow: hidden;
 		}
 	}
 	&[hidden] {


### PR DESCRIPTION
Before:
![Screenshot 2025-03-10 at 4 38 02 PM](https://github.com/user-attachments/assets/a3aa5d65-049a-4925-a034-533fb7384f27)

After:
![Screenshot 2025-03-10 at 4 38 11 PM](https://github.com/user-attachments/assets/6a1cb49c-0f5e-48c2-852e-e1a3b060b9b7)

Fixes #4716