### PR TITLE
File renaming: add support for counting creators

### DIFF
--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -2398,6 +2398,9 @@ Zotero.Attachments = new function () {
 			obj[name] = (args) => {
 				return common(commonCreators(name, args), args);
 			};
+			obj[`${name}Count`] = (args) => {
+				return common(getSlicedCreatorsOfType(name, Infinity).length.toString(), args);
+			};
 			return obj;
 		}, {});
 

--- a/test/tests/attachmentsTest.js
+++ b/test/tests/attachmentsTest.js
@@ -1755,6 +1755,73 @@ describe("Zotero.Attachments", function() {
 			);
 		});
 
+		it("should be possible to count authors", function () {
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, { formatString: '{{ authorsCount }}' }),
+				'4'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, { formatString: '{{ editorsCount }}' }),
+				'3'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, { formatString: '{{ creatorsCount }}' }),
+				'7'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, { formatString: 'test{{ if authorsCount > 4 }}{{ authorsCount prefix="-" }}{{ endif }}' }),
+				'test'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, { formatString: 'test{{ if authorsCount >= 4 }}{{ authorsCount prefix="-" }}{{ endif }}' }),
+				'test-4'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, { formatString: 'test{{ if editorsCount <= 4 }}{{ editorsCount prefix="-" }}{{ endif }}' }),
+				'test-3'
+			);
+		});
+
+		it("should be possible to test number of authors using equality operator", function () {
+			const template = `{{ if {{ authorsCount == "2" }} }}two{{ else }}not two{{ endif }}`;
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, { formatString: template }),
+				'not two'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, { formatString: template }),
+				'two'
+			);
+		});
+
+		it("should be possible to test number of authors using relational operators", function () {
+			const template = `{{ if {{ authorsCount > "2" }} }}
+{{ authors max="1" suffix=" et al" }}
+{{ else }}
+{{ authors join=" & " }}
+{{ endif }}`;
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemManyAuthors, { formatString: template }),
+				'Author et al'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, { formatString: template }),
+				'Barius & Pixelus'
+			);
+		});
+
+		it("should handle zero in relational operators", function () {
+			const template = '{{ if {{ authorsCount > 0 }} }}more than zero{{ elseif {{ authorsCount <= 0 }} }}zero{{ endif }}';
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, { formatString: template }),
+				'more than zero'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemIncomplete, { formatString: template }),
+				'zero'
+			);
+		});
+
 		it("should perform regex in a case-insensitive way, unless configured otherwise", function () {
 			assert.equal(
 				Zotero.Attachments.getFileBaseNameFromItem(item, { formatString: '{{ title match="lorem" }}' }),

--- a/test/tests/utilities_internalTest.js
+++ b/test/tests/utilities_internalTest.js
@@ -655,6 +655,42 @@ describe("Zotero.Utilities.Internal", function () {
 			assert.equal(out15, 'yes');
 		});
 
+		it("should support relational operators", function () {
+			const vars = {
+				sum: ({ a, b }) => (parseInt(a) + parseInt(b)).toString(),
+				v1: '1',
+				v2: 'foo',
+				v3: '100',
+				v4: '99',
+				π: '3.14',
+			};
+
+			const template1 = `{{if v1 > π}}more than π{{elseif v1 <= π}}less or equal to π{{endif}}`;
+			const out1 = Zotero.Utilities.Internal.generateHTMLFromTemplate(template1, vars);
+			assert.equal(out1, 'less or equal to π');
+
+			const template2 = `{{if {{ sum a="2" b="3" }} > π}}more than π{{else}}less or equal to π{{endif}}`;
+			const out2 = Zotero.Utilities.Internal.generateHTMLFromTemplate(template2, vars);
+			assert.equal(out2, 'more than π');
+
+			const template3 = `{{if 3.14 >= π}}more than or equal to π{{else}}less than π{{endif}}`;
+			const out3 = Zotero.Utilities.Internal.generateHTMLFromTemplate(template3, vars);
+			assert.equal(out3, 'more than or equal to π');
+
+			const template4 = `{{if v3 > v4}}100 is more than 99{{else}}string "100" would be sorted before "99"{{endif}}`;
+			const out4 = Zotero.Utilities.Internal.generateHTMLFromTemplate(template4, vars);
+			assert.equal(out4, '100 is more than 99');
+
+			// This is undocumented and unsupported behavior, but comparing strings should work
+			const template5 = `{{if "test" > v2}}"t" is after "f" in the alphabet{{else}}no{{endif}}`;
+			const out5 = Zotero.Utilities.Internal.generateHTMLFromTemplate(template5, vars);
+			assert.equal(out5, '"t" is after "f" in the alphabet');
+
+			const template6 = `{{if "bar" < v2 }}"f" is before "b" in the alphabet{{else}}no{{endif}}`;
+			const out6 = Zotero.Utilities.Internal.generateHTMLFromTemplate(template6, vars);
+			assert.equal(out6, '"f" is before "b" in the alphabet');
+		});
+
 		it("should accept hyphen-case variables and attributes", function () {
 			const vars = {
 				fooBar: ({ isFoo }) => (isFoo === 'true' ? 'foo' : 'bar'),


### PR DESCRIPTION
Extends the templating engine to support inequality comparisons (`>`, `<`, `>=`, and `<=`). Adds support for `authorsCount`, `editorsCount`, and `creatorsCount` variables in `getFileBaseNameFromItem`. Together, these changes enable the ability to format file names differently depending on the number of authors. This is what I now believe to be a better approach than #5173 and thus supersedes that PR.

Close #4575