### PR TITLE
Fix dropping or copy-pasting of annotation rows into note editor

### DIFF
--- a/chrome/content/zotero/elements/noteEditor.js
+++ b/chrome/content/zotero/elements/noteEditor.js
@@ -83,6 +83,18 @@
 						'zotero/item': event.dataTransfer.getData('zotero/item')
 					}, this._iframe.contentWindow);
 				}, true);
+
+				// If annotations are copies from itemTree, zotero/annotation will not
+				// be included in event.clipboardData, so we fetch it manually
+				// from the clipboard and provide it to the note-editor
+				this._iframe.contentWindow.addEventListener('paste', (event) => {
+					let stringifiedAnnotations = Zotero_File_Interface.getDataFromClipboard("zotero/annotation");
+					console.log('paste', stringifiedAnnotations);
+					if (!stringifiedAnnotations) return;
+					this._iframe.contentWindow.wrappedJSObject.clipboardData = Components.utils.cloneInto({
+						'zotero/annotation': stringifiedAnnotations,
+					}, this._iframe.contentWindow);
+				}, true);
 				this._initialized = true;
 			});
 			this.append(content);

--- a/chrome/content/zotero/elements/noteEditor.js
+++ b/chrome/content/zotero/elements/noteEditor.js
@@ -89,7 +89,6 @@
 				// from the clipboard and provide it to the note-editor
 				this._iframe.contentWindow.addEventListener('paste', (event) => {
 					let stringifiedAnnotations = Zotero_File_Interface.getDataFromClipboard("zotero/annotation");
-					console.log('paste', stringifiedAnnotations);
 					if (!stringifiedAnnotations) return;
 					this._iframe.contentWindow.wrappedJSObject.clipboardData = Components.utils.cloneInto({
 						'zotero/annotation': stringifiedAnnotations,

--- a/chrome/content/zotero/note.xhtml
+++ b/chrome/content/zotero/note.xhtml
@@ -44,6 +44,7 @@
 		Services.scriptloader.loadSubScript("chrome://zotero/content/editMenuOverlay.js", this);
 		Services.scriptloader.loadSubScript("chrome://zotero/content/customElements.js", this);
 		Services.scriptloader.loadSubScript("chrome://zotero/content/note.js", this);
+		Services.scriptloader.loadSubScript("chrome://zotero/content/fileInterface.js", this);
 	</script>
 
 	<commandset id="mainCommandSet">

--- a/chrome/content/zotero/xpcom/annotations.js
+++ b/chrome/content/zotero/xpcom/annotations.js
@@ -116,7 +116,7 @@ Zotero.Annotations = new function () {
 	};
 	
 	
-	this.toJSONSync = function (item) {
+	this.toJSONSync = function (item, addSerializationFields) {
 		var o = {};
 		o.libraryID = item.libraryID;
 		o.key = item.key;
@@ -176,6 +176,12 @@ Zotero.Annotations = new function () {
 		}
 		
 		o.dateModified = Zotero.Date.sqlToISO8601(item.dateModified);
+		// Convenience shortcut to add fields needed for annotation
+		// serialization in Zotero.EditorInstanceUtilities.serializeAnnotations
+		if (addSerializationFields) {
+			o.attachmentItemID = item.parentItemID;
+			o.id = item.key;
+		}
 		return o;
 	};
 

--- a/chrome/content/zotero/xpcom/quickCopy.js
+++ b/chrome/content/zotero/xpcom/quickCopy.js
@@ -325,8 +325,7 @@ Zotero.QuickCopy = new function() {
 				if (["ink", "image"].includes(annotation.type)) {
 					continue;
 				}
-				let json = Zotero.Annotations.toJSONSync(annotation);
-				json.attachmentItemID = annotation.parentItemID;
+				let json = Zotero.Annotations.toJSONSync(annotation, true);
 				jsonAnnotations.push(json);
 			}
 			else {

--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -3360,9 +3360,12 @@ Zotero.Utilities.Internal.onDragItems = function (event, itemIDs, dragImage = ev
 	}
 
 	// If all items are annotations, wrap them in a note object for translation
+	// And set zotero/annotation data, which is used by note-editor to add a citation
 	if (items.every(item => item.isAnnotation())) {
+		let jsonAnnotations = items.map(item => Zotero.Annotations.toJSONSync(item, true));
+		event.dataTransfer.setData('zotero/annotation', JSON.stringify(jsonAnnotations));
 		format = Zotero.QuickCopy.getNoteFormat();
-		items = [Zotero.QuickCopy.annotationsToNote(items)];
+		items = [Zotero.QuickCopy.annotationsToNote(jsonAnnotations)];
 	}
 
 	Zotero.debug("Dragging with format " + format);

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -2677,8 +2677,11 @@ var ZoteroPane = new function()
 		if (items.every(item => item.isNote() || item.isAttachment())) {
 			format = Zotero.QuickCopy.getNoteFormat();
 		}
+		let annotationsToExport = [];
 		// To copy annotations, wrap them in a temp note
 		if (items.every(item => item.isAnnotation())) {
+			// Record original annotation items to add them as zotero/annotation in exportItemsToClipboard
+			annotationsToExport = items;
 			format = Zotero.QuickCopy.getNoteFormat();
 			items = [Zotero.QuickCopy.annotationsToNote(items)];
 		}
@@ -2717,7 +2720,7 @@ var ZoteroPane = new function()
 				return;
 			}
 			else {
-				Zotero_File_Interface.exportItemsToClipboard(items, format);
+				Zotero_File_Interface.exportItemsToClipboard(items, format, annotationsToExport);
 			}
 		}
 	}


### PR DESCRIPTION
- set `zotero/annotation` data when annotation rows are dragged into the note editor, so that it can add a citation, the same way as when dragging from the reader
- when copying annotations to the clipboard as a note, set `zotero/annotation` data so that note-editor can handle it. `zotero/annotation` does not appear by itself in `event.clipboardData` on paste, so it will be passed into note-editor iframe in `window.clipboardData` object, similar to how drop events are handled
- tweak `Zotero.Annotations.toJSONSync` to optionally add fields used to serialize annotations in `Zotero.EditorInstanceUtilities.serializeAnnotations`. Set annotation.id to be item.key, which will add
the &annotation= param into the link to the zotero://open-pdf/ link after the citation.

Fixes: #5235
Needs: https://github.com/zotero/note-editor/pull/66 to handle pasting of annotation rows into note-editor

https://github.com/user-attachments/assets/c5487602-b423-4a42-8cdd-09eb2ebd119a


