### PR TITLE
citation dialog: fix menubar not appearing on first open

### DIFF
--- a/chrome/content/zotero/integration/citationDialog.js
+++ b/chrome/content/zotero/integration/citationDialog.js
@@ -564,6 +564,7 @@ class LibraryLayout extends Layout {
 				return undefined;
 			}
 		});
+		doc.querySelector("item-tree-menu-bar").init(this.itemsView);
 		// handle icon click to add/remove items
 		itemsTree.addEventListener("mousedown", event => this._handleItemsViewRowClick(event), true);
 		itemsTree.addEventListener("mouseup", event => this._handleItemsViewRowClick(event), true);

--- a/chrome/content/zotero/integration/citationDialog.xhtml
+++ b/chrome/content/zotero/integration/citationDialog.xhtml
@@ -45,6 +45,10 @@
 		<script src="citationDialog.js"/>
 		<script src="../titlebar.js" type="text/javascript"/>
 	</head>
+
+	<!-- do not wait for itemTree to add the menubar, otherwise it does not appear on the first dialog open -->
+	<xul:item-tree-menu-bar/>
+
 	<body class="vbox flex">
 		<div id="search-area" class="layout">
 			<div id="search-row" class="hbox">


### PR DESCRIPTION
Do not wait for the `itemTree` to add the menubar but create it immediately and just initialize it when `itemTree` is ready.

Fixes: #5153