### PR TITLE
Fix table columns misaligned after resizing

### DIFF
--- a/chrome/content/zotero/components/virtualized-table.jsx
+++ b/chrome/content/zotero/components/virtualized-table.jsx
@@ -842,7 +842,10 @@ class VirtualizedTable extends React.Component {
 		event.stopPropagation();
 		const result = this._getResizeColumns();
 		if (!result) return;
+		const columns = this._getVisibleColumns();
 		const [aColumn, bColumn, resizingColumn] = result;
+		const isFirstColumn = columns[0].dataKey === aColumn.dataKey;
+		const firstColumnExtraWidth = isFirstColumn ? (this.props.firstColumnExtraWidth || 0) : 0;
 		const a = document.querySelector(`#${this.props.id} .virtualized-table-header .cell.${window.CSS.escape(aColumn.dataKey)}`);
 		const b = document.querySelector(`#${this.props.id} .virtualized-table-header .cell.${window.CSS.escape(bColumn.dataKey)}`);
 		const resizing = document.querySelector(`#${this.props.id} .virtualized-table-header .cell.${window.CSS.escape(resizingColumn.dataKey)}`);
@@ -856,7 +859,7 @@ class VirtualizedTable extends React.Component {
 		const widthSum = aRect.width + bRect.width;
 		const aColumnPadding = aColumn.iconLabel ? 0 : COLUMN_PADDING;
 		const bColumnPadding = bColumn.iconLabel ? 0 : COLUMN_PADDING;
-		const aSpacingOffset = (aColumn.minWidth ? aColumn.minWidth : COLUMN_MIN_WIDTH) + aColumnPadding;
+		const aSpacingOffset = (aColumn.minWidth ? aColumn.minWidth : COLUMN_MIN_WIDTH) + aColumnPadding + firstColumnExtraWidth;
 		const bSpacingOffset = (bColumn.minWidth ? bColumn.minWidth : COLUMN_MIN_WIDTH) + bColumnPadding;
 		const aColumnWidth = Math.min(widthSum - bSpacingOffset, Math.max(aSpacingOffset, event.clientX - (RESIZER_WIDTH / 2) - offset));
 		const bColumnWidth = widthSum - aColumnWidth;
@@ -864,7 +867,7 @@ class VirtualizedTable extends React.Component {
 		onResizeData[aColumn.dataKey] = aColumnWidth;
 		onResizeData[bColumn.dataKey] = bColumnWidth;
 		this._columns.onResize(onResizeData);
-	}
+	};
 	
 	/**
 	 * Get all columns including hidden ones

--- a/chrome/content/zotero/components/virtualized-table.jsx
+++ b/chrome/content/zotero/components/virtualized-table.jsx
@@ -1088,6 +1088,7 @@ class VirtualizedTable extends React.Component {
 	
 		this._setXulTooltip();
 
+		this._topDiv.style.setProperty("--firstColumnExtraWidth", `${this.props.firstColumnExtraWidth || 0}px`);
 		window.addEventListener("resize", () => {
 			this._debouncedRerender();
 		});

--- a/chrome/content/zotero/components/virtualized-table.jsx
+++ b/chrome/content/zotero/components/virtualized-table.jsx
@@ -1602,10 +1602,6 @@ var Columns = class {
 		this._virtualizedTable.props.storeColumnPrefs(prefs);
 	}
 
-	// Injects extra width into the first column if that column has
-	// `staticWidth` or `minWidth` configured, in order to accommodate space for
-	// the item type icon and the chevron.The original width is restored if the
-	// column is reordered to a different position.
 	_adjustColumnWidths = () => {
 		if (!this._virtualizedTable.props.firstColumnExtraWidth) {
 			return;
@@ -1622,55 +1618,6 @@ var Columns = class {
 				column.width = isFirstColumn ? Math.max(parseInt(column.width) ?? 0, column.minWidth) : column.width;
 			}
 		});
-	};
-
-	// Measures the current width of the table header and redistributes the
-	// available width among visible columns. Static- and fixed-width columns
-	// preserve their stored width, while the remaining space is distributed
-	// proportionally among other columns based on each column's width property.
-	// This resolves an issue where the flex model causes slight column
-	// misalignment (see #4993).
-	_redistributeColumnWidths = () => {
-		let header = document.querySelector(`#${this._virtualizedTable.props.id} .virtualized-table-header`);
-		let headerRect = header.getBoundingClientRect();
-		const headerPadding = parseInt(window.getComputedStyle(header).paddingLeft) + parseInt(window.getComputedStyle(header).paddingRight);
-		const headerWidth = headerRect.width - headerPadding;
-		let nextVisibleColumns = this._columns.filter(c => !c.hidden);
-
-		// Normalize widths. Calculate widths for columns without a set value using the flex property.
-		nextVisibleColumns = nextVisibleColumns.map((column) => {
-			let width = parseFloat(column.width);
-			if (isNaN(width)) {
-				width = Math.max((headerWidth / nextVisibleColumns.length * (column.flex || 1)), column.minWidth || COLUMN_MIN_WIDTH);
-			}
-			return { ...column, width };
-		});
-
-		// Calculate the combined width of fixed and static columns, then subtract it from the header width to determine the available space.
-		let fixedColumns = nextVisibleColumns.filter(c => c.staticWidth || c.fixedWidth);
-		let fixedColumnsTotalWidth = fixedColumns.reduce((accumulator, column) => accumulator += column.width, 0);
-		let availableWidth = Math.max(headerWidth - fixedColumnsTotalWidth, 1); // safety catch for extreme case where fixed columns take up all the space
-
-		// Calculate the total width of the other columns
-		let otherColumns = nextVisibleColumns.filter(c => !c.staticWidth && !c.fixedWidth);
-		let otherColumnsTotalWidth = otherColumns.reduce((accumulator, column) => accumulator += column.width, 0);
-		
-		// Calculate the fraction of space each non-fixed column should occupy. This iterates over all visible columns to keep the indexes, but calculations for fixed and static columns will be discarded
-		let otherColumnsFractions = nextVisibleColumns.map(column => column.width / otherColumnsTotalWidth);
-		let resizeData = {};
-
-		for (let i = 0; i < nextVisibleColumns.length; i++) {
-			let column = nextVisibleColumns[i];
-			if (column.staticWidth || column.fixedWidth) {
-				resizeData[column.dataKey] = column.width;
-			}
-			else {
-				const width = availableWidth * otherColumnsFractions[i];
-				resizeData[column.dataKey] = width;
-			}
-		}
-
-		this.onResize(resizeData);
 	};
 
 	/**
@@ -1724,7 +1671,7 @@ var Columns = class {
 		});
 
 		this._adjustColumnWidths();
-		this.onResize(Object.fromEntries(this._columns.filter(c => !c.hidden).map(c => [c.dataKey, c.width])));
+		this.onResize(Object.fromEntries(this._columns.map(c => [c.dataKey, c.width])));
 
 		let prefs = this._getPrefs();
 		// reassign columns their ordinal values and set the prefs
@@ -1754,7 +1701,7 @@ var Columns = class {
 		}
 		this._columns.sort((a, b) => a.ordinal - b.ordinal);
 		this._adjustColumnWidths();
-		this.onResize(Object.fromEntries(this._columns.filter(c => !c.hidden).map(c => [c.dataKey, c.width])));
+		this.onResize(Object.fromEntries(this._columns.map(c => [c.dataKey, c.width])));
 		this._storePrefs(prefs);
 		this._updateVirtualizedTable();
 	}
@@ -1767,9 +1714,8 @@ var Columns = class {
 		if (prefs[column.dataKey]) {
 			prefs[column.dataKey].hidden = column.hidden;
 		}
-
 		this._adjustColumnWidths();
-		this._redistributeColumnWidths();
+		this.onResize(Object.fromEntries(this._columns.map(c => [c.dataKey, c.width])));
 		this._storePrefs(prefs);
 		this._updateVirtualizedTable();
 	}

--- a/chrome/content/zotero/itemTreeColumns.jsx
+++ b/chrome/content/zotero/itemTreeColumns.jsx
@@ -78,8 +78,7 @@ const COLUMNS = [
 		dataKey: "itemType",
 		label: "zotero.items.itemType",
 		showInColumnPicker: true,
-		width: "56",
-		staticWidth: true,
+		width: "40",
 		zoteroPersist: ["width", "hidden", "sortDirection"]
 	},
 	{

--- a/scss/components/_item-tree.scss
+++ b/scss/components/_item-tree.scss
@@ -30,15 +30,9 @@
 		.cell.numNotes {
 			padding: 0;
 			text-align: center;
-
-			&.first-column {
-				padding-inline-start: 32px;
-			}
 		}
 
 		.first-column {
-			padding-inline-start: 36px;
-
 			&::before {
 				content: "";
 				display: inline-block;

--- a/scss/components/_virtualized-table.scss
+++ b/scss/components/_virtualized-table.scss
@@ -40,7 +40,10 @@
 	}
 	
 	.cell {
-		padding: 0 8px;
+		// NOTE: To avoid the complexities of dealing with padding in the
+		// flexbox model, `.cell` padding must be identical in the header and
+		// body. See #5198, #5162.
+		padding: 0 8px; 
 		min-width: 30px;
 		cursor: default;
 		white-space: nowrap;
@@ -50,6 +53,11 @@
 		&.label {
 			padding-inline-start: 0;
 			padding-inline-end: 4px;
+		}
+
+		&.first-column {
+			padding-inline-start: 0;
+			min-width: calc(var(--firstColumnExtraWidth, 0px) + 30px);
 		}
 
 		&.first-column,
@@ -278,6 +286,13 @@
 		text-align: center;
 	}
 
+	.first-column {
+		> :first-child {
+			// offset header's column label/icon to align with the text in the first column, without introducing padding to the cell itself to avoid flexbox issues
+			padding-inline-start: calc(var(--firstColumnExtraWidth, 0px) + 8px);
+		}
+	}
+
 	.cell {
 		display: flex;
 		position: relative;
@@ -352,6 +367,7 @@
 	padding: 4px 8px 8px;
 
 	.cell {
+		// NOTE: Do not add padding here. See #5198
 		text-overflow: ellipsis;
 		overflow: hidden;
 		max-height: 100%;
@@ -361,10 +377,6 @@
 		// pointer-events are enabled, and we need to rerender the rows for selection
 		// before dragging.
 		pointer-events: none;
-
-		&.first-column {
-			padding-inline-start: 0;
-		}
 	}
 }
 


### PR DESCRIPTION
This PR is a follow-up to #5162 and fixes misaligned columns that sometimes appear after:

- [x] Resizing the first column to the minimal width  
- [x] Shrinking the items tree table pane  
- [x] Shrinking the entire window

Resolves #5198