### PR TITLE
Fix sidenav notes button not switching to notes list in context pane

### DIFF
--- a/chrome/content/zotero/elements/itemPaneSidenav.js
+++ b/chrome/content/zotero/elements/itemPaneSidenav.js
@@ -665,21 +665,25 @@
 					});
 					firstBtn.dispatchEvent(clickEvent);
 				}
-				setTimeout(() => {
-					// If notes are visible, tab into them
-					if (this._contextNotesPaneVisible) {
-						Services.focus.moveFocus(window, this.contextNotesPane, Services.focus.MOVEFOCUS_FORWARD, 0);
-					}
-					// Tab into the pinned section if it exists
-					else if (this.pinnedPane) {
-						Services.focus.moveFocus(window, this.container.getEnabledPane(this.pinnedPane),
-							Services.focus.MOVEFOCUS_FORWARD, 0);
-					}
-					// Otherwise, focus the top-level scrollable itemPane
-					else {
-						this._container.querySelector(".zotero-view-item").focus();
-					}
-				});
+				// Otherwise, just click on the focused button
+				else if (event.target.classList.contains("btn")) {
+					event.preventDefault();
+					event.target.click();
+				}
+
+				// If notes are visible, tab into them
+				if (this._contextNotesPaneVisible) {
+					Services.focus.moveFocus(window, this.contextNotesPane, Services.focus.MOVEFOCUS_FORWARD, 0);
+				}
+				// Tab into the pinned section if it exists
+				else if (this.pinnedPane) {
+					Services.focus.moveFocus(window, this.container.getEnabledPane(this.pinnedPane),
+						Services.focus.MOVEFOCUS_FORWARD, 0);
+				}
+				// Otherwise, focus the top-level scrollable itemPane if visible
+				else if (!this.container._collapsed) {
+					this._container.querySelector(".zotero-view-item").focus();
+				}
 			}
 		};
 

--- a/chrome/content/zotero/elements/itemPaneSidenav.js
+++ b/chrome/content/zotero/elements/itemPaneSidenav.js
@@ -680,8 +680,8 @@
 					Services.focus.moveFocus(window, this.container.getEnabledPane(this.pinnedPane),
 						Services.focus.MOVEFOCUS_FORWARD, 0);
 				}
-				// Otherwise, focus the top-level scrollable itemPane if visible
-				else if (!this.container._collapsed) {
+				// Otherwise, focus the top-level scrollable itemPane
+				else {
 					this._container.querySelector(".zotero-view-item").focus();
 				}
 			}

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -678,7 +678,7 @@ class ReaderInstance {
 		if (!open && this._window.document.activeElement.dataset.action == "toggle-pane") {
 			// Context pane collapsed when sidenav button is focused - try to focus btn in reader toolbar
 			setTimeout(() => {
-				this._iframeWindow.document.querySelector(".context-pane-toggle").focus();
+				this._iframeWindow.document.querySelector(".context-pane-toggle").focus({ focusVisible: true });
 			});
 		}
 		else if (open && this._iframeWindow.document.activeElement.classList.contains("context-pane-toggle")) {
@@ -686,7 +686,7 @@ class ReaderInstance {
 			// Try to focus the sidenav button, if reader's button was hidden
 			setTimeout(() => {
 				if (this._iframeWindow.document.querySelector("context-pane-toggle")) return;
-				this._window.document.querySelector("#zotero-context-pane-sidenav .btn[data-action='toggle-pane']").focus();
+				this._window.document.querySelector("#zotero-context-pane-sidenav .btn[data-action='toggle-pane']").focus({ focusVisible: true });
 			});
 		}
 

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -671,6 +671,25 @@ class ReaderInstance {
 
 	async setContextPaneOpen(open) {
 		await this._initPromise;
+
+		// There are two toggle-pane buttons: in the reader and in the sidenav. Closing/opening
+		// the context pane may display one and hide the other. If a focused toggle-pane btn is being hidden,
+		// try to focus the other toggle-pane btn so that focus is not just lost.
+		if (!open && this._window.document.activeElement.dataset.action == "toggle-pane") {
+			// Context pane collapsed when sidenav button is focused - try to focus btn in reader toolbar
+			setTimeout(() => {
+				this._iframeWindow.document.querySelector(".context-pane-toggle").focus();
+			});
+		}
+		else if (open && this._iframeWindow.document.activeElement.classList.contains("context-pane-toggle")) {
+			// Context pane expanded when toggle-pane in reader toolbar is focused.
+			// Try to focus the sidenav button, if reader's button was hidden
+			setTimeout(() => {
+				if (this._iframeWindow.document.querySelector("context-pane-toggle")) return;
+				this._window.document.querySelector("#zotero-context-pane-sidenav .btn[data-action='toggle-pane']").focus();
+			});
+		}
+
 		this._internalReader.setContextPaneOpen(open);
 	}
 


### PR DESCRIPTION
Also, try to not loose focus when toggling context pane open/closed. If one toggle-pane button disappears, and the other one appears - move focus to the new button.

Fixes: #5306


https://github.com/user-attachments/assets/147f3e0f-d9fb-47f2-9a1e-f3c9abd2dee1

