### PR TITLE
citation dialog: fix collectionTree sometimes not rendering

### DIFF
--- a/chrome/content/zotero/integration/citationDialog.js
+++ b/chrome/content/zotero/integration/citationDialog.js
@@ -290,10 +290,13 @@ class Layout {
 		if (this.forceUpdateTablesAfterRefresh && this.type == "library") {
 			this.forceUpdateTablesAfterRefresh = false;
 			setTimeout(() => {
-				libraryLayout.collectionsView?.tree.invalidate();
 				libraryLayout.itemsView.tree?.invalidate();
-				libraryLayout.collectionsView?.tree.forceUpdate();
 				libraryLayout.itemsView.tree?.forceUpdate();
+				// Necessary for the collectionTree to be properly rendered after switching to library mode
+				if (libraryLayout.collectionsView) {
+					let currentCollectionIndex = libraryLayout.collectionsView.tree.selection.focused;
+					libraryLayout.collectionsView.ensureRowIsVisible(currentCollectionIndex);
+				}
 			}, 250);
 		}
 	}


### PR DESCRIPTION
After switching from list mode to library mode if the selected collection row is close to the bottom.

Fixes: #5104

For comparison with the recording in the linked issue:


https://github.com/user-attachments/assets/68f9a02f-8da9-4785-bc47-809240191a9c

