### PR TITLE
Fix new annotation changing the scroll position in itemTree

### DIFF
--- a/chrome/content/zotero/components/windowed-list.js
+++ b/chrome/content/zotero/components/windowed-list.js
@@ -202,8 +202,8 @@ module.exports = class {
 
 	/**
 	 * Scroll the scrollbox to a specified item. No-op if already in view
-	 * @param index
-	 * @param forceScrollToTop {Boolean} if true, the row will be scrolled to the top of the scrollbox
+	 * @param {Integer} index
+	 * @param {Boolean} forceScrollToTop  If true, the row will be scrolled to the top of the scrollbox
 	 * even if it is below the current scroll position.
 	 */
 	scrollToRow(index, forceScrollToTop = false) {

--- a/chrome/content/zotero/components/windowed-list.js
+++ b/chrome/content/zotero/components/windowed-list.js
@@ -204,7 +204,7 @@ module.exports = class {
 	 * Scroll the scrollbox to a specified item. No-op if already in view
 	 * @param {Integer} index
 	 * @param {Boolean} forceScrollToTop  If true, the row will be scrolled to the top of the scrollbox
-	 * even if it is below the current scroll position.
+	 * even if it is below the current scroll window.
 	 */
 	scrollToRow(index, forceScrollToTop = false) {
 		const { scrollOffset } = this;

--- a/chrome/content/zotero/components/windowed-list.js
+++ b/chrome/content/zotero/components/windowed-list.js
@@ -203,8 +203,10 @@ module.exports = class {
 	/**
 	 * Scroll the scrollbox to a specified item. No-op if already in view
 	 * @param index
+	 * @param forceScrollToTop {Boolean} if true, the row will be scrolled to the top of the scrollbox
+	 * even if it is below the current scroll position.
 	 */
-	scrollToRow(index) {
+	scrollToRow(index, forceScrollToTop = false) {
 		const { scrollOffset } = this;
 		const itemCount = this._getItemCount();
 		const height = this.getWindowHeight();
@@ -216,7 +218,7 @@ module.exports = class {
 			this.scrollTo(startPosition);
 		}
 		else if (endPosition > scrollOffset + height) {
-			this.scrollTo(endPosition - height - 1);
+			this.scrollTo(forceScrollToTop ? startPosition : endPosition - height - 1);
 		}
 	}
 	

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -3752,7 +3752,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 		if (row === false) {
 			return;
 		}
-		this._treebox.scrollToRow(Math.max(row - scrollPosition.offset, 0));
+		this._treebox.scrollToRow(Math.max(row - scrollPosition.offset, 0), true);
 	}
 
 	/**


### PR DESCRIPTION
Extend `scrollToRow` in `windowed-list.js` to allow to scroll the specified row to the top of the window
even if it is located below the current scroll position. With this, when scroll position is restored in `itemTree`, the same row remains at the top. The root of the issue happening now is that when the scroll position is restored, the row that was originally at the top would be scrolled to in a way that would place it at the bottom of the visible window.

Fixes: #5233

Before: [recording](https://www.dropbox.com/scl/fi/i3pkb99zk5zneyavkuvkv/before.mov?rlkey=0x2e8mmbqmj8dca5uo6p3zu8r&st=p2r76zvw&dl=0)

After: [recording](https://www.dropbox.com/scl/fi/gdw9fk25i52ie91xo7blb/after.mov?rlkey=9kxf50qmfvozre09nde5o8be1&st=50xo3jzl&dl=0)