### PR TITLE
Editable annotation cards in itemPane

### DIFF
--- a/chrome/content/zotero/elements/annotationItemsPane.js
+++ b/chrome/content/zotero/elements/annotationItemsPane.js
@@ -106,6 +106,7 @@
 					let row = document.createXULElement('annotation-row');
 					row.annotation = annotation;
 					row.container = this._body;
+					row.draggable = true;
 					section.querySelector('.body').append(row);
 				}
 			}

--- a/chrome/content/zotero/elements/annotationItemsPane.js
+++ b/chrome/content/zotero/elements/annotationItemsPane.js
@@ -105,6 +105,7 @@
 					if (this.querySelector(`annotation-row[annotation-id="${annotation.id}"]`)) continue;
 					let row = document.createXULElement('annotation-row');
 					row.annotation = annotation;
+					row.container = this._body;
 					section.querySelector('.body').append(row);
 				}
 			}

--- a/chrome/content/zotero/elements/annotationRow.js
+++ b/chrome/content/zotero/elements/annotationRow.js
@@ -37,7 +37,6 @@
 			<html:div class="body">
 				<html:img/>
 				<html:div class="quote"/>
-				<html:div class="comment keyboard-clickable" tabindex="0" role="button"/>
 			</html:div>
 			<html:div class="tags keyboard-clickable" tabindex="0"/>
 		`);
@@ -85,10 +84,16 @@
 			this._body = this.querySelector('.body');
 			this._tags = this.querySelector('.tags');
 			this._options = this.querySelector('.head toolbarbutton');
-			this._comment = this.querySelector('.comment');
 			this._img = this.querySelector('img');
 			this._quote = this.querySelector('.quote');
 			this._commentInEditor = null;
+
+			// <html:div> placed directly in content string will strip all
+			// html tags when .innerHTML is set. But a node created dynamically won't.
+			this._comment = document.createElement('div');
+			this._comment.className = "comment keyboard-clickable";
+			this._comment.setAttribute('role', 'button');
+			this._quote.after(this._comment);
 
 			this.addEventListener('keydown', this._handleKeyDown.bind(this));
 			this._tags.addEventListener('click', this._handleTagsClick.bind(this));
@@ -174,7 +179,6 @@
 			let content = this._annotation.annotationComment;
 			if (!content) return "";
 			content = content.replace(/\n/g, '<br/>');
-			content = content.replace(/ /g, '&nbsp;');
 			return content;
 		};
 
@@ -380,7 +384,7 @@
 			// let plainComment = parserUtils.convertToPlainText(this._annotation.annotationComment, Ci.nsIDocumentEncoder.OutputRaw, 0) || "Add comment";
 			if (this._annotation.annotationComment) {
 				this._comment.hidden = false;
-				this._comment.innerHTML = this._annotation.annotationComment;
+				this._comment.innerHTML = this._commentToHTML();
 			}
 			else if (this.isEditable) {
 				this._comment.hidden = false;

--- a/chrome/content/zotero/elements/annotationRow.js
+++ b/chrome/content/zotero/elements/annotationRow.js
@@ -31,9 +31,15 @@
 			<html:div class="head">
 				<image class="icon"/>
 				<html:div class="title"/>
+				<spacer flex="1"/>
+				<toolbarbutton class="button zotero-clicky zotero-clicky-options" tabindex="0"/>
 			</html:div>
-			<html:div class="body"/>
-			<html:div class="tags"/>
+			<html:div class="body">
+				<html:img/>
+				<html:div class="quote"/>
+				<html:div class="comment keyboard-clickable" tabindex="0" role="button"/>
+			</html:div>
+			<html:div class="tags keyboard-clickable" tabindex="0"/>
 		`);
 
 		_annotation = null;
@@ -55,9 +61,22 @@
 			return this._annotation;
 		}
 
+		get isEditable() {
+			return this._annotation.isEditable() && !this._annotation.annotationIsExternal;
+		}
+
 		set annotation(annotation) {
 			this._annotation = annotation;
 			this.setAttribute('annotation-id', annotation.id);
+		}
+
+		destroy() {
+			this.removeEventListener('keydown', this._handleKeyDown);
+			this._tags.removeEventListener('click', this._handleTagsClick);
+			this._options.removeEventListener('click', this._openMenu);
+			this._comment.removeEventListener('click', this._makeCommentEditable);
+			this._img.removeEventListener('error', this._handleImageError);
+			this._deleteEditor();
 		}
 
 		init() {
@@ -65,37 +84,286 @@
 			this._title = this.querySelector('.title');
 			this._body = this.querySelector('.body');
 			this._tags = this.querySelector('.tags');
+			this._options = this.querySelector('.head toolbarbutton');
+			this._comment = this.querySelector('.comment');
+			this._img = this.querySelector('img');
+			this._quote = this.querySelector('.quote');
+			this._commentInEditor = null;
+
+			this.addEventListener('keydown', this._handleKeyDown.bind(this));
+			this._tags.addEventListener('click', this._handleTagsClick.bind(this));
+			this._options.addEventListener('click', this._openMenu.bind(this));
+			this._comment.addEventListener('click', this._makeCommentEditable.bind(this));
+			// show a placeholder text if the image could not be loaded for some reason (e.g. file is not there)
+			this._img.addEventListener('error', this._handleImageError);
+			
 			this.render();
 		}
