### PR TITLE
Fix sometimes unable to select a custom theme

### DIFF
--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -550,6 +550,19 @@ class ReaderInstance {
 				}
 			},
 			onSaveCustomThemes: async (customThemes) => {
+				// If a custom theme is deleted, clear the theme preference.
+				// This ensures that the correct light/dark theme is auto-picked and also fixes #5070.
+				const lightTheme = Zotero.Prefs.get('reader.lightTheme');
+				const darkTheme = Zotero.Prefs.get('reader.darkTheme');
+
+				if (lightTheme.startsWith('custom') && !customThemes?.some(theme => theme.id === lightTheme)) {
+					Zotero.Prefs.clear('reader.lightTheme');
+				}
+
+				if (darkTheme.startsWith('custom') && !customThemes?.some(theme => theme.id === darkTheme)) {
+					Zotero.Prefs.clear('reader.darkTheme');
+				}
+				
 				if (customThemes?.length) {
 					await Zotero.SyncedSettings.set(Zotero.Libraries.userLibraryID, 'readerCustomThemes', customThemes);
 				}


### PR DESCRIPTION
This resolves an issue where, after the selected theme was deleted, it was impossible to select a newly added custom theme. This happened because the preference key for the selected theme uses consecutive IDs and wasn't cleared when the theme was deleted. As a result, the newly created theme would receive exactly the same ID. When that theme was selected, the preference observer did not trigger (because the ID did not change), leading to this bug.

The fix here is to clear the theme preference when it is deleted. The added benefit is that when this happens in dark mode, the dark theme is auto-picked instead of falling back to "Original".

Close #5070