### PR TITLE
Citation dialog: initial followup fixes

### DIFF
--- a/chrome/content/zotero/integration/citationDialog/searchHandler.mjs
+++ b/chrome/content/zotero/integration/citationDialog/searchHandler.mjs
@@ -191,6 +191,7 @@ export class CitationDialogSearchHandler {
 	cleanSearchQuery(str) {
 		str = str.replace(/ (?:&|and) /g, " ", "g").replace(/^,/, '');
 		str = this._cleanYear(str);
+		str = str.trim();
 
 		// If the query is very short, treat it as empty
 		if (this.minQueryLengthEnforced && str.trim().length < MIN_QUERY_LENGTH) {

--- a/chrome/content/zotero/preferences/preferences_cite.xhtml
+++ b/chrome/content/zotero/preferences/preferences_cite.xhtml
@@ -52,7 +52,7 @@
 				<hbox align="center">
 					<label id="citation-dialog-mode-label" data-l10n-id="preferences-citation-dialog-mode">:</label>
 					<radiogroup orient="horizontal" id="citation-dialog-mode" preference="extensions.zotero.integration.citationDialogMode">
-						<radio data-l10n-id="preferences-citation-dialog-mode-last-used" value="last-closed"/>
+						<radio data-l10n-id="preferences-citation-dialog-mode-last-used" value="last-used"/>
 						<radio data-l10n-id="preferences-citation-dialog-mode-library" value="library"/>
 						<radio data-l10n-id="preferences-citation-dialog-mode-list" value="list"/>
 					</radiogroup>

--- a/chrome/content/zotero/xpcom/prefs.js
+++ b/chrome/content/zotero/xpcom/prefs.js
@@ -44,7 +44,7 @@ Zotero.Prefs = new function() {
 
 		// Process pref version updates
 		var fromVersion = this.get('prefVersion');
-		var toVersion = 14;
+		var toVersion = 15;
 		if (!fromVersion) {
 			this.set('prefVersion', toVersion);
 		}
@@ -164,6 +164,21 @@ Zotero.Prefs = new function() {
 							this.clear('reader.customThemes');
 						}
 						break;
+					}
+					case 15: {
+						// If classic citation dialog was used before the redesigned citation dialog was implemented,
+						// set new dialog's last used mode to "library"
+						if (this.get('integration.useClassicAddCitationDialog')) {
+							this.set('integration.citationDialogLastUsedMode', 'library');
+							this.clear('integration.useClassicAddCitationDialog');
+						}
+						// pref citationDialogLastClosedMode was renamed to citationDialogLastUsedMode
+						// when the dialog was in beta. If the old pref is found, migrate and clear it
+						let lastClosed = this.get('integration.citationDialogLastClosedMode');
+						if (lastClosed) {
+							this.set('integration.citationDialogLastUsedMode', lastClosed);
+							this.clear('integration.citationDialogLastClosedMode');
+						}
 					}
 				}
 			}

--- a/defaults/preferences/zotero.js
+++ b/defaults/preferences/zotero.js
@@ -142,7 +142,7 @@ pref("extensions.zotero.integration.useClassicAddCitationDialog", false);
 pref("extensions.zotero.integration.keepAddCitationDialogRaised", false);
 pref("extensions.zotero.integration.upgradeTemplateDelayedOn", 0);
 pref("extensions.zotero.integration.dontPromptMendeleyImport", false);
-pref("extensions.zotero.integration.citationDialogMode", "last-closed");
+pref("extensions.zotero.integration.citationDialogMode", "last-used");
 
 // Connector settings
 pref("extensions.zotero.httpServer.enabled", true);

--- a/test/tests/citationDialogTest.js
+++ b/test/tests/citationDialogTest.js
@@ -1,0 +1,169 @@
+describe("Citation Dialog", function () {
+	let io = {
+		accept() {},
+		cancel() {},
+		sort() {},
+		sortable: false,
+		citation: {
+			properties: {
+				unsorted: false,
+			}
+		},
+		getItems() {
+			return [];
+		}
+	};
+	let dialog, win;
+
+	before(async function () {
+		// one of helper functions of searchHandler uses zotero pane
+		win = await loadZoteroPane();
+		let dialogPromise = waitForWindow("chrome://zotero/content/integration/citationDialog.xhtml");
+		Services.ww.openWindow(null, "chrome://zotero/content/integration/citationDialog.xhtml", "", "", io);
+		dialog = await dialogPromise;
+		// wait for everything (e.g. itemTree/collectionTree) inside of the dialog to be loaded.
+		// it is not used currently but may be required when more complex tests are added
+		// while (!dialog.loaded) {
+		// 	await Zotero.Promise.delay(10);
+		// }
+	});
+
+	after(function () {
+		dialog.close();
+		win.close();
+	});
+
+	describe("Helpers.extractLocator", function () {
+		let locator;
+		describe("Invalid locators", function () {
+			it("has no locator label with numeric locator value", function() {
+				locator = dialog.Helpers.extractLocator('history of the US 10-15');
+				assert.isNull(locator);
+				locator = dialog.Helpers.extractLocator('10-15');
+				assert.isNull(locator);
+			});
+
+			it("has no locator label with textual locator value", function() {
+				locator = dialog.Helpers.extractLocator('history of the US "test"');
+				assert.isNull(locator);
+				locator = dialog.Helpers.extractLocator('"test"');
+				assert.isNull(locator);
+			});
+			
+			it("has no quotes around textual locator value", function() {
+				locator = dialog.Helpers.extractLocator('history of the US chapter something');
+				assert.isNull(locator);
+				locator = dialog.Helpers.extractLocator('chapter search query');
+				assert.isNull(locator);
+			});
+			
+			it("has no locator value", function() {
+				locator = dialog.Helpers.extractLocator('history of the US p');
+				assert.isNull(locator);
+				locator = dialog.Helpers.extractLocator('page');
+				assert.isNull(locator);
+			});
+			
+			it("has textual locator value that does not follow locator label", function() {
+				locator = dialog.Helpers.extractLocator('history of the US note blank "testing"');
+				assert.isNull(locator);
+			});
+			
+			it("has numeric locator value that does not follow locator label", function() {
+				locator = dialog.Helpers.extractLocator('history of the US p blank 11-12');
+				assert.isNull(locator);
+			});
+			
+			it("has textual locator value not in the end of the string", function() {
+				locator = dialog.Helpers.extractLocator('history of the US chapter "some quotations" some more text');
+				assert.isNull(locator);
+			});
+			
+			it("has numeric locator value not in the end of the string", function() {
+				locator = dialog.Helpers.extractLocator('history of the US page 10-15 some more text');
+				assert.isNull(locator);
+			});
+		});
+
+		describe("Valid locator labels", function () {
+			it("is a valid numeric locator by itself", function () {
+				let locators = [
+					'line 10-15',
+					'line10-15',
+					'l. 10-15',
+					'l.10-15',
+					'l    10-15',
+					' l10-15'
+				];
+				for (let locatorString of locators) {
+					let locator = dialog.Helpers.extractLocator(locatorString);
+					assert.isOk(locator);
+					assert.equal(locator.label, 'line');
+					assert.equal(locator.locator, '10-15');
+					assert.equal(locator.onlyLocator, true);
+					assert.equal(locator.fullLocatorString, locatorString.trim());
+				}
+			});
+
+			it("is a valid textual locator by itself", function () {
+				let locators = [
+					'note "this is a note"',
+					'note"this is a note"',
+					'n. "this is a note"',
+					'n."this is a note"',
+					'n    "this is a note"',
+					' n"this is a note"'
+				];
+				
+				for (let locatorString of locators) {
+					let locator = dialog.Helpers.extractLocator(locatorString);
+					assert.isOk(locator);
+					assert.equal(locator.label, 'note');
+					assert.equal(locator.locator, 'this is a note');
+					assert.equal(locator.onlyLocator, true);
+					assert.equal(locator.fullLocatorString, locatorString.trim());
+				}
+			});
+
+			it("is a valid numeric locator with other text", function () {
+				let locators = [
+					{ str: 'history of the US page 10-15', locatorStr: 'page 10-15' },
+					{ str: 'history of the US page10-15', locatorStr: 'page10-15' },
+					{ str: 'history of the US p. 10-15', locatorStr: 'p. 10-15' },
+					{ str: 'history of the US p.10-15', locatorStr: 'p.10-15' },
+					{ str: 'history of the US p    10-15', locatorStr: 'p    10-15' },
+					{ str: 'history of the US  p10-15', locatorStr: 'p10-15' }
+				];
+				
+				for (let locatorObj of locators) {
+					let locator = dialog.Helpers.extractLocator(locatorObj.str);
+					assert.isOk(locator);
+					assert.equal(locator.label, 'page');
+					assert.equal(locator.locator, '10-15');
+					assert.equal(locator.onlyLocator, false);
+					assert.equal(locator.fullLocatorString, locatorObj.locatorStr);
+				}
+			});
+
+			it("is a valid textual locator with other text", function () {
+				let locators = [
+					{ str: 'history of the US chapter  "one and two"', locatorStr: 'chapter  "one and two"' },
+					{ str: 'history of the US chapter"one and two"', locatorStr: 'chapter"one and two"' },
+					{ str: 'history of the US chap. "one and two"', locatorStr: 'chap. "one and two"' },
+					{ str: 'history of the US chap."one and two"', locatorStr: 'chap."one and two"' },
+					{ str: 'history of the US chap    "one and two"', locatorStr: 'chap    "one and two"' },
+					{ str: 'history of the US chap"one and two"', locatorStr: 'chap"one and two"' }
+				];
+				
+				for (let locatorObj of locators) {
+					let locator = dialog.Helpers.extractLocator(locatorObj.str);
+					assert.isOk(locator);
+					assert.equal(locator.label, 'chapter');
+					assert.equal(locator.locator, 'one and two');
+					assert.equal(locator.onlyLocator, false);
+					assert.equal(locator.fullLocatorString, locatorObj.locatorStr);
+				}
+			});
+		});
+	});
+});


### PR DESCRIPTION
- `last-closed` -> `last-used` for `citationDialogMode` pref value
- pref label `citationDialogLastClosedMode` -> `citationDialogLastUsedMode`
- update `Zotero.Pref`s version. While migrating, if `integration.useClassicAddCitationDialog` is true, set `integration.citationDialogLastUsedMode` to 'library' so the citation dialog opens in library mode on the first run. If `citationDialogLastClosedMode` pref exists, it is migrated to `citationDialogLastUsedMode` and cleared
- redone logic of extracting the locator to allow for better detection of locators and to not rely on long regular expressions that are hard to troubleshoot. Added tests for it.

These are the new rules for extracting locators:
- locator value can be either a set of numbers potentially with some punctuation in between OR text surrounded with single or double quotes
- locator labels can be typed in any of 3 formats: full (chapter), short (chap.), or short with no punctuation (chap)
- locator labels go before the locator values and there may or may not be a space in between. For example, chap.10 is the same as chap. 10.

Fixes: #5092
Fixes: #5093