### PR TITLE
transform menu: preserve letter cases when capitalizing the title

### DIFF
--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -6853,7 +6853,7 @@ var ZoteroPane = new function()
 	this.buildFieldTransformMenu = function ({ target, onTransform }) {
 		let doc = target.ownerDocument;
 		let value = target.value;
-		let valueTitleCased = Zotero.Utilities.capitalizeTitle(value.toLowerCase(), true);
+		let valueTitleCased = Zotero.Utilities.capitalizeTitle(value, true);
 		let valueSentenceCased = Zotero.Utilities.sentenceCase(value);
 
 		let menupopup = doc.createXULElement('menupopup');


### PR DESCRIPTION
Do not lowercase the entire title before capitalizing the first letter of each word to preserve abbreviations or spelling of unusual words (e.g. 3D or iPhone).

Fixes: #5165

For reference, this is the behavior of the transform menu with a few different titles:

https://github.com/user-attachments/assets/496f5568-0f23-4ac1-b441-824c4494f7f9

