### PR TITLE
Annotation filters in tag selector

### DIFF
--- a/chrome/content/zotero/components/tagSelector.jsx
+++ b/chrome/content/zotero/components/tagSelector.jsx
@@ -28,24 +28,171 @@
 const React = require('react');
 const PropTypes = require('prop-types');
 const TagList = require('./tagSelector/tagSelectorList');
+const AnnotationFiltersSelector = require('./tagSelector/annotationFiltersSelector');
 const { Button } = require('./button');
 const { CSSIcon } = require('./icons');
 const Search = require('./search');
 
+const annotationColorsHeight = 20;
+const minTagsListHeight = 150;
+const annotationsVerticalPadding = 14;
+const annotationsAuthorsFirstRow = 22 + 6; // 22px for first row, 6px for margin between colors and authors
+const minAnnotationSectionHeight = annotationColorsHeight + annotationsAuthorsFirstRow;
+const splitterHeight = 9;
+
 class TagSelector extends React.PureComponent {
+	constructor(props) {
+		super(props);
+		this.state = {
+			annotationSectionHeight: minAnnotationSectionHeight,
+			isDragging: false,
+			dragStartY: 0,
+			dragStartHeight: 0
+		};
+	}
+
+	// Resize the annotation section height when the annotation authors are added or filtered out
+	componentDidUpdate() {
+		if (this.state.isDragging) return;
+		let newHeight = 0;
+		
+		// If annotation authors are visible, ensure the minimum height to display them
+		if (this.props.annotationAuthors.length > 0) {
+			newHeight = Math.max(this.state.annotationSectionHeight, minAnnotationSectionHeight);
+		}
+		// If no authors are present, set the height just enough to show colors
+		else if (this.props.annotationColors.length > 0) {
+			newHeight = annotationColorsHeight + annotationsVerticalPadding;
+		}
+		if (newHeight !== this.state.annotationSectionHeight) {
+			this.setState({ annotationSectionHeight: newHeight });
+		}
+	}
+
+	// Handle resizing of the section with annotation authors and colors
+	handleSplitterMouseDown = (e) => {
+		if (!this.props.annotationAuthors.length) return;
+		e.preventDefault();
+		this.setState({
+			isDragging: true,
+			dragStartY: e.clientY,
+			dragStartHeight: this.state.annotationSectionHeight
+		});
+		
+		document.addEventListener('mousemove', this.handleSplitterMouseMove);
+		document.addEventListener('mouseup', this.handleSplitterMouseUp);
+	};
+
+	handleSplitterMouseMove = (e) => {
+		if (!this.state.isDragging) return;
+		
+		let deltaY = e.clientY - this.state.dragStartY;
+		
+		// Ensure min-heights for annotation section and tags list are respected
+		let newAnnotationSectionHeight = this.state.dragStartHeight + deltaY;
+		newAnnotationSectionHeight = Math.min(this.props.height - minTagsListHeight, newAnnotationSectionHeight);
+		newAnnotationSectionHeight = Math.max(minAnnotationSectionHeight, newAnnotationSectionHeight);
+		
+		this.setState({ annotationSectionHeight: newAnnotationSectionHeight });
+	};
+
+	handleSplitterMouseUp = () => {
+		this.setState({ isDragging: false });
+		document.removeEventListener('mousemove', this.handleSplitterMouseMove);
+		document.removeEventListener('mouseup', this.handleSplitterMouseUp);
+	};
+
+
+	// Handle tab navigation within the tag selector between tags/annotation authors and colors
+	_handleTab = (event) => {
+		if (event.key !== "Tab") return;
+		var container = document.getElementById(this.props.container);
+		// Only include visible components in the focus sequence
+		let focusSequence = [];
+		if (this.props.annotationColors.length) {
+			focusSequence.push('annotation-color');
+		}
+		if (this.props.annotationAuthors.length) {
+			focusSequence.push('annotation-author');
+		}
+		if (this.props.tags.length) {
+			focusSequence.push('tag-selector-item');
+		}
+		focusSequence.push("search-input");
+		focusSequence.push("tag-selector-actions");
+		
+		if (event.shiftKey) {
+			focusSequence.reverse();
+		}
+		
+		// If for some reason it's not apparent where in the sequence we are, let
+		// tab propagate higher
+		let currentIndex = focusSequence.findIndex(cls => event.target.classList.contains(cls));
+		if (currentIndex === -1 || currentIndex === focusSequence.length - 1) return;
+		
+		let nextClass = focusSequence[currentIndex + 1];
+		let handled = false;
+		// Special handling to refocus the last tag that was focused
+		if (nextClass == "tag-selector-item") {
+			this.props.tagListRef.current.focus();
+			handled = true;
+		}
+		else if (nextClass == "annotation-color") {
+			this.props.annotationFiltersSelectorRef.current.focusColor();
+			handled = true;
+		}
+		else if (nextClass == "annotation-author") {
+			this.props.annotationFiltersSelectorRef.current.focusAuthor();
+			handled = true;
+		}
+		else {
+			let nextElement = container.querySelector(`.${nextClass}`);
+			if (nextElement) {
+				nextElement.focus();
+				handled = true;
+			}
+		}
+		if (handled) {
+			event.stopPropagation();
+			event.preventDefault();
+		}
+	};
+
+
 	render() {
+		let annotationSelectorHeight = 0;
+		if (this.props.annotationAuthors.length > 0 || this.props.annotationColors.length > 0) {
+			annotationSelectorHeight = this.state.annotationSectionHeight + splitterHeight + annotationsVerticalPadding;
+		}
+		let availableTagsHeight = this.props.height - annotationSelectorHeight;
+
 		return (
-			<div className="tag-selector">
+			<div className={`tag-selector ${this.state.isDragging ? 'splitter-drag' : ''}`} onKeyDown={this._handleTab.bind(this)}>
+				{annotationSelectorHeight > 0 && (
+					<>
+						<AnnotationFiltersSelector
+							ref={this.props.annotationFiltersSelectorRef}
+							annotationColors={this.props.annotationColors}
+							annotationAuthors={this.props.annotationAuthors}
+							onSelect={this.props.onSelect}
+							height={this.state.annotationSectionHeight}
+						/>
+						<div onMouseDown={this.handleSplitterMouseDown}
+							className={`horizontal-splitter ${this.state.isDragging ? 'dragging' : ''} ${this.props.annotationAuthors?.length > 0 ? '' : 'disabled'}`}>
+							<div className="grippy"></div>
+						</div>
+					</>
+				)}
+
 				<TagList
 					ref={this.props.tagListRef}
 					tags={this.props.tags}
 					dragObserver={this.props.dragObserver}
 					onSelect={this.props.onSelect}
-					onKeyDown={this.props.onKeyDown}
 					onTagContext={this.props.onTagContext}
 					loaded={this.props.loaded}
 					width={this.props.width}
-					height={this.props.height}
+					height={availableTagsHeight}
 					fontSize={this.props.fontSize}
 					lineHeight={this.props.lineHeight}
 					uiDensity={this.props.uiDensity}
@@ -58,6 +205,7 @@ class TagSelector extends React.PureComponent {
 							onSearch={this.props.onSearch}
 							className="tag-selector-filter"
 							data-l10n-id="tagselector-search"
+							data-l10n-args={`{"annotationsFilter": "${this.props.annotationAuthors?.length > 0 ? 'yes' : 'no'}"}`}
 						/>
 						<Button
 							icon={<CSSIcon name="filter" className="icon-16" />}
@@ -76,12 +224,22 @@ class TagSelector extends React.PureComponent {
 TagSelector.propTypes = {
 	// TagList
 	tagListRef: PropTypes.object,
+	annotationFiltersSelectorRef: PropTypes.object,
 	tags: PropTypes.arrayOf(PropTypes.shape({
 		name: PropTypes.string,
 		selected: PropTypes.bool,
 		color: PropTypes.string,
 		disabled: PropTypes.bool,
 		width: PropTypes.number
+	})),
+	container: PropTypes.string,
+	annotationColors: PropTypes.arrayOf(PropTypes.shape({
+		color: PropTypes.string,
+		name: PropTypes.string,
+	})),
+	annotationAuthors: PropTypes.arrayOf(PropTypes.shape({
+		label: PropTypes.string,
+		userID: PropTypes.string
 	})),
 	dragObserver: PropTypes.shape({
 		onDragOver: PropTypes.func,
@@ -109,6 +267,8 @@ TagSelector.propTypes = {
 
 TagSelector.defaultProps = {
 	tags: [],
+	annotationColors: [],
+	annotationAuthors: [],
 	searchString: '',
 	onSelect: () => Promise.resolve(),
 	onTagContext: () => Promise.resolve(),

--- a/chrome/content/zotero/components/tagSelector/annotationFiltersSelector.jsx
+++ b/chrome/content/zotero/components/tagSelector/annotationFiltersSelector.jsx
@@ -1,0 +1,175 @@
+/*
+    ***** BEGIN LICENSE BLOCK *****
+    
+    Copyright © 2019 Corporation for Digital Scholarship
+                     Vienna, Virginia, USA
+                     https://digitalscholar.org
+    
+    This file is part of Zotero.
+    
+    Zotero is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    
+    Zotero is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+    
+    You should have received a copy of the GNU Affero General Public License
+    along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
+    
+    ***** END LICENSE BLOCK *****
+*/
+
+const React = require('react');
+const PropTypes = require('prop-types');
+
+// Component with annotation colors and authors above the tags list
+class AnnotationFiltersSelector extends React.PureComponent {
+	constructor(props) {
+		super(props);
+		this.authorCollectionRef = React.createRef();
+		this.state = {
+			lastFocusedAuthor: null,
+			lastFocusedColor: null
+		};
+	}
+
+	_handleColorsClick = (colorObj) => {
+		if (!colorObj.enabled && !colorObj.selected) return;
+		this.props.onSelect(colorObj);
+	};
+
+	_getAnnotationsHeight() {
+		if (this.props.annotationAuthors?.length > 0) {
+			return this.props.height;
+		}
+		return 'auto';
+	}
+
+	_handleArrowKey = (event) => {
+		let nextTarget;
+		if (event.key == "ArrowLeft") {
+			nextTarget = event.target.previousElementSibling;
+		}
+		else if (event.key == "ArrowRight") {
+			nextTarget = event.target.nextElementSibling;
+		}
+		if (!nextTarget) return;
+		nextTarget.focus();
+		if (nextTarget.classList.contains('annotation-color')) {
+			this.setState({ lastFocusedColor: nextTarget.dataset.color });
+		}
+		else if (nextTarget.classList.contains('annotation-author')) {
+			this.setState({ lastFocusedAuthor: nextTarget.dataset.userId });
+		}
+	};
+
+	focusAuthor = () => {
+		if (this.state.lastFocusedAuthor) {
+			let lastAuthor = document.querySelector(`.tag-selector .annotation-author[data-user-id="${this.state.lastFocusedAuthor}"]`);
+			if (lastAuthor) {
+				lastAuthor.focus();
+				return;
+			}
+		}
+		document.querySelector('.tag-selector .annotation-author')?.focus();
+	};
+
+	focusColor = () => {
+		if (this.state.lastFocusedColor) {
+			let lastColor = document.querySelector(`.tag-selector .annotation-color[data-color="${this.state.lastFocusedColor}"]`);
+			if (lastColor) {
+				lastColor.focus();
+				return;
+			}
+		}
+		document.querySelector('.tag-selector .annotation-color')?.focus();
+	};
+
+	renderAnnotationColors() {
+		if (!this.props.annotationColors.length) {
+			return null;
+		}
+		return (
+			<div className="annotation-colors-section">
+				{this.props.annotationColors.map((colorObj, index) => (
+					<div key={`color_${index}_${colorObj.color}`}
+						className={`annotation-color keyboard-clickable ${colorObj.selected ? 'selected' : ''} ${(colorObj.enabled || colorObj.selected) ? '' : ' disabled'}`}
+						title={Zotero.getString(`general.${colorObj.name}`)}
+						onClick={() => this._handleColorsClick(colorObj)}
+						tabIndex={0}
+						data-color={colorObj.color}>
+						<span className="color-box" style={{ backgroundColor: colorObj.color }}/>
+					</div>
+				))}
+			</div>
+		);
+	}
+
+	renderAnnotationAuthors() {
+		if (!this.props.annotationAuthors.length) {
+			return null;
+		}
+		return (
+			<div className="annotation-authors-section">
+				{this.props.annotationAuthors.map((author, index) => {
+					var className = 'annotation-author keyboard-clickable';
+					if (author.selected) {
+						className += ' selected';
+					}
+					
+					return (
+						<div key={`author_${index}_${author.userID}`}
+							className={className}
+							onClick={() => this.props.onSelect(author)}
+							tabIndex={0}
+							data-user-id={author.userID}>
+							<span className="icon icon-css icon-user-8 icon-8"></span>
+							<span>{author.name}</span>
+						</div>
+					);
+				})}
+			</div>
+		);
+	}
+
+	render() {
+		return (
+			<div className="annotation-selector">
+				<div className="annotation-data" onKeyDown={this._handleArrowKey} style={{ height: this._getAnnotationsHeight() }}>
+					{this.renderAnnotationColors()}
+					{this.renderAnnotationAuthors()}
+				</div>
+			</div>
+		);
+	}
+}
+
+AnnotationFiltersSelector.propTypes = {
+	annotationColors: PropTypes.arrayOf(PropTypes.shape({
+		color: PropTypes.string,
+		name: PropTypes.string,
+		selected: PropTypes.bool,
+		enabled: PropTypes.bool
+	})),
+	annotationAuthors: PropTypes.arrayOf(PropTypes.shape({
+		name: PropTypes.string,
+		userID: PropTypes.string,
+		selected: PropTypes.bool
+	})),
+	onSelect: PropTypes.func,
+	height: PropTypes.number,
+	width: PropTypes.number,
+};
+
+AnnotationFiltersSelector.defaultProps = {
+	annotationColors: [],
+	annotationAuthors: [],
+	onSelect: () => {},
+	height: 120
+};
+
+module.exports = AnnotationFiltersSelector;

--- a/chrome/content/zotero/components/tagSelector/tagSelectorList.jsx
+++ b/chrome/content/zotero/components/tagSelector/tagSelectorList.jsx
@@ -181,7 +181,7 @@ class TagList extends React.PureComponent {
 		
 		let props = {
 			className,
-			onClick: ev => !tag.disabled && this.props.onSelect(tag.name, ev),
+			onClick: ev => !tag.disabled && this.props.onSelect({ tag: tag.name }, ev),
 			onContextMenu: ev => this.props.onTagContext(tag, ev),
 			onDragOver,
 			onDragExit,
@@ -391,7 +391,6 @@ class TagList extends React.PureComponent {
 			onDrop: PropTypes.func
 		}),
 		onSelect: PropTypes.func,
-		onKeyDown: PropTypes.func,
 		onTagContext: PropTypes.func,
 		loaded: PropTypes.bool,
 		width: PropTypes.number.isRequired,

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -655,10 +655,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 			}
 
 			// If saved search, publications, or trash, just re-run search
-			if (collectionTreeRow.isSearch()
-				|| collectionTreeRow.isPublications()
-				|| collectionTreeRow.isTrash()
-				|| hasQuickSearch) {
+			if (collectionTreeRow.isSearchMode()) {
 				await this.refresh();
 				refreshed = true;
 				madeChanges = true;
@@ -1257,7 +1254,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 					if (!noRecurse && window.ZoteroPane) {
 						let cleared1 = await window.ZoteroPane.clearQuicksearch();
 						let cleared2 = window.ZoteroPane.tagSelector
-							&& window.ZoteroPane.tagSelector.clearTagSelection();
+							&& window.ZoteroPane.tagSelector.clearSelection();
 						if (cleared1 || cleared2) {
 							return this.selectItems(ids, true);
 						}
@@ -1611,8 +1608,8 @@ var ItemTree = class ItemTree extends LibraryTree {
 			case 'citation-search':
 				this.collectionTreeRow.setSearch(data, 'fields');
 				break;
-			case 'tags':
-				this.collectionTreeRow.setTags(data);
+			case 'annotation-tags':
+				this.collectionTreeRow.setAnnotationTagFilters(data);
 				break;
 			default:
 				throw ('Invalid filter type in setFilter');

--- a/chrome/content/zotero/xpcom/annotations.js
+++ b/chrome/content/zotero/xpcom/annotations.js
@@ -41,6 +41,20 @@ Zotero.Annotations = new function () {
 		value: ['type', 'authorName', 'text', 'comment', 'color', 'pageLabel', 'sortIndex', 'position'],
 		writable: false
 	});
+
+	Zotero.defineProperty(this, 'COLORS', {
+		value: [
+			{ name: 'yellow', color: '#ffd400' },
+			{ name: 'red', color: '#ff6666' },
+			{ name: 'green', color: '#5fb236' },
+			{ name: 'blue', color: '#2ea8e5' },
+			{ name: 'purple', color: '#a28ae5' },
+			{ name: 'magenta', color: '#e56eee' },
+			{ name: 'orange', color: '#f19837' },
+			{ name: 'gray', color: '#aaaaaa' }
+		],
+		writable: false
+	});
 	
 	
 	this.getCacheImagePath = function ({ libraryID, key }) {

--- a/chrome/content/zotero/xpcom/data/search.js
+++ b/chrome/content/zotero/xpcom/data/search.js
@@ -1216,14 +1216,9 @@ Zotero.Search.prototype._buildQuery = async function () {
 					}
 					
 					switch (condition.name) {
-						case 'tag':
-							condSQL += "SELECT itemID FROM itemTags "
-								+ "LEFT JOIN itemAnnotations IAnT USING (itemID) WHERE (";
-							break;
-						
-						case 'annotationText':
-						case 'annotationComment':
-							condSQL += `SELECT itemID FROM ${condition.table} WHERE (`
+						case 'annotationAuthor':
+							condSQL += "SELECT itemID FROM itemAnnotations "
+								+ "LEFT JOIN groupItems USING (itemID) WHERE (";
 							break;
 							
 						default:

--- a/chrome/content/zotero/xpcom/data/searchConditions.js
+++ b/chrome/content/zotero/xpcom/data/searchConditions.js
@@ -587,6 +587,28 @@ Zotero.SearchConditions = new function () {
 			},
 			
 			{
+				name: 'annotationColor',
+				operators: {
+					is: true,
+					isNot: true
+				},
+				table: 'itemAnnotations',
+				field: 'color',
+				special: true,
+			},
+
+			{
+				name: 'annotationAuthor',
+				operators: {
+					is: true,
+					isNot: true,
+				},
+				table: 'groupItems',
+				field: 'createdByUserID',
+				special: true,
+			},
+
+			{
 				name: 'fulltextWord',
 				operators: {
 					contains: true,

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -429,6 +429,10 @@ var ZoteroPane = new function () {
 						if (tagContainer.getAttribute('collapsed') == "true") {
 							return document.getElementById('zotero-tb-add');
 						}
+						if (tagSelector.querySelector('.annotation-color')) {
+							ZoteroPane.tagSelector.focusAnnotationColors();
+							return null;
+						}
 						// If tag selector is collapsed, go to "New item" button, otherwise focus tag selector
 						if (ZoteroPane.tagSelector.isTagListEmpty()) {
 							return tagSelector.querySelector(".search-input");
@@ -453,28 +457,15 @@ var ZoteroPane = new function () {
 
 		tagSelector.addEventListener("keydown", (e) => {
 			let actionsMap = {
-				'search-input': {
-					Tab: () => tagSelector.querySelector('.tag-selector-actions'),
-					ShiftTab: () => {
-						if (ZoteroPane.tagSelector.isTagListEmpty()) {
-							return document.getElementById("collection-tree");
-						}
-						ZoteroPane.tagSelector.focusTagList();
-						return null;
-					},
-				},
 				'tag-selector-item': {
-					Tab: () => tagSelector.querySelector(".search-input"),
+					ShiftTab: () => document.getElementById("collection-tree"),
+				},
+				'annotation-color': {
 					ShiftTab: () => document.getElementById("collection-tree"),
 				},
 				'tag-selector-actions': {
-					Tab: () => document.getElementById('zotero-tb-add'),
-					ShiftTab: () => tagSelector.querySelector(".search-input")
+					Tab: () => document.getElementById('zotero-tb-add')
 				},
-				'tag-selector-list': {
-					Tab: () => tagSelector.querySelector(".search-input"),
-					ShiftTab: () => document.getElementById("collection-tree"),
-				}
 			};
 			moveFocus(actionsMap, e);
 		});
@@ -1735,7 +1726,7 @@ var ZoteroPane = new function () {
 	 */
 	this.updateTagFilter = async function () {
 		if (this.itemsView) {
-			await this.itemsView.setFilter('tags', ZoteroPane_Local.tagSelector.getTagSelection());
+			await this.itemsView.setFilter('annotation-tags', ZoteroPane_Local.tagSelector.getSelection());
 		}
 	};
 	
@@ -1804,6 +1795,11 @@ var ZoteroPane = new function () {
 
 			// Update enabled actions, in case editability has changed
 			this._updateEnabledActionsForRow(collectionTreeRow);
+			// Make sure the itemsView has the most current instanced of
+			// collectionTree, so that annotation color and authors filters
+			// get enabled/disabled in sync with itemTree.
+			this.itemsView.collectionTreeRow = collectionTreeRow;
+			collectionTreeRow.setAnnotationTagFilters(ZoteroPane.tagSelector.getSelection());
 			return;
 		}
 		
@@ -1815,12 +1811,12 @@ var ZoteroPane = new function () {
 		// Clear quick search and tag selector when switching views
 		document.getElementById('zotero-tb-search-textbox').value = "";
 		if (ZoteroPane.tagSelector) {
-			ZoteroPane.tagSelector.clearTagSelection();
+			ZoteroPane.tagSelector.clearSelection();
 		}
 		
 		collectionTreeRow.setSearch('');
 		if (ZoteroPane.tagSelector) {
-			collectionTreeRow.setTags(ZoteroPane.tagSelector.getTagSelection());
+			collectionTreeRow.setAnnotationTagFilters(ZoteroPane.tagSelector.getSelection());
 		}
 		
 		this._updateEnabledActionsForRow(collectionTreeRow);

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -1033,8 +1033,10 @@
 		<menupopup id="tag-selector-view-settings-menu"
 			onpopupshowing="
 				document.getElementById('show-automatic').setAttribute('checked', ZoteroPane.tagSelector.showAutomatic);
+				document.getElementById('show-annotation-filters').setAttribute('checked', ZoteroPane.tagSelector.showAnnotationFilters);
 				document.getElementById('display-all-tags').setAttribute('checked', ZoteroPane.tagSelector.displayAllTags);
-				document.getElementById('num-selected').label = ZoteroPane.tagSelector.label;
+				let numSelectedNode = document.getElementById('num-selected');
+				document.l10n.setAttributes(numSelectedNode, 'tagselector-menu-filters-count',  ZoteroPane.tagSelector.filtersCount);
 				(async function () {
 					var libraryID = ZoteroPane.tagSelector.libraryID;
 					var library = Zotero.Libraries.get(libraryID);
@@ -1049,6 +1051,9 @@
 			<menuitem id="num-selected" disabled="true"/>
 			<menuitem id="deselect-all" label="&zotero.tagSelector.clearAll;"
 				oncommand="ZoteroPane.tagSelector.deselectAll();;"/>
+			<menuseparator/>
+			<menuitem id="show-annotation-filters" data-l10n-id="tagselector-menu-show-annotation-filters" type="checkbox"
+				oncommand="ZoteroPane.tagSelector.toggleShowAnnotationFilters();"/>		
 			<menuseparator/>
 			<menuitem id="show-automatic" label="&zotero.tagSelector.showAutomatic;" type="checkbox"
 				oncommand="ZoteroPane.tagSelector.toggleShowAutomatic();"/>

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -594,7 +594,25 @@ tag-field =
     .aria-label = { general-tag }
 
 tagselector-search =
-    .placeholder = Filter Tags
+    .placeholder = { $annotationsFilter ->
+        [yes] Filter Tags and Annotation Authors
+        *[other] Filter Tags
+    }
+tagselector-menu-show-annotation-filters =
+    .label = Show Annotation Filters
+tagselector-menu-filters-count =
+    .label =
+        { $tagCount ->
+            [one] { $tagCount } tag
+            *[other] { $tagCount } tags
+        }{ $annotationsFilterCount ->
+            [-1] {""}
+            *[other] {", "}
+        }{ $annotationsFilterCount ->
+            [-1] {""}
+            [one] { $annotationsFilterCount } annotation filter
+            *[other] { $annotationsFilterCount } annotation filters
+        } selected
 
 context-notes-search =
     .placeholder = Search Notes

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -842,6 +842,8 @@ searchConditions.programmingLanguage	= Programming Language
 searchConditions.fileTypeID		= Attachment File Type
 searchConditions.annotationText = Annotation Text
 searchConditions.annotationComment = Annotation Comment
+searchConditions.annotationColor = Annotation Color
+searchConditions.annotationAuthor = Annotation Author
 searchConditions.anyField = Any Field
 
 fulltext.indexState.indexed								= Indexed

--- a/chrome/skin/default/zotero/8/universal/user-8.svg
+++ b/chrome/skin/default/zotero/8/universal/user-8.svg
@@ -1,0 +1,3 @@
+<svg width="8" height="8" viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5 5C6.65685 5 8 6.34315 8 8H0C0 6.34315 1.34315 5 3 5H5ZM4 0C5.10457 0 6 0.895431 6 2C6 3.10457 5.10457 4 4 4C2.89543 4 2 3.10457 2 2C2 0.895431 2.89543 0 4 0Z" fill="context-fill"/>
+</svg>

--- a/defaults/preferences/zotero.js
+++ b/defaults/preferences/zotero.js
@@ -82,6 +82,7 @@ pref("extensions.zotero.itemPaneHeader.bibEntry.locale", "");
 //Tag Selector
 pref("extensions.zotero.tagSelector.showAutomatic", true);
 pref("extensions.zotero.tagSelector.displayAllTags", false);
+pref("extensions.zotero.tagSelector.showAnnotationFilters", false);
 
 pref("extensions.zotero.downloadPDFViaBrowser.onLoadTimeout", 3000);
 pref("extensions.zotero.downloadPDFViaBrowser.downloadTimeout", 60000);

--- a/scss/components/_icons.scss
+++ b/scss/components/_icons.scss
@@ -42,7 +42,8 @@ $-icons: (
 	filter: 16,
 	note: 16,
 	x-8: 16,
-	chevron-tabs: 20
+	chevron-tabs: 20,
+	user-8: 8,
 );
 
 @each $icon, $size in $-icons {

--- a/scss/components/_tagSelector.scss
+++ b/scss/components/_tagSelector.scss
@@ -181,3 +181,98 @@
 		background-color: var(--fill-secondary);
 	}
 }
+
+// Without this, if you briefly hover over a clickable element while dragging the splitter
+// cursor will flash quickly switching between different modes.
+.tag-selector.splitter-drag {
+	cursor: row-resize !important;
+	.annotation-author,
+	.annotation-colors-section .annotation-color,
+	.tag-selector-item {
+		cursor: row-resize !important;
+	}
+}
+
+
+.horizontal-splitter {
+	padding: 4px 10px;
+	&:not(.disabled) {
+		cursor: row-resize;
+	}
+	.grippy {
+		border-bottom: var(--material-border);
+	}
+}
+.annotation-selector {
+	.annotation-data {
+		padding: 7px 10px;
+		font-size: $font-size-small;
+		overflow: auto;
+		scrollbar-color: var(--color-scrollbar) var(--color-scrollbar-background);
+
+		.annotation-colors-section {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 1px;
+
+			.annotation-color {
+				width: 20px;
+				height: 20px;
+				border-radius: 5px;
+				cursor: pointer;
+				display: flex;
+				justify-content: center;
+  				align-items: center;
+
+				.color-box {
+					display: block;
+					width: 14px;
+					height: 14px;
+					border-radius: 2px;
+				}
+
+				&.selected {
+					background: var(--fill-secondary);
+				}
+
+				&.disabled {
+					opacity: 0.3;
+					cursor: default;
+				}
+			}
+		}
+		
+		.annotation-authors-section {
+			display: flex;
+			margin-top: 4px;
+			flex-wrap: wrap;
+			gap: 2px;
+
+			.annotation-author {
+				border-radius: 5px;
+				height: 20px;
+				padding: 1px 4px;
+				display: flex;
+				align-items: center;
+				cursor: pointer;
+
+				.icon {
+					margin-inline-end: 4px;
+					margin-top: 1px;
+				}
+
+				&:hover {
+					background-color: var(--fill-quarternary);
+				}
+				&.selected {
+					background-color: var(--fill-secondary);
+					color: var(--material-background);
+
+					.icon {
+						fill: var(--material-background50);
+					}
+				}
+			}
+		}
+	}
+}

--- a/test/content/support.js
+++ b/test/content/support.js
@@ -1067,7 +1067,7 @@ async function createAnnotation(type, parentItem, options = {}) {
 	else {
 		annotation.annotationComment = Zotero.Utilities.randomString();
 	}
-	annotation.annotationColor = '#ffd400';
+	annotation.annotationColor = options.color || '#ffd400';
 	var page = Zotero.Utilities.rand(1, 100);
 	annotation.annotationPageLabel = `${page}`;
 	page = page.toString().padStart(5, '0');

--- a/test/tests/collectionTreeRowTest.js
+++ b/test/tests/collectionTreeRowTest.js
@@ -34,4 +34,100 @@ describe("CollectionTreeRow", function () {
 			assert.isFalse(itemsView.getRowIndexByID(item2.id));
 		});
 	});
+	describe("Annotation filters", function () {
+		let group, annotationOne, annotationTwo, annotationThree;
+
+		before(async function () {
+			let otherUserID = 2;
+			await Zotero.Users.setCurrentUserID(1);
+			await Zotero.Users.setName(1, 'this-user');
+			await Zotero.Users.setName(otherUserID, 'another-user');
+			
+			// Create a group
+			group = await createGroup();
+
+
+			let item = await createDataObject('item',
+				{
+					libraryID: group.libraryID,
+					title: 'Item 1'
+				});
+			
+			// Create attachments for each item
+			let attachment = await importPDFAttachment(item);
+			
+			// Create 2 annotations with #ffd400 and #ff6666 colors
+			annotationOne = await createAnnotation('highlight', attachment, { color: '#ffd400', createdByUserID: 1 });
+			annotationTwo = await createAnnotation('highlight', attachment, { color: '#ff6666', createdByUserID: 1 });
+			
+			// Create another annotation with #5fb236 color by another user
+			annotationThree = await createAnnotation('highlight', attachment, { color: '#5fb236', createdByUserID: otherUserID });
+		});
+		
+		after(async function () {
+			await group.eraseTx();
+		});
+
+		it("should return only relevant annotation authors", async function () {
+			await select(win, group);
+			let treeRow = zp.getCollectionTreeRow();
+			// First, all authors are available
+			let authors = await treeRow.getAnnotationAuthors();
+			assert.sameMembers([...authors], [1, 2]);
+
+			// Authors that do not match any existing filters is excluded
+			treeRow.setAnnotationTagFilters({ annotationColors: ['#ffd400'] });
+			authors = await treeRow.getAnnotationAuthors();
+			assert.sameMembers([...authors], [1]);
+			treeRow.setAnnotationTagFilters({ annotationColors: ['#5fb236'] });
+			authors = await treeRow.getAnnotationAuthors();
+			assert.sameMembers([...authors], [2]);
+
+			// An exception is a filter by another author.
+			// That does not prevent other authors from appearing
+			treeRow.setAnnotationTagFilters({ annotationAuthors: [1], annotationColors: [] });
+			authors = await treeRow.getAnnotationAuthors();
+			assert.sameMembers([...authors], [1, 2]);
+		});
+
+		it("should return possible annotation colors", async function () {
+			await select(win, group);
+			let treeRow = zp.getCollectionTreeRow();
+			// First, all colors are available
+			let colors = await treeRow.getAnnotationColors();
+			assert.sameMembers([...colors], ['#ffd400', '#ff6666', '#5fb236']);
+
+			// Colors that do not match any existing filters are excluded
+			treeRow.setAnnotationTagFilters({ annotationAuthors: [1] });
+			colors = await treeRow.getAnnotationColors();
+			assert.sameMembers([...colors], ['#ffd400', '#ff6666']);
+			treeRow.setAnnotationTagFilters({ annotationAuthors: [2] });
+			colors = await treeRow.getAnnotationColors();
+			assert.sameMembers([...colors], ['#5fb236']);
+
+			// An exception is a filter by another color.
+			// That does not prevent other colors from appearing
+			treeRow.setAnnotationTagFilters({ annotationColors: ['#ffd400', '#ff6666'], annotationAuthors: [] });
+			colors = await treeRow.getAnnotationColors();
+			assert.sameMembers([...colors], ['#ffd400', '#ff6666', '#5fb236']);
+		});
+
+		it("should return matches for colors and annotations", async function () {
+			await select(win, group);
+			let treeRow = zp.getCollectionTreeRow();
+
+			// (AuthorOne OR AuthorTwo) AND (ColorOne OR ColorTwo)
+			treeRow.setAnnotationTagFilters({ annotationAuthors: [1, 2], annotationColors: ['#ffd400', '#ff6666', '#5fb236'] });
+			let results = await treeRow.getSearchResults();
+			assert.sameMembers(results, [annotationOne.id, annotationTwo.id, annotationThree.id]);
+
+			treeRow.setAnnotationTagFilters({ annotationAuthors: [1], annotationColors: ['#ffd400'] });
+			results = await treeRow.getSearchResults();
+			assert.sameMembers(results, [annotationOne.id]);
+
+			treeRow.setAnnotationTagFilters({ annotationAuthors: [2], annotationColors: ['#ffd400'] });
+			results = await treeRow.getSearchResults();
+			assert.sameMembers(results, []);
+		});
+	});
 });

--- a/test/tests/searchTest.js
+++ b/test/tests/searchTest.js
@@ -440,6 +440,53 @@ describe("Zotero.Search", function () {
 					assert.sameMembers(matches, [annotation.id]);
 				});
 			});
+
+			describe("annotationColor", function () {
+				it("should return matches for annotation colors", async function () {
+					var attachment = await importPDFAttachment();
+					var annotationOne = await createAnnotation('highlight', attachment, { color: '#ffd400' });
+					var annotationTwo = await createAnnotation('highlight', attachment, { color: '#ff6666' });
+					
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('joinMode', 'any');
+					s.addCondition('annotationColor', 'is', '#ffd400');
+					var matches = await s.search();
+					assert.include(matches, annotationOne.id);
+				});
+			});
+
+			describe("annotationAuthor", function () {
+				let group;
+
+				before(async function () {
+					group = await createGroup();
+				});
+
+				after(async function () {
+					await group.eraseTx();
+				});
+
+				it("should return matches for annotation author", async function () {
+					await Zotero.Users.setCurrentUserID(1);
+					var otherUserID = 92624235;
+					await Zotero.Users.setName(1, 'this-user');
+					await Zotero.Users.setName(otherUserID, 'another-user');
+
+					// One annotation created by the current user, one by another user
+					let item = await createDataObject('item', { libraryID: group.libraryID });
+					var attachment = await importPDFAttachment(item);
+					var annotationOne = await createAnnotation('highlight', attachment, { color: '#ffd400', createdByUserID: 1 });
+					var annotationTwo = await createAnnotation('highlight', attachment, { color: '#ffd400', createdByUserID: otherUserID });
+					
+					var s = new Zotero.Search();
+					s.libraryID = group.libraryID;
+					s.addCondition('joinMode', 'any');
+					s.addCondition('annotationAuthor', 'is', otherUserID);
+					var matches = await s.search();
+					assert.include(matches, annotationTwo.id);
+				});
+			});
 			
 			describe("fulltextWord", function () {
 				it("should return matches with full-text conditions", async function () {


### PR DESCRIPTION
- added new component annotationFiltersSelector.jsx to display annotation colors followed by a list of annotation authors
- added a splitter between the annotations filters and the actual tag selector, so that one can adjust the heights of these two subsections
- search box of the tag selector will also filter the annotation authors
- added new search conditions to accommodate searching by annotation color and author
- the logic of which tag colors/authors are visible is somewhat different from tags, and a bit more convoluted. Filtering by many annotation colors or authors is done with OR operator, not AND as with tags. It means that if one annotation author is selected, other annotation authors should not be removed from the list of options, so that one can select more than one author.
The current search logic can be described as below: (tag1 AND tag2) AND (color1 OR color2) AND (author1 OR author2)

Current behavior:

https://github.com/user-attachments/assets/3cadad02-436d-417b-93be-2fca036454e3

Still in works - need to add keyboard nav with a11y properties, tests, and polish out the UI.

Fixes: #5316