### PR TITLE
Citation dialog: updated Enter handling in panels

### DIFF
--- a/chrome/content/zotero/integration/citationDialog.xhtml
+++ b/chrome/content/zotero/integration/citationDialog.xhtml
@@ -122,7 +122,7 @@
 								<input id="suffix" class="details-data"/>
 							</div>
 							<div id="suppress-author-row" class="row">
-								<input id="suppress-author" type="checkbox" class="keyboard-clickable"/>
+								<input id="suppress-author" type="checkbox"/>
 								<label for="suppress-author" data-l10n-id="integration-citationDialog-details-suppressAuthor"></label>
 							</div>				
 					</div>
@@ -138,7 +138,7 @@
 				<div class="vbox popup">
 					<div class="title" data-l10n-id="integration-citationDialog-settings-title"></div>
 					<div class="hbox">
-						<input id="keepSorted" type="checkbox" class="keyboard-clickable"/>
+						<input id="keepSorted" type="checkbox"/>
 						<label for="keepSorted" data-l10n-id="integration-citationDialog-settings-keepSorted"></label>
 					</div>
 				</div>

--- a/chrome/content/zotero/integration/citationDialog/keyboardHandler.mjs
+++ b/chrome/content/zotero/integration/citationDialog/keyboardHandler.mjs
@@ -86,11 +86,11 @@ export class CitationDialogKeyboardHandler {
 	_handleTopLevelKeydown(event) {
 		let handled = false;
 		let tgt = event.target;
+		let isKeyboardClickable = tgt.classList.contains("keyboard-clickable") || (Zotero.isWin && tgt.tagName.localName == "button");
 		// Space/Enter will click on keyboard-clickable components.
 		// On macOS, focused buttons are only clickable with Space (not Enter),
 		// and on Windows they are clickable with both.
 		// This distinction determines if Enter on a button in a panel will perform a click or close it.
-		let isKeyboardClickable = tgt.classList.contains("keyboard-clickable") || (Zotero.isWin && tgt.tagName.localName == "button");
 		if (["Enter", " "].includes(event.key) && isKeyboardClickable) {
 			tgt.click();
 			handled = true;

--- a/chrome/content/zotero/integration/citationDialog/keyboardHandler.mjs
+++ b/chrome/content/zotero/integration/citationDialog/keyboardHandler.mjs
@@ -86,8 +86,11 @@ export class CitationDialogKeyboardHandler {
 	_handleTopLevelKeydown(event) {
 		let handled = false;
 		let tgt = event.target;
-		let isKeyboardClickable = tgt.classList.contains("keyboard-clickable") || (Zotero.isWin && tgt.tagName.includes("button"));
-		// Space/Enter will click on keyboard-clickable components
+		// Space/Enter will click on keyboard-clickable components.
+		// On macOS, focused buttons are only clickable with Space (not Enter),
+		// and on Windows they are clickable with both.
+		// This distinction determines if Enter on a button in a panel will perform a click or close it.
+		let isKeyboardClickable = tgt.classList.contains("keyboard-clickable") || (Zotero.isWin && tgt.tagName.localName == "button");
 		if (["Enter", " "].includes(event.key) && isKeyboardClickable) {
 			tgt.click();
 			handled = true;

--- a/chrome/content/zotero/integration/citationDialog/keyboardHandler.mjs
+++ b/chrome/content/zotero/integration/citationDialog/keyboardHandler.mjs
@@ -86,8 +86,8 @@ export class CitationDialogKeyboardHandler {
 	_handleTopLevelKeydown(event) {
 		let handled = false;
 		let tgt = event.target;
-		let isKeyboardClickable = tgt.classList.contains("keyboard-clickable") || tgt.tagName.includes("button");
-		// Space/Enter will click on a button or keyboard-clickable components
+		let isKeyboardClickable = tgt.classList.contains("keyboard-clickable") || (Zotero.isWin && tgt.tagName.includes("button"));
+		// Space/Enter will click on keyboard-clickable components
 		if (["Enter", " "].includes(event.key) && isKeyboardClickable) {
 			tgt.click();
 			handled = true;

--- a/chrome/content/zotero/integration/citationDialog/keyboardHandler.mjs
+++ b/chrome/content/zotero/integration/citationDialog/keyboardHandler.mjs
@@ -49,8 +49,8 @@ export class CitationDialogKeyboardHandler {
 	// lower-level components
 	captureKeydown(event) {
 		let cmdOrCtrl = Zotero.isMac ? event.metaKey : event.ctrlKey;
-		// Cmd/Ctrl-Enter will always accept the dialog regardless of the target (unless within a panel)
-		if (event.key == "Enter" && cmdOrCtrl && !event.target.closest("panel")) {
+		// Cmd/Ctrl-Enter will always accept the dialog regardless of the target
+		if (event.key == "Enter" && cmdOrCtrl) {
 			this.doc.dispatchEvent(new CustomEvent("dialog-accepted"));
 			event.stopPropagation();
 			event.preventDefault();
@@ -91,6 +91,11 @@ export class CitationDialogKeyboardHandler {
 		if (["Enter", " "].includes(event.key) && isKeyboardClickable) {
 			tgt.click();
 			handled = true;
+		}
+		// Unhandled Enter in a panel will close it
+		else if (event.key == "Enter" && tgt.closest("panel")) {
+			handled = true;
+			tgt.closest("panel").hidePopup();
 		}
 		// Unhandled Enter will accept the existing dialog's state
 		else if (event.key == "Enter" && !tgt.closest("panel")) {

--- a/chrome/content/zotero/integration/citationDialog/keyboardHandler.mjs
+++ b/chrome/content/zotero/integration/citationDialog/keyboardHandler.mjs
@@ -86,11 +86,11 @@ export class CitationDialogKeyboardHandler {
 	_handleTopLevelKeydown(event) {
 		let handled = false;
 		let tgt = event.target;
-		let isKeyboardClickable = tgt.classList.contains("keyboard-clickable") || (Zotero.isWin && tgt.tagName.localName == "button");
 		// Space/Enter will click on keyboard-clickable components.
 		// On macOS, focused buttons are only clickable with Space (not Enter),
 		// and on Windows they are clickable with both.
 		// This distinction determines if Enter on a button in a panel will perform a click or close it.
+		let isKeyboardClickable = tgt.classList.contains("keyboard-clickable") || (Zotero.isWin && tgt.tagName.localName == "button");
 		if (["Enter", " "].includes(event.key) && isKeyboardClickable) {
 			tgt.click();
 			handled = true;

--- a/chrome/content/zotero/integration/citationDialog/keyboardHandler.mjs
+++ b/chrome/content/zotero/integration/citationDialog/keyboardHandler.mjs
@@ -49,8 +49,8 @@ export class CitationDialogKeyboardHandler {
 	// lower-level components
 	captureKeydown(event) {
 		let cmdOrCtrl = Zotero.isMac ? event.metaKey : event.ctrlKey;
-		// Cmd/Ctrl-Enter will always accept the dialog regardless of the target
-		if (event.key == "Enter" && cmdOrCtrl) {
+		// Cmd/Ctrl-Enter will always accept the dialog regardless of the target (unless within a panel
+		if (event.key == "Enter" && cmdOrCtrl && !event.target.closest("panel")) {
 			this.doc.dispatchEvent(new CustomEvent("dialog-accepted"));
 			event.stopPropagation();
 			event.preventDefault();

--- a/chrome/content/zotero/integration/citationDialog/keyboardHandler.mjs
+++ b/chrome/content/zotero/integration/citationDialog/keyboardHandler.mjs
@@ -89,7 +89,6 @@ export class CitationDialogKeyboardHandler {
 		// Space/Enter will click on keyboard-clickable components.
 		// On macOS, focused buttons are only clickable with Space (not Enter),
 		// and on Windows they are clickable with both.
-		// This distinction determines if Enter on a button in a panel will perform a click or close it.
 		let isKeyboardClickable = tgt.classList.contains("keyboard-clickable") || (Zotero.isWin && tgt.localName == "button");
 		if (["Enter", " "].includes(event.key) && isKeyboardClickable) {
 			tgt.click();

--- a/chrome/content/zotero/integration/citationDialog/keyboardHandler.mjs
+++ b/chrome/content/zotero/integration/citationDialog/keyboardHandler.mjs
@@ -90,7 +90,7 @@ export class CitationDialogKeyboardHandler {
 		// On macOS, focused buttons are only clickable with Space (not Enter),
 		// and on Windows they are clickable with both.
 		// This distinction determines if Enter on a button in a panel will perform a click or close it.
-		let isKeyboardClickable = tgt.classList.contains("keyboard-clickable") || (Zotero.isWin && tgt.tagName.localName == "button");
+		let isKeyboardClickable = tgt.classList.contains("keyboard-clickable") || (Zotero.isWin && tgt.localName == "button");
 		if (["Enter", " "].includes(event.key) && isKeyboardClickable) {
 			tgt.click();
 			handled = true;

--- a/chrome/content/zotero/integration/citationDialog/keyboardHandler.mjs
+++ b/chrome/content/zotero/integration/citationDialog/keyboardHandler.mjs
@@ -49,7 +49,7 @@ export class CitationDialogKeyboardHandler {
 	// lower-level components
 	captureKeydown(event) {
 		let cmdOrCtrl = Zotero.isMac ? event.metaKey : event.ctrlKey;
-		// Cmd/Ctrl-Enter will always accept the dialog regardless of the target (unless within a panel
+		// Cmd/Ctrl-Enter will always accept the dialog regardless of the target (unless within a panel)
 		if (event.key == "Enter" && cmdOrCtrl && !event.target.closest("panel")) {
 			this.doc.dispatchEvent(new CustomEvent("dialog-accepted"));
 			event.stopPropagation();

--- a/chrome/content/zotero/integration/citationDialog/popupHandler.mjs
+++ b/chrome/content/zotero/integration/citationDialog/popupHandler.mjs
@@ -84,8 +84,6 @@ export class CitationDialogPopupsHandler {
 			if (this._getNode("#itemDetails").state !== "open") return;
 			this.captureItemDetailsKeyDown(event);
 		}, true);
-		// Handle remaining keypress events with a usual bubbling listener
-		this._getNode("#itemDetails").addEventListener("keypress", this.handleItemDetailsKeypress.bind(this));
 	}
 
 	openItemDetails(dialogReferenceID, item, citationItem, itemDescription) {
@@ -179,13 +177,6 @@ export class CitationDialogPopupsHandler {
 			this.discardItemDetailsEdits = true;
 			event.stopPropagation();
 			event.preventDefault();
-		}
-	}
-
-	handleItemDetailsKeypress(event) {
-		// Enter on a an input will save changes and hide the popup
-		if (event.key == "Enter" && ["input"].includes(event.target.tagName) && !event.target.getAttribute("type")) {
-			this._getNode("#itemDetails").hidePopup();
 		}
 	}
 


### PR DESCRIPTION
Unhandled Enter keypress from inside of a panel will now close it. Enter on "Omit Author" checkbox or on the inactive locator label dropdown will close the item details popup.
Enter on "Keep sources sorted" checkbox of settings popup will close it for consistency.

Also, allow Cmd/Ctrl+Enter to accept the dialog even from inside of a panel.

Fixes: #5277

Enter on item details buttons at the bottom will still just perform the click, as it would be strange if Enter on a focused "Remove" button would not actually remove the item.