+
+		_handleTagsClick() {
+			if (!this.isEditable) return;
+			let { x, y, height } = this.getBoundingClientRect();
+			Zotero.Annotations.insertAnnotationsTagsPopup(this, this._annotation, x, y + height);
+		}
+
+		_handleImageError() {
+			let placeholder = document.createElement('div');
+			placeholder.classList.add('comment');
+			document.l10n.setAttributes(placeholder, 'annotation-image-not-available');
+			this._body.replaceChildren(placeholder);
+		}
+
+		// To edit comment, replace the comment div with the simpleEditor.html iframe
+		_makeCommentEditable() {
+			if (!this.isEditable) return;
+
+			let editorFrameWrapper = document.createElement('div');
+			editorFrameWrapper.className = "comment editable";
+			this._editorFrame = document.createElement('iframe');
+			this._editorFrame.setAttribute('src', 'chrome://zotero/content/integration/simpleEditor.html');
+			this._editorFrame.setAttribute('type', 'content');
+			this._editorFrame.setAttribute('tight', 'true');
+			this._editorFrame.setAttribute('toolbar-below-editor', 'true');
+			this._editorFrame.setAttribute('actions', 'bold,italic,underline,subscript,superscript,removeformat');
+			let actionBarHeight = 20;
+			this._editorFrame.style.height = (this._comment.getBoundingClientRect().height + actionBarHeight) + 'px';
+
+			// Hide the comment div and insert the editor frame
+			editorFrameWrapper.appendChild(this._editorFrame);
+			this._comment.after(editorFrameWrapper);
+			this._comment.classList.add('hidden');
+
+			this._editorFrame.addEventListener('input', this._handleEditorInput);
+			this._editorFrame.addEventListener('focusout', this._handleEditorFocusOut);
+			this._editorFrame.addEventListener('keydown', this._handleEditorKeyDown);
+			this._editorFrame.contentWindow.addEventListener('load', this._handleEditorIframeLoaded, { once: true });
+		}
+
+		// Adjust the height of the frame as the user types to match
+		// the height of the content
+		_handleEditorInput = () => {
+			let height = this._editorFrame.contentWindow.editor.getTotalHeight();
+			this._editorFrame.style.height = height + 'px';
+			this._commentInEditor = this._editorFrame.contentWindow.editor.getContent();
+		};
+
+		_handleEditorFocusOut = async () => {
+			if (this._commentInEditor === null) return;
+			let content = this._commentFromHTML();
+			// Wait a moment to see if the focus remains in the editor
+			await Zotero.Promise.delay(10);
+			if (this._editorFrame.contentDocument && this._editorFrame.contentDocument.hasFocus()) return;
+			// Place updated content into the comment div, so it appears faster
+			this._comment.innerHTML = content || Zotero.getString('pdfReader.addComment');
+			this._comment.classList.remove('hidden');
+			this._deleteEditor();
+
+			this._annotation.annotationComment = content || null;
+			this._annotation.saveTx();
+		};
+
+		// <br> -> \n, &nbsp; -> ' ', <div></div> -> \n
+		_commentFromHTML = () => {
+			let content = this._commentInEditor.replace(/<br>/g, '\n');
+			content = content.replace(/&nbsp;/g, ' ');
+			content = content.replace(/<div>/g, '').replace(/<\/?div>/g, '\n');
+			return content.trim();
+		};
+
+		_commentToHTML = () => {
+			let content = this._annotation.annotationComment;
+			if (!content) return "";
+			content = content.replace(/\n/g, '<br/>');
+			content = content.replace(/ /g, '&nbsp;');
+			return content;
+		};
+
+		// Ctrl/Cmd+Enter in the editor will save current changes
+		// Escape will cancel the edits
+		_handleEditorKeyDown = (event) => {
+			if (event.key == "Enter" && (event.metaKey && !event.ctrlKey)) {
+				this._editorFrame.blur();
+			}
+			else if (event.key == "Escape") {
+				this._comment.classList.remove('hidden');
+				this._deleteEditor();
+				this._comment.focus({ focusVisible: true });
+				event.stopPropagation();
+			}
+		};
+
+		// Set the content of the editor to the current comment and adjust
+		// the height of the editor frame to match the content
+		_handleEditorIframeLoaded = async () => {
+			let editor = this._editorFrame.contentWindow.editor;
+			editor.setContent(this._commentToHTML());
+			editor.focusContent();
+			this._commentInEditor = this._annotation.annotationComment || "";
+			let height = editor.getTotalHeight();
+			this._editorFrame.style.height = height + 'px';
+		};
+		
+		_deleteEditor() {
+			if (!this._editorFrame) return;
+			this._commentInEditor = null;
+			this._editorFrame.parentElement.remove();
+			this._editorFrame.removeEventListener('input', this._handleEditorInput);
+			this._editorFrame.removeEventListener('focusout', this._handleEditorFocusOut);
+			this._editorFrame.removeEventListener('keydown', this._handleEditorKeyDown);
+		}
+
+		// Keyboard navigation
+		// ArrowUp/Down navigate between annotations
+		// Tab/Shift+Tab will move focus through the currently focused annotation
+		_handleKeyDown(event) {
+			if (event.target.tagName == "annotation-row" && event.key == "Tab" && event.shiftKey) {
+				let firstAnnotation = this.parentNode.querySelector("annotation-row");
+				Services.focus.moveFocus(window, firstAnnotation, Services.focus.MOVEFOCUS_BACKWARD, 0);
+				event.preventDefault();
+			}
+			if (event.target.classList.contains("tags") && event.key == "Tab" && !event.shiftKey) {
+				let lastTags = this.parentNode.querySelector("annotation-row:last-child .tags");
+				Services.focus.moveFocus(window, lastTags, Services.focus.MOVEFOCUS_FORWARD, 0);
+				event.preventDefault();
+			}
+			else if (event.target.tagName == "annotation-row" && ["ArrowUp", "ArrowDown"].includes(event.key)) {
+				let annotationRows = [...this.parentNode.querySelectorAll("annotation-row")];
+				let currentRowIndex = annotationRows.indexOf(event.target);
+				let nextRowIndex = currentRowIndex + (event.key == "ArrowDown" ? 1 : -1);
+				annotationRows[nextRowIndex]?.focus();
+				event.preventDefault();
+			}
+		}
+
+		// Generate and open the menu with annotation color options
+		_openMenu() {
+			if (!this.isEditable) return;
+
+			let colors = [
+				{ color: "#ffd400", label: Zotero.getString('general.yellow') },
+				{ color: "#ff6666", label: Zotero.getString('general.red') },
+				{ color: "#5fb236", label: Zotero.getString('general.green') },
+				{ color: "#2ea8e5", label: Zotero.getString('general.blue') },
+				{ color: "#a28ae5", label: Zotero.getString('general.purple') },
+				{ color: "#e56eee", label: Zotero.getString('general.magenta') },
+				{ color: "#f19837", label: Zotero.getString('general.orange') },
+				{ color: "#aaaaaa", label: Zotero.getString('general.gray') }
+			];
+			
+			let optionsPopup = document.createXULElement('panel');
+			let vboxWrapper = document.createXULElement('vbox');
+			vboxWrapper.classList.add('annotations-options-popup');
+			optionsPopup.appendChild(vboxWrapper);
+			
+			// Create color menu options
+			for (let [index, colorOption] of colors.entries()) {
+				let hbox = document.createXULElement('hbox');
+				hbox.className = "menu-option color keyboard-clickable";
+				hbox.setAttribute('tabindex', 0);
+				hbox.setAttribute('index', index);
+				hbox.setAttribute('role', 'button');
+				hbox.setAttribute('aria-label', colorOption.label);
+				
+				// Create color swatch span
+				let colorSwatch = document.createElement('span');
+				colorSwatch.classList.add('color-swatch');
+				colorSwatch.style.backgroundColor = colorOption.color;
+				
+				// Create label for the color
+				let colorLabel = document.createXULElement('label');
+				colorLabel.textContent = colorOption.label;
+				colorLabel.classList.add('color-label');
+				
+				// Add elements to hbox
+				hbox.appendChild(colorSwatch);
+				hbox.appendChild(colorLabel);
+				vboxWrapper.appendChild(hbox);
+
+				hbox.addEventListener('click', () => {
+					this._annotation.annotationColor = colorOption.color;
+					this._annotation.saveTx();
+					optionsPopup.hidePopup();
+				});
+			}
+
+			let separator = document.createXULElement('menuseparator');
+			let deleteOption = document.createXULElement('hbox');
+			deleteOption.className = "menu-option delete keyboard-clickable";
+			deleteOption.setAttribute('tabindex', 0);
+			deleteOption.setAttribute('index', colors.length);
+
+			// Add delete menu option
+			let deleteLabel = document.createXULElement('label');
+			deleteLabel.textContent = Zotero.getString('general.delete');
+			deleteLabel.classList.add('delete-label');
+			deleteOption.appendChild(deleteLabel);
+			deleteOption.addEventListener('click', () => {
+				this._annotation.eraseTx();
+				optionsPopup.hidePopup();
+			});
+			vboxWrapper.appendChild(separator);
+			vboxWrapper.appendChild(deleteOption);
+			
+			this.append(optionsPopup);
+
+			// Focus the first option when the popup is shown
+			optionsPopup.addEventListener('popupshown', () => {
+				optionsPopup.querySelector(".menu-option").focus();
+			});
+
+			// When the popup is closed, it is deleted
+			optionsPopup.addEventListener('popuphidden', (event) => {
+				if (event.target === optionsPopup) {
+					optionsPopup.remove();
+				}
+			});
+
+			// ArrowUp/Down will navigate between menu options
+			optionsPopup.addEventListener('keydown', (event) => {
+				if (["ArrowUp", "ArrowDown"].includes(event.key)) {
+					let currentIndex = parseInt(event.target.getAttribute('index'));
+					let nextIndex = event.key == "ArrowDown" ? (currentIndex + 1) : (currentIndex - 1);
+					optionsPopup.querySelector(`.menu-option[index="${nextIndex}"]`)?.focus();
+				}
+			});
+
+			// Open popup by the bottom left corner of the button
+			let { x, y, height } = this._options.getBoundingClientRect();
+			optionsPopup.openPopup(null, 'before_start', x, y + height, true);
+		}
+		
 
 		render() {
 			if (!this.initialized) return;
 
 			this._title.textContent = Zotero.getString('pdfReader.page') + ' '
 				+ (this._annotation.annotationPageLabel || '-');
+			// Begin by hiding all elements, relevant ones will be un-hidden lower
+			this._img.hidden = true;
+			this._quote.hidden = true;
+			this._comment.hidden = true;
+			this._tags.hidden = true;
 			
+			if (this.isEditable) {
+				document.l10n.setAttributes(this._options, 'annotation-change-color');
+			}
+			else {
+				document.l10n.setAttributes(this._options, 'annotation-not-editable-' + (this.annotation.annotationIsExternal ? 'external' : 'other-user'));
+			}
+			this._options.disabled = !this.isEditable;
+
 			let type = this._annotation.annotationType;
 			if (type == 'image') {
 				type = 'area';
 			}
 			this.querySelector('.icon').src = 'chrome://zotero/skin/16/universal/annotate-' + type + '.svg';
-			this._body.replaceChildren();
 			
 			if (['image', 'ink'].includes(this._annotation.annotationType)) {
+				this._img.hidden = false;
 				let imagePath = Zotero.Annotations.getCacheImagePath(this._annotation);
 				if (imagePath) {
-					let img = document.createElement('img');
-					img.src = Zotero.File.pathToFileURI(imagePath);
-					img.draggable = false;
-					this._body.append(img);
-					// if the image could not be loaded for some reason (e.g. file is not there),
-					// show a placeholder text
-					img.addEventListener('error', () => {
-						let placeholder = document.createElement('div');
-						placeholder.classList.add('comment');
-						document.l10n.setAttributes(placeholder, 'annotation-image-not-available');
-						this._body.replaceChildren(placeholder);
-					});
+					this._img.src = Zotero.File.pathToFileURI(imagePath);
+					this._img.draggable = false;
 				}
 			}
 			
@@ -104,24 +372,33 @@
 			let parserUtils = Cc["@mozilla.org/parserutils;1"].getService(Ci.nsIParserUtils);
 
 			if (this._annotation.annotationText) {
-				let text = document.createElement('div');
-				text.classList.add('quote');
 				let plainQuote = parserUtils.convertToPlainText(this._annotation.annotationText, Ci.nsIDocumentEncoder.OutputRaw, 0);
-				text.textContent = plainQuote;
-				this._body.append(text);
+				this._quote.textContent = plainQuote;
+				this._quote.hidden = false;
 			}
 			
+			// let plainComment = parserUtils.convertToPlainText(this._annotation.annotationComment, Ci.nsIDocumentEncoder.OutputRaw, 0) || "Add comment";
 			if (this._annotation.annotationComment) {
-				let comment = document.createElement('div');
-				comment.classList.add('comment');
-				let plainComment = parserUtils.convertToPlainText(this._annotation.annotationComment, Ci.nsIDocumentEncoder.OutputRaw, 0);
-				comment.textContent = plainComment;
-				this._body.append(comment);
+				this._comment.hidden = false;
+				this._comment.innerHTML = this._annotation.annotationComment;
 			}
-			
+			else if (this.isEditable) {
+				this._comment.hidden = false;
+				this._comment.innerHTML = Zotero.getString('pdfReader.addComment');
+			}
+			this._comment.setAttribute('aria-description', Zotero.getString('pdfReader.annotationComment'));
+
 			let tags = this._annotation.getTags();
-			this._tags.hidden = !tags.length;
-			this._tags.textContent = tags.map(tag => tag.tag).sort(Zotero.localeCompare).join(Zotero.getString('punctuation.comma') + ' ');
+			if (tags.length) {
+				this._tags.hidden = false;
+				this._tags.textContent = tags.map(tag => tag.tag).sort(Zotero.localeCompare).join(Zotero.getString('punctuation.comma') + ' ');
+			}
+			else if (this.isEditable) {
+				this._tags.hidden = false;
+				this._tags.textContent = Zotero.getString('pdfReader.addTags');
+			}
+			this._tags.setAttribute('aria-description', Zotero.getString('pdfReader.manageTags'));
+			
 			
 			this.style.setProperty('--annotation-color', this._annotation.annotationColor);
 			// A11y - make focusable + add screen reader's labels

--- a/chrome/content/zotero/elements/annotationRow.js
+++ b/chrome/content/zotero/elements/annotationRow.js
@@ -287,10 +287,16 @@
 			if (event.shiftKey) {
 				let anchor = this.container.querySelector("annotation-row.anchor");
 				if (!anchor) {
-					anchor = this.container.querySelector("annotation-row");
+					if (document.activeElement.tagName == "annotation-row") {
+						anchor = document.activeElement;
+					}
+					else {
+						anchor = this.container.querySelector("annotation-row");
+					}
 					anchor.classList.add("anchor");
 				}
 				this._selectRange(anchor, this);
+				this.focus();
 				event.stopPropagation();
 				event.preventDefault();
 				return;
@@ -298,6 +304,7 @@
 			// Ctrl/Cmd click will toggle selection
 			if (event.metaKey || event.ctrlKey) {
 				this.classList.toggle("selected");
+				this.focus();
 				event.stopPropagation();
 				event.preventDefault();
 				return;

--- a/chrome/content/zotero/elements/annotationRow.js
+++ b/chrome/content/zotero/elements/annotationRow.js
@@ -60,8 +60,21 @@
 			return this._annotation;
 		}
 
+		set readOnly(val) {
+			if (val) {
+				this.setAttribute("read-only", "true");
+			}
+			else {
+				this.removeAttribute("read-only");
+			}
+		}
+
+		get readOnly() {
+			return this.getAttribute("read-only");
+		}
+
 		get isEditable() {
-			return this._annotation.isEditable() && !this._annotation.annotationIsExternal;
+			return !this.readOnly && this._annotation.isEditable() && !this._annotation.annotationIsExternal;
 		}
 
 		set annotation(annotation) {
@@ -147,6 +160,7 @@
 		}
 
 		async _makeEditorVisible() {
+			if (!this.isEditable) return;
 			if (!this._editorFrame) {
 				this._createCommentEditor();
 			}
@@ -369,6 +383,9 @@
 			this._quote.hidden = true;
 			this._comment.hidden = true;
 			this._tags.hidden = true;
+			this._options.hidden = true;
+			this._comment.removeAttribute("tabindex");
+			this._tags.removeAttribute("tabindex");
 			
 			if (this.isEditable) {
 				document.l10n.setAttributes(this._options, 'annotation-change-color');
@@ -376,7 +393,10 @@
 			else {
 				document.l10n.setAttributes(this._options, 'annotation-not-editable-' + (this.annotation.annotationIsExternal ? 'external' : 'other-user'));
 			}
-			this._options.disabled = !this.isEditable;
+			if (!this.readOnly) {
+				this._options.hidden = false;
+				this._options.disabled = !this.isEditable;
+			}
 
 			let type = this._annotation.annotationType;
 			if (type == 'image') {
@@ -424,7 +444,11 @@
 				this._tags.textContent = Zotero.getString('pdfReader.addTags');
 			}
 			this._tags.setAttribute('aria-description', Zotero.getString('pdfReader.manageTags'));
-			
+
+			if (this.isEditable) {
+				this._comment.setAttribute('tabindex', 0);
+				this._tags.setAttribute('tabindex', 0);
+			}
 			
 			this.style.setProperty('--annotation-color', this._annotation.annotationColor);
 			// A11y - make focusable + add screen reader's labels

--- a/chrome/content/zotero/elements/annotationRow.js
+++ b/chrome/content/zotero/elements/annotationRow.js
@@ -425,6 +425,7 @@
 				let selectedNodes = this._getSelectedSiblingAnnotations();
 				targets = selectedNodes.map(node => node._annotation);
 			}
+			let withinSameItem = (new Set(targets.map(a => a.topLevelItem.id))).size == 1;
 
 			let colors = [
 				{ color: "#ffd400", label: Zotero.getString('general.yellow') },
@@ -477,13 +478,36 @@
 				});
 			}
 
-			let separator = document.createXULElement('menuseparator');
+			// "Create note / Add to note" menu option
+			let separatorOne = document.createXULElement('menuseparator');
+			let makeNoteOption = document.createXULElement('hbox');
+			makeNoteOption.className = "menu-option make-note keyboard-clickable";
+			makeNoteOption.setAttribute('tabindex', 0);
+			makeNoteOption.setAttribute('index', colors.length);
+			let makeNoteLabel = document.createXULElement('label');
+			makeNoteLabel.textContent = withinSameItem ? Zotero.getString('annotations-add-note') : Zotero.getString('annotations-create-note');
+			makeNoteLabel.classList.add('make-note-label');
+			makeNoteOption.appendChild(makeNoteLabel);
+			makeNoteOption.addEventListener('click', () => {
+				if (withinSameItem) {
+					window.ZoteroPane.addNoteFromAnnotationsFromSelected(targets);
+				}
+				else {
+					window.ZoteroPane.createStandaloneNoteFromAnnotationsFromSelected(targets);
+				}
+				optionsPopup.hidePopup();
+			});
+
+			vboxWrapper.appendChild(separatorOne);
+			vboxWrapper.appendChild(makeNoteOption);
+
+			// "Delete" menu option
+			let separatorTwo = document.createXULElement('menuseparator');
 			let deleteOption = document.createXULElement('hbox');
 			deleteOption.className = "menu-option delete keyboard-clickable";
 			deleteOption.setAttribute('tabindex', 0);
-			deleteOption.setAttribute('index', colors.length);
+			deleteOption.setAttribute('index', colors.length + 1);
 
-			// Add delete menu option
 			let deleteLabel = document.createXULElement('label');
 			deleteLabel.textContent = Zotero.getString('general.delete');
 			deleteLabel.classList.add('delete-label');
@@ -494,7 +518,7 @@
 				}
 				optionsPopup.hidePopup();
 			});
