### PR TITLE
Citation dialog: fix broken item details popup with some non-english locales

### DIFF
--- a/chrome/content/zotero/integration/citationDialog.xhtml
+++ b/chrome/content/zotero/integration/citationDialog.xhtml
@@ -108,23 +108,22 @@
 						</div>
 					</div>
 					<div class="details" role="group">
-							<div class="row">
-								<!--fx128: size="0" forces select have default native style -->
-								<select name="locator" id="label" class="details-label" size="0"></select>
-								<input id="locator" class="details-data" aria-labelledby="label" aria-describedby="itemDetails-combinedInfo"/>
-							</div>
-							<div class="row">
-								<label class="details-label" for="prefix" data-l10n-id="integration-citationDialog-details-prefix"></label>
-								<input id="prefix" class="details-data"/>					
-							</div>
-							<div class="row">
-								<label class="details-label" for="suffix" data-l10n-id="integration-citationDialog-details-suffix"></label>
-								<input id="suffix" class="details-data"/>
-							</div>
-							<div id="suppress-author-row" class="row">
+							<!--fx128: size="0" forces select have default native style -->
+							<select name="locator" id="label" class="details-label" size="0"></select>
+							<input id="locator" class="details-data" aria-labelledby="label" aria-describedby="itemDetails-combinedInfo"/>
+							
+							<label class="details-label" for="prefix" data-l10n-id="integration-citationDialog-details-prefix"></label>
+							<input id="prefix" class="details-data"/>
+							
+							<label class="details-label" for="suffix" data-l10n-id="integration-citationDialog-details-suffix"></label>
+							<input id="suffix" class="details-data"/>
+							
+							<!-- empty div for the left cell, so suppress author appears in the right cell -->
+							<div></div>
+							<div id="suppress-author-container" class="hbox">
 								<input id="suppress-author" type="checkbox"/>
 								<label for="suppress-author" data-l10n-id="integration-citationDialog-details-suppressAuthor"></label>
-							</div>				
+							</div>
 					</div>
 					<div class="buttons">
 						<button class="remove" data-l10n-id="integration-citationDialog-details-remove"></button>

--- a/scss/components/_citationDialog.scss
+++ b/scss/components/_citationDialog.scss
@@ -604,7 +604,7 @@
 					margin: 16px 0;
 					display: grid;
 					grid-template-columns: auto 1fr;
-					gap: 8px 2px;
+					gap: 8px 1px;
 					align-items: center;
 					.details-label:not(select) {
 						text-align: end;
@@ -625,7 +625,7 @@
 					}
 					#label {
 						// align <select>'s end with the end of prefix/suffix labels better
-						margin-inline-end: -3px;
+						margin-inline-end: -1px;
 						@media (-moz-platform: macos) {
 							height: 22px;
 							// <select> with increased height is hard to position but this helps

--- a/scss/components/_citationDialog.scss
+++ b/scss/components/_citationDialog.scss
@@ -606,8 +606,8 @@
 					grid-template-columns: auto 1fr;
 					gap: 8px 1px;
 					align-items: center;
-					.details-label {
-						text-align: right;
+					.details-label:not(select) {
+						text-align: end;
 					}
 					.details-data {
 						@media not (-moz-platform: windows) {

--- a/scss/components/_citationDialog.scss
+++ b/scss/components/_citationDialog.scss
@@ -591,8 +591,8 @@
 			}
 		}
 		#itemDetails {
-			width: 400px;
 			.popup {
+				width: 364px; // with padding and border, the panel is 400px
 				.details-header {
 					.icon {
 						margin-inline-end: 5px;
@@ -602,16 +602,12 @@
 				}
 				.details {
 					margin: 16px 0;
-					display: flex;
-					flex-direction: column;
-					justify-content: space-between;
-					gap: 8px;
-
-					.row {
-						display: flex;
-						flex-direction: row;
-						align-items: center;
-						justify-content: end;
+					display: grid;
+					grid-template-columns: auto 1fr;
+					gap: 8px 1px;
+					align-items: center;
+					.details-label {
+						text-align: right;
 					}
 					.details-data {
 						@media not (-moz-platform: windows) {
@@ -622,17 +618,14 @@
 						border-radius: 5px;
 						border: none;
 						box-shadow: 0px 0.5px 2.5px 0px rgba(0, 0, 0, 0.3);
-						width: 250px;
-						@media (-moz-platform: linux) {
-							width: 240px;
-						}
 					}
-					#suppress-author-row {
-						justify-content: start;
-						padding-inline-start: 100px;
+					#suppress-author-container {
+						// undo input's left margin to align checkbox with inputs
+						margin-left: -3px;
 					}
 					#label {
-						flex: 1;
+						// align <select>'s end with the end of prefix/suffix labels better
+						margin-inline-end: -3px;
 						@media (-moz-platform: macos) {
 							height: 22px;
 							// <select> with increased height is hard to position but this helps

--- a/scss/components/_citationDialog.scss
+++ b/scss/components/_citationDialog.scss
@@ -604,7 +604,7 @@
 					margin: 16px 0;
 					display: grid;
 					grid-template-columns: auto 1fr;
-					gap: 8px 1px;
+					gap: 8px 2px;
 					align-items: center;
 					.details-label:not(select) {
 						text-align: end;


### PR DESCRIPTION
Make sure that `<select>` element does not stretch and cutoff the popup for locales that have longer locator labels than English.

Fixes: #5350

<img width="513" alt="Screenshot 2025-06-23 at 9 34 11 AM" src="https://github.com/user-attachments/assets/a83614cf-0f62-478c-acc2-631f194b1ea0" />
