### PR TITLE
itemBox: fix overlapping rows on initial load

### DIFF
--- a/scss/elements/_infoBox.scss
+++ b/scss/elements/_infoBox.scss
@@ -75,6 +75,10 @@ info-box {
 	.meta-label > .single-creator-grippy {
 		visibility: hidden !important;
 	}
+	// Avoids shifting itemBox columns when the svg is initially loaded
+	.meta-label > .zotero-clicky-grippy {
+		width: 18px !important;
+	}
 
 	textarea {
 		font: inherit;


### PR DESCRIPTION
On initial load, the `grippy` does not immediately appear because it needs to be loaded. This means that when `itemBox` is rendered for the first time, the `grippy` has a width of 0, which later becomes 18px. If the itemPane is narrow, it may push the columns out and lead to text of value components wrapping without the rows getting stretched.

This sets explicit width to the `grippy` to avoid such behavior.

Fixes: zotero#5166