### PR TITLE
citation dialog: only do not hide cancel button when search runs

### DIFF
--- a/chrome/content/zotero/integration/citationDialog.js
+++ b/chrome/content/zotero/integration/citationDialog.js
@@ -243,11 +243,7 @@ class Layout {
 	async search(value, { skipDebounce = false } = {}) {
 		if (accepted) return;
 		_id("loading-spinner").setAttribute("status", "animate");
-		for (let node of _id("top-level-btn-group").childNodes) {
-			if (node.id !== "loading-spinner") {
-				node.hidden = true;
-			}
-		}
+		_id("accept-button").hidden = true;
 		SearchHandler.searching = true;
 		// search for selected/opened/cited items
 		// only enforce min query length in list mode
@@ -284,9 +280,7 @@ class Layout {
 
 		SearchHandler.searching = false;
 		_id("loading-spinner").removeAttribute("status");
-		for (let node of _id("top-level-btn-group").childNodes) {
-			node.hidden = false;
-		}
+		_id("accept-button").hidden = false;
 		if (this.forceUpdateTablesAfterRefresh && this.type == "library") {
 			this.forceUpdateTablesAfterRefresh = false;
 			setTimeout(() => {


### PR DESCRIPTION
Instead, when the search runs, replace just the accept button with the spinner.

Fixes: #5115

https://github.com/user-attachments/assets/db1f8193-cdd1-4cf4-a328-dd126f730c0a

