### PR TITLE
Fix leftover annotation rows and disappearing attachment rows after drag-drop

### DIFF
--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -686,9 +686,14 @@ var ItemTree = class ItemTree extends LibraryTree {
 					if (row !== undefined) {
 						let parentItemID = this.getRow(row).ref.parentItemID;
 						let parentIndex = this.getParentIndex(row);
-
+						
+						// If item moved from top level to under another item, remove the old row
+						if (parentIndex == -1 && parentItemID) {
+							this._closeContainer(row);
+							this._removeRow(row);
+						}
 						// If moved from under another item to top level, remove old row and add new one
-						if (parentIndex != -1 && !parentItemID) {
+						else if (parentIndex != -1 && !parentItemID) {
 							this._closeContainer(row);
 							this._removeRow(row);
 
@@ -697,12 +702,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 
 							sort = true;
 						}
-						// If item moved from top-level to under another item, remove the old row.
-						else if (parentIndex == -1 && parentItemID) {
-							this._closeContainer(row);
-							this._removeRow(row);
-						}
-						// If item was moved from one parent to another, remove from old parent
+						// If moved from one parent to another, remove from old parent
 						else if (parentItemID && parentIndex != -1 && this._rowMap[parentItemID] != parentIndex) {
 							this._closeContainer(row);
 							this._removeRow(row);

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -687,23 +687,9 @@ var ItemTree = class ItemTree extends LibraryTree {
 						let parentItemID = this.getRow(row).ref.parentItemID;
 						let parentIndex = this.getParentIndex(row);
 
-						// Top-level item
-						if (item.isTopLevelItem()) {
-							// If Unfiled Items and itm was added to a collection, remove from view
-							if (collectionTreeRow.isUnfiled() && item.getCollections().length) {
-								this._removeRow(row);
-							}
-							// Otherwise just resort
-							else {
-								sort = true;
-							}
-						}
-						// If item moved from top-level to under another item, remove the old row.
-						else if (parentIndex == -1 && parentItemID) {
-							this._removeRow(row);
-						}
 						// If moved from under another item to top level, remove old row and add new one
-						else if (parentIndex != -1 && !parentItemID) {
+						if (parentIndex != -1 && !parentItemID) {
+							this._closeContainer(row);
 							this._removeRow(row);
 
 							let beforeRow = this.rowCount;
@@ -711,9 +697,24 @@ var ItemTree = class ItemTree extends LibraryTree {
 
 							sort = true;
 						}
+						// If item moved from top-level to under another item, remove the old row.
+						else if (parentIndex == -1 && parentItemID) {
+							this._closeContainer(row);
+							this._removeRow(row);
+						}
 						// If item was moved from one parent to another, remove from old parent
 						else if (parentItemID && parentIndex != -1 && this._rowMap[parentItemID] != parentIndex) {
+							this._closeContainer(row);
 							this._removeRow(row);
+						}
+						// If Unfiled Items and item was added to a collection, remove from view
+						else if (this.isContainer(row) && collectionTreeRow.isUnfiled() && item.getCollections().length) {
+							this._closeContainer(row);
+							this._removeRow(row);
+						}
+						// Resort everything if a container is updated, just in case
+						else if (this.isContainer(row)) {
+							sort = true;
 						}
 						// If not moved from under one item to another, just resort the row,
 						// which also invalidates it and refreshes it

--- a/test/tests/itemTreeTest.js
+++ b/test/tests/itemTreeTest.js
@@ -798,7 +798,7 @@ describe("Zotero.ItemTree", function() {
 				await collection.addItem(item.id);
 			});
 			assert.isFalse(zp.itemsView.getRowIndexByID(item.id));
-			// Ensure there is no leftover ghost attachment row
+			// Ensure there is no leftover attachment row
 			assert.isFalse(zp.itemsView.getRowIndexByID(attachment.id));
 		});
 
@@ -818,7 +818,7 @@ describe("Zotero.ItemTree", function() {
 				zp.itemsView.expandAllRows();
 			});
 			
-			it("should leave no ghost child rows after changing attachment's parent", async function () {
+			it("should remove old attachment and annotation rows on attachment parent change", async function () {
 				// Change attachment parent
 				attachment1.parentID = item2.id;
 				await attachment1.saveTx();
@@ -835,7 +835,7 @@ describe("Zotero.ItemTree", function() {
 				assert.isFalse(annotationRowIndex);
 			});
 		
-			it("should leave no ghost rows after making an attachment top level", async function () {
+			it("should remove old attachment and annotation rows after a child attachment is moved to top level", async function () {
 				// Make attachment top level
 				attachment1.parentID = null;
 				await attachment1.saveTx();
@@ -849,7 +849,7 @@ describe("Zotero.ItemTree", function() {
 				assert.isFalse(annotationRowIndex);
 			});
 		
-			it("should leave no ghost rows after making a top-level attachment a child", async function () {
+			it("should remove old attachment and annotation rows after a top-level attachment is made a child", async function () {
 				// Make a top-level attachment
 				let topLevelAttachment = await importFileAttachment('test.pdf', { title: 'Top Level Attachment', parentItemID: null });
 				let highlightOfTopLevel = await createAnnotation('highlight', topLevelAttachment);
@@ -870,7 +870,7 @@ describe("Zotero.ItemTree", function() {
 				assert.isFalse(annotationRowIndex);
 			});
 		
-			it("should not loose note row after making it top-level", async function () {
+			it("should handle child note being moved to top level", async function () {
 				let note1 = await createDataObject('item', { itemType: 'note', parentID: item1.id });
 				let itemRowIndex = itemsView.getRowIndexByID(item1.id);
 				let noteRowIndex = itemsView.getRowIndexByID(note1.id);
@@ -885,7 +885,7 @@ describe("Zotero.ItemTree", function() {
 				assert.equal(itemsView.getRow(noteRowIndex).level, 0);
 			});
 		
-			it("should not loose note row after making it a child", async function () {
+			it("should handle top-level note being made a child note", async function () {
 				// Make a top-level note
 				let note = await createDataObject('item', { itemType: 'note', parentID: null });
 
@@ -901,7 +901,7 @@ describe("Zotero.ItemTree", function() {
 				assert.equal(noteRowIndex, secondItemRowIndex + 1);
 			});
 
-			it("should not loose note row after moving it between items", async function () {
+			it("should handle child note being moved between items", async function () {
 				let note1 = await createDataObject('item', { itemType: 'note', parentID: item1.id });
 				let itemRowIndex = itemsView.getRowIndexByID(item1.id);
 				let noteRowIndex = itemsView.getRowIndexByID(note1.id);


### PR DESCRIPTION
- collapse all rows before removing them. It makes sure that annotation rows will be cleaned up properly when an annotation row is moved into another parent.
- move handling of inserting a new row when attachment is moved to be a top-level row from under a parent into the `item.isTopLevelItem()` condition. Otherwise, it never gets reached and attachment row just disappears when dragged to the top level.

Fixes: #5246

https://github.com/user-attachments/assets/cb277e7f-1330-497c-89f8-0dc57c218081

