### PR TITLE
Open annotation in new window on Shift+Enter on annotation row

### DIFF
--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -4991,7 +4991,7 @@ var ZoteroPane = new function()
 				yield this.viewAttachment(item.id, event);
 			}
 			else if (item.isAnnotation()) {
-				this.viewPDF(item.parentItemID, { annotationID: item.key });
+				this.viewAttachment(item.parentItemID, event, false, { location: { annotationID: item.key } });
 			}
 		}
 	});


### PR DESCRIPTION
Per https://forums.zotero.org/discussion/123944/shift-enter-to-open-the-annotations-in-separate-windows-of-the-reader