### PR TITLE
runJS: better message if nothing is returned

### DIFF
--- a/chrome/content/zotero/runJS.html
+++ b/chrome/content/zotero/runJS.html
@@ -28,8 +28,9 @@
 			</div>
 			
 			<div class="textbox-container">
-				<div class="textbox-header">
-					<label id="result-label" class="textbox-label" for="result" data-l10n-id="runJS-result"/>
+				<div class="textbox-header result-header">
+					<label id="result-label" class="textbox-label" for="result" data-l10n-id="runJS-result"></label>
+					<div id="loading-spinner" class="zotero-spinner-16"></div>
 				</div>
 				<textarea id="result" readonly aria-disabled="true"></textarea>
 			</div>

--- a/chrome/content/zotero/runJS.js
+++ b/chrome/content/zotero/runJS.js
@@ -14,6 +14,8 @@ async function run() {
 	var isAsync = document.getElementById('run-as-async').checked;
 	var result;
 	var resultTextbox = document.getElementById('result');
+	var spinner = document.getElementById("loading-spinner");
+	spinner.setAttribute("status", "animate");
 	try {
 		if (isAsync) {
 			code = '(async function () {' + code + '})()';
@@ -28,6 +30,12 @@ async function run() {
 		resultTextbox.textContent = e;
 		return;
 	}
+	// Hide the spinner after a small delay so it briefly appears even
+	// if the code runs fast to indicate that everything did run
+	setTimeout(() => {
+		spinner.removeAttribute("status");
+	}, 100);
+	
 	resultTextbox.classList.remove('error');
 	if (typeof result == 'string') {
 		resultTextbox.textContent = result;
@@ -36,7 +44,7 @@ async function run() {
 		resultTextbox.textContent = Zotero.Utilities.varDump(result);
 	}
 	else {
-		resultTextbox.textContent = "Completed successfully";
+		document.l10n.setAttributes(resultTextbox, "runJS-completed");
 	}
 }
 

--- a/chrome/content/zotero/runJS.js
+++ b/chrome/content/zotero/runJS.js
@@ -29,7 +29,15 @@ async function run() {
 		return;
 	}
 	resultTextbox.classList.remove('error');
-	resultTextbox.textContent = typeof result == 'string' ? result : Zotero.Utilities.varDump(result);
+	if (typeof result == 'string') {
+		resultTextbox.textContent = result;
+	}
+	else if (result !== undefined) {
+		resultTextbox.textContent = Zotero.Utilities.varDump(result);
+	}
+	else {
+		resultTextbox.textContent = "Completed successfully";
+	}
 }
 
 // eslint-disable-next-line no-unused-vars

--- a/chrome/content/zotero/runJS.js
+++ b/chrome/content/zotero/runJS.js
@@ -44,7 +44,7 @@ async function run() {
 		resultTextbox.textContent = Zotero.Utilities.varDump(result);
 	}
 	else {
-		document.l10n.setAttributes(resultTextbox, "runJS-completed");
+		resultTextbox.textContent = Zotero.getString("runJS-completed");
 	}
 }
 

--- a/chrome/content/zotero/runJS.js
+++ b/chrome/content/zotero/runJS.js
@@ -28,6 +28,7 @@ async function run() {
 	catch (e) {
 		resultTextbox.classList.add('error');
 		resultTextbox.textContent = e;
+		spinner.removeAttribute("status");
 		return;
 	}
 	// Hide the spinner after a small delay so it briefly appears even
@@ -44,7 +45,9 @@ async function run() {
 		resultTextbox.textContent = Zotero.Utilities.varDump(result);
 	}
 	else {
-		resultTextbox.textContent = Zotero.getString("runJS-completed");
+		// when nothing is returned, log undefined as the return value but
+		// for clarity also add a note that the JS run was successful
+		resultTextbox.textContent = `===>undefined<=== (${Zotero.getString("runJS-completed")})`;
 	}
 }
 

--- a/chrome/locale/en-GB/zotero/zotero.ftl
+++ b/chrome/locale/en-GB/zotero/zotero.ftl
@@ -241,6 +241,7 @@ runJS-title = Run JavaScript
 runJS-editor-label = Code:
 runJS-run = Run
 runJS-help = { general-help }
+runJS-completed = Completed successfully
 runJS-result =
     { $type ->
         [async] Return value:

--- a/chrome/locale/en-GB/zotero/zotero.ftl
+++ b/chrome/locale/en-GB/zotero/zotero.ftl
@@ -241,7 +241,6 @@ runJS-title = Run JavaScript
 runJS-editor-label = Code:
 runJS-run = Run
 runJS-help = { general-help }
-runJS-completed = Completed successfully
 runJS-result =
     { $type ->
         [async] Return value:

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -309,7 +309,7 @@ runJS-title = Run JavaScript
 runJS-editor-label = Code:
 runJS-run = Run
 runJS-help = { general-help }
-runJS-completed = Completed successfully
+runJS-completed = completed successfully
 runJS-result = {
     $type ->
         [async] Return value:

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -309,6 +309,7 @@ runJS-title = Run JavaScript
 runJS-editor-label = Code:
 runJS-run = Run
 runJS-help = { general-help }
+runJS-completed = Completed successfully
 runJS-result = {
     $type ->
         [async] Return value:

--- a/scss/components/_runJS.scss
+++ b/scss/components/_runJS.scss
@@ -44,6 +44,14 @@
         line-height: 1.5;
     }
 
+	.result-header {
+		justify-content: start;
+	}
+
+	#loading-spinner {
+		margin-inline-start: 5px;
+	}
+
     .textbox-label {
         font-size: 15px;
     }


### PR DESCRIPTION
Display "Completed successfully" instead of current undefined, which is a bit misleading.

Fixes: #5180

@AbeJellinek I agree that showing `undefined` has always been a bit misleading. Displaying "Completed successfully" at the very least conveys that everything ran and nothing broke.

While we are at it, I wonder if it would be worth to maybe also add a timestamp before the return value? While rerunning the code more than once, I find that it's not quite clear that rerunning actually happened, since the return value does not change. If there is a prefixed timestamp, something would look different on every run. Or would it just be confusing to have something go before the return value?