### PR TITLE
Citation dialog: move locator label lower

### DIFF
--- a/scss/components/_citationDialog.scss
+++ b/scss/components/_citationDialog.scss
@@ -623,7 +623,10 @@
 							height: 22px;
 							// <select> with increased height is hard to position but this helps
 							// to align it with <input> better
-							margin-bottom: -2px;
+							margin-bottom: -3px;
+							// push label text a bit higher 
+							padding-top: 0;
+							padding-bottom: 3px;
 						}
 						@media (-moz-platform: windows) {
 							border: 1px solid var(--color-border);

--- a/scss/components/_citationDialog.scss
+++ b/scss/components/_citationDialog.scss
@@ -621,6 +621,9 @@
 						flex: 1;
 						@media (-moz-platform: macos) {
 							height: 22px;
+							// <select> with increased height is hard to position but this helps
+							// to align it with <input> better
+							margin-bottom: -2px;
 						}
 						@media (-moz-platform: windows) {
 							border: 1px solid var(--color-border);

--- a/scss/components/_citationDialog.scss
+++ b/scss/components/_citationDialog.scss
@@ -624,9 +624,6 @@
 							// <select> with increased height is hard to position but this helps
 							// to align it with <input> better
 							margin-bottom: -3px;
-							// push label text a bit higher 
-							padding-top: 0;
-							padding-bottom: 3px;
 						}
 						@media (-moz-platform: windows) {
 							border: 1px solid var(--color-border);


### PR DESCRIPTION
So it aligns with inputs a bit better. Positioning is tricky with native select elements but with a bit extra margins, it looks better I think.

Fixes: #5091

Before:
<img width="401" alt="Screenshot 2025-03-11 at 4 14 42 PM" src="https://github.com/user-attachments/assets/366f7443-019b-4338-b22e-54247ce47809" />

After:
<img width="404" alt="Screenshot 2025-03-11 at 4 13 58 PM" src="https://github.com/user-attachments/assets/29efc8f0-e17d-4107-ba31-e7937cee5a4c" />
