### PR TITLE
Keep item pane scroll position after refresh

### DIFF
--- a/chrome/content/zotero/elements/itemDetails.js
+++ b/chrome/content/zotero/elements/itemDetails.js
@@ -407,6 +407,8 @@
 				if (type == 'itempane') {
 					this.renderCustomSections();
 				}
+				// Keep the scroll position after refresh
+				this._lastScrollTop = this._paneParent.scrollTop;
 				await this.render();
 			}
 


### PR DESCRIPTION
To reproduce:

1. Open reader and scroll the item pane
2. Delete an annotation. The item pane scrolls to the top (which should not happen)