### PR TITLE
add string for note-editor a11y link popup message

### DIFF
--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -1355,6 +1355,7 @@ noteEditor.insertColumnAfter = Insert Column Right
 noteEditor.deleteRow = Delete Row
 noteEditor.deleteColumn = Delete Column
 noteEditor.deleteTable = Delete Table
+noteEditor.a11yLinkPopupAppearedAlert = Link popup appeared. Use Shift-Tab to navigate it.
 
 pdfReader.annotations = Annotations
 pdfReader.showAnnotations = Show Annotations


### PR DESCRIPTION
String read out by screen readers when the link popup appears instructing users to navigate it.

Needed for https://github.com/zotero/note-editor/pull/65
Addresses: #5199

Not sure if the message needs to be more detailed (e.g. "Use Shift-Tab to navigate it to remove/edit/open the link") or if it's better to just be concise.