### PR TITLE
Fix itemTree broken keyboard navigation after deleting child row during quickSearch

### DIFF
--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -3908,7 +3908,14 @@ var ItemTree = class ItemTree extends LibraryTree {
 						if (expandCollapsedParents) {
 							await this._closeContainer(this._rowMap[parent]);
 							await this.toggleOpenState(this._rowMap[parent]);
-							toggleSelect(selection[i].treeViewID);
+							// Re-select original row if it exists
+							if (this._rowMap[selection[i].treeViewID] != null) {
+								toggleSelect(selection[i].treeViewID);
+							}
+							// If it does not (e.g. child item moved to trash), select the parent
+							else {
+								toggleSelect(parent);
+							}
 						}
 						else {
 							!this.selection.isSelected(this._rowMap[parent]) &&

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -894,13 +894,29 @@ var ItemTree = class ItemTree extends LibraryTree {
 			}
 			// On removal of a selected row, select item at previous position
 			else if (savedSelection.length) {
+				// TEMP: trashing an item emits two events: modify and trash.
+				// When not in search mode, on 'modify', we attempt to process rows manually, which does nothing.
+				// The next 'trash' event reaches here and the selection is properly handled.
+				// In search mode, however, trashing an item reruns the search and sets madeChanges=true,
+				// which brings us here on the first 'modify' event. If not handled below, it will try
+				// to restore the selection, which may select the parent of the trashed item instead of the previous/next row.
+				// To avoid losing row selection, for now, assume that a 'modify' event in search
+				// could also represent item deletion/removal.
+				let potentialDeletionInSearch = collectionTreeRow.isSearchMode() && action == 'modify';
 				if ((action == 'remove'
 						|| action == 'trash'
 						|| action == 'delete'
-						|| action == 'removeDuplicatesMaster')
+						|| action == 'removeDuplicatesMaster'
+						|| potentialDeletionInSearch)
 					&& savedSelection.some(o => this.getRowIndexByID(o.id) === false)) {
+					// TEMP: see note above. If this is a 'modify' event that could be a deletion but is not,
+					// just restore selection, the same way it would have happened outside of this conditional.
+					if (potentialDeletionInSearch && Zotero.Items.get(ids).every(item => !item.deleted)) {
+						await this._restoreSelection(savedSelection);
+						reselect = true;
+					}
 					// In duplicates view, select the next set on delete
-					if (collectionTreeRow.isDuplicates()) {
+					else if (collectionTreeRow.isDuplicates()) {
 						if (this._rows[previousFirstSelectedRow]) {
 							var itemID = this._rows[previousFirstSelectedRow].ref.id;
 							var setItemIDs = collectionTreeRow.ref.getSetItemsByItemID(itemID);

--- a/test/tests/itemTreeTest.js
+++ b/test/tests/itemTreeTest.js
@@ -177,6 +177,21 @@ describe("Zotero.ItemTree", function() {
 			await itemsView._refreshPromise;
 			assert.equal(quicksearch.value, "test");
 		});
+
+		it("should not loose selection when a child item is deleted during search", async function () {
+			let item = await createDataObject('item', { title: "test" });
+			var note = await createDataObject('item', { itemType: 'note', parentID: item.id });
+			await itemsView.selectItem(note.id);
+
+			quicksearch.value = "test";
+			quicksearch.doCommand();
+			await itemsView._refreshPromise;
+
+			note.deleted = true;
+			await note.saveTx();
+
+			assert.isFalse(isNaN(itemsView.selection.focused));
+		});
 	});
 	
 	describe("#selectItem()", function () {


### PR DESCRIPTION
Fixed `itemTree.selection.focused` being set to `NaN` while trying to restore selection to a no-longer existing child row after it is trashed when `quickSearch` is active. Then, trying to find the next/previous row following/before row with index `NaN` would result in broken keyboard navigation of the tree.

Fixes: #5280

Before. Note, no row is selected, and `itemTree.selection.focused` is `NaN`. If at this point, up/down arrow is pressed, an error will be thrown in `windowed-list`, and keyboard navigation will be broken.

https://github.com/user-attachments/assets/079f3f0e-39a4-467a-aef2-3a113b9f6421

After. Since the child row is gone, the parent is re-selected:


https://github.com/user-attachments/assets/e31e8512-7b39-4f2e-abeb-4ce0781e4efc


