### PR TITLE
Fixes to annotation rows behavior in trash

### DIFF
--- a/chrome/content/zotero/collectionTree.jsx
+++ b/chrome/content/zotero/collectionTree.jsx
@@ -1663,6 +1663,9 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 					return true;
 				}
 
+				// Cannot add items to collections from trash
+				if (Zotero.DragDrop.currentDragSource.isTrash()) return false;
+
 				var ids = data;
 				var items = Zotero.Items.get(ids);
 				items = Zotero.Items.keepTopLevel(items);

--- a/chrome/content/zotero/containers/tagSelectorContainer.jsx
+++ b/chrome/content/zotero/containers/tagSelectorContainer.jsx
@@ -610,6 +610,9 @@ Zotero.TagSelector = class TagSelectorContainer extends React.PureComponent {
 				return;
 			}
 			
+			// Cannot add tags via drag-drop from trash
+			if (Zotero.DragDrop.currentDragSource.isTrash()) return;
+
 			elem.classList.add('dragged-over');
 			event.preventDefault();
 			// Don't show + cursor when removing tags

--- a/chrome/content/zotero/elements/attachmentBox.js
+++ b/chrome/content/zotero/elements/attachmentBox.js
@@ -433,6 +433,7 @@
 			else {
 				fileNameRow.hidden = true;
 			}
+			this._id("title").toggleAttribute("readonly", (!this.editable || !fileExists));
 			this._id("fileName").toggleAttribute("readonly", (!this.editable || !fileExists));
 
 			// Page count

--- a/chrome/content/zotero/elements/contextPane.js
+++ b/chrome/content/zotero/elements/contextPane.js
@@ -306,6 +306,10 @@
 			let previousPinnedPane = this._sidenav.container?.pinnedPane || "";
 			
 			let targetItem = parentID ? Zotero.Items.get(parentID) : item;
+			// If the parent item or the attachment itself is in trash, itemPane is not editable
+			if (targetItem.deleted || item.deleted) {
+				editable = false;
+			}
 	
 			let itemDetails = document.createXULElement('item-details');
 			itemDetails.id = tabID + '-context';

--- a/chrome/content/zotero/elements/contextPane.js
+++ b/chrome/content/zotero/elements/contextPane.js
@@ -300,16 +300,15 @@
 				return;
 			}
 			libraryID = item.libraryID;
-			let editable = Zotero.Libraries.get(libraryID).editable;
 			let parentID = item.parentID;
 	
 			let previousPinnedPane = this._sidenav.container?.pinnedPane || "";
 			
 			let targetItem = parentID ? Zotero.Items.get(parentID) : item;
-			// If the parent item or the attachment itself is in trash, itemPane is not editable
-			if (targetItem.deleted || item.deleted) {
-				editable = false;
-			}
+			
+			let editable = Zotero.Libraries.get(libraryID).editable
+				// If the parent item or the attachment itself is in trash, itemPane is not editable
+				&& !item.deleted && !targetItem.deleted;
 	
 			let itemDetails = document.createXULElement('item-details');
 			itemDetails.id = tabID + '-context';

