### PR TITLE
Citation dialog: fixed errors thrown if you type in itemTree

### DIFF
--- a/chrome/content/zotero/integration/citationDialog.js
+++ b/chrome/content/zotero/integration/citationDialog.js
@@ -517,11 +517,14 @@ class LibraryLayout extends Layout {
 			// getExtraField helps itemTree fetch the data for a column that's
 			// not a part of actual item properties
 			getExtraField: (item, key) => {
-				if (key == "removeFromCitation" || key == "addToCitation") {
+				if (key == "addToCitation") {
 					if (!(item instanceof Zotero.Item)) return null;
 					if (isCitingNotes && !item.isNote()) return null;
 					if (!isCitingNotes && !item.isRegularItem()) return null;
-					return CitationDataManager.itemAddedCache.has(item.id);
+					// The returned value needs to be a string due to a call to .toLowerCase()
+					// in _handleTyping of virtualized-table. Otherwise, errors are thrown if you type
+					// when the addToCitation column is used for sorting.
+					return CitationDataManager.itemAddedCache.has(item.id) ? " " : "";
 				}
 				return undefined;
 			}
@@ -587,7 +590,8 @@ class LibraryLayout extends Layout {
 			},
 			isSearch: () => true,
 			isSearchMode: () => true,
-			setSearch: str => collectionTreeRow.setSearch(str)
+			setSearch: str => collectionTreeRow.setSearch(str),
+			ref: collectionTreeRow.ref
 		});
 		await this.itemsView.setFilter('search', SearchHandler.searchValue);
 		

--- a/chrome/content/zotero/integration/citationDialog.js
+++ b/chrome/content/zotero/integration/citationDialog.js
@@ -524,6 +524,10 @@ class LibraryLayout extends Layout {
 					// The returned value needs to be a string due to a call to .toLowerCase()
 					// in _handleTyping of virtualized-table. Otherwise, errors are thrown if you type
 					// when the addToCitation column is used for sorting.
+					// Strings have to be different to allow for sorting by the addToCitation column.
+					// "" indicates the item is not in the citation, " " indicates that it is.
+					// " " is picked over other strings to never be picked up by _handleTyping
+					//  of virtualized-table, which could change row selection in a way that's irrelevant here.
 					return CitationDataManager.itemAddedCache.has(item.id) ? " " : "";
 				}
 				return undefined;


### PR DESCRIPTION
- pass ref to `itemsView.changeCollectionTreeRow` to avoid errors thrown when typing numbers (related to [tags shortcuts](https://github.com/zotero/zotero/blob/9a58be243eb6f087a6ad0b2f1c1bfc58145e7943/chrome/content/zotero/itemTree.jsx#L995))
- return string equivalents of true/false in `getExtraField`. `virtualied-table` [expects a string](https://github.com/zotero/zotero/blob/9a58be243eb6f087a6ad0b2f1c1bfc58145e7943/chrome/content/zotero/components/virtualized-table.jsx#L675) in its typing handler. Previously returned boolean value was causing an error if you tried to type when the "add to citation" `+` column was used for sorting.