### PR TITLE
citation dialog: fix not handled click on cancel/accept buttons of unfocused dialog

### DIFF
--- a/chrome/content/zotero/integration/citationDialog.js
+++ b/chrome/content/zotero/integration/citationDialog.js
@@ -1552,10 +1552,10 @@ window.addEventListener("focus", async () => {
 	if (Zotero.isLinux && now - windowLostFocusOn < 100) {
 		return;
 	}
-	// Wait a moment to allow close/accept button handling to complete in case they
-	// were clicked when the window was out-of-focus. Without this, clicking X
-	// when the dialog is not focused would just run the search here and the
-	// dialog would not be cancelled.
+	// Wait a moment to allow accept button click event to fire.
+	// Without this, clicking accept button when the dialog is not focused
+	// would refocus the dialog, run the search below,
+	// which replaces accept button with the spinner and interrupts the click event.
 	await Zotero.Promise.delay(100);
 	if (accepted) return;
 	SearchHandler.clearNonLibraryItemsCache();

--- a/chrome/content/zotero/integration/citationDialog.js
+++ b/chrome/content/zotero/integration/citationDialog.js
@@ -1545,13 +1545,19 @@ let windowLostFocusOn = 0;
 window.addEventListener("blur", () => {
 	windowLostFocusOn = (new Date()).getTime();
 });
-window.addEventListener("focus", () => {
+window.addEventListener("focus", async () => {
 	let now = (new Date()).getTime();
 	// On linux, resizing the dialog causes the window to loose and immediately regain focus.
 	// Do not run the search if the window lost focus less than 100 ms ago.
 	if (Zotero.isLinux && now - windowLostFocusOn < 100) {
 		return;
 	}
+	// Wait a moment to allow close/accept button handling to complete in case they
+	// were clicked when the window was out-of-focus. Without this, clicking X
+	// when the dialog is not focused would just run the search here and the
+	// dialog would not be cancelled.
+	await Zotero.Promise.delay(100);
+	if (accepted) return;
 	SearchHandler.clearNonLibraryItemsCache();
 	currentLayout?.search(SearchHandler.searchValue);
 });


### PR DESCRIPTION
Fix issue where clicking cancel or accept buttons would not work when the dialog itself is unfocused. Add a small delay in the focus handler of the dialog to allow cancel/accept button clicks to be handled before rerunning the search.

Fixes: #5110


https://github.com/user-attachments/assets/bafa169a-80ad-4768-b41d-c964882e88db

