### PR TITLE
a11y: clear aria-expanded on empty itemTree rows

### DIFF
--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -3167,7 +3167,10 @@ var ItemTree = class ItemTree extends LibraryTree {
 		// Accessibility
 		div.setAttribute('role', 'treeitem');
 		div.setAttribute('aria-level', this.getLevel(index) + 1);
-		if (!this.isContainerEmpty(index)) {
+		if (this.isContainerEmpty(index)) {
+			div.removeAttribute('aria-expanded');
+		}
+		else {
 			div.setAttribute('aria-expanded', this.isContainerOpen(index));
 		}
 		if (rowData.contextRow) {


### PR DESCRIPTION
Per https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-expanded#treeitems only treeitems that contain children should have the `aria-expanded` attribute. This is instead of having `aria-expanded=false` on empty regular items or standalone attachments, which erroneously indicates to screen readers that the row has children but is collapsed.

Fixes: #5200