### PR TITLE
Do not open hidden Zotero window on connector save

### DIFF
--- a/chrome/content/zotero/xpcom/server/saveSession.js
+++ b/chrome/content/zotero/xpcom/server/saveSession.js
@@ -188,7 +188,7 @@ Zotero.Server.Connector.SaveSession = class {
 			item = item.isTopLevelItem() ? item : item.parentItem;
 			// Don't select if in trash
 			if (!item.deleted) {
-				await zp.selectItem(item.id);
+				await zp.selectItem(item.id, { noTabSwitch: true, noWindowRestore: true });
 			}
 		}
 	}

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -3023,7 +3023,7 @@ var ZoteroPane = new function()
 			Zotero.warn("ZoteroPane.selectItems() now takes an 'options' object -- update your code");
 			options = { inLibraryRoot: options };
 		}
-		let { inLibraryRoot, noTabSwitch } = options;
+		let { inLibraryRoot, noTabSwitch, noWindowRestore } = options;
 		if (!itemIDs.length) {
 			return false;
 		}
@@ -3034,7 +3034,7 @@ var ZoteroPane = new function()
 		}
 		
 		// Restore window if it's in the dock
-		if (window.windowState == window.STATE_MINIMIZED) {
+		if (window.windowState == window.STATE_MINIMIZED && !noWindowRestore) {
 			window.restore();
 		}
 		


### PR DESCRIPTION
And fix regression where selecting a collection in connector would always switch to the library tab, even if a reader tab is selected.

It was originally added in https://github.com/zotero/zotero/pull/5020 but was lost after https://github.com/zotero/zotero/pull/5148