### PR TITLE
Undo Scholaread changes to `user.js`

### DIFF
--- a/chrome/content/zotero/xpcom/prefs.js
+++ b/chrome/content/zotero/xpcom/prefs.js
@@ -582,8 +582,7 @@ Zotero.Prefs = new function() {
 
 			Zotero.alert(null,
 				Zotero.getString('general-error'),
-				Zotero.getString('userjs-pref-warning'
-					+ (userJS.toLowerCase().includes('scholaread') ? '-program' : ''))
+				Zotero.getString('userjs-pref-warning')
 			);
 			Services.startup.quit(
 				Components.interfaces.nsIAppStartup.eAttemptQuit

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -738,4 +738,5 @@ mac-word-plugin-install-dont-ask-again-button =
 
 connector-version-warning = The { -app-name } Connector must be updated to work with this version of { -app-name }.
 
-userjs-pref-warning = A program on your computer attempted to override { -app-name }’s settings using an unsupported method. { -app-name } will undo the changes and restart.
+userjs-pref-warning = Your { -app-name } profile directory contains settings in a nonstandard location. { -app-name } will remove them and restart.
+userjs-pref-warning-program = A program on your computer attempted to override { -app-name }’s settings using an unsupported method. { -app-name } will undo the changes and restart.

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -738,5 +738,4 @@ mac-word-plugin-install-dont-ask-again-button =
 
 connector-version-warning = The { -app-name } Connector must be updated to work with this version of { -app-name }.
 
-userjs-pref-warning = Your { -app-name } profile directory contains settings in a nonstandard location. { -app-name } will remove them and restart.
-userjs-pref-warning-program = A program on your computer attempted to override { -app-name }’s settings using an unsupported method. { -app-name } will undo the changes and restart.
+userjs-pref-warning = A program on your computer attempted to override { -app-name }’s settings using an unsupported method. { -app-name } will undo the changes and restart.

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -738,5 +738,4 @@ mac-word-plugin-install-dont-ask-again-button =
 
 connector-version-warning = The { -app-name } Connector must be updated to work with this version of { -app-name }.
 
-userjs-pref-warning = Your { -app-name } profile directory contains settings in a nonstandard location. { -app-name } will remove them and restart.
-userjs-pref-warning-program = A program on your computer attempted to override { -app-name }’s settings using an unsupported method. { -app-name } will undo the changes and restart.
+userjs-pref-warning = Some { -app-name } settings have been overridden using an unsupported method. { -app-name } will revert them and restart.

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -737,3 +737,6 @@ mac-word-plugin-install-dont-ask-again-button =
     .label = { general-dont-ask-again }
 
 connector-version-warning = The { -app-name } Connector must be updated to work with this version of { -app-name }.
+
+userjs-pref-warning = Your { -app-name } profile directory contains settings in a nonstandard location. { -app-name } will remove them and restart.
+userjs-pref-warning-program = A program on your computer attempted to override { -app-name }’s settings using an unsupported method. { -app-name } will undo the changes and restart.


### PR DESCRIPTION
Scholaread sets `extensions.zotero.fileHandler.pdf` in `<profile>/user.js`, not `prefs.js`, so changing the pref via the UI does nothing (`user.js` takes precedence). This PR checks `user.js` for `user_pref()` directives, and if any are found, removes them, shows an alert, and restarts.

As far as I can tell (I haven't run it), Scholaread asks the user before adding its pref, so this _shouldn't_ happen every time you start Zotero. But if it does, maybe that's more impetus for them to stop setting it in the wrong location?