-			vboxWrapper.appendChild(separator);
+			vboxWrapper.appendChild(separatorTwo);
 			vboxWrapper.appendChild(deleteOption);
 			
 			this.append(optionsPopup);

--- a/chrome/content/zotero/elements/annotationRow.js
+++ b/chrome/content/zotero/elements/annotationRow.js
@@ -551,9 +551,15 @@
 				}
 			});
 
+			// Open popup at the position of right-click
+			if (event.type == "contextmenu") {
+				optionsPopup.openPopup(null, 'before_start', event.clientX, event.clientY, true);
+			}
 			// Open popup by the bottom left corner of the button
-			let { x, y, height } = this._options.getBoundingClientRect();
-			optionsPopup.openPopup(null, 'before_start', x, y + height, true);
+			else {
+				let { x, y, height } = this._options.getBoundingClientRect();
+				optionsPopup.openPopup(null, 'before_start', x, y + height, true);
+			}
 		}
 
 		_getSelectedSiblingAnnotations() {

--- a/chrome/content/zotero/elements/collapsibleSection.js
+++ b/chrome/content/zotero/elements/collapsibleSection.js
@@ -472,7 +472,10 @@
 				this._listenerAdded = true;
 			}
 			
-			this._head.setAttribute('aria-expanded', this.open);
+			// presence of aria-expanded implies the section can be expanded and collapsed
+			if (!this._disableCollapsing) {
+				this._head.setAttribute('aria-expanded', this.open);
+			}
 			this._head.setAttribute("aria-label", this.label);
 			this._title.textContent = this.label;
 			this._summary.textContent = this.summary;

