### PR TITLE
Fix item pane blank

### DIFF
--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -6650,6 +6650,12 @@ var ZoteroPane = new function()
 						&& Zotero.Prefs.get('reopenPanesOnRestart')) {
 					continue;
 				}
+				// For some reason, the persisted state of the splitter is empty. This will cause
+				// the splitter to behave unexpectedly. We set it to 'collapsed' here.
+				if (["zotero-context-splitter-stacked", "zotero-context-splitter"].includes(el.id)
+						&& attr === 'state' && elValues[attr] === '') {
+					elValues[attr] = 'collapsed';
+				}
 				// Ignore attributes that are no longer persisted for the element
 				if (!allowedAttributes.includes(attr)) {
 					Zotero.debug(`Not restoring '${attr}' for #${id}`);


### PR DESCRIPTION
This is caused by the persisted splitter state value being blank from either older versions of clients or plugins. Resetting the empty values fixes this bug.

To reproduce: set the `zotero-context-splitter-stacked#state` to `"collapsed"` and `zotero-context-splitter#state` to `""` in `prefs.js` and then start Zotero. The item pane in reader tabs are blank without this fix.