### PR TITLE
Citation dialog: stricter cleanup of search value

### DIFF
--- a/chrome/content/zotero/integration/citationDialog.js
+++ b/chrome/content/zotero/integration/citationDialog.js
@@ -312,7 +312,7 @@ class Layout {
 			while (!this.itemsView.collectionTreeRow) {
 				await Zotero.Promise.delay(10);
 			}
-			await this.itemsView.setFilter('citation-search', value);
+			await this.itemsView.setFilter('citation-search', SearchHandler.searchValue);
 		}
 
 		SearchHandler.searching = false;

--- a/chrome/content/zotero/integration/citationDialog/searchHandler.mjs
+++ b/chrome/content/zotero/integration/citationDialog/searchHandler.mjs
@@ -194,7 +194,14 @@ export class CitationDialogSearchHandler {
 	}
 
 	cleanSearchQuery(str) {
-		str = str.replace(/ (?:&|and) /g, " ", "g").replace(/^,/, '');
+		// Remove brackets, some punctuation, "et al", and localized "and" from the search string.
+		// This allows one to paste an existing citation like "(Smith et al., 2020)" and
+		// still get appropriate search results.
+		str = str.replace(/[()]/g, '').replace(/[&,.:;]/g, '');
+		str = str.replace(" " + Zotero.getString("general.and") + " ", " ");
+		let etAl = Zotero.getString("general.etAl").replace(/\./g, "");
+		str = str.replace(new RegExp(" " + etAl + "(?:.\\s*|\\s+|$)", "g"), " ");
+
 		let isbn = Zotero.Utilities.cleanISBN(str);
 		let doi = Zotero.Utilities.cleanDOI(str);
 		// if the string looks like an identifier, do not try to extract the year


### PR DESCRIPTION
Additional cleanup of the search value to not include some punctuation `(),.;:`, localized "and",
ampersand, and localized "et al". That way, if one copies a citation like "(Smith et al., 2020)" and pastes it into the citation dialog, it is more likely that appropriate search results will appear.

Fixes: #1864