### PR TITLE
Let autocomplete popup get wider

### DIFF
--- a/app/scripts/fetch_xulrunner
+++ b/app/scripts/fetch_xulrunner
@@ -404,6 +404,12 @@ function modify_omni {
 		overflow: var(--moz-text-control-overflow);
 	}' >> chrome/toolkit/res/forms.css
 	
+	# By default, an autocomplete popup's width is calculated based on the input that opened it.
+	# Allow an ancestor to designate itself as the width container instead. (For creator inputs.)
+	replace_line 'aElement.getBoundingClientRect\(\).width' \
+		'(aElement.closest(".autocomplete-popup-width-container") || aElement).getBoundingClientRect().width' \
+		chrome/toolkit/content/global/elements/autocomplete-popup.js
+	
 	zip -qr9XD omni.ja *
 	mv omni.ja ..
 	cd ..

--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -1221,7 +1221,7 @@
 			labelWrapper.appendChild(label);
 			
 			var rowData = document.createElement("div");
-			rowData.className = 'creator-type-value';
+			rowData.classList.add('creator-type-value', 'autocomplete-popup-width-container');
 			
 			// Name
 			var firstlast = document.createElement("span");


### PR DESCRIPTION
The popup tries to size itself based on the width of the input that opened it (input's width or 100px, whatever is greater). This removes that constraint so it uses the standard popup layout algorithm. It still doesn't grow past the edge of the `info-box` for some reason (which is good).

This is the simple approach. I also have alternative code to patch `autocomplete-popup.js` so it still explicitly calculates its width, but allows a parent (e.g. the info-box row) to set itself as the anchor in place of the input. Can go with either approach.

Fixes #5140