### PR TITLE
Tweak column behaviour on visibility and order changes

### DIFF
--- a/chrome/content/zotero/itemTreeColumns.jsx
+++ b/chrome/content/zotero/itemTreeColumns.jsx
@@ -78,7 +78,8 @@ const COLUMNS = [
 		dataKey: "itemType",
 		label: "zotero.items.itemType",
 		showInColumnPicker: true,
-		width: "40",
+		width: "56",
+		staticWidth: true,
 		zoteroPersist: ["width", "hidden", "sortDirection"]
 	},
 	{


### PR DESCRIPTION
When column visibility is changed, we now redistribute the available space between the columns. I believe this fixes #4993.