### PR TITLE
Citation dialog: no input refocus on Enter from details popup

### DIFF
--- a/chrome/content/zotero/integration/citationDialog.js
+++ b/chrome/content/zotero/integration/citationDialog.js
@@ -1398,12 +1398,6 @@ const IOManager = {
 			let popup = event.target;
 			if (!["xul:panel"].includes(popup.tagName)) return;
 			IOManager._noRefocusing = false;
-			// after item details popup closes on Enter, refocus the last input
-			if (popup.id == "itemDetails" && popup.getAttribute("refocus-input")) {
-				_id("bubble-input").refocusInput();
-				popup.removeAttribute("refocus-input");
-				return;
-			}
 			if (IOManager._focusBeforePanelShow) {
 				IOManager._focusBeforePanelShow.focus();
 			}

--- a/chrome/content/zotero/integration/citationDialog/popupHandler.mjs
+++ b/chrome/content/zotero/integration/citationDialog/popupHandler.mjs
@@ -183,9 +183,8 @@ export class CitationDialogPopupsHandler {
 	}
 
 	handleItemDetailsKeypress(event) {
-		// Enter on a an input will save changes, hide the popup and refocus last input
+		// Enter on a an input will save changes and hide the popup
 		if (event.key == "Enter" && ["input"].includes(event.target.tagName) && !event.target.getAttribute("type")) {
-			this._getNode("#itemDetails").setAttribute("refocus-input", true);
 			this._getNode("#itemDetails").hidePopup();
 		}
 	}


### PR DESCRIPTION
Brought up in https://forums.zotero.org/discussion/122823/some-advice-for-citation-dialog-in-beta

Remove refocusing of the input on Enter from item details popup - just let focus go back to the bubble.
Input refocusing was initially added with the idea that once you make some edits and confirm them with Enter,
you are ready to go back to typing in the search input. But then, Enter on Done or Cancel buttons is treated as equivalent to click, so the focus goes back to where it was before (the bubble). When the dialog is cancelled via Escape, focus lands
on the bubble as well, in case you need to keep going to locate the another item to customize.

This different focus behavior on Enter is indeed a bit inconsistent and likely no longer needed, now that you can always refocus input with Cmd/Ctrl+F.