### PR TITLE
itemBox: fix creator row removed on label click

### DIFF
--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -774,13 +774,6 @@
 					menuitem.setAttribute("typeid", Zotero.CreatorTypes.getID(i));
 					this._creatorTypeMenu.appendChild(menuitem);
 				}
-				this._creatorTypeMenu.addEventListener('popuphidden', () => {
-					// If the popup was opened with a mouse click, blur the field to hide icons
-					if (this._creatorTypeMenu.getAttribute("blur-on-hidden")) {
-						document.activeElement.blur();
-						this._creatorTypeMenu.removeAttribute("blur-on-hidden");
-					}
-				});
 			}
 			
 			// Creator rows
@@ -1192,14 +1185,14 @@
 				let span = document.createElement('span');
 				span.className = 'creator-type-dropmarker';
 				labelWrapper.appendChild(span);
-				labelWrapper.addEventListener('click', (e) => {
+				// Prevent focus from landing on the dropdown.
+				// Otherwise, when the popup is closed, the row's icons would remain visible.
+				labelWrapper.addEventListener('mousedown', (e) => {
+					e.preventDefault();
+				});
+				labelWrapper.addEventListener('click', (_) => {
 					this._popupNode = rowLabel;
 					this._creatorTypeMenu.openPopup(rowLabel);
-					// If the creator menu is opened via mouse-click, add a special attribute to
-					// blur the focused field so that icons do not show up after the menu is closed.
-					if (e.x !== 0 && e.y !== 0) {
-						this._creatorTypeMenu.setAttribute("blur-on-hidden", "true");
-					}
 				});
 			}
 
@@ -1670,7 +1663,8 @@
 				}
 			}
 			// On click of the label, toggle the focus of the value field
-			if (this.editable) {
+			// Creator rows have their own handling, so it does not apply to them
+			if (this.editable && !id.includes("creator")) {
 				label.addEventListener('mousedown', (event) => {
 					// Prevent default focus/blur behavior - we implement our own below
 					event.preventDefault();


### PR DESCRIPTION
- do not add regular label click handling that refocuses itemTree/reader (d3cee95fb73af714e01bcd17ac129cacb1cfc1ba) to creator rows, since their labels should just open the creator type dropdown on click. Having focus moved from itemBox to itemTree/reader when an empty creator is present would remove it. With this, an empty creator row will remain.

- do not blur currently focused field when the creator type dropdown closes via "blur-on-hidden" class. That logic was
added to make sure that focus does not land on the dropdown (which keeps all row's icons visible after popup goes away). Instead, prevent focus via `event.preventDefault()` on `mousedown` event. Now, when the popup appears, the currently focused field just remains focused.

Fixes: #5117

https://github.com/user-attachments/assets/afdd7f44-86b5-4d5d-9199-bfbe46d6ee9e

