### PR TITLE
Citation dialog: interactability before cited items are loaded

### DIFF
--- a/chrome/content/zotero/integration/citationDialog.js
+++ b/chrome/content/zotero/integration/citationDialog.js
@@ -207,6 +207,14 @@ class Layout {
 				items.push(itemNode);
 				index++;
 			}
+			// if cited group is present but has no items, cited items must be
+			// still loading, so show a placeholder item card
+			if (group.length === 0 && key == "cited") {
+				let placeholder = Helpers.createCitedItemPlaceholder();
+				items = [placeholder];
+				let spinner = Helpers.createNode("image", { id: "cited-items-spinner", status: "animate" }, "zotero-spinner-16");
+				section.querySelector(".header .header-btn-group").prepend(spinner);
+			}
 			itemContainer.replaceChildren(...items);
 			sections.push(section);
 			if (isGroupCollapsible) {
@@ -331,7 +339,7 @@ class Layout {
 			itemNode.classList.remove("selected");
 			itemNode.classList.remove("current");
 		}
-		let firstItemNode = _id(`${currentLayout.type}-layout`).querySelector(`.item`);
+		let firstItemNode = _id(`${currentLayout.type}-layout`).querySelector(`.item:not([disabled])`);
 		if (!firstItemNode) return;
 		let activeSearch = SearchHandler.searchValue.length > 0;
 		let noBubbles = !CitationDataManager.items.length;
@@ -738,7 +746,7 @@ class ListLayout extends Layout {
 			"data-tabindex": 30,
 			"data-arrow-nav-enabled": true,
 			draggable: true
-		}, "item vbox keyboard-clickable");
+		}, "item keyboard-clickable");
 		let id = item.cslItemID || item.id;
 		itemNode.setAttribute("itemID", id);
 		itemNode.setAttribute("role", "option");

--- a/chrome/content/zotero/integration/citationDialog/helpers.mjs
+++ b/chrome/content/zotero/integration/citationDialog/helpers.mjs
@@ -140,12 +140,13 @@ export class CitationDialogHelpers {
 		let itemContainer = this.createNode("div", { id: `${id}_container`, role: "group", "aria-label": headerText }, "itemsContainer");
 		section.append(header, itemContainer, divider);
 
+		let buttonGroup = this.createNode("div", {}, "header-btn-group");
+		header.append(buttonGroup);
+
 		if (isCollapsible) {
 			headerSpan.id = `header_${id}`;
 			section.classList.add("expandable");
 			section.style.setProperty('--deck-length', deckLength);
-			let buttonGroup = this.createNode("div", { }, "header-btn-group");
-			header.append(buttonGroup);
 
 			let addAllBtn = this.createNode("span", { tabindex: -1, 'data-tabindex': 22, role: "button", "aria-describedby": headerSpan.id }, "add-all keyboard-clickable");
 			buttonGroup.append(addAllBtn);
@@ -166,6 +167,20 @@ export class CitationDialogHelpers {
 			}
 		}
 		return section;
+	}
+
+	// Create mock item node to use as a the placeholder for cited items that are loading
+	createCitedItemPlaceholder() {
+		let itemNode = this.createNode("div", {
+			role: "option",
+			disabled: true
+		}, "item cited-placeholder");
+		let title = this.createNode("div", {}, "title");
+		let description = this.createNode("div", {}, "description");
+		title.textContent = Zotero.getString("general.loading");
+		description.textContent = " ";
+		itemNode.append(title, description);
+		return itemNode;
 	}
 
 	// Extract locator from a string and return an object: { label: string, page: string, onlyLocator: bool}

