### PR TITLE
Fix locate button for annotation item

### DIFF
--- a/chrome/content/zotero/locateMenu.js
+++ b/chrome/content/zotero/locateMenu.js
@@ -40,7 +40,7 @@ var Zotero_LocateMenu = new function() {
 			locateMenu.removeChild(locateMenu.firstChild);
 		}
 		
-		var selectedItems = _getSelectedItems();
+		var selectedItems = await _getSelectedItems();
 		
 		if(selectedItems.length) {
 			await _addViewOptions(locateMenu, selectedItems, true, true, true);
@@ -99,7 +99,7 @@ var Zotero_LocateMenu = new function() {
 	 */
 	this.buildContextMenu = Zotero.Promise.coroutine(function* (menu, showIcons) {
 		// get selected items
-		var selectedItems = _getSelectedItems();
+		var selectedItems = yield _getSelectedItems();
 		
 		// if no items selected or >20 items selected, stop now
 		if(!selectedItems.length || selectedItems.length > 20) return;
@@ -298,9 +298,9 @@ var Zotero_LocateMenu = new function() {
 	/**
 	 * Locate selected items
 	 */
-	this.locateItem = function(event, selectedItems) {
+	this.locateItem = async function(event, selectedItems) {
 		if(!selectedItems) {
-			selectedItems = _getSelectedItems();
+			selectedItems = await _getSelectedItems();
 		}
 		
 		// find selected engine
@@ -344,13 +344,19 @@ var Zotero_LocateMenu = new function() {
 	/**
 	 * Get the first 50 selected items
 	 */
-	function _getSelectedItems() {
+	async function _getSelectedItems() {
 		var allSelectedItems = ZoteroPane.getSelectedItems();
 		var selectedItems = [];
 		while (selectedItems.length < 50 && allSelectedItems.length) {
 			var item = allSelectedItems.shift();
 			if (item.isAnnotation()) {
-				selectedItems.push(item.parentItem);
+				let attachment = item.parentItem;
+				if (attachment.parentItem && attachment.id === await attachment.parentItem.getBestAttachment()?.id) {
+					selectedItems.push(attachment.parentItem);
+				}
+				else {
+					selectedItems.push(attachment);
+				}
 			}
 			else if (!item.isNote()) {
 				selectedItems.push(item);

--- a/chrome/content/zotero/locateMenu.js
+++ b/chrome/content/zotero/locateMenu.js
@@ -349,7 +349,12 @@ var Zotero_LocateMenu = new function() {
 		var selectedItems = [];
 		while (selectedItems.length < 50 && allSelectedItems.length) {
 			var item = allSelectedItems.shift();
-			if (!item.isNote() && !item.isAnnotation()) selectedItems.push(item);
+			if (item.isAnnotation()) {
+				selectedItems.push(item.parentItem);
+			}
+			else if (!item.isNote()) {
+				selectedItems.push(item);
+			}
 		}
 		return selectedItems;
 	}

--- a/chrome/content/zotero/locateMenu.js
+++ b/chrome/content/zotero/locateMenu.js
@@ -351,7 +351,7 @@ var Zotero_LocateMenu = new function() {
 			var item = allSelectedItems.shift();
 			if (item.isAnnotation()) {
 				let attachment = item.parentItem;
-				if (attachment.parentItem && attachment.id === await attachment.parentItem.getBestAttachment()?.id) {
+				if (attachment.parentItem && attachment === await attachment.parentItem.getBestAttachment()) {
 					selectedItems.push(attachment.parentItem);
 				}
 				else {


### PR DESCRIPTION
For any selected annotation items in library, the locate button will show operations for its parent item, instead of showing nothing.