### PR TITLE
citation dialog: remove cited item placeholder in library mode

### DIFF
--- a/scss/components/_citationDialog.scss
+++ b/scss/components/_citationDialog.scss
@@ -233,6 +233,10 @@
 							&.selected {
 								background-color: var(--selected-item-background) !important;
 							}
+							// no visible border around the placeholder
+							&[disabled] {
+								border: 1px solid transparent;
+							}
 						}
 					}
 	


### PR DESCRIPTION
Keep the placeholder node to retain the positioning of the text consistent but remove the border so the item card is invisible.

Fixes: #5151

<img width="808" alt="Screenshot 2025-03-21 at 2 29 08 PM" src="https://github.com/user-attachments/assets/1dcac430-b941-41a3-9f2f-5d0cf72beb80" />
