### PR TITLE
citation dialog: Enter adds row when only 1 match

### DIFF
--- a/chrome/content/zotero/integration/citationDialog.js
+++ b/chrome/content/zotero/integration/citationDialog.js
@@ -1207,8 +1207,8 @@ const IOManager = {
 			let items = selectedIDs.map(id => SearchHandler.getItem(id));
 			IOManager.addItemsToCitation(items);
 		}
-		// if there are no selected items in library mode and something was searched for add the first row from items table
-		else if (currentLayout.type == "library" && libraryLayout.itemsView.rowCount > 0 && input.value.length) {
+		// in library mode, if there are no selected/open/cited items but there is a single match in itemTree, add that one matching item
+		else if (currentLayout.type == "library" && libraryLayout.itemsView.rowCount === 1 && input.value.length) {
 			let firstRowID = libraryLayout.itemsView.getRow(0).ref.id;
 			IOManager.addItemsToCitation(Zotero.Items.get(firstRowID));
 		}


### PR DESCRIPTION
In library mode when there are no selected/open/cited items, Enter keypress from input will add the first row of itemTree into the citation only if it is the only row.

Fixes: #5098