### PR TITLE
Include mru types in the main list of "New Item" menu

### DIFF
--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -700,15 +700,18 @@ var ZoteroPane = new function()
 				localized: Zotero.ItemTypes.getLocalizedString(type.id)
 			};
 		});
+
+		let allItemTypes = [...primaryItemTypes, ...secondaryItemTypes];
+		
 		var collation = Zotero.getLocaleCollation();
 		primaryItemTypes.sort(function (a, b) {
 			return collation.compareString(1, a.localized, b.localized);
 		});
-		secondaryItemTypes.sort(function (a, b) {
+		allItemTypes.sort(function (a, b) {
 			return collation.compareString(1, a.localized, b.localized);
 		});
-		let lastPrimaryType = primaryItemTypes[primaryItemTypes.length - 1];
-		let itemTypes = primaryItemTypes.concat(secondaryItemTypes);
+		// The array of all item types with MRU prepended to the top
+		let itemTypes = primaryItemTypes.concat(allItemTypes);
 		for (let itemType of itemTypes) {
 			let menuitem = document.createXULElement("menuitem");
 			menuitem.setAttribute("label", itemType.localized);
@@ -719,7 +722,7 @@ var ZoteroPane = new function()
 			});
 			addMenu.appendChild(menuitem);
 			// Add a separator between primary and secondary types
-			if (lastPrimaryType.id == type) {
+			if (addMenu.childElementCount == primaryItemTypes.length) {
 				let separator = document.createXULElement("menuseparator");
 				addMenu.appendChild(separator);
 			}


### PR DESCRIPTION
Per https://forums.zotero.org/discussion/123269/bad-practice-in-new-item-drop-down-menu.

In "New Item" menu, most recently used item types should also appear in the main list of all item types.

<img width="1206" alt="Screenshot 2025-04-08 at 10 20 15 AM" src="https://github.com/user-attachments/assets/0337ec96-0f82-44c5-bbcf-603915b3602b" />
