### PR TITLE
Always show item/context pane toggle

### DIFF
--- a/chrome/content/zotero/contextPane.js
+++ b/chrome/content/zotero/contextPane.js
@@ -145,6 +145,9 @@ var ZoteroContextPane = new function () {
 			// needed for standard layout
 			_contextPane.style.width = 'auto';
 			_contextPaneInner.style.removeProperty("min-height");
+
+			// Propagate state to standard splitter
+			_contextPaneSplitter.setAttribute('state', this.collapsed ? 'collapsed' : 'open');
 		}
 		else {
 			_contextPaneSplitter.setAttribute('hidden', false);
@@ -160,6 +163,9 @@ var ZoteroContextPane = new function () {
 			// force it to occupy all height available
 			_contextPaneInner.style.minHeight = `100%`;
 			_contextPane.style.width = `${_contextPane.getAttribute("width")}px`;
+
+			// Propagate state to stacked splitter
+			_contextPaneSplitterStacked.setAttribute('state', this.collapsed ? 'collapsed' : 'open');
 		}
 		
 		Zotero.Reader.setContextPaneOpen(!this.collapsed);

--- a/chrome/content/zotero/elements/contextPane.js
+++ b/chrome/content/zotero/elements/contextPane.js
@@ -25,6 +25,10 @@
 
 
 {
+	let { isPaneCollapsed, setPaneCollapsed } = ChromeUtils.importESModule(
+		'chrome://zotero/content/elements/utils/collapsiblePane.mjs'
+	);
+
 	class ContextPane extends XULElementBase {
 		content = MozXULElement.parseXULToFragment(`
 			<deck id="zotero-context-pane-deck" flex="1" selectedIndex="0">
@@ -61,6 +65,14 @@
 		get activeEditor() {
 			let currentContext = this._getCurrentNotesContext();
 			return currentContext?._getCurrentEditor();
+		}
+
+		get collapsed() {
+			return isPaneCollapsed(this);
+		}
+
+		set collapsed(val) {
+			setPaneCollapsed(this, val);
 		}
 
 		init() {
@@ -329,9 +341,7 @@
 		}
 	
 		handleFocus() {
-			let splitter = ZoteroContextPane.splitter;
-	
-			if (splitter.getAttribute('state') != 'collapsed') {
+			if (!this.collapsed) {
 				if (this.mode == "item") {
 					let header = this._itemPaneDeck.selectedPanel.querySelector("item-pane-header");
 					// Focus the first focusable node after header

--- a/chrome/content/zotero/elements/itemDetails.js
+++ b/chrome/content/zotero/elements/itemDetails.js
@@ -164,7 +164,7 @@
 		 * @returns {boolean}
 		 */
 		get _collapsed() {
-			let parentPane = this.closest('splitter:not([hidden="true"]) + *');
+			let parentPane = this.closest('item-pane, context-pane');
 			if (!parentPane) {
 				return false;
 			}
@@ -176,7 +176,7 @@
 		 * @param {boolean} val
 		 */
 		set _collapsed(val) {
-			let parentPane = this.closest('splitter:not([hidden="true"]) + *');
+			let parentPane = this.closest('item-pane, context-pane');
 			if (!parentPane) {
 				return;
 			}

--- a/chrome/content/zotero/elements/itemDetails.js
+++ b/chrome/content/zotero/elements/itemDetails.js
@@ -157,29 +157,30 @@
 			this._paneParent.style.setProperty('--min-scroll-height', val + 'px');
 		}
 
+		/**
+		 * Convenience getter that delegates to our <item-pane> / <context-pane>
+		 * parent. This exists because the sidenav controls us, not the <item-pane>,
+		 * but needs to get/set its collapsed state.
+		 * @returns {boolean}
+		 */
 		get _collapsed() {
-			let collapsible = this.closest('splitter:not([hidden="true"]) + *');
-			if (!collapsible) return false;
-			return collapsible.getAttribute('collapsed') === 'true';
+			let parentPane = this.closest('splitter:not([hidden="true"]) + *');
+			if (!parentPane) {
+				return false;
+			}
+			return parentPane.collapsed;
 		}
 		
+		/**
+		 * Convenience setter for collapsed state. See above.
+		 * @param {boolean} val
+		 */
 		set _collapsed(val) {
-			let collapsible = this.closest('splitter:not([hidden="true"]) + *');
-			if (!collapsible) return;
-			let splitter = collapsible.previousElementSibling;
-			if (val) {
-				collapsible.setAttribute('collapsed', 'true');
-				collapsible.removeAttribute("width");
-				collapsible.removeAttribute("height");
-				splitter.setAttribute('state', 'collapsed');
-				splitter.setAttribute('substate', 'after');
+			let parentPane = this.closest('splitter:not([hidden="true"]) + *');
+			if (!parentPane) {
+				return;
 			}
-			else {
-				collapsible.removeAttribute('collapsed');
-				splitter.setAttribute('state', '');
-				splitter.setAttribute('substate', 'after');
-			}
-			window.dispatchEvent(new Event('resize'));
+			parentPane.collapsed = val;
 		}
 
 		get sidenav() {

--- a/chrome/content/zotero/elements/itemPane.js
+++ b/chrome/content/zotero/elements/itemPane.js
@@ -25,6 +25,10 @@
 
 
 {
+	let { isPaneCollapsed, setPaneCollapsed } = ChromeUtils.importESModule(
+		'chrome://zotero/content/elements/utils/collapsiblePane.mjs'
+	);
+	
 	class ItemPane extends XULElementBase {
 		content = MozXULElement.parseXULToFragment(`
 			<deck id="zotero-item-pane-content" class="zotero-item-pane-content" selectedIndex="0" flex="1">
@@ -105,6 +109,14 @@
 		 */
 		set mode(type) {
 			this.setAttribute("view-type", type);
+		}
+
+		get collapsed() {
+			return isPaneCollapsed(this);
+		}
+
+		set collapsed(val) {
+			setPaneCollapsed(this, val);
 		}
 
 		render() {

--- a/chrome/content/zotero/elements/itemPane.js
+++ b/chrome/content/zotero/elements/itemPane.js
@@ -121,7 +121,6 @@
 
 		render() {
 			if (!this.data) return false;
-			let hideSidenav = false;
 			let renderStatus = false;
 			// Only annotations selected
 			if (this.data.length > 0 && this.data.every(item => item.isAnnotation())) {
@@ -136,7 +135,6 @@
 					renderStatus = this.renderMessage();
 				}
 				else if (item.isNote()) {
-					hideSidenav = true;
 					renderStatus = this.renderNoteEditor(item);
 				}
 				else {
@@ -147,7 +145,6 @@
 			else {
 				renderStatus = this.renderMessage();
 			}
-			this._sidenav.hidden = hideSidenav;
 			return renderStatus;
 		}
 

--- a/chrome/content/zotero/elements/itemPaneSidenav.js
+++ b/chrome/content/zotero/elements/itemPaneSidenav.js
@@ -28,6 +28,14 @@
 {
 	class ItemPaneSidenav extends XULElementBase {
 		content = MozXULElement.parseXULToFragment(`
+			<!-- Standard mode only: Toggle Item/Context Pane button -->
+			<toolbarbutton class="btn"
+				data-action="toggle-pane"
+				tabindex="0"
+			/>
+			
+			<html:div class="divider"/>
+			
 			<html:div class="inherit-flex highlight-notes-inactive" tabindex="0" role="tab" data-l10n-id="sidenav-main-btn-grouping">
 				<!-- Buttons will be added dynamically -->
 			</html:div>
@@ -215,6 +223,11 @@
 			for (let button of this.querySelectorAll('.btn[data-action]')) {
 				let action = button.dataset.action;
 				
+				if (action === 'toggle-pane') {
+					button.addEventListener('command', () => {
+						this._collapsed = !this._collapsed;
+					});
+				}
 				if (action === 'locate') {
 					button.addEventListener('mousedown', async (event) => {
 						if (event.button !== 0 || button.open) {
@@ -313,8 +326,14 @@
 			for (let button of this.querySelectorAll('.btn[data-action]')) {
 				let action = button.dataset.action;
 				
-				if (action == 'locate') {
+				if (action == 'toggle-pane' || action == 'locate') {
 					button.parentElement.hidden = false;
+				}
+				if (action == 'toggle-pane') {
+					document.l10n.setAttributes(button,
+						Zotero_Tabs.selectedType === 'library'
+							? 'toggle-item-pane'
+							: 'toggle-context-pane');
 				}
 			}
 			
@@ -601,7 +620,7 @@
 			return {
 				index,
 				position: index === 0 ? 0 : index * (btnSize + btnGap) + btnGap / 2
-			}
+			};
 		};
 
 		handleKeyDown = (event) => {

--- a/chrome/content/zotero/elements/itemPaneSidenav.js
+++ b/chrome/content/zotero/elements/itemPaneSidenav.js
@@ -127,7 +127,7 @@
 		}
 
 		get _collapsed() {
-			return this.container?._collapsed;
+			return !!this.container?._collapsed;
 		}
 
 		set _collapsed(val) {

--- a/chrome/content/zotero/elements/utils/collapsiblePane.mjs
+++ b/chrome/content/zotero/elements/utils/collapsiblePane.mjs
@@ -1,0 +1,64 @@
+/*
+    ***** BEGIN LICENSE BLOCK *****
+    
+    Copyright © 2025 Corporation for Digital Scholarship
+                     Vienna, Virginia, USA
+                     https://www.zotero.org
+    
+    This file is part of Zotero.
+    
+    Zotero is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    
+    Zotero is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+    
+    You should have received a copy of the GNU Affero General Public License
+    along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
+    
+    ***** END LICENSE BLOCK *****
+*/
+
+/**
+ * Get the collapsed state of an <item-pane> or <context-pane>.
+ *
+ * @param {XULElement} pane
+ * @returns {boolean}
+ */
+export function isPaneCollapsed(pane) {
+	if (pane.previousElementSibling?.localName !== 'splitter') {
+		return false;
+	}
+	return pane.getAttribute('collapsed') === 'true';
+}
+
+/**
+ * Set the collapsed state of an <item-pane> or <context-pane>.
+ *
+ * @param {XULElement} pane
+ * @param {boolean} collapsed
+ */
+export function setPaneCollapsed(pane, collapsed) {
+	let splitter = pane.previousElementSibling;
+	if (splitter.localName !== 'splitter') {
+		return;
+	}
+
+	if (collapsed) {
+		pane.setAttribute('collapsed', 'true');
+		pane.removeAttribute('width');
+		pane.removeAttribute('height');
+		splitter.setAttribute('state', 'collapsed');
+		splitter.setAttribute('substate', 'after');
+	}
+	else {
+		pane.removeAttribute('collapsed');
+		splitter.setAttribute('state', '');
+		splitter.setAttribute('substate', 'after');
+	}
+	pane.ownerDocument.defaultView.dispatchEvent(new Event('resize'));
+}

--- a/chrome/content/zotero/elements/utils/collapsiblePane.mjs
+++ b/chrome/content/zotero/elements/utils/collapsiblePane.mjs
@@ -30,10 +30,11 @@
  * @returns {boolean}
  */
 export function isPaneCollapsed(pane) {
-	if (pane.previousElementSibling?.localName !== 'splitter') {
+	let collapsibleParent = pane.closest('splitter:not([hidden="true"]) + *');
+	if (collapsibleParent.previousElementSibling?.localName !== 'splitter') {
 		return false;
 	}
-	return pane.getAttribute('collapsed') === 'true';
+	return collapsibleParent.getAttribute('collapsed') === 'true';
 }
 
 /**
@@ -43,20 +44,21 @@ export function isPaneCollapsed(pane) {
  * @param {boolean} collapsed
  */
 export function setPaneCollapsed(pane, collapsed) {
-	let splitter = pane.previousElementSibling;
-	if (splitter.localName !== 'splitter') {
+	let collapsibleParent = pane.closest('splitter:not([hidden="true"]) + *');
+	if (!collapsibleParent) {
 		return;
 	}
+	let splitter = collapsibleParent.previousElementSibling;
 
 	if (collapsed) {
-		pane.setAttribute('collapsed', 'true');
-		pane.removeAttribute('width');
-		pane.removeAttribute('height');
+		collapsibleParent.setAttribute('collapsed', 'true');
+		collapsibleParent.removeAttribute('width');
+		collapsibleParent.removeAttribute('height');
 		splitter.setAttribute('state', 'collapsed');
 		splitter.setAttribute('substate', 'after');
 	}
 	else {
-		pane.removeAttribute('collapsed');
+		collapsibleParent.removeAttribute('collapsed');
 		splitter.setAttribute('state', '');
 		splitter.setAttribute('substate', 'after');
 	}

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -201,6 +201,7 @@ class ReaderInstance {
 			sidebarWidth: this._sidebarWidth,
 			sidebarOpen: this._sidebarOpen,
 			bottomPlaceholderHeight: this._bottomPlaceholderHeight,
+			contextPaneOpen: this._contextPaneOpen,
 			rtl: Zotero.rtl,
 			fontSize: Zotero.Prefs.get('fontSize'),
 			localizedStrings: {
@@ -1236,6 +1237,7 @@ class ReaderTab extends ReaderInstance {
 		super(options);
 		this._sidebarWidth = options.sidebarWidth;
 		this._sidebarOpen = options.sidebarOpen;
+		this._contextPaneOpen = options.bottomPlaceholderHeight;
 		this._bottomPlaceholderHeight = options.bottomPlaceholderHeight;
 		this._showContextPaneToggle = true;
 		this._onToggleSidebarCallback = options.onToggleSidebar;
@@ -1388,6 +1390,7 @@ class ReaderWindow extends ReaderInstance {
 		super(options);
 		this._sidebarWidth = options.sidebarWidth;
 		this._sidebarOpen = options.sidebarOpen;
+		this._contextPaneOpen = false;
 		this._bottomPlaceholderHeight = 0;
 		this._onClose = options.onClose;
 
@@ -1800,6 +1803,7 @@ class Reader {
 	constructor() {
 		this._sidebarWidth = 240;
 		this._sidebarOpen = false;
+		this._contextPaneOpen = false;
 		this._bottomPlaceholderHeight = 0;
 		this._readers = [];
 		this._notifierID = Zotero.Notifier.registerObserver(this, ['item', 'setting', 'tab'], 'reader');
@@ -1924,6 +1928,14 @@ class Reader {
 			reader.toggleSidebar(open);
 		}
 		this._setSidebarState();
+	}
+
+	setContextPaneOpen(open) {
+		this._contextPaneOpen = open;
+		let readers = this._readers.filter(r => r instanceof ReaderTab);
+		for (let reader of readers) {
+			reader.setContextPaneOpen(open);
+		}
 	}
 	
 	setBottomPlaceholderHeight(height) {
@@ -2107,6 +2119,7 @@ class Reader {
 				background: openInBackground,
 				sidebarWidth: this._sidebarWidth,
 				sidebarOpen: this._sidebarOpen,
+				contextPaneOpen: this._contextPaneOpen,
 				bottomPlaceholderHeight: this._bottomPlaceholderHeight,
 				preventJumpback: preventJumpback,
 				onToggleSidebar: (open) => {

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -669,6 +669,11 @@ class ReaderInstance {
 		setTimeout(() => this._iframeWindow.focus());
 	}
 
+	async setContextPaneOpen(open) {
+		await this._initPromise;
+		this._internalReader.setContextPaneOpen(open);
+	}
+
 	async setBottomPlaceholderHeight(height) {
 		await this._initPromise;
 		this._internalReader.setBottomPlaceholderHeight(height);

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -227,7 +227,8 @@ var ZoteroPane = new function()
 				// If desired target is hidden/disabled, create a fake event
 				// and dispatch it on the hidden target to rerun moveFocus
 				// and place focus on the next non-hidden node
-				if (target.disabled || target.hidden || target.parentNode.hidden) {
+				if (target.disabled || target.hidden || target.parentNode.hidden
+						|| getComputedStyle(target).display === 'none') {
 					event.target = target;
 					let fakeEventCopy = new KeyboardEvent('keydown', {
 						key: event.key,
@@ -405,14 +406,18 @@ var ZoteroPane = new function()
 					ShiftTab: () => {
 						document.getElementById("zotero-tb-search")._searchModePopup.flattenedTreeParentNode.focus();
 					},
-					Tab: () => itemTree.querySelector(".virtualized-table")
+					Tab: () => document.getElementById("zotero-tb-toggle-item-pane-stacked")
 				},
 				'zotero-tb-search-dropmarker': {
 					ArrowNext: () => null,
 					ArrowPrevious: () => null,
 					Tab: () => document.getElementById("zotero-tb-search-textbox"),
 					ShiftTab: () => document.getElementById('zotero-tb-add')
-				}
+				},
+				'zotero-tb-toggle-item-pane-stacked': {
+					Tab: () => itemTree.querySelector(".virtualized-table"),
+					ShiftTab: () => document.getElementById("zotero-tb-search-textbox")
+				},
 			};
 			moveFocus(actionsMap, event, true);
 		});
@@ -441,7 +446,7 @@ var ZoteroPane = new function()
 		itemTree.addEventListener("keydown", (event) => {
 			let actionsMap = {
 				'item-tree-main-default': {
-					ShiftTab: () => document.getElementById('zotero-tb-search-textbox')
+					ShiftTab: () => document.getElementById('zotero-tb-toggle-item-pane-stacked')
 				}
 			};
 			moveFocus(actionsMap, event);

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -161,14 +161,14 @@ var ZoteroPane = new function()
 	};
 
 	function setUpKeyboardNavigation() {
-		let collectionTreeToolbar = this.document.getElementById("zotero-toolbar-collection-tree");
-		let itemTreeToolbar = this.document.getElementById("zotero-toolbar-item-tree");
-		let titleBar = this.document.getElementById("zotero-title-bar");
-		let itemTree = this.document.getElementById("zotero-items-tree");
-		let collectionsTree = this.document.getElementById("zotero-collections-tree");
-		let tagSelector = this.document.getElementById("zotero-tag-selector");
-		let tagContainer = this.document.getElementById('zotero-tag-selector-container');
-		let collectionsPane = this.document.getElementById("zotero-collections-pane");
+		let collectionTreeToolbar = document.getElementById("zotero-toolbar-collection-tree");
+		let itemTreeToolbar = document.getElementById("zotero-toolbar-item-tree");
+		let titleBar = document.getElementById("zotero-title-bar");
+		let itemTree = document.getElementById("zotero-items-tree");
+		let collectionsTree = document.getElementById("zotero-collections-tree");
+		let tagSelector = document.getElementById("zotero-tag-selector");
+		let tagContainer = document.getElementById('zotero-tag-selector-container');
+		let collectionsPane = document.getElementById("zotero-collections-pane");
 
 		// function to handle actual focusing based on a given event
 		// and a mapping of event targets + keys to the focus destinations

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -402,17 +402,17 @@ var ZoteroPane = new function()
 					Tab: () => document.getElementById("zotero-tb-search")._searchModePopup.flattenedTreeParentNode.focus(),
 					ShiftTab: () => document.getElementById('zotero-tb-collections-search').click()
 				},
-				'zotero-tb-search-textbox': {
-					ShiftTab: () => {
-						document.getElementById("zotero-tb-search")._searchModePopup.flattenedTreeParentNode.focus();
-					},
-					Tab: () => document.getElementById("zotero-tb-toggle-item-pane-stacked")
-				},
 				'zotero-tb-search-dropmarker': {
 					ArrowNext: () => null,
 					ArrowPrevious: () => null,
 					Tab: () => document.getElementById("zotero-tb-search-textbox"),
 					ShiftTab: () => document.getElementById('zotero-tb-add')
+				},
+				'zotero-tb-search-textbox': {
+					Tab: () => document.getElementById("zotero-tb-toggle-item-pane-stacked"),
+					ShiftTab: () => {
+						document.getElementById("zotero-tb-search")._searchModePopup.flattenedTreeParentNode.focus();
+					}
 				},
 				'zotero-tb-toggle-item-pane-stacked': {
 					Tab: () => itemTree.querySelector(".virtualized-table"),

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -6853,8 +6853,14 @@ var ZoteroPane = new function()
 		this.handleTagSelectorResize();
 
 		this.itemPane.handleResize();
-	}
-
+	};
+	
+	
+	this.toggleItemPane = function () {
+		this.itemPane.collapsed = !this.itemPane.collapsed;
+		this.updateLayoutConstraints();
+	};
+	
 	
 	// Set the label of the dynamic tooltip. Can be used when we cannot set .tooltiptext
 	// property, e.g. if we don't want the tooltip to be announced by screenreaders.

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -1344,6 +1344,15 @@
 														onkeydown="ZoteroPane_Local.handleSearchKeypress(this, event)"
 														oninput="ZoteroPane_Local.handleSearchInput(this, event)"
 														oncommand="ZoteroPane_Local.search()"/>
+												
+												<!-- Stacked mode only: Toggle Item Pane button -->
+												<toolbarbutton
+													id="zotero-tb-toggle-item-pane-stacked"
+													class="zotero-tb-button"
+													tabindex="-1"
+													data-l10n-id="toggle-item-pane"
+													oncommand="ZoteroPane.toggleItemPane()"
+												/>
 											</hbox>
 											
 										</toolbar>

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -537,6 +537,11 @@ sidenav-reorder-down =
 sidenav-reorder-reset =
     .label = Reset Section Order
 
+toggle-item-pane =
+    .tooltiptext = Toggle Item Pane
+toggle-context-pane =
+    .tooltiptext = Toggle Context Pane
+
 pin-section =
     .label = Pin Section
 unpin-section =

--- a/chrome/skin/default/zotero/20/universal/sidebar-bottom.svg
+++ b/chrome/skin/default/zotero/20/universal/sidebar-bottom.svg
@@ -1,0 +1,5 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6 15V16.25L14 16.25V15L6 15Z" fill="context-fill"/>
+<path d="M6 12.75V14L12 14V12.75L6 12.75Z" fill="context-fill"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M17 17.75C17 18.4404 16.4404 19 15.75 19L4.25 19C3.55964 19 3 18.4404 3 17.75L3 2.25C3 1.55964 3.55964 1 4.25 1L15.75 1C16.4404 1 17 1.55964 17 2.25L17 17.75ZM15.75 2.25L15.75 10L4.25 10L4.25 2.25L15.75 2.25ZM15.75 17.75L15.75 11.25L4.25 11.25L4.25 17.75L15.75 17.75Z" fill="context-fill"/>
+</svg>

--- a/chrome/skin/default/zotero/20/universal/sidebar.svg
+++ b/chrome/skin/default/zotero/20/universal/sidebar.svg
@@ -1,0 +1,6 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7 7.25H4V6H7V7.25Z" fill="context-fill"/>
+<path d="M7 10.25H4V9H7V10.25Z" fill="context-fill"/>
+<path d="M7 13.25H4V12H7V13.25Z" fill="context-fill"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M2.25 3C1.55964 3 1 3.55964 1 4.25V15.75C1 16.4404 1.55964 17 2.25 17H17.75C18.4404 17 19 16.4404 19 15.75V4.25C19 3.55964 18.4404 3 17.75 3H2.25ZM17.75 4.25H10V15.75H17.75V4.25ZM2.25 4.25H8.75V15.75H2.25V4.25Z" fill="context-fill"/>
+</svg>

--- a/scss/components/_toolbar.scss
+++ b/scss/components/_toolbar.scss
@@ -122,6 +122,20 @@
 	margin-top: 1px;
 }
 
+#zotero-tb-toggle-item-pane-stacked {
+	// Hidden except in Stacked mode
+	display: none;
+}
+
+#main-window.stacked #zotero-toolbar-item-tree {
+	padding-inline-end: 0;
+	
+	#zotero-tb-toggle-item-pane-stacked { // Keep nested for specificity
+		display: flex;
+		margin-inline-start: 9px;
+	}
+}
+
 toolbox {
 	@media (-moz-platform: linux) {
 		background: Menu;

--- a/scss/components/_toolbarbutton.scss
+++ b/scss/components/_toolbarbutton.scss
@@ -74,6 +74,7 @@ $toolbarbutton-icons: (
 	tabs-menu: "chevron",
 	sync-error: "error",
 	sync: "sync",
+	toggle-item-pane-stacked: "sidebar-bottom",
 );
 
 @each $cls, $icon in $toolbarbutton-icons {

--- a/scss/elements/_itemPane.scss
+++ b/scss/elements/_itemPane.scss
@@ -9,21 +9,11 @@ item-pane {
 		min-height: $width-sidenav;
 		max-width: $width-sidenav;
 
-		&[view-type=note] {
-			min-width: 0;
-			width: 0px !important;
-		}
-
 		visibility: inherit;
 
 		&.stacked {
 			max-width: unset;
 			max-height: $width-sidenav;
-
-			&[view-type=note] {
-				min-height: 0;
-				height: 0px !important;
-			}
 		}
 
 		#zotero-item-pane-content {

--- a/scss/elements/_itemPaneSidenav.scss
+++ b/scss/elements/_itemPaneSidenav.scss
@@ -108,13 +108,32 @@ item-pane-sidenav {
 			stroke: map.get($item-pane-sections, "notes");
 		}
 		
-		// Locate button
-		&[data-action="locate"] {
+		&[data-action="locate"], &[data-action="toggle-pane"] {
 			color: var(--fill-secondary);
+		}
+
+		&[data-action="locate"] {
 			@include svgicon-menu("go-to", "universal", "20");
-			
+
+			// Locate is flipped in RTL
 			&:-moz-locale-dir(rtl) {
 				transform: scaleX(-1);
+			}
+		}
+
+		&[data-action="toggle-pane"] {
+			@include svgicon-menu("sidebar", "universal", "20");
+
+			// ...And Toggle Item/Context Pane is flipped in LTR
+			&:-moz-locale-dir(ltr) {
+				transform: scaleX(-1);
+			}
+
+			// Hide in Stacked mode, since we show it in the toolbar instead
+			@include state("item-pane-sidenav.stacked") {
+				&, & + .divider {
+					display: none;
+				}
 			}
 		}
 

--- a/test/tests/zoteroPaneTest.js
+++ b/test/tests/zoteroPaneTest.js
@@ -1619,8 +1619,8 @@ describe("ZoteroPane", function() {
 			assert.equal(doc.activeElement.className, "tab selected");
 
 			doc.activeElement.dispatchEvent(shiftTab);
-			// One of tab buttons in the sidenav
-			assert.equal(doc.activeElement.getAttribute("role"), "tab");
+			// Toggle Item/Context Pane button
+			assert.equal(doc.activeElement.dataset.action, "toggle-pane");
 		});
 
 		it("should tab across the zotero pane", async function () {


### PR DESCRIPTION
And:

- Make everything in `ZoteroContextPane` an instance method to reduce confusion about what `this` means
- Remove redundant `if (Zotero_Tabs.selectedIndex > 0)` check and use tab type instead of index

Needs zotero/reader#164, closes #5260