--- a/chrome/content/zotero/integration/citationDialog/helpers.mjs
+++ b/chrome/content/zotero/integration/citationDialog/helpers.mjs
@@ -137,7 +137,7 @@ export class CitationDialogHelpers {
 		let divider = this.createNode("div", {}, "divider");
 		headerSpan.innerText = headerText;
 		header.append(headerSpan);
-		let itemContainer = this.createNode("div", { role: "group", "aria-label": headerText }, "itemsContainer");
+		let itemContainer = this.createNode("div", { id: `${id}_container`, role: "group", "aria-label": headerText }, "itemsContainer");
 		section.append(header, itemContainer, divider);
 
 		if (isCollapsible) {

--- a/chrome/content/zotero/integration/citationDialog/keyboardHandler.mjs
+++ b/chrome/content/zotero/integration/citationDialog/keyboardHandler.mjs
@@ -65,7 +65,7 @@ export class CitationDialogKeyboardHandler {
 			let rowIndex = focusedRow.id.split("-")[4];
 			if (rowIndex !== "0") return;
 			// if there are suggested items, focus them
-			if (this._id("library-other-items").querySelector(".item")) {
+			if (this._id("library-other-items").querySelector(".item:not([disabled])")) {
 				let current = this.doc.querySelector(".selected.current");
 				if (current) {
 					current.focus();
@@ -124,7 +124,7 @@ export class CitationDialogKeyboardHandler {
 			if (current) {
 				current.focus();
 			}
-			else if (group.querySelector(".item")) {
+			else if (group.querySelector(".item:not([disabled])")) {
 				this._navigateGroup({ group, current: null, forward: true, shouldSelect: true, shouldFocus: true, multiSelect: false });
 			}
 			else if (this._id("zotero-items-tree").querySelector(".row")) {
@@ -144,7 +144,7 @@ export class CitationDialogKeyboardHandler {
 			// on arrowUp from the first row, clear selection
 			if (current === firstRow && event.key == "ArrowUp" && !event.shiftKey) {
 				this._selectItems(null);
-				firstRow.classList.remove("current");
+				firstRow?.classList.remove("current");
 				group.scrollTo(0, 0);
 				this._multiselectStart = null;
 			}

--- a/chrome/content/zotero/integration/citationDialog/searchHandler.mjs
+++ b/chrome/content/zotero/integration/citationDialog/searchHandler.mjs
@@ -45,7 +45,15 @@ export class CitationDialogSearchHandler {
 		this.minQueryLengthEnforced = false;
 		this.searching = false;
 		this.searchResultIDs = [];
-		this._nonLibraryItems = {};
+
+		// cache selected/open/cited items
+		this.selectedItems = null;
+		this.openItems = null;
+		this.citedItems = null;
+
+		this.loadCitedItemsPromise = this._getCitedItems().then((citedItems) => {
+			this.citedItems = citedItems;
+		});
 	}
 
 	setSearchValue(str, enforceMinQueryLength) {
@@ -69,10 +77,10 @@ export class CitationDialogSearchHandler {
 
 	// how many selected items there are without applying the filter
 	allSelectedItemsCount() {
-		if (this._nonLibraryItems.selected !== undefined) {
-			return this._nonLibraryItems.selected.length;
+		if (this.selectedItems === null) {
+			this.selectedItems = this._getSelectedLibraryItems();
 		}
-		return this._getSelectedLibraryItems().length;
+		return this.selectedItems.length;
 	}
 
 	// Return results in a more helpful formatfor rendering.
@@ -122,34 +130,23 @@ export class CitationDialogSearchHandler {
 		return result;
 	}
 
-	// Refresh selected/opened/cited items.
+	// Refresh selected/opened items.
 	// These items are searched for separately from actual library matches
 	// because it is much faster for large libraries, so we don't have to wait
 	// for the library search to complete to show these results.
-	async refreshNonLibraryItems() {
-		// Use cached selected/cited/open items if available to not
-		// re-fetch them every time
-		if (!Object.keys(this._nonLibraryItems).length) {
-			this._nonLibraryItems = {
-				open: this._getReaderOpenItems(),
-				cited: await this._getCitedItems(),
-				selected: this._getSelectedLibraryItems(),
-			};
+	refreshSelectedAndOpenItems() {
+		if (this.openItems === null) {
+			this.openItems = this._getReaderOpenItems();
 		}
-		let { open, cited, selected } = this._nonLibraryItems;
+		if (this.selectedItems === null) {
+			this.selectedItems = this._getSelectedLibraryItems();
+		}
 		
 		// apply filtering to item groups
-		this.results.open = this.searchValue ? this._filterNonMatchingItems(open) : open;
-		this.results.selected = this.searchValue ? this._filterNonMatchingItems(selected) : selected;
+		this.results.open = this.searchValue ? this._filterNonMatchingItems(this.openItems) : this.openItems;
+		this.results.selected = this.searchValue ? this._filterNonMatchingItems(this.selectedItems) : this.selectedItems;
 		// clear matching library items to make sure items stale results are not showing
 		this.results.found = [];
-		// if "ibid" is typed, return all cited items
-		if (this.searchValue.toLowerCase() === Zotero.getString("integration.ibid").toLowerCase()) {
-			this.results.cited = cited;
-		}
-		else {
-			this.results.cited = this.searchValue ? this._filterNonMatchingItems(cited) : [];
-		}
 		// Ensure duplicates across groups before library items are found
 		this._deduplicate();
 	}
@@ -165,10 +162,24 @@ export class CitationDialogSearchHandler {
 		this._deduplicate();
 	}
 
-	// clear selected/open/cited items cache to re-fetch those items
+	async refreshCitedItems() {
+		if (this.citedItems === null) {
+			return;
+		}
+		// if "ibid" is typed, return all cited items
+		if (this.searchValue.toLowerCase() === Zotero.getString("integration.ibid").toLowerCase()) {
+			this.results.cited = this.citedItems;
+		}
+		else {
+			this.results.cited = this.searchValue ? this._filterNonMatchingItems(this.citedItems) : [];
+		}
+	}
+
+	// clear selected/open items cache to re-fetch those items
 	// after they may have changed
 	clearNonLibraryItemsCache() {
-		this._nonLibraryItems = {};
+		this.selectedItems = null;
+		this.openItems = null;
 	}
 
 	cleanSearchQuery(str) {
@@ -183,17 +194,14 @@ export class CitationDialogSearchHandler {
 	}
 
 	// make sure that each item appears only in one group.
-	// Items that are selected are removed from opened and cited.
-	// Items that are opened are removed from cited.
-	// Items that are selected or opened or cited are removed from library results.
+	// Items that are selected are removed from opened.
+	// Items that are selected or opened are removed from library results.
 	_deduplicate() {
 		let selectedIDs = new Set(this.results.selected.map(item => item.id));
 		let openIDs = new Set(this.results.open.map(item => item.id));
-		let citedIDs = new Set(this.results.cited.filter(item => item.id).map(item => item.id));
 
 		this.results.open = this.results.open.filter(item => !selectedIDs.has(item.id));
-		this.results.cited = this.results.cited.filter(item => !selectedIDs.has(item.id) && !openIDs.has(item.id));
-		this.results.found = this.results.found.filter(item => !selectedIDs.has(item.id) && !openIDs.has(item.id) && !citedIDs.has(item.id));
+		this.results.found = this.results.found.filter(item => !selectedIDs.has(item.id) && !openIDs.has(item.id));
 	}
 		
 	// Run the actual search query and find all items matching query across all libraries

--- a/chrome/content/zotero/integration/citationDialog/searchHandler.mjs
+++ b/chrome/content/zotero/integration/citationDialog/searchHandler.mjs
@@ -107,6 +107,12 @@ export class CitationDialogSearchHandler {
 			if (groupItems.length) {
 				result.push({ key: groupKey, group: groupItems });
 			}
+			// if cited items are being loaded, add their group with no items to indicate
+			// that a placeholder should be displayed
+			let loadingCitedItemsGroup = this.citedItems === null && groupKey === "cited";
+			if (loadingCitedItemsGroup && this.searchValue) {
+				result.push({ key: "cited", group: [] });
+			}
 		}
 		// library items go after
 		let libraryItems = Object.values(this.results.found.reduce((acc, item) => {

--- a/chrome/locale/en-US/zotero/integration.ftl
+++ b/chrome/locale/en-US/zotero/integration.ftl
@@ -23,7 +23,10 @@ integration-quickFormatDialog-window =
 integration-citationDialog = Citation Dialog
 integration-citationDialog-section-open = Open Documents ({ $count })
 integration-citationDialog-section-selected = Selected Items ({ $count }/{ $total })
-integration-citationDialog-section-cited = Cited Items ({ $count })
+integration-citationDialog-section-cited = { $count ->
+    [0] Cited Items
+    *[other] Cited Items ({ $count })
+}
 integration-citationDialog-details-suffix = Suffix
 integration-citationDialog-details-prefix = Prefix
 integration-citationDialog-details-suppressAuthor = Omit Author

--- a/scss/components/_citationDialog.scss
+++ b/scss/components/_citationDialog.scss
@@ -81,12 +81,6 @@
 			#loading-spinner {
 				width: 28px;
 				height: 28px;
-				background-size: 60%;
-				background-repeat: no-repeat;
-				display: none;
-				&[status="animate"] {
-					display: inline-block;
-				}
 			}
 			.vertical-separator {
 				border-inline-end: 1px solid var(--fill-quarternary);
@@ -110,6 +104,20 @@
 		&:hover {
 			cursor: pointer;
 		}
+	}
+
+	.zotero-spinner-16 {
+		background-size: 60%;
+		background-repeat: no-repeat;
+		display: none;
+		&[status="animate"] {
+			display: inline-block;
+		}
+	}
+
+	#cited-items-spinner {
+		width: 20px;
+		height: 20px;
 	}
 
 	// alternative to var(--accent-blue10) without opacity
@@ -168,7 +176,11 @@
 						text-wrap: nowrap;
 						text-overflow: ellipsis;
 						overflow: hidden;
-						display: block;
+						display: flex;
+						.header-btn-group {
+							display: flex;
+							align-items: center;
+						}
 					}
 			
 					.itemsContainer {
@@ -230,8 +242,6 @@
 						width: calc((var(--item-horizontal-size) * var(--deck-length)) + (var(--item-margin) * (var(--deck-length) - 1)));
 	
 						.header {
-							display: flex;
-							justify-content: space-between;
 							.header-label {
 								// make sure header text does not overlap with buttons
 								max-width: 160px;
@@ -240,9 +250,6 @@
 							}
 
 							.header-btn-group {
-								display: flex;
-								flex-direction: row;
-								align-items: center;
 								gap: 4px;
 								flex: 1;
 								margin-inline-start: 2px;
@@ -294,7 +301,7 @@
 					// separate items get a hover effect, unless they are in
 					// a collapsed expandable group, in which case the whole group is hovered
 					&:not(.expandable), &.expandable.expanded {
-						.item:hover {
+						.item:not([disabled]):hover {
 							background-color: var(--color-quinary-on-background);
 						}
 					}
@@ -420,6 +427,12 @@
 					font-size: 13px;
 					color: var(--fill-secondary);
 					padding: 4px 8px 4px 16px;
+					display: flex;
+					.header-btn-group {
+						display: flex;
+						align-items: center;
+						height: 17px;
+					}
 				}
 				.item {
 					@include focus-ring(true);
@@ -429,7 +442,7 @@
 					color: var(--fill-primary);
 					cursor: default;
 					-moz-window-dragging: no-drag;
-					&:hover {
+					&:not([disabled]):hover {
 						background-color: var(--fill-quinary);
 					}
 					&.selected {
@@ -479,6 +492,7 @@
 						.header-label {
 							@include focus-ring;
 							border-radius: 5px;
+							-moz-window-dragging: no-drag;
 							&:hover {
 								cursor: pointer;
 								text-decoration: underline;


### PR DESCRIPTION
- Initialize asynchronous loading of cited items via `io.getItems` when the dialog appears. The dialog is usable when the cited items are not yet loaded, they just don't appear in search results.
- Once cited items are loaded, the list of items is refreshed to include matching items and all subsequent searches will include them too.
- During the refresh immediately after cited items load, try to preserve focused/selected state of items.
- Minor refactoring of `SearchHandler` to handle refreshing of cited items separately from selected and open items. Some cleanup.

I added a `Zotero.Promise.delay(4000)` to `SearchHandler._getCitedItems()` to test out the behavior. Note the cited items appearing after a delay:

https://github.com/user-attachments/assets/664edf11-2158-4366-ad3a-a152df249e34




As a separate but related tweak, move initialization of accept/cancel functionality of the dialog into a separate function and call it in the very beginning of `onLoad`. `IOManager.init()` relies on layouts being loaded, which is why it is ran in the very end. But one should be able to close the dialog immediately, even if `IOManager.init()` doesn't run for a while or doesn't run at all (due to some unexpected error).

Fixes: #5121 