### PR TITLE
Improve attachment row annotation button click behavior

### DIFF
--- a/chrome/content/zotero/elements/attachmentRow.js
+++ b/chrome/content/zotero/elements/attachmentRow.js
@@ -106,9 +106,20 @@ import { getCSSItemTypeIcon } from 'components/icons';
 			Zotero.Utilities.Internal.onDragItems(event, [this._attachment.id]);
 		};
 
-		_handleAnnotationClick = () => {
-			Zotero_Tabs.select('zotero-pane');
-			ZoteroPane.selectItems(this._attachment.getAnnotations().map(a => a.id));
+		_handleAnnotationClick = async () => {
+			let paneID = "attachment-annotations";
+			let win = Zotero.getMainWindow();
+			if (win) {
+				win.Zotero_Tabs.select('zotero-pane');
+				let itemDetails = win.ZoteroContextPane.sidenav?.container;
+				let pane = itemDetails?.getPane(paneID);
+				if (pane) {
+					pane._section.open = true;
+					await itemDetails?.scrollToPane(paneID, 'instant', { pendingScroll: true });
+				}
+				await win.ZoteroPane.selectItem(this._attachment.id);
+				win.focus();
+			}
 		};
 
 		_handleRemove = async () => {

--- a/chrome/content/zotero/elements/attachmentRow.js
+++ b/chrome/content/zotero/elements/attachmentRow.js
@@ -107,20 +107,8 @@ import { getCSSItemTypeIcon } from 'components/icons';
 		};
 
 		_handleAnnotationClick = () => {
-			// TODO: jump to annotations pane
-			let pane;
-			if (ZoteroContextPane) {
-				pane = ZoteroContextPane.sidenav?.container.querySelector(`:scope > [data-pane="attachment-annotations"]`);
-			}
-			if (pane) {
-				pane._section.open = true;
-			}
-			let win = Zotero.getMainWindow();
-			if (win) {
-				win.ZoteroPane.selectItem(this._attachment.id);
-				win.Zotero_Tabs.select('zotero-pane');
-				win.focus();
-			}
+			Zotero_Tabs.select('zotero-pane');
+			ZoteroPane.selectItems(this._attachment.getAnnotations().map(a => a.id));
 		};
 
 		_handleRemove = async () => {

--- a/chrome/content/zotero/elements/itemDetails.js
+++ b/chrome/content/zotero/elements/itemDetails.js
@@ -541,19 +541,35 @@
 			}
 		}
 
-		async scrollToPane(paneID, behavior = 'smooth') {
-			let panes = this.getEnabledPanes();
+		/**
+		 * Scroll to a specific pane section.
+		 * @param {string} paneID - ID of the section to scroll to
+		 * @param {'smooth' | 'instant'} behavior - 'smooth' for smooth scrolling, 'instant' for instant scroll
+		 * @param {object} [options]
+		 * @param {boolean} [options.pendingScroll = false] - If true, the pane will be scrolled to when `render` is called.
+		 * @returns {Promise<boolean>} - Returns true if the pane was/will be scrolled to, false otherwise.
+		 */
+		async scrollToPane(paneID, behavior = 'smooth', options = {}) {
+			let { pendingScroll = false } = options;
+			let panes;
+			// For pending scroll, hidden sections are also considered
+			if (pendingScroll) {
+				panes = this.getPanes();
+			}
+			else {
+				panes = this.getEnabledPanes();
+			}
 			let paneIndex = panes.findIndex(elem => elem.dataset.pane == paneID);
 			let pane = panes[paneIndex];
-			if (!pane) return null;
+			if (!pane) return false;
 
 			let scrollPromise;
 
 			// If the itemPane is collapsed, just remember which pane needs to be scrolled to
 			// when itemPane is expanded.
-			if (this._collapsed) {
+			if (this._collapsed || pendingScroll) {
 				this._lastScrollPaneID = paneID;
-				return null;
+				return true;
 			}
 
 			// Temporarily disable intersection observer to prevent unwanted rendering

--- a/test/tests/itemPaneTest.js
+++ b/test/tests/itemPaneTest.js
@@ -1157,8 +1157,8 @@ describe("Item pane", function () {
 			let attachmentRow = attachmentsBox.querySelector(`attachment-row[attachment-id="${attachment.id}"]`);
 			attachmentRow._annotationButton.click();
 			await Zotero.Promise.delay(100);
-			// Should select annotations
-			assert.deepEqual(ZoteroPane.getSelectedItems(true), [_annotation.id]);
+			// Should select attachment
+			assert.equal(ZoteroPane.getSelectedItems(true)[0], attachment.id);
 		});
 
 		it("should open attachment on double-clicking attachments pane preview", async function () {

--- a/test/tests/itemPaneTest.js
+++ b/test/tests/itemPaneTest.js
@@ -1157,8 +1157,8 @@ describe("Item pane", function () {
 			let attachmentRow = attachmentsBox.querySelector(`attachment-row[attachment-id="${attachment.id}"]`);
 			attachmentRow._annotationButton.click();
 			await Zotero.Promise.delay(100);
-			// Should select attachment
-			assert.equal(ZoteroPane.getSelectedItems(true)[0], attachment.id);
+			// Should select annotations
+			assert.deepEqual(ZoteroPane.getSelectedItems(true), [_annotation.id]);
 		});
 
 		it("should open attachment on double-clicking attachments pane preview", async function () {


### PR DESCRIPTION
fix: #5249

For now, I'm doing the selecting annotation items in the library, since I believe that's the interface where interactions between user and annotations would happen, for example, now we have the add note from annotations button there. If we select the attachment item with the annotations section in the item pane, there are no operations actually available.