### PR TITLE
Citation Dialog: more optimization of initial loading

### DIFF
--- a/chrome/content/zotero/integration/citationDialog.js
+++ b/chrome/content/zotero/integration/citationDialog.js
@@ -51,12 +51,11 @@ var { CitationDialogKeyboardHandler } = ChromeUtils.importESModule('chrome://zot
 async function onLoad() {
 	doc = document;
 	io = window.arguments[0].wrappedJSObject;
-	ioReadyPromise = io.allCitedDataLoadedDeferred.promise;
+	ioReadyPromise = io.allCitedDataLoadedPromise;
 	// if io did not send the promise indiciating when io.sort() and io.getItems() will be ready to run,
 	// use an immediately resolved promise
 	if (!ioReadyPromise) {
-		ioReadyPromise = Zotero.Promise.defer();
-		ioReadyPromise.resolve();
+		ioReadyPromise = Zotero.Promise.resolve();
 	}
 	isCitingNotes = !!io.isCitingNotes;
 	window.isPristine = true;

--- a/chrome/content/zotero/integration/citationDialog/searchHandler.mjs
+++ b/chrome/content/zotero/integration/citationDialog/searchHandler.mjs
@@ -50,10 +50,6 @@ export class CitationDialogSearchHandler {
 		this.selectedItems = null;
 		this.openItems = null;
 		this.citedItems = null;
-
-		this.loadCitedItemsPromise = this._getCitedItems().then((citedItems) => {
-			this.citedItems = citedItems;
-		});
 	}
 
 	setSearchValue(str, enforceMinQueryLength) {
@@ -174,8 +170,9 @@ export class CitationDialogSearchHandler {
 
 	async refreshCitedItems() {
 		if (this.citedItems === null) {
-			return;
+			this.citedItems = await this._getCitedItems();
 		}
+		if (!this.citedItems) return;
 		// if "ibid" is typed, return all cited items
 		if (this.searchValue.toLowerCase() === Zotero.getString("integration.ibid").toLowerCase()) {
 			this.results.cited = this.citedItems;
@@ -267,6 +264,8 @@ export class CitationDialogSearchHandler {
 
 	async _getCitedItems() {
 		if (this.isCitingNotes) return [];
+		// Noop until io loads all cited data
+		if (!this.io.allCitedDataLoadedDeferred.promise.isResolved()) return null;
 		// Fetch all cited items in the document, not just items currently in the dialog
 		let citedItems = await this.io.getItems();
 		return citedItems;

--- a/chrome/content/zotero/integration/citationDialog/searchHandler.mjs
+++ b/chrome/content/zotero/integration/citationDialog/searchHandler.mjs
@@ -265,7 +265,7 @@ export class CitationDialogSearchHandler {
 	async _getCitedItems() {
 		if (this.isCitingNotes) return [];
 		// Noop until io loads all cited data
-		if (!this.io.allCitedDataLoadedDeferred.promise.isResolved()) return null;
+		if (this.io.allCitedDataLoadedPromise && !this.io.allCitedDataLoadedPromise.isResolved()) return null;
 		// Fetch all cited items in the document, not just items currently in the dialog
 		let citedItems = await this.io.getItems();
 		return citedItems;

--- a/chrome/content/zotero/xpcom/integration.js
+++ b/chrome/content/zotero/xpcom/integration.js
@@ -1736,10 +1736,7 @@ Zotero.Integration.CitationEditInterface = function(items, sortable, fieldIndexP
 	this.promise = this._acceptDeferred.promise;
 
 	// Resolve when all data needed to run getItems() or sort() is loaded
-	this.allCitedDataLoadedDeferred = Zotero.Promise.defer();
-	Promise.all([fieldIndexPromise, citationsByItemIDPromise]).then(() => {
-		this.allCitedDataLoadedDeferred.resolve();
-	});
+	this.allCitedDataLoadedPromise = Zotero.Promise.all([fieldIndexPromise, citationsByItemIDPromise]);
 }
 
 Zotero.Integration.CitationEditInterface.prototype = {

--- a/chrome/content/zotero/xpcom/integration.js
+++ b/chrome/content/zotero/xpcom/integration.js
@@ -1734,6 +1734,12 @@ Zotero.Integration.CitationEditInterface = function(items, sortable, fieldIndexP
 
 	this._acceptDeferred = Zotero.Promise.defer();
 	this.promise = this._acceptDeferred.promise;
+
+	// Resolve when all data needed to run getItems() or sort() is loaded
+	this.allCitedDataLoadedDeferred = Zotero.Promise.defer();
+	Promise.all([fieldIndexPromise, citationsByItemIDPromise]).then(() => {
+		this.allCitedDataLoadedDeferred.resolve();
+	});
 }
 
 Zotero.Integration.CitationEditInterface.prototype = {

--- a/test/tests/citationDialogTest.js
+++ b/test/tests/citationDialogTest.js
@@ -13,7 +13,7 @@ describe("Citation Dialog", function () {
 		getItems() {
 			return [];
 		},
-		allCitedDataLoadedDeferred: Zotero.Promise.defer(),
+		allCitedDataLoadedPromise: Zotero.Promise.resolve(),
 	};
 	let dialog, win, IOManager, CitationDataManager, SearchHandler;
 
@@ -26,7 +26,6 @@ describe("Citation Dialog", function () {
 		IOManager = dialog.IOManager;
 		CitationDataManager = dialog.CitationDataManager;
 		SearchHandler = dialog.SearchHandler;
-		io.allCitedDataLoadedDeferred.resolve();
 		// wait for everything (e.g. itemTree/collectionTree) inside of the dialog to be loaded.
 		while (!dialog.loaded) {
 			await Zotero.Promise.delay(10);
@@ -483,15 +482,15 @@ describe("Citation Dialog", function () {
 						unsorted: false,
 					}
 				},
-				// allCitedDataLoadedDeferred is what citation dialog checks
+				// allCitedDataLoadedPromise is what citation dialog checks
 				// but make all functions unresolved promises just to be sure
 				sort() {
-					return Zotero.Promise.defer().promise;
+					return new Zotero.Promise(() => {});
 				},
 				getItems() {
-					return Zotero.Promise.defer().promise;
+					return new Zotero.Promise(() => {});
 				},
-				allCitedDataLoadedDeferred: Zotero.Promise.defer(),
+				allCitedDataLoadedPromise: new Zotero.Promise(() => {}),
 			};
 
 			let newDialogPromise = waitForWindow("chrome://zotero/content/integration/citationDialog.xhtml");


### PR DESCRIPTION
https://forums.zotero.org/discussion/124211/zotero-update-bug-delay-in-citation-insertion-search

It can take a while for all the promises that `io` needs to sort to resolve. It means that if we await for sorting while building citation on initial load, it can cause a visible delay. This is somewhat of a continuation of #5127, in which `await`-ing of cited items was removed because we should not `await` for sorting to be ready as well. 

When an item is added, only run sorting if `io` is ready for it. If `io` is not ready to sort during initial load, some bubbles may be added out of order. They will be sorted as soon as `io` is ready.

This is what it looks like with an added `Zotero.Promise.delay(5000)` to [Zotero.Integration.Session.prototype.getFields](https://github.com/zotero/zotero/blob/2bc0c4861c35d08ceff25723a6f8d0e7c77842b4/chrome/content/zotero/xpcom/integration.js#L1096). 

https://github.com/user-attachments/assets/1e69b2fb-fe9f-46e1-a9d7-c2de6754b89b

For comparison, this is if we try to `await` for sorting with the same fake 5 seconds delay on load:

https://github.com/user-attachments/assets/aba7621e-8686-4f9a-8e4b-c1af50546a99

Also, add a few `Zotero.debug` lines.

---

I didn't realize that the source of the delay comes from awaiting for `citationsByItemIDPromise` and `fieldIndexPromise` from `CitationEditInterface` while testing #5127. Now, though, there should be nothing preventing the dialog from being fully interactive while everything else in `io` is loading. I wonder if, instead of adding `CitationDataManager.readyToSortItems()`, it may be cleaner to add a new property to `CitationEditInterface`? Then, we could achieve the same via something like `io.isEverythingLoaded()`, without having to look into exactly what is being loaded in `CitationEditInterface`. We could also combine sorting items when `io` is ready with handling `SearchHandler.loadCitedItemsPromise` because they both should resolve at the same time based on such `io.isEverythingLoaded()`?

