### PR TITLE
Potential fix to sciencedirect infinite captcha

### DIFF
--- a/chrome/content/zotero/xpcom/browserDownload.js
+++ b/chrome/content/zotero/xpcom/browserDownload.js
@@ -212,24 +212,10 @@ Zotero.BrowserDownload = {
 		// make sure that you are using the browser you are claiming to be.
 		delete options.cookieSandbox?.userAgent;
 		
-		// Going to the URL of a sciencedirect PDF immediately opens a page with captcha stuck in
-		// an infinite loop. Opening a home page first and waiting a bit before redirecting to the PDF file
-		// seems to not trigger the captcha and should successfully download the PDF.
-		// When homepage opens, CF sets a number of cookies (like cf_clearance) which are
-		// indicators that this is a real user and are required for the PDF to be downloaded.
-		if (uri.host.includes("sciencedirect") && options.cookieSandbox) {
-			let homepage = new URL("https://sciencedirect.com");
-			win = Zotero.openInViewer(homepage, { cookieSandbox: options.cookieSandbox });
-			let loopCount = 0;
-			let receivedCookies;
-			// wait for cf_clearance cookie to be set but not more than 10 seconds
-			do {
-				receivedCookies = options.cookieSandbox.getCookiesForURI(Services.io.newURI(homepage)) || {};
-				await Zotero.Promise.delay(100);
-			} while (!receivedCookies.cf_clearance && loopCount++ < 100);
-			win.close();
-			// At this point, all the right cookies should be set but if not - just try to open the PDF anyway
+		if (uri.host.includes("sciencedirect")) {
+			await this._waitForSciencedirectCookies(uri, options.cookieSandbox);
 		}
+		
 		try {
 			wmListener = {
 				onOpenWindow(xulWindow) {
@@ -283,4 +269,24 @@ Zotero.BrowserDownload = {
 			}
 		}
 	},
+
+	// Going to the URL of a sciencedirect PDF immediately opens a page with captcha stuck in
+	// an infinite loop. Opening a home page first and waiting a bit before redirecting to the PDF file
+	// seems to not trigger the captcha and should successfully download the PDF.
+	// When homepage opens, CF sets a number of cookies (like cf_clearance) which are
+	// indicators that this is a real user and are required for the PDF to be downloaded.
+	async _waitForSciencedirectCookies(uri, cookieSandbox) {
+		if (!uri.host.includes("sciencedirect") || !cookieSandbox) return;
+		let homepage = "https://" + uri.host;
+		let win = Zotero.openInViewer(homepage, { cookieSandbox: cookieSandbox });
+		let loopCount = 0;
+		let receivedCookies = cookieSandbox.getCookiesForURI(Services.io.newURI(homepage)) || {};
+		let initialCfClearance = receivedCookies.cf_clearance;
+		// wait for cf_clearance cookie to be updated but not more than 10 seconds
+		do {
+			await Zotero.Promise.delay(100);
+			receivedCookies = cookieSandbox.getCookiesForURI(Services.io.newURI(homepage)) || {};
+		} while (initialCfClearance == receivedCookies.cf_clearance && loopCount++ < 100);
+		win.close();
+	}
 };


### PR DESCRIPTION
Before opening the PDF, open sciencedirect homepage where a number of cloudflare cookies (including cf_clearance indicating that this is a real user) are set. Wait for the cookies to be added to the sandbox, and then proceed to open the PDF. In that case, captcha should not appear at all.

This has been working consistently for me but I'm not sure if this is the best way to do it (e.g. is it worth to try to do it when we download via HiddenBrowser first?) and if this is something that should be more generalized, as opposed to being just a sciencedirect special case.
