### PR TITLE
Select Items dialog: Fix scrollbars and padding, add title

### DIFF
--- a/app/scripts/fetch_xulrunner
+++ b/app/scripts/fetch_xulrunner
@@ -398,6 +398,9 @@ function modify_omni {
 	# Remove non-native text input styles
 	remove_between 'html\|input\:where\(' '^}' chrome/toolkit/skin/classic/global/global-shared.css
 	
+	# Prevent window dragging on scrollbars
+	echo 'scrollbar { -moz-window-dragging: no-drag; }' >> chrome/toolkit/res/scrollbars.css
+	
 	# Provide a mechanism for non-UA stylesheets to override the overflow property
 	# of a text control's anonymous text node child
 	echo '::placeholder, ::-moz-text-control-editing-root, ::-moz-text-control-preview {

--- a/chrome/content/zotero/selectItemsDialog.xhtml
+++ b/chrome/content/zotero/selectItemsDialog.xhtml
@@ -40,6 +40,7 @@
 	onunload="doUnload();"
 	persist="screenX screenY width height"
 	class="zotero-dialog"
+	data-l10n-id="select-items-window"
 	drawintitlebar-platforms="mac,win"
 >
 <dialog

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -676,6 +676,8 @@ find-pdf-files-added = { $count ->
     *[other] { $count } files added
 }
 
+select-items-window =
+    .title = Select Items
 select-items-dialog =
     .buttonlabelaccept = Select
 select-items-convertToStandalone =

--- a/scss/components/_selectItemsDialog.scss
+++ b/scss/components/_selectItemsDialog.scss
@@ -21,9 +21,12 @@
     #zotero-collections-tree-container {
         min-width: 200px;
 		min-height: 100%;
-        padding: 16px 0;
         background: var(--material-sidepane);
         border-inline-end: var(--material-panedivider);
+        
+        .virtualized-table-body {
+            padding: 16px 8px;
+        }
     }
 
     #zotero-collections-tree {
@@ -73,19 +76,6 @@
     .dialog-button-box button {
         -moz-window-dragging: no-drag;
     }
-
-	// Move padding into rows so that draggable collection container does not
-	// expand all the way past the scrollbar and cause dragging the scrollbar
-	// to drag the entire window
-	#zotero-collections-tree-container {
-		.virtualized-table-body {
-			padding-inline-end: 0;
-			.row {
-				padding-inline-end: 8px;
-				width: 183px;
-			}
-		}
-	}
 }
 
 // richlistbox elements are crazy and will expand beyond the window size


### PR DESCRIPTION
- Prevent dragging all windows via scrollbars with `fetch_xulrunner`. Can't apply styles to anonymous `<scrollbar>` elements in normal CSS, and it doesn't seem to me like we'd ever want this behavior anywhere.
- Match intended padding in Figma
- Remove space between scrollbars and the edge of the container (visible in the screenshot in https://forums.zotero.org/discussion/123401/zotero-related-window-the-scroll-bar-for-the-list-of-collections-is-unusable; I think this dates back to 7c7d8c143341b3ad6b96030e902500d0608756d7)
- Revert a past attempt at fixing the drag issue from 15ccf28fb41892df90acc3a943788b611cf99b01, which doesn't seem to have done the trick
- Add a title to the dialog (not drawn) for the Dock/taskbar/accessibility

Fixes #5206