### PR TITLE
Citation dialog: stricter search conditions for selected/open/cited items

### DIFF
--- a/chrome/content/zotero/integration/citationDialog/searchHandler.mjs
+++ b/chrome/content/zotero/integration/citationDialog/searchHandler.mjs
@@ -267,11 +267,13 @@ export class CitationDialogSearchHandler {
 			let itemStr = item.getCreators()
 				.map(creator => creator.firstName + " " + creator.lastName)
 				.concat([item.getField("title"), item.getField("date", true, true).substr(0, 4)])
-				.join(" ");
+				.join(" ")
+				.toLowerCase();
 			
-			// See if words match
-			for (let split of splits) {
-				if (itemStr.toLowerCase().includes(split)) matchedItems.add(item);
+			// Include items that match every word that was typed
+			let allMatch = splits.every(split => itemStr.includes(split));
+			if (allMatch) {
+				matchedItems.add(item);
 			}
 		}
 		return Array.from(matchedItems);


### PR DESCRIPTION
While filtering selected/open/cited items, include items that match EVERY word from the search string, as opposed to items that match ANY of the searched words.

Fixes: #5099

Now, if there are 3 opened items, and there are two matches for one word, and two matches for another word, when both words are typed, only one item matching both of them will stay.


https://github.com/user-attachments/assets/a2698c53-f4db-4c38-a75c-72fe823475e7

