### PR TITLE
Improve layout of the buttons in the locate manager

### DIFF
--- a/chrome/content/zotero/locateManager.xhtml
+++ b/chrome/content/zotero/locateManager.xhtml
@@ -59,13 +59,13 @@
 			
 			<separator class="thin"/>
 			
-			<hbox id="button-bar" align="center">
-				<hbox pack="start" flex="1">
-					<button label="Toggle" onclick="toggleLocateEngines()" flex="1"/>
-					<button id="locateManager-restoreDefaults" label="&zotero.preferences.locate.restoreDefaults;" oncommand="restoreDefaultLocateEngines()" flex="1"/>
+			<hbox id="button-bar">
+				<hbox pack="start">
+					<button label="Toggle" onclick="toggleLocateEngines()" />
+					<button id="locateManager-restoreDefaults" label="&zotero.preferences.locate.restoreDefaults;" oncommand="restoreDefaultLocateEngines()" />
 				</hbox>
-				<hbox pack="end" flex="2">
-					<button disabled="true" id="locateManager-delete" label="-" oncommand="deleteLocateEngine()" flex="0.5"/>
+				<hbox pack="end">
+					<button disabled="true" id="locateManager-delete" label="-" oncommand="deleteLocateEngine()" />
 				</hbox>
 			</hbox>
 

--- a/scss/components/_locateManager.scss
+++ b/scss/components/_locateManager.scss
@@ -3,6 +3,7 @@
 	@include contain-richlistbox;
 	
 	#button-bar, #button-bar > hbox {
+		justify-content: flex-end;
 		display: flex;
 		gap: 6px;
 	}


### PR DESCRIPTION
Simple tweak removes button justification:

![Screenshot 2025-03-20 at 09 33 42](https://github.com/user-attachments/assets/27c8fe62-be12-4aa7-b4d0-78b8a07eda03)

With extra-long content in German:
![Screenshot 2025-03-20 at 09 34 03](https://github.com/user-attachments/assets/3b5c3e28-6939-4da5-8198-4073a5622679)

RTL:
![Screenshot 2025-03-20 at 09 34 22](https://github.com/user-attachments/assets/8b20dcc5-9709-4fbe-942b-9d4d8199e18f)

Closes #4825
