### PR TITLE
Move note-editor popup a11y strings to zotero.ftl

### DIFF
--- a/chrome/content/zotero/xpcom/intl.js
+++ b/chrome/content/zotero/xpcom/intl.js
@@ -85,6 +85,7 @@ Zotero.Intl = new function () {
 			'zotero.ftl',
 			'reader.ftl',
 			'integration.ftl',
+			'note-editor.ftl',
 			// More FTL files can be hardcoded here, or added later with
 			// Zotero.ftl.addResourceIds(['...'])
 		], true);

--- a/chrome/locale/en-US/zotero/note-editor.ftl
+++ b/chrome/locale/en-US/zotero/note-editor.ftl
@@ -1,0 +1,2 @@
+note-editor-link-popup-appeared = Link popup appeared. Use Shift-Tab to navigate it.
+note-editor-citation-popup-appeared = Citation popup appeared. Use Shift-Tab to navigate it.

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -717,3 +717,6 @@ mac-word-plugin-install-remind-later-button =
     .label = { general-remind-me-later }
 mac-word-plugin-install-dont-ask-again-button =
     .label = { general-dont-ask-again }
+
+note-editor-link-popup-appeared = Link popup appeared. Use Shift-Tab to navigate it.
+note-editor-citation-popup-appeared = Citation popup appeared. Use Shift-Tab to navigate it.

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -717,6 +717,3 @@ mac-word-plugin-install-remind-later-button =
     .label = { general-remind-me-later }
 mac-word-plugin-install-dont-ask-again-button =
     .label = { general-dont-ask-again }
-
-note-editor-link-popup-appeared = Link popup appeared. Use Shift-Tab to navigate it.
-note-editor-citation-popup-appeared = Citation popup appeared. Use Shift-Tab to navigate it.

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -1355,7 +1355,6 @@ noteEditor.insertColumnAfter = Insert Column Right
 noteEditor.deleteRow = Delete Row
 noteEditor.deleteColumn = Delete Column
 noteEditor.deleteTable = Delete Table
-noteEditor.a11yLinkPopupAppearedAlert = Link popup appeared. Use Shift-Tab to navigate it.
 
 pdfReader.annotations = Annotations
 pdfReader.showAnnotations = Show Annotations

--- a/js-build/config.js
+++ b/js-build/config.js
@@ -129,6 +129,7 @@ const ftlFileBaseNames = [
 	'scaffold',
 	'reader',
 	'integration',
+	'note-editor'
 ];
 
 const buildsURL = 'https://zotero-download.s3.amazonaws.com/ci/';


### PR DESCRIPTION
Per https://github.com/zotero/zotero/pull/5205#issuecomment-2809055908

Needed for https://github.com/zotero/note-editor/pull/65
Addresses: https://github.com/zotero/zotero/issues/5199

This also adds a new string to announce when citation popup opens because it should be announced as well.