### PR TITLE
Citation Dialog: fix added suffix/prefix properties persisting on items

### DIFF
--- a/chrome/content/zotero/elements/bubbleInput.js
+++ b/chrome/content/zotero/elements/bubbleInput.js
@@ -50,21 +50,20 @@
 		 * are not present, remove bubbles whose citation items were removed, rearrange bubbles
 		 * if the items were moved, update bubble text if locator/prefix/suffix was changed.
 		 * Make sure that there is an input for user to type in before and after every bubble.
-		 * @param {Object[]} combinedItems - array of objects { zoteroItem, citationItem, dialogReferenceID, selected }.
-		 * zoteroItem - Zotero.Item, citationItem - object from io.citation.citationItems
-		 * dialogReferenceID - String ID of this citation entry, selected - Boolean indicator if bubble should be highlighted
+		 * @param {Object[]} bubblesConfig - array of objects { dialogReferenceID, bubbleString, selected}
+		 * representing each bubble.
 		 */
-		refresh(combinedItems) {
+		refresh(bubblesConfig) {
 			// Remove bubbles of items that are no longer in the citations
 			for (let bubble of this.getAllBubbles()) {
 				let bubbleDialogReferenceID = bubble.getAttribute("dialogReferenceID");
-				let itemExistsForBubble = combinedItems.find(({ dialogReferenceID }) => dialogReferenceID == bubbleDialogReferenceID);
+				let itemExistsForBubble = bubblesConfig.find(({ dialogReferenceID }) => dialogReferenceID == bubbleDialogReferenceID);
 				if (!itemExistsForBubble) {
 					bubble.remove();
 				}
 			}
 			// Ensure each item in the citation has a bubble in the right position
-			for (let [index, { dialogReferenceID, bubbleString }] of Object.entries(combinedItems)) {
+			for (let [index, { dialogReferenceID, bubbleString }] of Object.entries(bubblesConfig)) {
 				let allBubbles = this.getAllBubbles();
 				let bubbleNode = allBubbles.find(candidate => candidate.getAttribute("dialogReferenceID") == dialogReferenceID);
 				// Create bubble if it does not exist and append to the input
@@ -95,7 +94,7 @@
 			// Highlight bubbles selected in the library view
 			for (let bubble of this.getAllBubbles()) {
 				let bubbleDialogReferenceID = bubble.getAttribute("dialogReferenceID");
-				let itemObj = combinedItems.find(({ dialogReferenceID }) => dialogReferenceID == bubbleDialogReferenceID);
+				let itemObj = bubblesConfig.find(({ dialogReferenceID }) => dialogReferenceID == bubbleDialogReferenceID);
 				if (itemObj) {
 					bubble.classList.toggle("has-item-selected", !!itemObj.selected);
 				}

--- a/chrome/content/zotero/integration/citationDialog/helpers.mjs
+++ b/chrome/content/zotero/integration/citationDialog/helpers.mjs
@@ -282,13 +282,13 @@ export class CitationDialogHelpers {
 		return height + margins + border;
 	}
 
-	buildBubbleString({ citationItem, zoteroItem }) {
+	buildBubbleString(bubbleItem) {
 		// Creator
 		var title;
-		var str = zoteroItem.getField("firstCreator");
+		var str = bubbleItem.item.getField("firstCreator");
 		
 		// Title, if no creator (getDisplayTitle in order to get case, e-mail, statute which don't have a title field)
-		title = zoteroItem.getDisplayTitle();
+		title = bubbleItem.item.getDisplayTitle();
 		title = title.substr(0, 32) + (title.length > 32 ? "…" : "");
 		if (!str && title) {
 			str = Zotero.getString("punctuation.openingQMark") + title + Zotero.getString("punctuation.closingQMark");
@@ -298,32 +298,32 @@ export class CitationDialogHelpers {
 		}
 		
 		// Date
-		var date = zoteroItem.getField("date", true, true);
+		var date = bubbleItem.item.getField("date", true, true);
 		if (date && (date = date.substr(0, 4)) !== "0000") {
 			str += ", " + parseInt(date);
 		}
 		
 		// Locator
-		if (citationItem.locator) {
+		if (bubbleItem.locator) {
 			// Try to fetch the short form of the locator label. E.g. "p." for "page"
 			// If there is no locator label, default to "page" for now
-			let label = (Zotero.Cite.getLocatorString(citationItem.label || 'page', 'short') || '').toLocaleLowerCase();
+			let label = (Zotero.Cite.getLocatorString(bubbleItem.label || 'page', 'short') || '').toLocaleLowerCase();
 			
-			str += `, ${label} ${citationItem.locator}`;
+			str += `, ${label} ${bubbleItem.locator}`;
 		}
 		
 		// Prefix
-		if (citationItem.prefix && Zotero.CiteProc.CSL.ENDSWITH_ROMANESQUE_REGEXP) {
-			let prefix = citationItem.prefix.substr(0, 10) + (citationItem.prefix.length > 10 ? "…" : "");
+		if (bubbleItem.prefix && Zotero.CiteProc.CSL.ENDSWITH_ROMANESQUE_REGEXP) {
+			let prefix = bubbleItem.prefix.substr(0, 10) + (bubbleItem.prefix.length > 10 ? "…" : "");
 			str = prefix
-				+ (Zotero.CiteProc.CSL.ENDSWITH_ROMANESQUE_REGEXP.test(citationItem.prefix) ? " " : "")
+				+ (Zotero.CiteProc.CSL.ENDSWITH_ROMANESQUE_REGEXP.test(bubbleItem.prefix) ? " " : "")
 				+ str;
 		}
 		
 		// Suffix
-		if (citationItem.suffix && Zotero.CiteProc.CSL.STARTSWITH_ROMANESQUE_REGEXP) {
-			let suffix = citationItem.suffix.substr(0, 10) + (citationItem.suffix.length > 10 ? "…" : "");
-			str += (Zotero.CiteProc.CSL.STARTSWITH_ROMANESQUE_REGEXP.test(citationItem.suffix) ? " " : "") + suffix;
+		if (bubbleItem.suffix && Zotero.CiteProc.CSL.STARTSWITH_ROMANESQUE_REGEXP) {
+			let suffix = bubbleItem.suffix.substr(0, 10) + (bubbleItem.suffix.length > 10 ? "…" : "");
+			str += (Zotero.CiteProc.CSL.STARTSWITH_ROMANESQUE_REGEXP.test(bubbleItem.suffix) ? " " : "") + suffix;
 		}
 		
 		return str;

--- a/chrome/content/zotero/integration/citationDialog/searchHandler.mjs
+++ b/chrome/content/zotero/integration/citationDialog/searchHandler.mjs
@@ -91,10 +91,9 @@ export class CitationDialogSearchHandler {
 	// by the number of results in each library.
 	// Items/notes in the libraries group are sorted via _createItemsSort/_createNotesSort comparators.
 	// Takes citedItems as a parameter to filter them out from Selected, Opened and Cited groups.
-	getOrderedSearchResultGroups(citedItems = []) {
+	getOrderedSearchResultGroups(citedItemIDs = new Set()) {
 		let removeItemsIncludedInCitation = (items) => {
-			let citedItemsIDs = new Set(citedItems.map(item => item.cslItemID || item.id));
-			return items.filter(i => !citedItemsIDs.has(i.cslItemID ? i.cslItemID : i.id));
+			return items.filter(i => !citedItemIDs.has(i.cslItemID ? i.cslItemID : i.id));
 		};
 		let result = [];
 		// selected/open/cited go first
@@ -184,6 +183,7 @@ export class CitationDialogSearchHandler {
 		else {
 			this.results.cited = this.searchValue ? this._filterNonMatchingItems(this.citedItems) : [];
 		}
+		this._deduplicate();
 	}
 
 	// clear selected/open items cache to re-fetch those items
@@ -219,13 +219,16 @@ export class CitationDialogSearchHandler {
 
 	// make sure that each item appears only in one group.
 	// Items that are selected are removed from opened.
-	// Items that are selected or opened are removed from library results.
+	// Items that are selected or opened are removed from cited.
+	// Items that are selected or opened or cited are removed from library results.
 	_deduplicate() {
 		let selectedIDs = new Set(this.results.selected.map(item => item.id));
 		let openIDs = new Set(this.results.open.map(item => item.id));
+		let citedIDs = new Set(this.results.cited.map(item => item.id));
 
 		this.results.open = this.results.open.filter(item => !selectedIDs.has(item.id));
-		this.results.found = this.results.found.filter(item => !selectedIDs.has(item.id) && !openIDs.has(item.id));
+		this.results.cited = this.results.cited.filter(item => !selectedIDs.has(item.id) && !openIDs.has(item.id));
+		this.results.found = this.results.found.filter(item => !selectedIDs.has(item.id) && !openIDs.has(item.id) && !citedIDs.has(item.id));
 	}
 		
 	// Run the actual search query and find all items matching query across all libraries

--- a/chrome/content/zotero/xpcom/editorInstance.js
+++ b/chrome/content/zotero/xpcom/editorInstance.js
@@ -1079,6 +1079,10 @@ class EditorInstance {
 				else if (!citationItem.id && citationItem.itemData) {
 					let item = new Zotero.Item();
 					Zotero.Utilities.itemFromCSLJSON(item, citationItem.itemData);
+					// Add csl data in the same format as in Zotero.Integration.Citation.loadItemData
+					item.cslItemID = citationItem.id;
+					item.cslURIs = citationItem.uris;
+					item.cslItemData = citationItem.itemData;
 					return item;
 				}
 				// Otherwise returns `undefined` which makes this function to be

--- a/test/tests/citationDialogTest.js
+++ b/test/tests/citationDialogTest.js
@@ -5,6 +5,7 @@ describe("Citation Dialog", function () {
 		sort() {},
 		sortable: false,
 		citation: {
+			citationItems: [],
 			properties: {
 				unsorted: false,
 			}
@@ -13,7 +14,7 @@ describe("Citation Dialog", function () {
 			return [];
 		}
 	};
-	let dialog, win;
+	let dialog, win, IOManager, CitationDataManager, SearchHandler;
 
 	before(async function () {
 		// one of helper functions of searchHandler uses zotero pane
@@ -21,16 +22,445 @@ describe("Citation Dialog", function () {
 		let dialogPromise = waitForWindow("chrome://zotero/content/integration/citationDialog.xhtml");
 		Services.ww.openWindow(null, "chrome://zotero/content/integration/citationDialog.xhtml", "", "", io);
 		dialog = await dialogPromise;
+		IOManager = dialog.IOManager;
+		CitationDataManager = dialog.CitationDataManager;
+		SearchHandler = dialog.SearchHandler;
 		// wait for everything (e.g. itemTree/collectionTree) inside of the dialog to be loaded.
-		// it is not used currently but may be required when more complex tests are added
-		// while (!dialog.loaded) {
-		// 	await Zotero.Promise.delay(10);
-		// }
+		while (!dialog.loaded) {
+			await Zotero.Promise.delay(10);
+		}
+	});
+
+	beforeEach(async function () {
+		// Many operations (e.g. IOManager.addItemsToCitation) are disabled
+		// when search runs. Search can be triggered by a variety of events
+		// so before each test, we make sure that search has finished running
+		while (SearchHandler.searching) {
+			await Zotero.Promise.delay(10);
+		}
 	});
 
 	after(function () {
 		dialog.close();
 		win.close();
+	});
+
+	describe("Manage entries in the citation", function () {
+		let citedItemNotInLibrary = {
+			id: "o7HzMbH6/6iMXHx6s",
+			itemData: {
+				id: "o7HzMbH6/6iMXHx6s",
+				type: "book",
+				title: "cited_not_in_library_test_title",
+				author: [
+					{
+						family: "Last",
+						given: "First"
+					}
+				]
+			},
+			uris: [
+				"http://zotero.org/users/11573780/items/K22KNVZL"
+			],
+			item: {
+				id: "o7HzMbH6/6iMXHx6s",
+				type: "book",
+				title: "cited_not_in_library_test_title",
+				author: [
+					{
+						family: "Last",
+						given: "First"
+					}
+				],
+				"title-main": "cited_not_in_library_test_title",
+				"title-sub": "",
+				"title-subjoin": ""
+			},
+			label: undefined,
+			locator: undefined,
+			prefix: undefined,
+			suffix: undefined,
+			"suppress-author": undefined
+		};
+		let citedItemOne = {
+			id: null,
+			item: {
+				id: null,
+				type: "book",
+				title: "cited_in_library_test_title",
+				author: [
+					{
+						family: "Last",
+						given: "First"
+					}
+				],
+				"title-main": "cited_in_library_test_title",
+				"title-sub": "",
+				"title-subjoin": ""
+			},
+			label: undefined,
+			locator: undefined,
+			prefix: undefined,
+			suffix: undefined,
+			"suppress-author": undefined
+		};
+		let itemOne, itemTwo, bubbleInput, ZoteroCiteGetItemStub, surrogateCitedItem;
+
+		before(async function () {
+			bubbleInput = dialog.document.querySelector("bubble-input");
+	
+			// Virtual Zotero.Item for a cited item that does not exist in the library.
+			// Same logic as in Zotero.Integration.Citation.loadItemData.
+			surrogateCitedItem = new Zotero.Item();
+			Zotero.Utilities.itemFromCSLJSON(surrogateCitedItem, citedItemNotInLibrary.itemData);
+			surrogateCitedItem.cslItemID = citedItemNotInLibrary.id;
+			surrogateCitedItem.cslURIs = citedItemNotInLibrary.uris;
+			surrogateCitedItem.cslItemData = citedItemNotInLibrary.itemData;
+			// Zotero.Cite.getItem called with citedItemNotInLibrary returns virtual Zotero.Item from above
+			ZoteroCiteGetItemStub = sinon.stub(Zotero.Cite, 'getItem').callsFake(function (id) {
+				if (id === citedItemNotInLibrary.id) {
+					return surrogateCitedItem;
+				}
+				return Zotero.Items.get(id);
+			});
+	
+			itemOne = await createDataObject('item', { title: "one" });
+			itemOne.setCreators([
+				{
+					firstName: "First_One",
+					lastName: "Last_One",
+					creatorType: "author"
+				}
+			]);
+			await itemOne.saveTx();
+			// citedItemOne is an earlier cited itemOne
+			citedItemOne.id = itemOne.id;
+			citedItemOne.item.id = itemOne.id;
+	
+			itemTwo = await createDataObject('item', { title: "two" });
+			itemTwo.setCreators([
+				{
+					firstName: "First_Two",
+					lastName: "Last_Two",
+					creatorType: "author"
+				}
+			]);
+			await itemTwo.saveTx();
+		});
+
+		after(function () {
+			ZoteroCiteGetItemStub.restore();
+		});
+
+		beforeEach(function () {
+			io.citation.citationItems = [];
+			io.citation.sortable = false;
+			dialog.document.getElementById("keepSorted").checked = false;
+			io.sort = () => {};
+			CitationDataManager.items = [];
+			IOManager.updateBubbleInput();
+		});
+
+		it("should add an item to citation", async function () {
+			await IOManager.addItemsToCitation([itemOne]);
+			
+			let bubbles = bubbleInput.getAllBubbles();
+			assert.equal(CitationDataManager.items.length, 1);
+			assert.equal(bubbles.length, 1);
+			assert.equal(bubbles[0].textContent, itemOne.getCreator(0).lastName);
+		});
+	
+		it("should remove an item from citation", async function () {
+			await IOManager.addItemsToCitation([itemOne, itemTwo]);
+			let bubbles = bubbleInput.getAllBubbles();
+			assert.equal(bubbles.length, 2);
+	
+			let firstBubbleItem = CitationDataManager.items[0];
+			IOManager._deleteItem(firstBubbleItem.dialogReferenceID);
+	
+			bubbles = bubbleInput.getAllBubbles();
+			assert.equal(CitationDataManager.items.length, 1);
+			assert.equal(CitationDataManager.items[0].id, itemTwo.id);
+			assert.equal(bubbles.length, 1);
+			assert.equal(bubbles[0].textContent, itemTwo.getCreator(0).lastName);
+		});
+	
+		it("should build citation with a cited item in library", async function () {
+			io.citation.citationItems = [citedItemOne];
+	
+			await CitationDataManager.buildCitation();
+			IOManager.updateBubbleInput();
+			
+			let bubbles = bubbleInput.getAllBubbles();
+			assert.equal(CitationDataManager.items.length, 1);
+			assert.equal(bubbles.length, 1);
+			assert.equal(bubbles[0].textContent, itemOne.getCreator(0).lastName);
+		});
+	
+		it("should build citation with a cited item not in library", async function () {
+			io.citation.citationItems = [citedItemNotInLibrary];
+	
+			await CitationDataManager.buildCitation();
+			IOManager.updateBubbleInput();
+	
+			let bubbles = bubbleInput.getAllBubbles();
+			assert.equal(CitationDataManager.items.length, 1);
+			assert.equal(bubbles.length, 1);
+			assert.equal(bubbles[0].textContent, surrogateCitedItem.getCreator(0).lastName);
+		});
+	
+		it("should add a locator/suffix/prefix to a bubble", async function () {
+			// add two bubbles for the same item
+			await IOManager.addItemsToCitation([itemOne, itemOne]);
+			assert.equal(CitationDataManager.items.length, 2);
+	
+			// open popup
+			let firstBubble = CitationDataManager.items[0];
+			IOManager._openItemDetailsPopup(firstBubble.dialogReferenceID);
+			let popup = dialog.document.getElementById("itemDetails");
+			
+			// give the popup time to open
+			await Zotero.Promise.delay(50);
+			assert.equal(popup.state, "open");
+	
+			// set locator/suffix/prefix values
+			popup.querySelector("#locator").value = "10";
+			popup.querySelector("#suffix").value = "suffix";
+			popup.querySelector("#prefix").value = "prefix";
+			popup.querySelector("#prefix").dispatchEvent(new Event('input', { bubbles: true }));
+	
+			// make sure they are set on the bubbleItem
+			assert.equal(firstBubble.locator, "10");
+			assert.equal(firstBubble.suffix, "suffix");
+			assert.equal(firstBubble.prefix, "prefix");
+			let bubble = dialog.document.querySelector(`.bubble[dialogReferenceID="${firstBubble.dialogReferenceID}"]`);
+			assert.equal(bubble.textContent, "prefix Last_One, p. 10 suffix");
+	
+			// make sure the other bubbleItem is not affected
+			let secondBubble = CitationDataManager.items[1];
+			assert.notOk(secondBubble.locator);
+			assert.notOk(secondBubble.suffix);
+			assert.notOk(secondBubble.prefix);
+		});
+	
+		it("should change the order of bubbles", async function () {
+			// add two items
+			await IOManager.addItemsToCitation([itemOne, itemTwo]);
+			let bubbleItemOne = CitationDataManager.items[0];
+			let bubbleItemTwo = CitationDataManager.items[1];
+	
+			// check initial order
+			let bubbles = bubbleInput.getAllBubbles();
+			assert.equal(bubbles[0].getAttribute("dialogReferenceID"), bubbleItemOne.dialogReferenceID);
+			assert.equal(bubbles[1].getAttribute("dialogReferenceID"), bubbleItemTwo.dialogReferenceID);
+	
+			// move the second item to the first position
+			IOManager._moveItem(bubbleItemTwo.dialogReferenceID, 0);
+	
+			// ensure the order is correct
+			assert.equal(CitationDataManager.items[0].dialogReferenceID, bubbleItemTwo.dialogReferenceID);
+			assert.equal(CitationDataManager.items[1].dialogReferenceID, bubbleItemOne.dialogReferenceID);
+			bubbles = dialog.document.querySelector("bubble-input").getAllBubbles();
+			assert.equal(bubbles[0].getAttribute("dialogReferenceID"), bubbleItemTwo.dialogReferenceID);
+			assert.equal(bubbles[1].getAttribute("dialogReferenceID"), bubbleItemOne.dialogReferenceID);
+		});
+	
+		it("should sort the citation", async function () {
+			// Make dialog sortable
+			io.citation.sortable = true;
+			dialog.document.getElementById("keepSorted").checked = true;
+			// Mock sort.io implementation that sorts itemOne to the first position
+			io.sort = () => {
+				let items = io.citation.citationItems;
+				items.sort((a, b) => {
+					if (a.id === itemOne.id) return -1;
+					if (b.id === itemOne.id) return 1;
+					return 0;
+				});
+				io.citation.sortedItems = [
+					[null, items[0]],
+					[null, items[1]]
+				];
+			};
+	
+			// Add items to citation in wrong order
+			await IOManager.addItemsToCitation([itemTwo, itemOne]);
+	
+			// Make sure the bubbleItems are sorted with itemOne being first
+			let firstBubbleItem = CitationDataManager.items[0];
+			let secondBubbleItem = CitationDataManager.items[1];
+			assert.equal(firstBubbleItem.id, itemOne.id);
+			assert.equal(secondBubbleItem.id, itemTwo.id);
+			let bubbles = bubbleInput.getAllBubbles();
+			assert.equal(bubbles[0].getAttribute("dialogReferenceID"), firstBubbleItem.dialogReferenceID);
+			assert.equal(bubbles[1].getAttribute("dialogReferenceID"), secondBubbleItem.dialogReferenceID);
+		});
+	
+		it("should update io.citation.items from bubbles", async function () {
+			let bubbleItems = CitationDataManager.items;
+			// Build citation with several cited items
+			io.citation.citationItems = [citedItemOne, citedItemNotInLibrary];
+			await CitationDataManager.buildCitation();
+	
+			// Add another item
+			await IOManager.addItemsToCitation([itemTwo], { index: 2 });
+	
+			// Add modifications
+			bubbleItems[0].label = "page";
+			bubbleItems[0].locator = "10";
+	
+			bubbleItems[1].prefix = "prefix";
+			bubbleItems[1].suffix = "suffix";
+	
+			bubbleItems[2].suppressAuthor = true;
+	
+			// Update io.citation.items and make sure it looks right
+			CitationDataManager.updateCitationObject(true);
+			let expected = [
+				{
+					id: itemOne.id,
+					locator: "10",
+					label: "page"
+				},
+				{
+					id: citedItemNotInLibrary.id,
+					suffix: "suffix",
+					prefix: "prefix",
+					itemData: citedItemNotInLibrary.itemData,
+					uris: citedItemNotInLibrary.uris,
+				},
+				{
+					id: itemTwo.id,
+					"suppress-author": true
+				}
+			];
+			assert.deepEqual(io.citation.citationItems, expected);
+		});
+	});
+
+	describe("UI", function () {
+		beforeEach(function () {
+			CitationDataManager.items = [];
+			IOManager.updateBubbleInput();
+		});
+
+		it("should switch dialog mode", async function () {
+			IOManager.toggleDialogMode("list");
+			assert.isFalse(dialog.document.getElementById("list-layout").hidden);
+			assert.isTrue(dialog.document.getElementById("library-layout").hidden);
+			IOManager.toggleDialogMode("library");
+			assert.isFalse(dialog.document.getElementById("library-layout").hidden);
+			assert.isTrue(dialog.document.getElementById("list-layout").hidden);
+		});
+
+		it("should highlight bubbles whose items are selected", async function () {
+			let itemOne = await createDataObject('item');
+			let itemTwo = await createDataObject('item');
+
+			IOManager.toggleDialogMode("library");
+			await IOManager.addItemsToCitation([itemOne, itemTwo]);
+
+			// Select row of the first bubble
+			await dialog.libraryLayout.itemsView.selectItem(itemOne.id);
+			// Check that the bubble is highlighted
+			let bubbleOne = dialog.document.querySelector(`.bubble[dialogReferenceID="${CitationDataManager.items[0].dialogReferenceID}"]`);
+			assert.isTrue(bubbleOne.classList.contains("has-item-selected"));
+			// Check the other bubble is unaffected
+			let bubbleTwo = dialog.document.querySelector(`.bubble[dialogReferenceID="${CitationDataManager.items[1].dialogReferenceID}"]`);
+			assert.isFalse(bubbleTwo.classList.contains("has-item-selected"));
+		});
+
+		it("should highlight rows of items in the citation", async function () {
+			let itemOne = await createDataObject('item');
+			IOManager.toggleDialogMode("library");
+
+			// Add the item to citation
+			await IOManager.addItemsToCitation([itemOne]);
+			// Select the row in itemTree, so it is visible
+			await dialog.libraryLayout.itemsView.selectItem(itemOne.id);
+			// Make sure the row node is highlighted
+			let rowIndex = dialog.libraryLayout.itemsView.getRowIndexByID(itemOne.id);
+			let rowID = "item-tree-citationDialog-row-" + rowIndex;
+			let rowNode = dialog.document.getElementById(rowID);
+			assert.isTrue(rowNode.classList.contains("highlighted"));
+		});
+	});
+
+	describe("Search", function () {
+		let selectedOne, selectedTwo, openOne, openTwo, selectedAndOpenOne, citedOne, citedAndOpenOne, libraryOne, libraryTwo;
+
+		before(async function () {
+			selectedOne = await createDataObject('item', { title: "one_selected" });
+			selectedTwo = await createDataObject('item', { title: "two_selected" });
+			openOne = await createDataObject('item', { title: "one_open" });
+			openTwo = await createDataObject('item', { title: "two_open" });
+			selectedAndOpenOne = await createDataObject('item', { title: "one_selected_open" });
+			libraryOne = await createDataObject('item', { title: "one_library" });
+			libraryTwo = await createDataObject('item', { title: "two_library" });
+			citedOne = await createDataObject('item', { title: "one_cited" });
+			citedAndOpenOne = await createDataObject('item', { title: "one_open_cited" });
+
+			// Present these items are selected/open/cited
+			SearchHandler.selectedItems = [selectedOne, selectedTwo, selectedAndOpenOne];
+			SearchHandler.openItems = [openOne, openTwo, selectedAndOpenOne, citedAndOpenOne];
+			SearchHandler.citedItems = [citedOne, citedAndOpenOne];
+		});
+
+		after(function () {
+			SearchHandler.openItems = [];
+			SearchHandler.selectedItems = [];
+		});
+
+		it("should perform search in list mode", async function () {
+			IOManager.toggleDialogMode("list");
+
+			// Search for "one"
+			await dialog.currentLayout.search("one", { skipDebounce: true });
+			// Selected items should have both "one_selected" and "one_selected_open"
+			let selectedIDs = SearchHandler.results.selected.map(item => item.id);
+			assert.sameMembers(selectedIDs, [selectedOne.id, selectedAndOpenOne.id]);
+			// Open items should have "one_open" and "one_open_cited" but not "one_selected_open", since it is selected
+			let openIDs = SearchHandler.results.open.map(item => item.id);
+			assert.sameMembers(openIDs, [openOne.id, citedAndOpenOne.id]);
+			// Cited items should have "one_cited"
+			let citedIDs = SearchHandler.results.cited.map(item => item.id);
+			assert.sameMembers(citedIDs, [citedOne.id]);
+			// Library items should have "one_library" but not "two_library", "one_cited", or "one_open_cited"
+			let libraryIDs = SearchHandler.results.found.map(item => item.id);
+			assert.include(libraryIDs, libraryOne.id);
+			assert.notInclude(libraryIDs, libraryTwo.id);
+			assert.notInclude(libraryIDs, citedOne.id);
+			// Make sure actual nodes for search matches are rendered
+			let expectedItemCardIDs = [...selectedIDs, ...openIDs, ...citedIDs, ...libraryIDs];
+			for (let itemID of expectedItemCardIDs) {
+				let node = dialog.document.querySelector(`.item[id="${itemID}"]`);
+				assert.isOk(node);
+			}
+		});
+
+		it("should perform search in library mode", async function () {
+			IOManager.toggleDialogMode("library");
+
+			// Search for "one"
+			await dialog.currentLayout.search("one", { skipDebounce: true });
+			// Selected items should have both "one_selected" and "one_selected_open"
+			let selectedIDs = SearchHandler.results.selected.map(item => item.id);
+			assert.sameMembers(selectedIDs, [selectedOne.id, selectedAndOpenOne.id]);
+			// Open items should have "one_open" and "one_open_cited" but not "one_selected_open", since it is selected
+			let openIDs = SearchHandler.results.open.map(item => item.id);
+			assert.sameMembers(openIDs, [openOne.id, citedAndOpenOne.id]);
+			// Cited items should have "one_cited"
+			let citedIDs = SearchHandler.results.cited.map(item => item.id);
+			assert.sameMembers(citedIDs, [citedOne.id]);
+			// In library mode, library is searched via itemTree, so this should be empty
+			assert.equal(SearchHandler.results.found.length, 0);
+			// Make sure actual nodes for search matches are rendered
+			let expectedItemCardIDs = [...selectedIDs, ...openIDs, ...citedIDs];
+			for (let itemID of expectedItemCardIDs) {
+				let node = dialog.document.querySelector(`.item[id="${itemID}"]`);
+				assert.isOk(node);
+			}
+		});
 	});
 
 	describe("Helpers.extractLocator", function () {


### PR DESCRIPTION
`CitationDataManager.items` is an array with `zoteroItem` and `citationItem` objects used to represent cited items. `zoteroItem` is an instance of `Zotero.Item`, and `citationItem` is an object with citation data (locator/suffix/prefix, cslItemData, etc.).

If an ordinary (non-cited) item from the library is added to the citation, `citationItem` [would end up](https://github.com/zotero/zotero/blob/ed24cce4a1aaa0d78a0e2ec0be6ab003d6ccb876/chrome/content/zotero/integration/citationDialog.js#L1470) having an instance of `Zotero.Item`. In that case, if a suffix/prefix/etc. is added to the `citationItem`, it would land on the instance of `Zotero.Item` and persist even if the bubble is removed and then re-added. If two bubbles for the same item are added, both of them would share those properties too.

This PR ensures that instances of `Zotero.Item` are only placed into `zoteroItem`, and `citationItem` is maintained in the format that is equivalent to `io.citation.citationItems`. This better separation allows for some streamlining of how items are being processed. `CitationDataManager.addItems` now expect an array with both `zoteroItem` and `citationItem`, instead of checking if a provided citation item (which is often already an instance of `Zotero.Item`) [can be converted to zoteroItem](https://github.com/zotero/zotero/blob/ed24cce4a1aaa0d78a0e2ec0be6ab003d6ccb876/chrome/content/zotero/integration/citationDialog.js#L1466). That allows handlers that call `CitationDataManager.addItems` to only perform necessary transformations using `_zoteroToCitationItem` (when adding a library item) and `_citationToZoteroItem` (when building a citation with cited items on initial load). As an added benefit, when `io` citation object is [being updated](https://github.com/zotero/zotero/blob/ed24cce4a1aaa0d78a0e2ec0be6ab003d6ccb876/chrome/content/zotero/integration/citationDialog.js#L1506-L1518), no transformations are now necessary - we can essentially just use the array of `citationItems`. I think this makes the flow of how items are handled significantly more straightforward.

Fixes: #5282