### PR TITLE
Do not exclude image annotations when creating a standalone note from multiple items

### DIFF
--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -5929,7 +5929,7 @@ var ZoteroPane = new function()
 						Zotero.logError(e);
 					}
 				}
-				annotations.push(...attachment.getAnnotations().filter(x => x.annotationType != 'ink' && x.annotationType != 'image'));
+				annotations.push(...attachment.getAnnotations().filter(x => x.annotationType != 'ink'));
 			}
 		}
 		


### PR DESCRIPTION
This was a regression from 48fd23ccec73156855f4c59170b332af2e4357dd. Image annotations are not excluded in other cases, like if a child note is created or if a standalone note is created from selected image annotation rows (not attachments).