### PR TITLE
Preference to hide context annotation rows

### DIFF
--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -154,6 +154,10 @@ var ItemTree = class ItemTree extends LibraryTree {
 				'itemTreeView',
 				50
 			);
+			this._prefsObserverID = Zotero.Prefs.registerObserver('hideContextAnnotationRows', async () => {
+				await this.refresh();
+				this.tree.invalidate();
+			});
 		}
 		
 		this._itemsPaneMessage = null;
@@ -170,6 +174,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 	unregister() {
 		this._uninitialized = true;
 		Zotero.Notifier.unregisterObserver(this._unregisterID);
+		Zotero.Notifier.unregisterObserver(this._prefsObserverID);
 		this._writeColumnPrefsToFile(true);
 	}
 
@@ -1724,6 +1729,9 @@ var ItemTree = class ItemTree extends LibraryTree {
 
 		if (item.isFileAttachment()) {
 			annotations = item.getAnnotations();
+			if (Zotero.Prefs.get("hideContextAnnotationRows") && this._searchMode) {
+				annotations = annotations.filter(annotation => this._searchItemIDs.has(annotation.id));
+			}
 		}
 		var newRows = [];
 		if (attachments.length && notes.length) {
@@ -2100,6 +2108,9 @@ var ItemTree = class ItemTree extends LibraryTree {
 
 		var item = this.getRow(index).ref;
 		if (item.isFileAttachment()) {
+			if (Zotero.Prefs.get("hideContextAnnotationRows") && this._searchMode) {
+				return !item.getAnnotations().some(annotation => this._searchItemIDs.has(annotation.id));
+			}
 			return item.numAnnotations() == 0;
 		}
 		if (!item.isRegularItem()) {

--- a/chrome/content/zotero/preferences/preferences_general.xhtml
+++ b/chrome/content/zotero/preferences/preferences_general.xhtml
@@ -276,6 +276,9 @@
 			<label><html:h2>&zotero.preferences.miscellaneous;</html:h2></label>
 			
 			<checkbox label="&zotero.preferences.automaticTags;" preference="extensions.zotero.automaticTags" native="true"/>
+			<checkbox data-l10n-id="preferences-hide-context-annotation-rows"
+				preference="extensions.zotero.hideContextAnnotationRows"
+				native="true"/>
 			<hbox align="center">
 				<label id="trashAutoEmpty-label1" value="&zotero.preferences.trashAutoEmptyDaysPre;"/>
 				<html:input aria-labelledby="trashAutoEmpty-label1 trashAutoEmpty-label2" type="text" size="2" preference="extensions.zotero.trashAutoEmptyDays"/>

--- a/chrome/locale/en-US/zotero/preferences.ftl
+++ b/chrome/locale/en-US/zotero/preferences.ftl
@@ -55,6 +55,9 @@ preferences-item-pane-header-style = Header Citation Style:
 preferences-item-pane-header-locale = Header Language:
 preferences-item-pane-header-missing-style = Missing style: <{ $shortName }>
 
+preferences-hide-context-annotation-rows =
+    .label = Hide annotation rows not matching search
+
 preferences-locate-library-lookup-intro = Library Lookup can find a resource online using your library’s OpenURL resolver.
 preferences-locate-resolver = Resolver:
 preferences-locate-base-url = Base URL:

--- a/defaults/preferences/zotero.js
+++ b/defaults/preferences/zotero.js
@@ -28,6 +28,7 @@ pref("extensions.zotero.downloadAssociatedFiles",true);
 pref("extensions.zotero.findPDFs.resolvers", '[]');
 pref("extensions.zotero.reportTranslationFailure",true);
 pref("extensions.zotero.automaticTags",true);
+pref("extensions.zotero.hideContextAnnotationRows", false);
 pref("extensions.zotero.fontSize", "1.00");
 pref("extensions.zotero.layout", "standard");
 pref("extensions.zotero.recursiveCollections", false);

--- a/test/tests/itemTreeTest.js
+++ b/test/tests/itemTreeTest.js
@@ -1844,5 +1844,23 @@ describe("Zotero.ItemTree", function() {
 			assert.include(text, toplevelItem.getDisplayTitle());
 			assert.include(text, toplevelItemTwo.getDisplayTitle());
 		});
+
+		it("should exclude context annotation rows if hideContextAnnotationRows=true", async () => {
+			Zotero.Prefs.set("hideContextAnnotationRows", true);
+
+			highlight.annotationText = "highlight";
+			underline.annotationText = "underline";
+			await highlight.saveTx();
+			await underline.saveTx();
+
+			await zp.itemsView.setFilter("search", "highlight");
+
+			zp.itemsView.expandAllRows();
+
+			let highlightRowIndex = zp.itemsView.getRowIndexByID(highlight.id);
+			assert.isNumber(highlightRowIndex);
+			let underlineRowIndex = zp.itemsView.getRowIndexByID(underline.id);
+			assert.isFalse(underlineRowIndex);
+		});
 	});
 })


### PR DESCRIPTION
This may be helpful while searching across many annotations to not be overwhelmed by non-matching rows. In the example below, I have a PDF with a few hundred annotations, and while searching for "evolution", almost the entire visible scrollbox is filled with irrelevant context rows. With this setting, only rows related to "evolution" remain.

https://github.com/user-attachments/assets/fe0bede8-2162-4233-ab61-e416c2f87c47

It does go against the currently existing practice of just displaying all child rows. But given how many annotation child rows there can be, maybe it's worth it?

Fixes #5264