### PR TITLE
Fix plugin scope not loaded if plugin is disabled when starting Zotero

### DIFF
--- a/chrome/content/zotero/xpcom/plugins.js
+++ b/chrome/content/zotero/xpcom/plugins.js
@@ -122,6 +122,9 @@ Zotero.Plugins = new function () {
 	 * https://searchfox.org/mozilla-esr60/source/toolkit/mozapps/extensions/internal/XPIProvider.jsm#4233
 	 */
 	function _loadScope(addon) {
+		if (scopes.has(addon.id)) {
+			return;
+		}
 		var scope = new Cu.Sandbox(
 			Services.scriptSecurityManager.getSystemPrincipal(),
 			{
@@ -662,6 +665,7 @@ Zotero.Plugins = new function () {
 				return;
 			}
 			Zotero.debug("Enabling plugin " + addon.id);
+			_loadScope(addon);
 			setDefaultPrefs(addon);
 			await registerLocales(addon);
 			await _callMethod(addon, 'startup', REASONS.ADDON_ENABLE);


### PR DESCRIPTION
Since the bootstrap plugin framework, from time to time I ran into cases where some plugins don't start.

It turned out that the sandbox scope is not loaded at all if the plugin is

1. installed before Zotero starts
2. disabled before Zotero starts

It is amazing that no one ever reported/found this bug, which is a quite serious bug... Maybe everyone would blame the plugin developers for not having the plugin well-written.