### PR TITLE
Make the info box ellipsis behave

### DIFF
--- a/chrome/content/zotero/elements/editableText.js
+++ b/chrome/content/zotero/elements/editableText.js
@@ -513,7 +513,7 @@
 				// If we're within a pixel from overflow, calculate the
 				// content's exact size and use that.
 				|| (
-					this._input.scrollWidth - this._input.getBoundingClientRect().width < 1
+					this._input.scrollWidth === Math.round(this._input.getBoundingClientRect().width)
 					&& this._getContentWidth() > this._input.getBoundingClientRect().width
 				)
 			);

--- a/chrome/content/zotero/elements/editableText.js
+++ b/chrome/content/zotero/elements/editableText.js
@@ -504,17 +504,19 @@
 		};
 		
 		_handleInputResize = () => {
+			// Very small floating-point-error allowance
+			const EPSILON = 0.001;
 			this.classList.toggle('overflowing',
 				// We're overflowing if the field can scroll at least a pixel
 				this._input.scrollLeftMax > 0
 				// But sometimes it can scroll a *sub*pixel, and every single
 				// scroll size-related method, including privileged JS hacks,
 				// rounds scroll-related values to the nearest int.
-				// If we're within a pixel from overflow, calculate the
-				// content's exact size and use that.
+				// If integer math puts us within a pixel of overflow,
+				// rerun the calculations using exact floating-point values
 				|| (
-					this._input.scrollWidth === Math.round(this._input.getBoundingClientRect().width)
-					&& this._getContentWidth() > this._input.getBoundingClientRect().width
+					Math.abs(this._input.scrollWidth - this._input.clientWidth) <= 1
+					&& this._getContentWidth() > this._input.getBoundingClientRect().width + EPSILON
 				)
 			);
 		};

--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -266,6 +266,8 @@
 			
 			this.style.setProperty('--comma-character',
 				"'" + Zotero.getString('punctuation.comma') + "'");
+			this.style.setProperty('--ellipsis-and-comma-character',
+				"'" + Zotero.getString('punctuation.ellipsis') + Zotero.getString('punctuation.comma') + "'");
 		}
 		
 		destroy() {

--- a/scss/elements/_editableText.scss
+++ b/scss/elements/_editableText.scss
@@ -111,7 +111,7 @@ editable-text {
 	}
 	&[nowrap] {
 		.input:not(:focus, :hover) {
-			text-overflow: ellipsis;
+			text-overflow: var(--ellipsis, ellipsis);
 			// Remove space before ellipsis by overriding UA style
 			// See fetch_xulrunner patch to chrome/toolkit/res/forms.css
 			--moz-text-control-overflow: hidden;

--- a/scss/elements/_infoBox.scss
+++ b/scss/elements/_infoBox.scss
@@ -138,6 +138,15 @@ info-box {
 				inset-inline-end: 0;
 				bottom: var(--editable-text-padding-block);
 			}
+			
+			&.overflowing {
+				--ellipsis: var(--ellipsis-and-comma-character, '…,');
+				
+				&::after {
+					display: none;
+				}
+			}
+			
 			&.focused::after {
 				visibility: hidden;
 			}

--- a/scss/elements/_infoBox.scss
+++ b/scss/elements/_infoBox.scss
@@ -137,6 +137,7 @@ info-box {
 				position: absolute;
 				inset-inline-end: 0;
 				bottom: var(--editable-text-padding-block);
+				pointer-events: none;
 			}
 			
 			&.overflowing {

--- a/scss/elements/_infoBox.scss
+++ b/scss/elements/_infoBox.scss
@@ -120,18 +120,21 @@ info-box {
 	.creator-name-box {
 		flex: 1;
 		display: flex;
+		
 		editable-text input {
 			min-width: 0;
 		}
 
 		// Margin adjusted by inline padding to have 4px between first and last name
-		*[fieldMode="0"]:first-child {
+		editable-text[fieldMode="0"]:first-child {
 			margin-inline-end: calc(max(0px, 4px - var(--editable-text-padding-inline)));
 			flex-grow: 3; // last name should have priority to expand over first name
 		}
+
 		// Add comma when the last name is not focused
-		*[fieldMode="0"]:first-child {
+		editable-text[fieldMode="0"]:first-child {
 			position: relative;
+			
 			&::after {
 				content: var(--comma-character, ',');
 				position: absolute;


### PR DESCRIPTION
https://github.com/zotero/zotero/pull/5087#issuecomment-2717115891

https://github.com/user-attachments/assets/4e03bb27-b843-46e0-b27f-2ccde4228f75

There's still a little extra space after the *comma* when the field is clipped on a wide character. But after a lot of trial and error, I think this is the best we're going to get.