### PR TITLE
citation dialog: restore arrowDown on bubbles opening details popup

### DIFF
--- a/chrome/content/zotero/elements/bubbleInput.js
+++ b/chrome/content/zotero/elements/bubbleInput.js
@@ -288,9 +288,9 @@
 				input.value += event.key;
 				input.dispatchEvent(new Event('input', { bubbles: true }));
 			}
-			// Space on bubble simulates a click
-			if (event.key == " ") {
-				event.target.click();
+			// Space or arrowDown on a bubble open item details popup
+			if (event.key == " " || event.key == "ArrowDown") {
+				Utils.notifyDialog("show-details-popup", { dialogReferenceID: bubble.getAttribute("dialogReferenceID") });
 				event.preventDefault();
 				event.stopPropagation();
 			}
@@ -301,18 +301,6 @@
 			// End - focus the last input
 			if (event.key == "End") {
 				this._body.lastChild.focus();
-			}
-			// Navigate bubble rows on arrow up/down
-			if (["ArrowUp", "ArrowDown"].includes(event.key)) {
-				let { x, y, width } = bubble.getBoundingClientRect();
-				let nextBubble = Utils.getLastBubbleBeforePoint(x + (width / 2), event.key == "ArrowUp" ? y - 25 : y + 30);
-				// Focus the next bubble if it exists. Otherwise, event will propagate to be handled
-				// by keyboardHandler.js of citationDialog.js
-				if (nextBubble) {
-					nextBubble.focus();
-					event.preventDefault();
-					event.stopPropagation();
-				}
 			}
 		}
 		

--- a/chrome/content/zotero/integration/citationDialog/keyboardHandler.mjs
+++ b/chrome/content/zotero/integration/citationDialog/keyboardHandler.mjs
@@ -150,10 +150,8 @@ export class CitationDialogKeyboardHandler {
 			}
 			else if (current || event.key == "ArrowDown") {
 				// Arrow down from input will just change the selected item without moving focus
-				// Arrow down from a bubble in the lowest row will move focus
-				let shouldFocus = event.target.classList.contains("bubble");
 				let multiSelect = event.shiftKey;
-				this._navigateGroup({ group, current, forward: event.key == "ArrowDown", shouldSelect: true, shouldFocus, multiSelect });
+				this._navigateGroup({ group, current, forward: event.key == "ArrowDown", shouldSelect: true, shouldFocus: false, multiSelect });
 			}
 			handled = true;
 		}

--- a/chrome/content/zotero/integration/citationDialog/popupHandler.mjs
+++ b/chrome/content/zotero/integration/citationDialog/popupHandler.mjs
@@ -188,6 +188,12 @@ export class CitationDialogPopupsHandler {
 			this._getNode("#itemDetails").setAttribute("refocus-input", true);
 			this._getNode("#itemDetails").hidePopup();
 		}
+		// Arrow up on anything except for the locator dropdown will close the popup
+		if (event.key == "ArrowUp" && event.target.tagName !== "select") {
+			this._getNode("#itemDetails").hidePopup();
+			event.stopPropagation();
+			event.preventDefault();
+		}
 	}
 
 	// Update item details and notify citation dialog about changes

--- a/chrome/content/zotero/integration/citationDialog/popupHandler.mjs
+++ b/chrome/content/zotero/integration/citationDialog/popupHandler.mjs
@@ -188,12 +188,6 @@ export class CitationDialogPopupsHandler {
 			this._getNode("#itemDetails").setAttribute("refocus-input", true);
 			this._getNode("#itemDetails").hidePopup();
 		}
-		// Arrow up on anything except for the locator dropdown will close the popup
-		if (event.key == "ArrowUp" && event.target.tagName !== "select") {
-			this._getNode("#itemDetails").hidePopup();
-			event.stopPropagation();
-			event.preventDefault();
-		}
 	}
 
 	// Update item details and notify citation dialog about changes


### PR DESCRIPTION
- restore earlier behavior of arrowDown on a bubble opening itemDetails popup
- arrowUp from inside itemDetails closes the popup (except when locator dropdown is focused)
- remove arrow navigation between rows of bubbles on arrowUp/down
- remove no longer needed edge case of arrowDown handling on the last row of bubbles

Fixes: #5118