### PR TITLE
Improve performance of annotation rows removal

### DIFF
--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -3346,7 +3346,10 @@ var ItemTree = class ItemTree extends LibraryTree {
 		while ((index + 1 < this._rows.length) && (this.getLevel(index + 1) > level)) {
 			// Skip the map update here and just refresh the whole map below,
 			// since we might be removing multiple rows
-			this._removeRow(index + 1, true);
+			// Also, do not update the selection with each row removal for better performance
+			// when attachment with many annotations is being closed if the selection
+			// is already being restored in the end
+			this._removeRow(index + 1, true, !skipRowMapRefresh);
 			count++;
 		}
 

--- a/chrome/content/zotero/libraryTree.js
+++ b/chrome/content/zotero/libraryTree.js
@@ -155,11 +155,12 @@ var LibraryTree = class LibraryTree extends React.Component {
 	 * Remove a row from the main array and parent row children arrays,
 	 * delete the row from the map, and optionally update all rows above it in the map
 	 */
-	_removeRow(index, skipMapUpdate) {
+	_removeRow(index, skipMapUpdate, skipSelectionUpdate) {
 		var id = this.getRow(index).id;
 		let level = this.getLevel(index);
 
-		if (index <= this.selection.focused) {
+		// Maintain selection unless specified otherwise
+		if (!skipSelectionUpdate && index <= this.selection.focused) {
 			this.selection.select(this.selection.focused - 1);
 		}
 


### PR DESCRIPTION
Do not update `itemTree` selection on each annotation row removal when an attachment row is collapsed.
It causes a significant delay when attachment with many annotations is collapsed if selection is on any row below the attachment. It is also redundant because the selection is updated at the end of `_closeContainer` anyway.

Fixes: #5255

This is the current behavior of attachment row collapse without the noticeable delay from recording in linked issue.

https://github.com/user-attachments/assets/b8387210-fd52-4dd6-86ac-f8998f778b3a

