### PR TITLE
citation dialog: persist screen position

### DIFF
--- a/chrome/content/zotero/integration/citationDialog.js
+++ b/chrome/content/zotero/integration/citationDialog.js
@@ -74,13 +74,6 @@ async function onLoad() {
 	// keypress from the top-most row in the items table
 	doc.addEventListener("keydown", event => KeyboardHandler.captureKeydown(event), true);
 
-	// Move dialog towards the center (it's needed even though we open the dialog with centerscreen param)
-	let targetX = Math.floor((window.screen.width - window.outerWidth) / 2);
-	let targetY = window.screen.height / 3;
-	setTimeout(() => {
-		window.moveTo(targetX, targetY);
-	});
-
 	// citation has to be built before libraryLayout.init to so itemTree knows which items to highlight
 	await CitationDataManager.buildCitation();
 	IOManager.updateBubbleInput();


### PR DESCRIPTION
Do not explicitly move the window to the center of the screen.

Fixes: #5119

With this, the dialog also appears on an external monitor if it was last closed there for me (https://forums.zotero.org/discussion/122594/zotero-beta-about-the-new-citation-dialog-window). There was some [special handling in QF](https://github.com/zotero/zotero/blob/4915f1fadf773f855507bd801137e87770583ec6/chrome/content/zotero/integration/quickFormat.js#L273) to move the dialog into the center if it is not properly visible - but such handling is not present in any other dialog, and I have no been able to get the dialog to appear without being properly visible. So I assume it's just no longer needed.