### PR TITLE
citation dialog: deduplicate open items

### DIFF
--- a/chrome/content/zotero/integration/citationDialog/searchHandler.mjs
+++ b/chrome/content/zotero/integration/citationDialog/searchHandler.mjs
@@ -248,7 +248,9 @@ export class CitationDialogSearchHandler {
 			}
 			return Zotero.Cite.getItem(itemID);
 		});
-		return items;
+		// Return deduplicated items since there may be multiple tabs opened per the same
+		// top-levle item (duplicate tabs or a multiple attachments belonging to the same item)
+		return [...new Set(items)];
 	}
 
 	_getSelectedLibraryItems() {

--- a/chrome/content/zotero/integration/citationDialog/searchHandler.mjs
+++ b/chrome/content/zotero/integration/citationDialog/searchHandler.mjs
@@ -248,8 +248,8 @@ export class CitationDialogSearchHandler {
 			}
 			return Zotero.Cite.getItem(itemID);
 		});
-		// Return deduplicated items since there may be multiple tabs opened per the same
-		// top-levle item (duplicate tabs or a multiple attachments belonging to the same item)
+		// Return deduplicated items since there may be multiple tabs opened for the same
+		// top-level item (duplicate tabs or a multiple attachments belonging to the same item)
 		return [...new Set(items)];
 	}
 


### PR DESCRIPTION
So that if there are multiple tabs opened for the same top level item, it appears only once in search results.