### PR TITLE
Unhide "title" column on "Restore Column Order"

### DIFF
--- a/chrome/content/zotero/components/virtualized-table.jsx
+++ b/chrome/content/zotero/components/virtualized-table.jsx
@@ -1703,6 +1703,16 @@ var Columns = class {
 			}
 		}
 		this._columns.sort((a, b) => a.ordinal - b.ordinal);
+
+		// Recover from scenarios where a plugin disables the "title" column and
+		// does not provide its own primary column, or is later removed and the
+		// "title" column is never restored.
+		let hasPrimaryColumn = this._columns.some(c => c.primary && !c.hidden);
+		if (!hasPrimaryColumn) {
+			Zotero.debug(`VirtualizedTable: Missing primary column, re-enabling the "title" column.`);
+			this._columns.find(c => c.dataKey === 'title').hidden = false;
+		}
+		
 		this._adjustColumnWidths();
 		this.onResize(Object.fromEntries(this._columns.map(c => [c.dataKey, c.width])));
 		this._storePrefs(prefs);


### PR DESCRIPTION
This actually checks for a "primary" column, so if an extension hides the "title" column but provides its own "primary" column, the "title" column remains hidden.