### PR TITLE
Suggest running `git lfs install` in check_requirements instructions

### DIFF
--- a/app/scripts/check_requirements
+++ b/app/scripts/check_requirements
@@ -42,7 +42,7 @@ for lfs_file in $lfs_files; do
 	file_type=$(file -b $lfs_file)
 	echo -n $file_type" "
 	if [ -z "$(echo -n $file_type | grep XZ)" ]; then
-		{ $FAIL_CMD_INLINE; FAILED=1; echo " -- run 'git lfs pull'"; }
+		{ $FAIL_CMD_INLINE; FAILED=1; echo " -- run 'git lfs install; git lfs pull'"; }
 	fi
 	echo
 done


### PR DESCRIPTION
Currently, `check_requirements` suggests running `git lfs pull`. In most cases, this will not be sufficient, as Git LFS hooks would not be installed yet. This PR extends the suggestion to also include `git lfs install` in the instruction.

(I was just setting up Zotero build on another machine and was confused by that for a second)