### PR TITLE
Log stringified exceptions in debug output

### DIFF
--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -1373,7 +1373,12 @@ Services.scriptloader.loadSubScript("resource://zotero/polyfill.js");
 			}
 			
 			if (asStrings) {
-				errors.push(altMessage || msg.message)
+				let message = altMessage || msg.message;
+				// Stringify exceptions object instead of just returning "Object"
+				if (message.includes('uncaught exception: Object') && typeof msg.exception == "object") {
+					message = "[JavaScript Error:" + JSON.stringify(msg.exception);
+				}
+				errors.push(message);
 			}
 			else {
 				errors.push(msg);


### PR DESCRIPTION
If an exception (e.g. `Zotero.Exception.UnloadedDataException`) is thrown without the debugger enabled, it can be logged as a non-descriptive `[JavaScript Error: "uncaught exception: Object"]`.

This stringifies the exception object and puts the string into the message, so that the actual error and the stacktrace are not lost.

Initially brought up in https://github.com/zotero/zotero/pull/5163#issuecomment-2755900429.

For a recent minimal example, this is a debug ID with the `Zotero.Exception.UnloadedDataException` triggered on current beta: D1339492968. Notice no information but `[JavaScript Error: "uncaught exception: Object"]` at the top.

For comparison, the debug ID from this PR D592550858 has JSON stringified "Item ... not yet loaded" error message.