--- a/chrome/content/zotero/elements/itemPane.js
+++ b/chrome/content/zotero/elements/itemPane.js
@@ -404,7 +404,7 @@
 		renderAnnotationsHead(data) {
 			let { doc, append } = data;
 			let button = doc.createXULElement("button");
-			button.disabled = this.collectionTreeRow.isTrash();
+			button.disabled = !this.collectionTreeRow.editable;
 			button.id = 'zotero-item-pane-note-from-annotations';
 			if (Zotero.Items.getTopLevel(this.data).length == 1) {
 				button.label = Zotero.getString('pane.items.menu.addNoteFromAnnotations');

--- a/chrome/content/zotero/elements/itemPane.js
+++ b/chrome/content/zotero/elements/itemPane.js
@@ -404,6 +404,7 @@
 		renderAnnotationsHead(data) {
 			let { doc, append } = data;
 			let button = doc.createXULElement("button");
+			button.disabled = this.collectionTreeRow.isTrash();
 			button.id = 'zotero-item-pane-note-from-annotations';
 			if (Zotero.Items.getTopLevel(this.data).length == 1) {
 				button.label = Zotero.getString('pane.items.menu.addNoteFromAnnotations');

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -554,9 +554,10 @@ var ItemTree = class ItemTree extends LibraryTree {
 					let row = this.getRowIndexByID(id);
 					if (row === false) continue;
 					let item = Zotero.Items.get(id);
-					// Remove parent row if it isn't deleted and doesn't have any deleted children
+					let isParentTrashed = item.parentItemID ? Zotero.Items.get(item.parentItemID).deleted : false;
+					// Remove parent row if it isn't deleted, it's parent isn't deleted, and it doesn't have any deleted children
 					// (shown by the numChildren including deleted being the same as numChildren not including deleted)
-					if (!item.deleted && (!item.isRegularItem() || item.numChildren(true) == item.numChildren(false))) {
+					if (!item.deleted && !isParentTrashed && (!item.isRegularItem() || item.numChildren(true) == item.numChildren(false))) {
 						rows.push(row);
 						// And all its children in the tree
 						for (let child = row + 1; child < this.rowCount && this.getLevel(child) > this.getLevel(row); child++) {

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -554,10 +554,14 @@ var ItemTree = class ItemTree extends LibraryTree {
 					let row = this.getRowIndexByID(id);
 					if (row === false) continue;
 					let item = Zotero.Items.get(id);
-					let isParentTrashed = item.parentItemID ? Zotero.Items.get(item.parentItemID).deleted : false;
-					// Remove parent row if it isn't deleted, it's parent isn't deleted, and it doesn't have any deleted children
-					// (shown by the numChildren including deleted being the same as numChildren not including deleted)
-					if (!item.deleted && !isParentTrashed && (!item.isRegularItem() || item.numChildren(true) == item.numChildren(false))) {
+					let isParentTrashed = item.parentItemID
+						? Zotero.Items.get(item.parentItemID).deleted
+						: false;
+					// Remove parent row if it isn't deleted, its parent isn't deleted, and it
+					// doesn't have any deleted children (shown by numChildren including deleted
+					// being the same as numChildren not including deleted)
+					if (!item.deleted && !isParentTrashed
+							&& (!item.isRegularItem() || item.numChildren(true) == item.numChildren(false))) {
 						rows.push(row);
 						// And all its children in the tree
 						for (let child = row + 1; child < this.rowCount && this.getLevel(child) > this.getLevel(row); child++) {

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -2178,9 +2178,8 @@ var ZoteroPane = new function()
 		else if (collectionTreeRow.isShare()) {
 			return false;
 		}
-		// If multiple items are selected, some are annotations and some are not, do nothing,
-		// since annotations have different treatment from other items,
-		// unless we are in the trash, in which case any selected item can be erased
+		// If multiple items are selected and only some are annotations, disallow delete unless we
+		// are in the trash, in which case any selected item can be erased
 		let selected = this.itemsView.getSelectedItems();
 		if (!selected.every(item => item.isAnnotation())
 			&& selected.some(item => item.isAnnotation())) {

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -2179,11 +2179,12 @@ var ZoteroPane = new function()
 			return false;
 		}
 		// If multiple items are selected, some are annotations and some are not, do nothing,
-		// since annotations have different treatment from other items
+		// since annotations have different treatment from other items,
+		// unless we are in the trash, in which case any selected item can be erased
 		let selected = this.itemsView.getSelectedItems();
 		if (!selected.every(item => item.isAnnotation())
 			&& selected.some(item => item.isAnnotation())) {
-			return false;
+			return collectionTreeRow.isTrash();
 		}
 		return true;
 	};
@@ -4029,10 +4030,12 @@ var ZoteroPane = new function()
 		// Only keep annotation-specific options if annotations are selected
 		let annotationsSelected = items.some(item => item.isAnnotation());
 		if (annotationsSelected) {
+			let menuItemsForAnnotations = [
+				'createNoteFromAnnotations',
+				'deleteFromLibrary'
+			];
 			for (let i in m) {
-				if (i == 'createNoteFromAnnotations') {
-					continue;
-				}
+				if (menuItemsForAnnotations.includes(i)) continue;
 				show.delete(m[i]);
 			}
 		}

--- a/test/tests/collectionTreeTest.js
+++ b/test/tests/collectionTreeTest.js
@@ -760,6 +760,7 @@ describe("Zotero.CollectionTree", function() {
 		var canDrop = Zotero.Promise.coroutine(function* (objectType, targetRowID, ids) {
 			var row = cv.getRowIndexByID(targetRowID);
 			
+			Zotero.DragDrop.currentDragSource = objectType == "item" && zp.itemsView.collectionTreeRow;
 			var dt = {
 				dropEffect: 'copy',
 				effectAllowed: 'copy',
@@ -774,6 +775,7 @@ describe("Zotero.CollectionTree", function() {
 			if (canDrop) {
 				canDrop = yield cv.canDropCheckAsync(row, 0, dt);
 			}
+			Zotero.DragDrop.currentDragSource = null;
 			return canDrop;
 		});
 		

--- a/test/tests/collectionTreeTest.js
+++ b/test/tests/collectionTreeTest.js
@@ -762,7 +762,9 @@ describe("Zotero.CollectionTree", function() {
 		var canDrop = Zotero.Promise.coroutine(function* (objectType, targetRowID, ids) {
 			var row = cv.getRowIndexByID(targetRowID);
 			
-			Zotero.DragDrop.currentDragSource = objectType == "item" && zp.itemsView.collectionTreeRow;
+			Zotero.DragDrop.currentDragSource = objectType == "item"
+				? zp.itemsView.collectionTreeRow
+				: null;
 			var dt = {
 				dropEffect: 'copy',
 				effectAllowed: 'copy',

--- a/test/tests/collectionTreeTest.js
+++ b/test/tests/collectionTreeTest.js
@@ -730,7 +730,9 @@ describe("Zotero.CollectionTree", function() {
 				var { row, orient } = targetRow;
 			}
 			
-			Zotero.DragDrop.currentDragSource = objectType == "item" && zp.itemsView.collectionTreeRow;
+			Zotero.DragDrop.currentDragSource = objectType == "item"
+				? zp.itemsView.collectionTreeRow
+				: null;
 			
 			if (!promise) {
 				promise = waitForNotifierEvent("add", objectType);


### PR DESCRIPTION
- right-click on annotation rows in trash will display "Delete permanently" option, instead of an empty menu
- in trash, "Add Note from Annotations" button in `itemPane` header is disabled
- remove ability to add tags to annotations and other items by dragging them into tag selector from trash
- remove ability to add items to collections by dragging them into collection tree from trash
- fix attachment row being removed from trash if its child annotation row is erased

Also:
- fix `contextPane` in reader tab being editable for items in trash
- fix title being editable in `attachmentBox` for item in trash

Fixes: #5261