--- a/chrome/content/zotero/integration/simpleEditor.html
+++ b/chrome/content/zotero/integration/simpleEditor.html
@@ -23,10 +23,12 @@
     
     ***** END LICENSE BLOCK *****
 -->
-<html xmlns="http://www.w3.org/1999/xhtml" style="height: 100%">
+<html xmlns="http://www.w3.org/1999/xhtml" style="height: 100%; overflow-y: hidden;">
 <head>
-	<link rel="stylesheet" type="text/css" href="chrome://zotero/skin/integration.css"/>
-	<link rel="stylesheet" type="text/css" href="chrome://zotero-platform/content/integration.css"/>
+	<link rel="stylesheet" href="chrome://global/skin/global.css" />
+	<link rel="stylesheet" href="chrome://zotero/skin/zotero.css" />
+	<link rel="stylesheet" href="chrome://zotero/skin/overlay.css" />
+	<link rel="stylesheet" href="chrome://zotero-platform/content/zotero.css" />
 </head>
 <body style="margin: 0; height: 100%">
 	<div id="simple-editor" class="zotero-simpleEditor"></div>

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -345,7 +345,8 @@ class ReaderInstance {
 				let libraryID = attachment.libraryID;
 				let annotation = Zotero.Items.getByLibraryAndKey(libraryID, key);
 				if (annotation) {
-					this._openTagsPopup(annotation, x, y);
+					let { left, top } = this._iframe.getBoundingClientRect();
+					Zotero.Annotations.insertAnnotationsTagsPopup(this._popupset, annotation, x + left, y + top);
 				}
 			},
 			onClosePopup: () => {

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -5920,12 +5920,14 @@ var ZoteroPane = new function () {
 	 *
 	 * Selected items must all have the same top-level item
 	 */
-	this.addNoteFromAnnotationsFromSelected = async function () {
+	this.addNoteFromAnnotationsFromSelected = async function (items = null) {
 		if (!this.canEdit()) {
 			this.displayCannotEditLibraryMessage();
 			return;
 		}
-		var items = this.getSelectedItems();
+		if (!items) {
+			items = this.getSelectedItems();
+		}
 		var topLevelItems = [...new Set(Zotero.Items.getTopLevel(items))];
 		if (topLevelItems.length > 1) {
 			throw new Error("Can't create child attachment from different top-level items");
@@ -6032,12 +6034,14 @@ var ZoteroPane = new function () {
 	};
 	
 	
-	this.createStandaloneNoteFromAnnotationsFromSelected = async function () {
+	this.createStandaloneNoteFromAnnotationsFromSelected = async function (items = null) {
 		if (!this.canEdit()) {
 			this.displayCannotEditLibraryMessage();
 			return;
 		}
-		var items = this.getSelectedItems();
+		if (!items) {
+			items = this.getSelectedItems();
+		}
 		
 		// Ignore selected top-level items if any descendant items are also selected
 		var topLevelOfSelectedDescendants = new Set();

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -2229,6 +2229,10 @@ var ZoteroPane = new function () {
 			&& selected.some(item => item.isAnnotation())) {
 			return collectionTreeRow.isTrash();
 		}
+		// External annotations cannot be deleted (unless their parent item is deleted )
+		if (selected.every(item => item.isAnnotation() && item.annotationIsExternal)) {
+			return false;
+		}
 		return true;
 	};
 

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -653,6 +653,8 @@ annotation-not-editable-external =
     .tooltiptext = Cannot edit annotations created outside of Zotero
 annotation-not-editable-other-user =
     .tooltiptext = Cannot edit other user's annotations
+annotations-create-note = Create Note
+annotations-add-note = Add Note
 
 quicksearch-mode =
     .aria-label = Quick Search mode

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -647,6 +647,12 @@ toggle-preview =
     } Attachment Preview
 
 annotation-image-not-available = [Image not available]
+annotation-change-color =
+    .tooltiptext = Change annotation color
+annotation-not-editable-external =
+    .tooltiptext = Cannot edit annotations created outside of Zotero
+annotation-not-editable-other-user =
+    .tooltiptext = Cannot edit other user's annotations
 
 quicksearch-mode =
     .aria-label = Quick Search mode

--- a/chrome/skin/default/zotero/16/universal/lock.svg
+++ b/chrome/skin/default/zotero/16/universal/lock.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path id="Vector" fill-rule="evenodd" clip-rule="evenodd" d="M6 4C6 2.89543 6.89543 2 8 2C9.10457 2 10 2.89543 10 4V6H6V4ZM5 6V4C5 2.34315 6.34315 1 8 1C9.65685 1 11 2.34315 11 4V6H12C12.5523 6 13 6.44772 13 7V14C13 14.5523 12.5523 15 12 15H4C3.44772 15 3 14.5523 3 14V7C3 6.44771 3.44772 6 4 6H5ZM4 14V7H12V14H4Z" fill="context-fill"/>
+</svg>

--- a/chrome/skin/default/zotero/integration.css
+++ b/chrome/skin/default/zotero/integration.css
@@ -344,43 +344,6 @@ richlistitem[selected="true"] {
 	grid-template-columns: max-content 1fr;
 }
 
-.zotero-simpleEditor {
-	box-sizing: border-box;
-	font-size: 14px;
-	height: 100%;
-}
-
-.zotero-simpleEditor-content {
-	box-sizing: border-box;
-	outline: 0;
-	overflow-y: auto;
-	padding: 36px 10px 10px 10px;
-}
-
-.zotero-simpleEditor-actionbar {
-	background-color: #fff;
-	border-bottom: 1px solid rgba(10, 10, 10, 0.1);
-	position: fixed;
-	width: 100%;
-}
-
-.zotero-simpleEditor-button {
-	background-color: transparent;
-	border: 1px solid transparent;
-	cursor: pointer;
-	height: 30px;
-	outline: 0;
-	width: 30px;
-	vertical-align: bottom;
-}
-
-.zotero-simpleEditor-button:focus-visible {
-	border: 1px solid #598bec;
-}
-
-.zotero-simpleEditor-button-selected {
-	background-color: #f0f0f0;
-}
 
 panel button .button-text {
 	margin: 0 !important;

--- a/scss/_zotero.scss
+++ b/scss/_zotero.scss
@@ -70,6 +70,7 @@
 @import "components/window";
 @import "components/newCollectionDialog";
 @import "components/reader";
+@import "components/simpleEditor";
 
 
 // Elements

--- a/scss/components/_simpleEditor.scss
+++ b/scss/components/_simpleEditor.scss
@@ -1,0 +1,57 @@
+#simple-editor {
+	box-sizing: border-box;
+	font-size: 14px;
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+	background: var(--material-background);
+
+	.content {
+		box-sizing: border-box;
+		outline: 0;
+		overflow-y: auto;
+		width: 100%;
+		padding: 0 3px;
+	}
+
+	.actionbar {
+		margin-bottom: 5px;
+		background-color: #fff;
+		border-bottom: 1px solid rgba(10, 10, 10, 0.1);
+		width: 100%;
+	}
+
+	.button {
+		background-color: transparent;
+		border: 1px solid transparent;
+		cursor: pointer;
+		height: 30px;
+		outline: 0;
+		width: 30px;
+		vertical-align: bottom;
+		margin: 0 2px 0 0;
+
+		&:focus-visible {
+			border: 1px solid #598bec;
+		}
+
+		&.selected {
+			background-color: #f0f0f0;
+		}
+	}
+
+	&.tight {
+		.button {
+			height: 20px;
+			width: 20px;
+		}
+	}
+
+	&.toolbar-below-editor {
+		.actionbar {
+			margin-bottom: 0;
+			border-top: 1px solid rgba(10, 10, 10, 0.1);
+			border-bottom: none;
+		}
+	}
+}

--- a/scss/elements/_annotationRow.scss
+++ b/scss/elements/_annotationRow.scss
@@ -24,6 +24,11 @@ annotation-row {
 		.title {
 			font-weight: 600;
 		}
+
+		// if context menu is disabled, show lock icon
+		.button[disabled] {
+			@include svgicon-menu("lock", "universal", "16");
+		}
 	}
 	
 	.body {
@@ -59,6 +64,22 @@ annotation-row {
 			@include comfortable {
 				margin-block: 4px;
 			}
+
+			&.hidden {
+				display: none;
+			}
+		}
+
+		.comment.editable {
+			margin-inline: 4px;
+			padding: 2px 0 0 0;
+			max-width: 100%;
+			iframe {
+				border: 1px solid var(--fill-quinary);
+				border-radius: 5px;
+				width: 100%;
+			}
+
 		}
 	}
 	
@@ -66,5 +87,33 @@ annotation-row {
 		border-top: 1px solid var(--fill-quinary);
 		padding: 3px 8px;
 		word-break: break-word;
+		font-size: 13px;
+	}
+
+	.tags-popup {
+		font-size: 13px;
+		min-width: 300px;
+	}
+
+	.annotations-options-popup {
+		width: 150px;
+		padding-inline: 5px;
+		.menu-option  {
+			height: 30px;
+			padding-inline: 25px;
+			align-items: center;
+			border-radius: 5px;
+			font-size: 12px;
+			&.color {
+				.color-swatch {
+					width: 16px;
+					height: 16px;
+					border-radius: 5px;
+				}
+			}
+			&:hover {
+				background: var(--fill-quinary);
+			}
+		}
 	}
 }

--- a/scss/elements/_annotationRow.scss
+++ b/scss/elements/_annotationRow.scss
@@ -7,7 +7,7 @@ annotation-row {
 	background: var(--material-background);
 	@include focus-ring;
 
-	.head {
+	> .head {
 		display: flex;
 		padding: 4px 8px;
 		align-items: center;
@@ -31,7 +31,7 @@ annotation-row {
 		}
 	}
 	
-	.body {
+	> .body {
 		img {
 			max-width: 100%;
 			@media (prefers-color-scheme: dark) {
@@ -92,14 +92,14 @@ annotation-row {
 		}
 	}
 	
-	.tags {
+	> .tags {
 		border-top: 1px solid var(--fill-quinary);
 		padding: 3px 8px;
 		word-break: break-word;
 		font-size: 13px;
 	}
 
-	.tags-popup {
+	> .tags-popup {
 		font-size: 13px;
 		min-width: 300px;
 	}

--- a/scss/elements/_annotationRow.scss
+++ b/scss/elements/_annotationRow.scss
@@ -104,6 +104,11 @@ annotation-row {
 		min-width: 300px;
 	}
 
+	&.selected {
+		background: var(--accent-blue10);
+		outline: 3px solid var(--accent-blue50);
+	}
+
 	.annotations-options-popup {
 		width: 150px;
 		padding-inline: 5px;

--- a/scss/elements/_annotationRow.scss
+++ b/scss/elements/_annotationRow.scss
@@ -79,7 +79,16 @@ annotation-row {
 				border-radius: 5px;
 				width: 100%;
 			}
-
+			// Special treatment to hide the iframe with the editor
+			// so that it is not visible but still renders the content
+			// properly, so that we know the necessary height before showing the editor
+			&.hidden {
+				display: block;
+				position: absolute;
+				opacity: 0;
+				z-index: -1;
+				pointer-events: none;
+			}
 		}
 	}
 	


### PR DESCRIPTION
- tags in the annotation cards will open a popup with tags section, same as in the reader. The functionality of creating and opening the popup is shared in new `Zotero.Annotations.insertAnnotationsTagsPopup`.
- options button in the top-right corner of the annotation card will open a menu with colors and "Delete" option
- keyboard navigation somewhat similar to one in the sidenav of the reader: arrowUp/Down will navigate
between annotations, tab will navigate through annotation comment and tags. Next tab will move focus out of the annotations list.
- annotation comment can be edited. On click, `simpleEditor.html` iframe will be inserted instead of the comment div. There, one has rich text editor capabilities, same as in the reader. `simpleEditor.html` iframe is used because `contenteditable` in the root chrome window does not work properly (this issue must have been the reason why the original `quickFormat` dialog had the `iframe` too) . Edits are saved on blur, or on Cmd/Ctrl+Enter. Escape cancels the edits. 
- refactoring of `simpleEditor` to allow for easier customization via attributes placed on the iframe. Possible attributes are: `actions` (to specify which actions should appear), `tight` (to indicate that the buttons should be smaller than default), and `toolbar-below-editor` (to indicate where toolbar should be placed). This way, simpleEditor can be customized here without affecting editBibliographyDialog. For convenience, moved simpleEditor stylesheet into new _simpleEditor.scss. I expect this customization will also help in the redesign of the `editBibliographyDialog`.
- do not set `aria-expanded` on non-expandable header of `collapsible-section`, since that implies the section can be expanded.

Notes: 
- marking this as a draft for now until https://github.com/zotero/zotero/issues/5247 is resolved. Currently, we strip all html tags from annotations. But https://github.com/zotero/zotero/pull/4607 should allow us to properly render them safely and perform any conversions necessary, as in the reader. Functions like `_commentFromHTML` and `_commentToHTML` of  `annotation-row` would likely be affected by it too, and for now are just minimal implementations to get some editing functionality working. 
- there is also a question about editable and delete-able annotations discussed in #5262. In reader, external annotations or annotations made by other users cannot be edited or deleted. However, external annotations are editable and delete-able on the `item.js` level. Annotations made by other users can not be edited but still can be deleted. I am not exactly sure about the intended behavior here. For now, external and other user's annotation cards cannot be interacted with, same as in the reader. Backspace on external annotation rows also will not delete them but backspace on group annotation rows will (as this is explicitly done in https://github.com/zotero/zotero/commit/df64a16b55c17264949f30cfc9edeb4c098f169a). Correct me if this is off.

Fixes: #5262
Fixes: #5229