### PR TITLE
Fix issue where subsequent updates provide stale changed object data

### DIFF
--- a/chrome/content/zotero/xpcom/data/dataObject.js
+++ b/chrome/content/zotero/xpcom/data/dataObject.js
@@ -1158,6 +1158,8 @@ Zotero.DataObject.prototype._postSave = function (env) {
 		let rel = env.relationsToUnregister[i];
 		Zotero.Relations.unregister(this._objectType, this.id, rel[0], rel[1]);
 	}
+	this._changed = {};
+	this._previousData = {};
 };
 
 


### PR DESCRIPTION
It seems that after 2bc0c48, the `changed` object does indeed contain previous values (thanks!), but this works only once—subsequent updates provide stale `changed` object data.

I encountered this while working on #3860, so I’ve extended the test to cover this scenario and attempted to fix the problem by clearing `_previousData` in `postSave`—no idea if that's the correct approach.
