### PR TITLE
Recently opened windows and tabs menus

### DIFF
--- a/chrome/content/zotero/note.js
+++ b/chrome/content/zotero/note.js
@@ -86,6 +86,7 @@ window.onEditorError = function () {
 function onUnload() {
 	Zotero.Notifier.unregisterObserver(notifierUnregisterID);
 	noteEditor.saveSync();
+	Zotero.WindowHistory.addToHistory(noteEditor.item.id, document.title, "note");
 }
 
 var NotifyCallback = {

--- a/chrome/content/zotero/standalone/standalone.js
+++ b/chrome/content/zotero/standalone/standalone.js
@@ -467,6 +467,8 @@ const ZoteroStandalone = new function() {
 			'view-menuitem-recursive-collections',
 			Zotero.Prefs.get('recursiveCollections')
 		);
+		document.getElementById("view-menu-recently-closed-windows").disabled = Zotero.WindowHistory.history.length == 0;
+		document.getElementById("view-menu-recently-closed-tabs").disabled = Zotero_Tabs.history.length == 0;
 	};
 	
 	

--- a/chrome/content/zotero/tabs.js
+++ b/chrome/content/zotero/tabs.js
@@ -69,6 +69,18 @@ var Zotero_Tabs = new function () {
 		get: () => document.getElementById('zotero-tabs-menu-panel')
 	});
 
