### PR TITLE
citation dialog: fix unloaded items errors

### DIFF
--- a/chrome/content/zotero/collectionTree.jsx
+++ b/chrome/content/zotero/collectionTree.jsx
@@ -118,7 +118,10 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 			var selected = await this.selectByID(lastViewedID);
 		}
 		if (!selected) {
-			await this.selectByID('L' + Zotero.Libraries.userLibraryID);
+			// If the last viewed folder was not selected, default to the first library from
+			// filterLibraryIDs (if any), or the user library
+			let libraryToSelect = ((this.props.filterLibraryIDs || [])[0] || Zotero.Libraries.userLibraryID);
+			await this.selectByID('L' + libraryToSelect);
 		}
 		if (this.selection.selectEventsSuppressed) {
 			let promise = this.waitForSelect();

--- a/chrome/content/zotero/integration/citationDialog.js
+++ b/chrome/content/zotero/integration/citationDialog.js
@@ -85,7 +85,7 @@ async function onLoad() {
 	await libraryLayout.init();
 	// fetch selected items so they are known
 	// before refreshing items list after dialog mode setting
-	SearchHandler.refreshSelectedAndOpenItems();
+	await SearchHandler.refreshSelectedAndOpenItems();
 	// some nodes (e.g. item-tree-menu-bar) are expected to be present to switch modes
 	// so this has to go after all layouts are loaded
 	IOManager.setInitialDialogMode();
@@ -276,7 +276,7 @@ class Layout {
 		// search for selected/opened items
 		// only enforce min query length in list mode
 		SearchHandler.setSearchValue(value, this.type == "list");
-		SearchHandler.refreshSelectedAndOpenItems();
+		await SearchHandler.refreshSelectedAndOpenItems();
 		// noop if cited items are not yet loaded
 		SearchHandler.refreshCitedItems();
 		
@@ -584,7 +584,8 @@ class LibraryLayout extends Layout {
 			onSelectionChange: this._onCollectionSelection.bind(this),
 			hideSources: ['duplicates', 'trash', 'feeds'],
 			initialFolder: Zotero.Prefs.get("integration.citationDialogCollectionLastSelected"),
-			onActivate: () => {}
+			onActivate: () => {},
+			filterLibraryIDs: io.filterLibraryIDs
 		});
 		// Add aria-description with instructions on what this collection tree is for
 		// Voiceover announces the description placed on the actual tree when focus enters it


### PR DESCRIPTION
- get opened items asynchronously and load their data in case if there are items opened across multiple
libraries, and some of them are unloaded.
This fixes: #5161, which makes the dialog unresponsive upon initial load.
- enforce `io.filterLibraryIDs` in library mode, the same way it already is being applies in list mode. This is currently used to only show items from the current library when adding citations in a note.
- account for the change above in collectionTree by focusing the first library from `io.filterLibraryIDs`, if those are present, and only default to `userLibraryID` if `io.filterLibraryIDs` is empty.