### PR TITLE
Use normal text color for selected context row

### DIFF
--- a/scss/components/_virtualized-table.scss
+++ b/scss/components/_virtualized-table.scss
@@ -150,7 +150,7 @@
 			font-weight: 600;
 		}
 
-		&.context-row {
+		&.context-row:not(.selected) {
 			color: var(--fill-secondary);
 		}
 


### PR DESCRIPTION
I couldn't find a color that didn't look kind of weird on top of the selected row background; just leaving it alone seems best.

Fixes #5196