### PR TITLE
Make hidden readers inactive, firing visibilitychange

### DIFF
--- a/chrome/content/zotero/elements/contextPane.js
+++ b/chrome/content/zotero/elements/contextPane.js
@@ -70,11 +70,17 @@
 			// Notes pane deck
 			this._notesPaneDeck = this.querySelector('#zotero-context-pane-notes-deck');
 
-			this._notifierID = Zotero.Notifier.registerObserver(this, ['item', 'tab'], 'contextPane');
+			this._notifierIDs = [
+				Zotero.Notifier.registerObserver(this, ['item'], 'contextPane'),
+				// We want to be notified quickly about tab events
+				Zotero.Notifier.registerObserver(this, ['tab'], 'contextPane', 20),
+			];
 		}
 
 		destroy() {
-			Zotero.Notifier.unregisterObserver(this._notifierID);
+			for (let id of this._notifierIDs) {
+				Zotero.Notifier.unregisterObserver(id);
+			}
 		}
 
 		notify(action, type, ids, extraData) {

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -1950,8 +1950,15 @@ class Reader {
 				}
 			}
 			else if (event === 'select') {
+				for (let reader of this._readers) {
+					if (reader instanceof ReaderTab) {
+						reader._iframe.docShellIsActive = false;
+					}
+				}
+
 				let reader = Zotero.Reader.getByTabID(ids[0]);
 				if (reader) {
+					reader._iframe.docShellIsActive = true;
 					this.triggerAnnotationsImportCheck(reader.itemID);
 				}
 			}


### PR DESCRIPTION
- Set `docShellIsActive` depending on the visibility state of the reader. Previously, we never told the browser that it was no longer visible, so the document's `visibilityState` was always `'visible'` and Firefox couldn't perform any visibility-related optimizations on inactive readers. This might have some minor performance benefits, but mostly it's just necessary to make https://github.com/zotero/reader/commit/c0a65316523b609f0dc40380a7900aa51818ce0b work in the client.
- Increase the priority of `<context-pane>`'s notifier observer. This codifies what was already happening by chance: `<context-pane>` is notified of tab switches before `Reader` is, so the tab layout is settled before the reader is notified that it's come into view.
- Update reader submodule

(Attachment preview tests will fail - see #5226.)

Fixes #5224