+	Object.defineProperty(this, 'history', {
+		get: () => this._history.flat().map((obj) => {
+			return {
+				itemID: obj.data.itemID,
+				tabIndex: obj.index,
+				secondViewState: obj.data.secondViewState,
+				title: obj.title,
+				type: "reader"
+			};
+		})
+	});
+
 	this._tabBarRef = React.createRef();
 	this._tabs = [{
 		id: 'zotero-pane',
@@ -361,7 +373,7 @@ var Zotero_Tabs = new function () {
 			if (tab.onClose) {
 				tab.onClose();
 			}
-			historyEntry.push({ index: tmpTabs.indexOf(tab), data: tab.data });
+			historyEntry.push({ index: tmpTabs.indexOf(tab), data: tab.data, title: tab.title });
 			closedIDs.push(id);
 
 			setTimeout(() => {
@@ -414,6 +426,33 @@ var Zotero_Tabs = new function () {
 				this.jump(maxIndex);
 			}
 		}
+	};
+
+	/**
+	 * Reopen a closed tab from one of entries in this._history
+	 * @param {Integer} itemID - Zotero.Item.id
+	 * @param {Integer} tabIndex - Index of the tab when it was closed
+	 */
+	this.reopenClosedTab = async function (itemID, tabIndex) {
+		for (let i = 0; i < this._history.length; i++) {
+			let historyEntry = this._history[i];
+			if (historyEntry.length == 0) continue;
+			// Find the correct tab in the tabs history (which may be groupped)
+			let historyIndex = historyEntry.findIndex(x => x.data.itemID == itemID && x.index == tabIndex);
+			if (historyIndex == -1) continue;
+			Zotero.Reader.open(itemID,
+				null,
+				{
+					tabIndex: tabIndex,
+					openInBackground: false,
+					allowDuplicate: true
+				}
+			);
+			// Remove the tab from the history entry
+			historyEntry = historyEntry.splice(historyIndex, 1);
+		}
+		// The history entry might be empty now, so remove it
+		this._history = this._history.filter(x => x.length);
 	};
 
 	/**

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -1448,6 +1448,7 @@ class ReaderWindow extends ReaderInstance {
 		this.uninit();
 		this._window.close();
 		this._onClose();
+		Zotero.WindowHistory.addToHistory(this._item.id, this._window.document.title, "reader");
 	}
 
 	_setTitleValue(title) {

--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -2227,3 +2227,40 @@ Zotero.JSON = new function() {
 		return JSON.parse(arg);
 	}
 }
+
+Zotero.WindowHistory = new function () {
+	this.history = [];
+
+	// Record recently closed windows. Keep track of the last 25.
+	this.addToHistory = (itemID, title, type) => {
+		let index = this.history.findIndex(obj => obj.itemID == itemID && obj.type == type);
+		if (index !== -1) {
+			this.history.splice(index, 1);
+		}
+		this.history.push({ itemID, type, title });
+		if (this.history.length > 25) {
+			this.history.shift();
+		}
+	};
+
+	// Reopen a window from history
+	this.reopenWindow = (index) => {
+		let historyEntry = this.history[index];
+		if (historyEntry.type == "note") {
+			let zp = Zotero.getActiveZoteroPane();
+			zp.openNoteWindow(historyEntry.itemID);
+		}
+		else if (historyEntry.type == "reader") {
+			Zotero.Reader.open(historyEntry.itemID,
+				null,
+				{
+					openInWindow: true,
+					allowDuplicate: true,
+					secondViewState: historyEntry.secondViewState,
+				}
+			);
+		}
+		// Remove the window from history
+		Zotero.WindowHistory.history.splice(index, 1);
+	};
+};

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -6794,6 +6794,33 @@ var ZoteroPane = new function()
 		this.itemPane.handleResize();
 	}
 
+	// Display recently closed windows/tabs in their menus
+	this.onRecentlyClosedPopupShowing = function (event) {
+		let menu = event.target.closest(".menu-type-library");
+		let isClosedWindows = !!event.target.closest("#view-menu-recently-closed-windows");
+		let recentlyClosed = isClosedWindows ? Zotero.WindowHistory.history : Zotero_Tabs.history;
+		// only display the last 25 records
+		recentlyClosed = recentlyClosed.slice(-25);
+		let menuitems = [];
+		for (let [index, obj] of recentlyClosed.entries()) {
+			let menuitem = document.createXULElement("menuitem");
+			menuitem.label = obj.title;
+			// cutoff the label at 50 characters
+			if (menuitem.label.length > 50) {
+				menuitem.label = menuitem.label.slice(0, 50) + "…";
+			}
+			menuitem.addEventListener("command", () => {
+				if (isClosedWindows) {
+					Zotero.WindowHistory.reopenWindow(index);
+				}
+				else {
+					Zotero_Tabs.reopenClosedTab(obj.itemID, obj.tabIndex);
+				}
+			});
+			menuitems.push(menuitem);
+		}
+		menu.menupopup.replaceChildren(...menuitems);
+	};
 	
 	// Set the label of the dynamic tooltip. Can be used when we cannot set .tooltiptext
 	// property, e.g. if we don't want the tooltip to be announced by screenreaders.

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -663,6 +663,20 @@
 								oncommand="ZoteroStandalone.onViewMenuItemClick(event)"
 								type="checkbox"
 							/>
+							<menuseparator class="menu-type-library menu-type-reader"/>
+							<menu id="view-menu-recently-closed-tabs"
+								class="menu-type-library menu-type-reader"
+								data-l10n-id="menu-view-recently-closed-tabs"
+								onpopupshowing="ZoteroPane.onRecentlyClosedPopupShowing(event)">
+						  		<menupopup/>
+					  		</menu>
+							<menu id="view-menu-recently-closed-windows"
+							  class="menu-type-library menu-type-reader"
+							  data-l10n-id="menu-view-recently-closed-windows"
+							  onpopupshowing="ZoteroPane.onRecentlyClosedPopupShowing(event)"
+							  onpopuphiding="document.getElementById('view-menu-recently-closed-windows').firstChild.replaceChildren();">
+								<menupopup/>
+							</menu>
 						</menupopup>
 					</menu>
 					

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -95,6 +95,10 @@ menu-view-columns-move-left =
     .label = Move Column Left
 menu-view-columns-move-right =
     .label = Move Column Right
+menu-view-recently-closed-tabs =
+    .label = Recently Closed Tabs
+menu-view-recently-closed-windows =
+    .label = Recently Closed Windows
 
 main-window-command =
     .label = Library


### PR DESCRIPTION
- added Recently Opened Tabs and Windows View > submenus
- Zotero.WindowHistory tracks and handles window reopening for reader and note windows
- Recently Opened Tabs displays unwrapped list of tabs history entries
- when a tab or window is re-opened, it is removed from the history so it's gone from the menu
- when there are no recently closed tabs or windows, the menus are disabled

Fixes: #4597

Brief demo: [recording](https://www.dropbox.com/scl/fi/fwapgws7greizb7vtpog7/recently_closed_tabs_windows.mov?rlkey=4fj9fvr13nika0tv420zi3ya3&st=ecpfgelm&dl=0)