### PR TITLE
Fix update checker _checker.stopCurrentCheck is not function

### DIFF
--- a/chrome/content/zotero/update/updates.js
+++ b/chrome/content/zotero/update/updates.js
@@ -644,6 +644,7 @@ var gCheckingPage = {
 	 * this so we can cancel the update check if the user closes the window.
 	 */
 	_checker: null,
+	_checkId: null,
 
 	/**
 	 * Initialize
@@ -657,6 +658,7 @@ var gCheckingPage = {
 				Ci.nsIUpdateChecker
 			);
 			let check = await this._checker.checkForUpdates(this._checker.FOREGROUND_CHECK);
+			this._checkId = check.id
 			let result;
 			try {
 				result = await makeAbortable(check.result);
@@ -664,7 +666,8 @@ var gCheckingPage = {
 			catch (e) {
 				// If we are aborting, stop the update check on our way out.
 				if (e instanceof AbortError) {
-					this._checker.stopCheck(check.id);
+					this._checker.stopCheck(this._checkId);
+					this._checkId = null;
 				}
 				throw e;
 			}
@@ -762,7 +765,8 @@ var gCheckingPage = {
 	 * Manager control, so stop checking for updates.
 	 */
 	onWizardCancel() {
-		this._checker.stopCurrentCheck();
+		this._checker.stopCheck(this._checkId);
+		this._checkId = null;
 	},
 };
 


### PR DESCRIPTION
Zotero 7.1-beta12, when closing the ‘check update’ window, I get the following error: 

![PixPin_2025-03-11_11-38-36](https://github.com/user-attachments/assets/4fd3b2d8-dd6a-4e35-99cd-cd467585af86)

I have not tested it and am not sure if the modifications make sense.

may ref: https://searchfox.org/mozilla-central/source/toolkit/mozapps/update/UpdateService.sys.mjs#46