### PR TITLE
Fix unintentional title transfer between attachments on item switch

### DIFF
--- a/chrome/content/zotero/elements/attachmentBox.js
+++ b/chrome/content/zotero/elements/attachmentBox.js
@@ -221,9 +221,9 @@
 			if (!(val instanceof Zotero.Item)) {
 				throw new Error("'item' must be a Zotero.Item");
 			}
-			// Blur editable-text of old attachment. Otherwise, _handleTitleBlur would fire after
-			// the new item is set but before updateInfo sets the title field to have the new item's value.
-			// Such race condition would cause the old item's title to be set on the new item.
+			// Blur editable-text of old attachment. Otherwise, _handleTitleBlur() would fire after
+			// the new item is set but before updateInfo() sets the title field to have the new
+			// item's value, causing the old item's title to be set on the new item.
 			if (this._item && val.id != this._item.id && document.activeElement.closest("editable-text")) {
 				document.activeElement.blur();
 			}

--- a/chrome/content/zotero/elements/attachmentBox.js
+++ b/chrome/content/zotero/elements/attachmentBox.js
@@ -221,6 +221,10 @@
 			if (!(val instanceof Zotero.Item)) {
 				throw new Error("'item' must be a Zotero.Item");
 			}
+			// Blur editable-text of old attachment so it is not refocused for new attachment after refresh
+			if (this._item && val.id != this._item.id && document.activeElement.closest("editable-text")) {
+				document.activeElement.blur();
+			}
 			if (val.isAttachment()) {
 				this._item = val;
 				this.hidden = false;

--- a/chrome/content/zotero/elements/attachmentBox.js
+++ b/chrome/content/zotero/elements/attachmentBox.js
@@ -221,7 +221,9 @@
 			if (!(val instanceof Zotero.Item)) {
 				throw new Error("'item' must be a Zotero.Item");
 			}
-			// Blur editable-text of old attachment so it is not refocused for new attachment after refresh
+			// Blur editable-text of old attachment. Otherwise, _handleTitleBlur would fire after
+			// the new item is set but before updateInfo sets the title field to have the new item's value.
+			// Such race condition would cause the old item's title to be set on the new item.
 			if (this._item && val.id != this._item.id && document.activeElement.closest("editable-text")) {
 				document.activeElement.blur();
 			}

--- a/test/tests/itemPaneTest.js
+++ b/test/tests/itemPaneTest.js
@@ -609,6 +609,25 @@ describe("Item pane", function () {
 			let fieldMode = newCreatorRow.querySelector("editable-text").getAttribute("fieldMode");
 			assert.equal(fieldMode, "0");
 		});
+
+		it("should save updated title when switching between items", async function () {
+			let itemOne = new Zotero.Item('book');
+			let itemTwo = new Zotero.Item('book');
+			itemOne.setField('title', 'Title_one');
+			await itemOne.saveTx();
+			await itemTwo.saveTx();
+			await ZoteroPane.selectItem(itemOne.id);
+
+			let itemDetails = ZoteroPane.itemPane._itemDetails;
+			let infoBox = itemDetails.getPane("info");
+
+			let titleField = infoBox.querySelector("#itembox-field-value-title");
+			titleField.focus();
+			titleField.value = "Updated title";
+			await ZoteroPane.selectItem(itemTwo.id);
+			await waitForNotifierEvent('modify', 'item');
+			assert.equal(itemOne.getDisplayTitle(), "Updated title");
+		});
 	});
 
 	describe("Libraries and collections pane", function () {
@@ -1659,9 +1678,8 @@ describe("Item pane", function () {
 			let attachmentBox = itemDetails.getPane(paneID);
 
 			attachmentBox.querySelector("#title").focus();
-			await Zotero.Promise.delay(10);
 			await ZoteroPane.selectItem(attachmentTwo.id);
-			await Zotero.Promise.delay(10);
+			await waitForNotifierEvent('modify', 'item');
 			assert.equal(attachmentTwo.getDisplayTitle(), "PDF_two");
 		});
 	});

--- a/test/tests/itemPaneTest.js
+++ b/test/tests/itemPaneTest.js
@@ -1648,6 +1648,22 @@ describe("Item pane", function () {
 
 			attachmentBox._discardPreviewTimeout = currentDiscardTimeout;
 		});
+
+		it("should not transfer focused title while switching between items", async function () {
+			let item = new Zotero.Item('book');
+			let attachmentOne = await importFileAttachment('test.pdf', { title: 'PDF_one', parentItemID: item.id });
+			let attachmentTwo = await importFileAttachment('test.pdf', { title: 'PDF_two', parentItemID: item.id });
+			await ZoteroPane.selectItem(attachmentOne.id);
+
+			let itemDetails = ZoteroPane.itemPane._itemDetails;
+			let attachmentBox = itemDetails.getPane(paneID);
+
+			attachmentBox.querySelector("#title").focus();
+			await Zotero.Promise.delay(10);
+			await ZoteroPane.selectItem(attachmentTwo.id);
+			await Zotero.Promise.delay(10);
+			assert.equal(attachmentTwo.getDisplayTitle(), "PDF_two");
+		});
 	});
 	
 	


### PR DESCRIPTION
To avoid re-focusing that fields for new attachment after refresh, which leads to the value of old attachment's field being transferred to the new attachment.

Fixes #5244


https://github.com/user-attachments/assets/d718043b-8ac6-4320-b73d-330e8af24069

