### PR TITLE
Fix HiddenBrowser test failures

### DIFF
--- a/chrome/content/zotero/HiddenBrowser.jsm
+++ b/chrome/content/zotero/HiddenBrowser.jsm
@@ -244,6 +244,16 @@ class HiddenBrowser {
 			}
 		}
 	}
+
+	/**
+	 * @param {number | false} [allowInteractiveAfter = false] Delay (in milliseconds) before resolving on 'interactive'.
+	 * 		If false, documentIsReady() won't resolve until 'complete'.
+	 * @returns {Promise<void>}
+	 */
+	waitForDocument({ allowInteractiveAfter = false } = {}) {
+		return this.browsingContext.currentWindowGlobal.getActor('DocumentIsReady')
+			.sendQuery('waitForDocument', { allowInteractiveAfter });
+	}
 	
 	/**
 	 * @param {String[]} props - 'characterSet', 'title', 'bodyText', 'documentHTML', 'cookie', 'channelInfo'

--- a/chrome/content/zotero/actors/ActorManager.jsm
+++ b/chrome/content/zotero/actors/ActorManager.jsm
@@ -86,3 +86,9 @@ ChromeUtils.registerWindowActor("MendeleyAuth", {
 		moduleURI: "chrome://zotero/content/actors/MendeleyAuthChild.jsm"
 	}
 });
+
+ChromeUtils.registerWindowActor("DocumentIsReady", {
+	child: {
+		moduleURI: "chrome://zotero/content/actors/DocumentIsReadyChild.jsm"
+	}
+});

--- a/chrome/content/zotero/actors/DocumentIsReadyChild.jsm
+++ b/chrome/content/zotero/actors/DocumentIsReadyChild.jsm
@@ -1,0 +1,14 @@
+var EXPORTED_SYMBOLS = ["DocumentIsReadyChild"];
+
+let { documentIsReady } = ChromeUtils.importESModule("chrome://zotero/content/actors/actorUtils.mjs");
+
+class DocumentIsReadyChild extends JSWindowActorChild {
+	async receiveMessage({ name, data }) {
+		if (name !== "waitForDocument") {
+			return null;
+		}
+
+		let { allowInteractiveAfter } = data;
+		await documentIsReady(this.document, { allowInteractiveAfter });
+	}
+}

--- a/chrome/content/zotero/actors/MendeleyAuthChild.jsm
+++ b/chrome/content/zotero/actors/MendeleyAuthChild.jsm
@@ -2,12 +2,14 @@
 
 var EXPORTED_SYMBOLS = ["MendeleyAuthChild"]; // eslint-disable-line no-unused-vars
 
+let { documentIsReady } = ChromeUtils.importESModule("chrome://zotero/content/actors/actorUtils.mjs");
+
 class MendeleyAuthChild extends JSWindowActorChild { // eslint-disable-line no-unused-vars
 	async receiveMessage(message) {
-		let window = this.contentWindow;
-		let document = window.document;
+		let document = this.document;
 
-		await this.documentIsReady();
+		// Wait for 'complete'
+		await documentIsReady(document);
 
 		switch (message.name) {
 			case "login":
@@ -35,35 +37,5 @@ class MendeleyAuthChild extends JSWindowActorChild { // eslint-disable-line no-u
 		}
 
 		return false;
-	}
-	
-	// From Mozilla's ScreenshotsComponentChild.jsm
-	documentIsReady() {
-		const contentWindow = this.contentWindow;
-		const document = this.document;
-		
-		function readyEnough() {
-			return document.readyState === "complete";
-		}
-		
-		if (readyEnough()) {
-			return Promise.resolve();
-		}
-		return new Promise((resolve, reject) => {
-			function onChange(event) {
-				if (event.type === "pagehide") {
-					document.removeEventListener("readystatechange", onChange);
-					contentWindow.removeEventListener("pagehide", onChange);
-					reject(new Error("document unloaded before it was ready"));
-				}
-				else if (readyEnough()) {
-					document.removeEventListener("readystatechange", onChange);
-					contentWindow.removeEventListener("pagehide", onChange);
-					resolve();
-				}
-			}
-			document.addEventListener("readystatechange", onChange);
-			contentWindow.addEventListener("pagehide", onChange, { once: true });
-		});
 	}
 }

--- a/chrome/content/zotero/actors/actorUtils.mjs
+++ b/chrome/content/zotero/actors/actorUtils.mjs
@@ -1,0 +1,42 @@
+import { setTimeout } from "resource://gre/modules/Timer.sys.mjs";
+
+/**
+ * @param {Document} document
+ * @param {number | false} [allowInteractiveAfter] Delay (in milliseconds) before resolving on 'interactive'.
+ * 		If false, documentIsReady() won't resolve until 'complete'.
+ * @returns {Promise<void>}
+ */
+export async function documentIsReady(document, { allowInteractiveAfter = false } = {}) {
+	// Adapted from Mozilla's ScreenshotsComponentChild.jsm
+	
+	function readyEnough(readyState) {
+		if (readyState === "interactive" && allowInteractiveAfter !== false) {
+			return allowInteractiveAfter > 0
+				? new Promise(resolve => setTimeout(() => resolve(true), allowInteractiveAfter))
+				: true;
+		}
+		return readyState === "complete";
+	}
+
+	let contentWindow = document.defaultView;
+
+	if (await readyEnough(document.readyState)) {
+		return Promise.resolve();
+	}
+	return new Promise((resolve, reject) => {
+		async function onChange(event) {
+			if (event.type === "pagehide") {
+				document.removeEventListener("readystatechange", onChange);
+				contentWindow.removeEventListener("pagehide", onChange);
+				reject(new Error("document unloaded before it was ready"));
+			}
+			else if (await readyEnough(document.readyState)) {
+				document.removeEventListener("readystatechange", onChange);
+				contentWindow.removeEventListener("pagehide", onChange);
+				resolve();
+			}
+		}
+		document.addEventListener("readystatechange", onChange);
+		contentWindow.addEventListener("pagehide", onChange, { once: true });
+	});
+}

--- a/test/tests/HiddenBrowserTest.js
+++ b/test/tests/HiddenBrowserTest.js
@@ -22,7 +22,6 @@ describe("HiddenBrowser", function() {
 				'/remote.png',
 				{
 					handle: function (request, response) {
-						Zotero.debug('Something loaded the image')
 						response.setHeader('Content-Type', 'image/png', false);
 						response.setStatusLine(null, 200, 'OK');
 						response.write('');
@@ -46,7 +45,7 @@ describe("HiddenBrowser", function() {
 			let path = OS.Path.join(getTestDataDirectory().path, 'test-hidden.html');
 			let browser = new HiddenBrowser({ blockRemoteResources: true });
 			await browser.load(path);
-			await browser.getPageData(['characterSet', 'bodyText']);
+			await browser.waitForDocument();
 			browser.destroy();
 			assert.isFalse(pngRequested);
 		});
@@ -55,7 +54,7 @@ describe("HiddenBrowser", function() {
 			let path = OS.Path.join(getTestDataDirectory().path, 'test-hidden.html');
 			let browser = new HiddenBrowser({ blockRemoteResources: false });
 			await browser.load(path);
-			await browser.getPageData(['characterSet', 'bodyText']);
+			await browser.waitForDocument();
 			browser.destroy();
 			assert.isTrue(pngRequested);
 		});


### PR DESCRIPTION
Wait for `'complete'` so we know the image has been loaded, not just `'interactive'` (which is what `getPageData()` was implicitly doing).

And use single `documentIsReady()` implementation instead of copy-pasting.