### PR TITLE
Citation dialog: allow to insert annotations

### DIFF
--- a/chrome/content/zotero/integration/citationDialog/keyboardHandler.mjs
+++ b/chrome/content/zotero/integration/citationDialog/keyboardHandler.mjs
@@ -166,6 +166,18 @@ export class CitationDialogKeyboardHandler {
 			}
 			handled = true;
 		}
+		// arrow right/left on expandable item will expand/collapse its children
+		else if (!this._id("list-layout").hidden && ["ArrowRight", "ArrowLeft"].includes(event.key) && noModifiers && event.target.parentElement.classList.contains("item-with-children")) {
+			let container = event.target.closest(".item-with-children");
+			let twisty = container.querySelector(".twisty");
+			if (event.key == "ArrowRight" && !container.classList.contains("expanded")) {
+				twisty.click();
+			}
+			if (event.key == "ArrowLeft" && container.classList.contains("expanded")) {
+				twisty.click();
+			}
+			handled = true;
+		}
 		// arrowUp from the first item will refocus bubbleInput
 		else if (event.key == "ArrowUp" && this._shouldRefocusBubbleInputOnArrowUp() && noModifiers) {
 			this._id("bubble-input").refocusInput();

--- a/chrome/content/zotero/integration/citationDialog/searchHandler.mjs
+++ b/chrome/content/zotero/integration/citationDialog/searchHandler.mjs
@@ -31,8 +31,9 @@ const MIN_QUERY_LENGTH = 2;
 // as the following object: { found: [], cited: [], open: [], selected: []}.
 // Can be refreshed via SearchHandler.refresh or refreshDebounced.
 export class CitationDialogSearchHandler {
-	constructor({ isCitingNotes, io }) {
-		this.isCitingNotes = isCitingNotes;
+	constructor({ io }) {
+		this.isCitingNotes = !!io.isCitingNotes;
+		this.isAddingAnnotations = !!io.isAddingAnnotations;
 		this.io = io;
 
 		this.searchValue = "";
@@ -63,12 +64,13 @@ export class CitationDialogSearchHandler {
 		if (typeof id == "string" && (id.includes("cited") || id.includes("/"))) {
 			return this.results.cited.find(item => item.cslItemID === id);
 		}
-		// otherwise, it will be a item with an ordinary id from the database (still potentially cited)
+		// otherwise, it may be a item with an ordinary id from the database (still potentially cited)
 		for (let key of ['selected', 'open', 'found', 'cited']) {
 			let item = this.results[key].find(item => item.id === parseInt(id));
 			if (item) return item;
 		}
-		return null;
+		// finally, it may be a non-matching parent of a search match
+		return Zotero.Items.get(id);
 	}
 
 	// how many selected items there are without applying the filter
@@ -191,6 +193,13 @@ export class CitationDialogSearchHandler {
 	}
 
 	cleanSearchQuery(str) {
+		let isbn = Zotero.Utilities.cleanISBN(str);
+		let doi = Zotero.Utilities.cleanDOI(str);
+		// if the string looks like an identifier, do not try to clean it further
+		// to not remove any punctuation that are legitimate parts of the identifier
+		if (isbn || doi) {
+			return str.trim();
+		}
 		// Remove brackets, some punctuation, "et al", and localized "and" from the search string.
 		// This allows one to paste an existing citation like "(Smith et al., 2020)" and
 		// still get appropriate search results.
@@ -198,20 +207,26 @@ export class CitationDialogSearchHandler {
 		str = str.replace(" " + Zotero.getString("general.and") + " ", " ");
 		let etAl = Zotero.getString("general.etAl").replace(/\./g, "");
 		str = str.replace(new RegExp(" " + etAl + "(?:.\\s*|\\s+|$)", "g"), " ");
-
-		let isbn = Zotero.Utilities.cleanISBN(str);
-		let doi = Zotero.Utilities.cleanDOI(str);
-		// if the string looks like an identifier, do not try to extract the year
-		if (!(isbn || doi)) {
-			str = this._cleanYear(str);
-		}
-		str = str.trim();
+		str = this._cleanYear(str);
 
 		// If the query is very short, treat it as empty
 		if (this.minQueryLengthEnforced && str.trim().length < MIN_QUERY_LENGTH) {
 			str = "";
 		}
 		return str;
+	}
+
+	// Return items that are either annotations or are ancestors of annotations
+	keepItemsWithAnnotations(items) {
+		return items.filter((item) => {
+			if (item.isAnnotation()) return true;
+			if (item.isFileAttachment() && item.getAnnotations().length) return true;
+			if (item.isRegularItem()) {
+				let attachments = Zotero.Items.get(item.getAttachments());
+				return attachments.some(att => att.isFileAttachment() && att.getAnnotations().length);
+			}
+			return false;
+		});
 	}
 
 	// make sure that each item appears only in one group.
@@ -227,38 +242,55 @@ export class CitationDialogSearchHandler {
 		this.results.cited = this.results.cited.filter(item => !selectedIDs.has(item.id) && !openIDs.has(item.id));
 		this.results.found = this.results.found.filter(item => !selectedIDs.has(item.id) && !openIDs.has(item.id) && !citedIDs.has(item.id));
 	}
-		
+
 	// Run the actual search query and find all items matching query across all libraries
 	async _getMatchingLibraryItems() {
+		let realInputRegex = /[\w\u007F-\uFFFF]/;
+		if (!realInputRegex.test(this.searchValue)) return [];
+
 		var s = new Zotero.Search();
 		Zotero.Feeds.getAll().forEach(feed => s.addCondition("libraryID", "isNot", feed.libraryID));
 		if (this.io.filterLibraryIDs) {
 			this.io.filterLibraryIDs.forEach(id => s.addCondition("libraryID", "is", id));
 		}
-		let realInputRegex = /[\w\u007F-\uFFFF]/;
-		if (this.isCitingNotes) {
-			s.addCondition("quicksearch-titleCreatorYearNote", "contains", this.searchValue);
+		
+		// While citing notes or adding annotations, one can search for the items themselves
+		// or for the items' top-level regular item.
+		// For this, we set a scope that matches both top-level and child items
+		// after which we only keep items of the desired type.
+		if (this.isCitingNotes || this.isAddingAnnotations) {
+			let scope = new Zotero.Search;
+			// Allow to search by ISBN/DOI for the top-level item
+			let hasIdentifier = this._addIdentifierConditions(scope, this.searchValue);
+			if (!hasIdentifier) {
+				// If identifier is not provided, search by conditions equivalent to quicksearch-titleCreatorYear
+				this._addQuickSearchEquivalentConditions(scope);
+				if (this.isCitingNotes) {
+					scope.addCondition("note", "contains", this.searchValue);
+				}
+				else if (this.isAddingAnnotations) {
+					scope.addCondition("annotationText", "contains", this.searchValue);
+					scope.addCondition("annotationComment", "contains", this.searchValue);
+				}
+				scope.addCondition("note", "contains", this.searchValue);
+			}
+			scope.addCondition("includeChildren", "true");
+			s.setScope(scope);
+			s.addCondition("itemType", "is", this.isCitingNotes ? "note" : "annotation");
 		}
-		else if (realInputRegex.test(this.searchValue)) {
-			// search for the identifier if it is provided,
-			// otherwise look up by title, creator and year
-			let isDOI = Zotero.Utilities.cleanDOI(this.searchValue);
-			let isISBN = Zotero.Utilities.cleanISBN(this.searchValue);
-			if (isDOI) {
-				s.addCondition("DOI", "contains", this.searchValue);
-			}
-			else if (isISBN) {
-				s.addCondition("ISBN", "contains", this.searchValue);
-			}
-			else {
+		else {
+			// search items by the identifier if provided, or by title/creator/year otherwise
+			let hasIdentifier = this._addIdentifierConditions(s, this.searchValue);
+			if (!hasIdentifier) {
 				s.addCondition("quicksearch-titleCreatorYear", "contains", this.searchValue);
-				s.addCondition("itemType", "isNot", "attachment");
 			}
+			s.addCondition("itemType", "isNot", "attachment");
 		}
 		let searchResultIDs = await s.search();
 		// Search results might be in an unloaded library, so get items asynchronously and load necessary data
 		var items = await Zotero.Items.getAsync(searchResultIDs);
-		await Zotero.Items.loadDataTypes(items);
+		await this._ensureRelevantItemsAreLoaded(items);
+
 		return items;
 	}
 
@@ -268,6 +300,12 @@ export class CitationDialogSearchHandler {
 		if (this.io.allCitedDataLoadedPromise && !this.io.allCitedDataLoadedPromise.isResolved()) return null;
 		// Fetch all cited items in the document, not just items currently in the dialog
 		let citedItems = await this.io.getItems();
+		if (this.isAddingAnnotations) {
+			// Only keep items that have actual annotations
+			citedItems = citedItems.filter(item => Number.isInteger(item.id));
+			await this._ensureRelevantItemsAreLoaded(citedItems);
+			citedItems = this.keepItemsWithAnnotations(citedItems);
+		}
 		return citedItems;
 	}
 
@@ -296,17 +334,22 @@ export class CitationDialogSearchHandler {
 			}
 			items.push(item);
 		}
-		await Zotero.Items.loadDataTypes(items);
+		await this._ensureRelevantItemsAreLoaded(items);
+		items = this.keepItemsWithAnnotations(items);
 		// Return deduplicated items since there may be multiple tabs opened for the same
 		// top-level item (duplicate tabs or a multiple attachments belonging to the same item)
 		return [...new Set(items)];
 	}
 
 	_getSelectedLibraryItems() {
+		let selected = Zotero.getActiveZoteroPane()?.getSelectedItems() || [];
 		if (this.isCitingNotes) {
-			return Zotero.getActiveZoteroPane()?.getSelectedItems().filter(i => i.isNote()) || [];
+			return selected.filter(i => i.isNote());
 		}
-		return Zotero.getActiveZoteroPane()?.getSelectedItems().filter(i => i.isRegularItem()) || [];
+		if (this.isAddingAnnotations) {
+			return this.keepItemsWithAnnotations(selected);
+		}
+		return selected.filter(i => i.isRegularItem());
 	}
 	
 
@@ -390,5 +433,58 @@ export class CitationDialogSearchHandler {
 		let stringNoYear = string.substr(0, maybeYear.index) + string.substring(maybeYear.index + maybeYear[0].length);
 		if (!year) return stringNoYear;
 		return stringNoYear + " " + year;
+	}
+
+	// Add identifier conditions (DOI/ISBN) to Zotero.Search if applicable
+	_addIdentifierConditions(search, searchValue) {
+		let cleanDOI = Zotero.Utilities.cleanDOI(searchValue);
+		let cleanISBN = Zotero.Utilities.cleanISBN(searchValue);
+		
+		if (cleanDOI) {
+			search.addCondition("DOI", "contains", cleanDOI);
+			return true;
+		}
+		else if (cleanISBN) {
+			search.addCondition("ISBN", "contains", cleanISBN);
+			return true;
+		}
+		return false;
+	}
+
+	_addQuickSearchEquivalentConditions(search) {
+		search.addCondition("title", "contains", this.searchValue);
+		search.addCondition("publicationTitle", "contains", this.searchValue);
+		search.addCondition("shortTitle", "contains", this.searchValue);
+		search.addCondition("court", "contains", this.searchValue);
+		search.addCondition("year", "contains", this.searchValue);
+		search.addCondition("creator", "contains", this.searchValue);
+		search.addCondition("joinMode", "any");
+	}
+
+	// load all ancestors,descendants, and siblings of provided items
+	async _ensureRelevantItemsAreLoaded(items) {
+		// first, get all top-level items of annotations and attachments from the list
+		let topLevelItems = items.filter(item => !item.parentItemID);
+		let parentIDs = items.map(item => item.parentItemID).filter(id => id);
+		let parentItems = [];
+		while (parentIDs.length) {
+			parentItems = await Zotero.Items.getAsync(parentIDs);
+			parentIDs = parentItems.map(item => item.parentItemID).filter(id => id);
+		}
+		topLevelItems = [...topLevelItems, ...parentItems];
+		// load all data of top-level items and their attachments
+		await Zotero.Items.loadDataTypes(topLevelItems);
+		let attachmentIDs = topLevelItems.flatMap(item => item.getAttachments());
+		let attachments = await Zotero.Items.getAsync(attachmentIDs);
+		await Zotero.Items.loadDataTypes(attachments);
+
+		// Load annotations.
+		// Zotero.Items.loadDataTypes on parent items will set the
+		// _annotations cache on attachments but not load the annotations themselves.
+		// So fetch annotationIDs from the cache and load annotations separately.
+		attachments = attachments.filter(attachment => attachment.isFileAttachment());
+		let annotationIDs = attachments.flatMap(attachment => attachment.getAnnotations(false, true));
+		let annotations = await Zotero.Items.getAsync(annotationIDs);
+		await Zotero.Items.loadDataTypes(annotations);
 	}
 }

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -4161,9 +4161,10 @@ Zotero.Item.prototype.numAnnotations = function (includeTrashed) {
  * Returns child annotations for an attachment item
  *
  * @param {Boolean} [includeTrashed=false] - Include annotations in trash
+ * @param {Boolean} [asIDs=false] - Return ids of annootations instead of Zotero.Item objects
  * @return {Zotero.Item[]}
  */
-Zotero.Item.prototype.getAnnotations = function (includeTrashed) {
+Zotero.Item.prototype.getAnnotations = function (includeTrashed, asIDs) {
 	if (!this.isFileAttachment()) {
 		throw new Error("getAnnotations() can only be called on file attachments");
 	}
@@ -4177,6 +4178,7 @@ Zotero.Item.prototype.getAnnotations = function (includeTrashed) {
 	var cacheKey = 'with' + (includeTrashed ? '' : 'out') + 'Trashed';
 	
 	if (this._annotations[cacheKey]) {
+		if (asIDs) return this._annotations[cacheKey];
 		return Zotero.Items.get([...this._annotations[cacheKey]]);
 	}
 	
@@ -4187,6 +4189,7 @@ Zotero.Item.prototype.getAnnotations = function (includeTrashed) {
 	}
 	var ids = rows.map(row => row.itemID);
 	this._annotations[cacheKey] = ids;
+	if (asIDs) return ids;
 	return Zotero.Items.get(ids);
 };
 

--- a/chrome/content/zotero/xpcom/data/search.js
+++ b/chrome/content/zotero/xpcom/data/search.js
@@ -1208,13 +1208,6 @@ Zotero.Search.prototype._buildQuery = Zotero.Promise.coroutine(function* () {
 					condSelectSQL += 'IN (';
 					selectOpenParens = 1;
 					
-					// TEMP: Don't match annotations for negation operators, since it would result in
-					// all parent attachments being returned
-					if (isNegationOperator) {
-						condSelectSQL += "SELECT itemID FROM items WHERE itemTypeID="
-							+ Zotero.ItemTypes.getID('annotation') + " UNION ";
-					}
-					
 					switch (condition.name) {
 						case 'tag':
 							condSQL += "SELECT itemID FROM itemTags "
@@ -1818,6 +1811,10 @@ Zotero.Search.prototype._buildQuery = Zotero.Promise.coroutine(function* () {
 			sql = sql.substring(0, sql.length-5); // remove last ' AND '
 		}
 		
+		// Enforce annotation type whenever there is annotation-specific conditions
+		if (conditionsToProcess.some(cond => cond.condition.includes("annotation") && ["isNot", "doesNotContain"].includes(cond.operator))) {
+			sql += " AND itemTypeID=" + Zotero.ItemTypes.getID('annotation');
+		}
 		// Add on quicksearch conditions
 		if (quicksearchSQLSet) {
 			sql = "SELECT itemID FROM items WHERE itemID IN (" + sql + ") "

--- a/chrome/content/zotero/xpcom/editorInstance.js
+++ b/chrome/content/zotero/xpcom/editorInstance.js
@@ -1310,9 +1310,11 @@ class EditorInstance {
 	 * @param {Object} options
 	 * @param {Integer} options.parentID - Creates standalone note if not provided
 	 * @param {Integer} options.collectionID - Only valid if parentID not provided
+	 * @param {Boolean} options.noSave - If true, note item is not saved and ink/image annotations are
+	 *									embedded as "data:image/..." strings instead of via imageAttachmentKey.
 	 * @returns {Promise<Zotero.Item>}
 	 */
-	static async createNoteFromAnnotations(annotations, { parentID, collectionID } = {}) {
+	static async createNoteFromAnnotations(annotations, { parentID, collectionID, noSave } = {}) {
 		if (!annotations.length) {
 			throw new Error("No annotations provided");
 		}
@@ -1332,14 +1334,16 @@ class EditorInstance {
 		}
 
 		let note = new Zotero.Item('note');
-		note.libraryID = annotations[0].libraryID;
-		if (parentID) {
-			note.parentID = parentID;
+		if (!noSave) {
+			note.libraryID = annotations[0].libraryID;
+			if (parentID) {
+				note.parentID = parentID;
+			}
+			else if (collectionID) {
+				note.addToCollection(collectionID);
+			}
+			await note.saveTx();
 		}
-		else if (collectionID) {
-			note.addToCollection(collectionID);
-		}
-		await note.saveTx();
 		let editorInstance = new EditorInstance();
 		editorInstance._item = note;
 		let jsonAnnotations = [];
@@ -1359,7 +1363,11 @@ class EditorInstance {
 		// New line is needed for note title parser
 		html += '\n';
 
-		await editorInstance.importImages(jsonAnnotations);
+		// If there is no real note item saved, do not import images as annotations.
+		// Instead, serializeAnnotations below will embed images as "data:image/..." strings
+		if (!noSave) {
+			await editorInstance.importImages(jsonAnnotations);
+		}
 
 		let multipleParentParent = false;
 		let lastParentParentID;
@@ -1421,7 +1429,9 @@ class EditorInstance {
 		}
 		html = `<div data-citation-items="${citationItems}" data-schema-version="${schemaVersion}">${html}</div>`;
 		note.setNote(html);
-		await note.saveTx();
+		if (!noSave) {
+			await note.saveTx();
+		}
 		return note;
 	}
 }
@@ -1446,7 +1456,7 @@ class EditorInstanceUtilities {
 			if (!annotation.text
 				&& !annotation.comment
 				&& !annotation.imageAttachmentKey
-				|| annotation.type === 'ink') {
+				&& !annotation.image) {
 				continue;
 			}
 
@@ -1498,12 +1508,31 @@ class EditorInstanceUtilities {
 			}
 
 			// Image
-			if (annotation.imageAttachmentKey) {
-				// // let imageAttachmentKey = await this._importImage(annotation.image);
-				// delete annotation.image;
-
+			if (annotation.imageAttachmentKey || annotation.image) {
+				// Find the bounding rectangle of the annotation
+				let rect;
+				if (annotation.type == "ink") {
+					let x = annotation.position.paths[0][0];
+					let y = annotation.position.paths[0][1];
+					rect = [x, y, x, y];
+					for (let path of annotation.position.paths) {
+						for (let i = 0; i < path.length - 1; i += 2) {
+							let x = path[i];
+							let y = path[i + 1];
+							rect[0] = Math.min(rect[0], x);
+							rect[1] = Math.min(rect[1], y);
+							rect[2] = Math.max(rect[2], x);
+							rect[3] = Math.max(rect[3], y);
+						}
+					}
+				}
+				else if (annotation.type == "image") {
+					rect = annotation.position.rects[0];
+				}
+				else {
+					throw new Error("Unexpected annotation type for image embedding: " + annotation.type);
+				}
 				// Normalize image dimensions to 1.25 of the print size
-				let rect = annotation.position.rects[0];
 				let rectWidth = rect[2] - rect[0];
 				let rectHeight = rect[3] - rect[1];
 				// Constants from pdf.js
@@ -1511,7 +1540,13 @@ class EditorInstanceUtilities {
 				const PDFJS_DEFAULT_SCALE = 1.25;
 				let width = Math.round(rectWidth * CSS_UNITS * PDFJS_DEFAULT_SCALE);
 				let height = Math.round(rectHeight * width / rectWidth);
-				imageHTML = `<img data-attachment-key="${annotation.imageAttachmentKey}" width="${width}" height="${height}" data-annotation="${encodeURIComponent(JSON.stringify(storedAnnotation))}"/>`;
+				// if imageAttachmentKey is provided, use it in the HTML, otherwise use data:image/... string as src
+				if (annotation.imageAttachmentKey) {
+					imageHTML = `<img data-attachment-key="${annotation.imageAttachmentKey}" width="${width}" height="${height}" data-annotation="${encodeURIComponent(JSON.stringify(storedAnnotation))}"/>`;
+				}
+				else {
+					imageHTML = `<img src="${annotation.image}" width="${width}" height="${height}" data-annotation="${encodeURIComponent(JSON.stringify(storedAnnotation))}"/>`;
+				}
 			}
 
 			// Text
@@ -1533,7 +1568,7 @@ class EditorInstanceUtilities {
 			else if (['note', 'text'].includes(annotation.type)) {
 				template = Zotero.Prefs.get('annotations.noteTemplates.note');
 			}
-			else if (annotation.type === 'image') {
+			else {
 				template = '<p>{{image}}<br/>{{citation}} {{comment}}</p>';
 			}
 

--- a/chrome/content/zotero/xpcom/integration.js
+++ b/chrome/content/zotero/xpcom/integration.js
@@ -761,7 +761,9 @@ Zotero.Integration.Interface.prototype.addNote = async function () {
 			"integration.error.title");
 	}
 
-	let citations = await this._session.cite(null, true);
+	// let citations = await this._session.cite(null, true);
+	// TEMP - adding note for now opens in add annotations mode
+	let citations = await this._session.cite(null, false, true);
 	if (this._session.data.prefs.delayCitationUpdates) {
 		for (let citation of citations) {
 			await this._session.writeDelayedCitation(citation.field, citation);
@@ -1485,7 +1487,7 @@ Zotero.Integration.Session.prototype._updateDocument = async function(forceCitat
  * display the citation dialog and perform any field/text inserts after
  * the dialog edits are accepted
  */
-Zotero.Integration.Session.prototype.cite = async function (field, addNote=false) {
+Zotero.Integration.Session.prototype.cite = async function (field, addNote=false, addAnnotations = false) {
 	var newField;
 	var citation;
 	
@@ -1561,6 +1563,7 @@ Zotero.Integration.Session.prototype.cite = async function (field, addNote=false
 		fieldIndexPromise, citationsByItemIDPromise, previewFn
 	);
 	io.isCitingNotes = addNote;
+	io.isAddingAnnotations = addAnnotations;
 	Zotero.debug(`Editing citation:`);
 	Zotero.debug(JSON.stringify(citation.toJSON()));
 
@@ -1629,6 +1632,18 @@ Zotero.Integration.Session.prototype.cite = async function (field, addNote=false
 Zotero.Integration.Session.prototype._insertCitingResult = async function (fieldIndex, field, citation) {
 	await citation.loadItemData();
 	
+	let allItems = citation.citationItems.map(item => Zotero.Cite.getItem(item.id));
+	// Handle adding selected annotations as a mock note
+	if (allItems.some(item => item.isAnnotation())) {
+		if (!allItems.every(item => item.isAnnotation())) {
+			throw new Error("Citing result with annotations must not include other item types");
+		}
+		// Note is created with embedded data to be inserted but nothing is saved to DB
+		let mockNote = await Zotero.EditorInstance.createNoteFromAnnotations(
+			allItems, { noSave: true }
+		);
+		return this._insertNoteIntoDocument(fieldIndex, field, mockNote);
+	}
 	let firstItem = Zotero.Cite.getItem(citation.citationItems[0].id);
 	if (firstItem && firstItem.isNote()) {
 		return this._insertNoteIntoDocument(fieldIndex, field, firstItem);

--- a/scss/components/_citationDialog.scss
+++ b/scss/components/_citationDialog.scss
@@ -31,6 +31,10 @@
 		background-repeat: no-repeat;
 		border-radius: 5px;
 		margin: 0;
+		&.small {
+			width: 14px;
+			height: 14px;
+		}
 		&:hover:not([disabled]) {
 			cursor: pointer;
 			background-color: var(--fill-quinary) !important;
@@ -124,8 +128,12 @@
 
 	#library-layout {
 		#library-other-items {
-
+			// constant height is so the message can appear/disappear without shifting the layout
 			height: 82px;
+			&.tall {
+				// to accomodate taller annotation item cards
+				height: 98px;
+			}
 			flex-shrink: 0; // make sure suggested items do not get shrunk when window is resized
 
 			--item-width: 210px;
@@ -192,7 +200,7 @@
 							flex-shrink: 0;
 							width: var(--item-width);
 							overflow: hidden;
-							white-space: nowrap;
+							white-space: pre;
 							border: 1px solid var(--fill-quarternary);
 							border-radius: 5px;
 			
@@ -215,6 +223,24 @@
 							.title {
 								overflow: hidden;
 								text-overflow: ellipsis;
+
+								&.annotation-quote {
+									width: min-content;
+									max-width: 100%;
+									position: relative;
+									.title-text {
+										font-style: italic;
+										padding-inline-end: 6px;
+										&::before {
+											content: attr(q-mark-open);
+										}
+									}
+									&::after {
+										content: attr(q-mark-close);
+										position: absolute;
+										right: 0px;
+									}
+								}
 							}
 			
 							.description {
@@ -232,6 +258,10 @@
 							&.cited-placeholder {
 								border: 1px solid transparent;
 								padding: 0;
+							}
+							&.tall {
+								// annotation item cards are taller
+								height: 58px;
 							}
 						}
 					}
@@ -460,7 +490,6 @@
 					}
 
 					.icon {
-						margin-top: -4px;
 						margin-inline-end: 4px;
 						flex-shrink: 0;
 						&.retracted {
@@ -468,6 +497,15 @@
 							height: 12px;
 							color: var(--accent-red);
 							@include svgicon("cross", "universal", "16");
+						}
+						&.annotation-icon {
+							-moz-context-properties: fill;
+						}
+						&.twisty {
+							@include svgicon("chevron-8", "universal", "8");
+							transform: rotate(180deg);
+							transform-origin: center;
+							transition: transform 0.2s ease-in-out;
 						}
 					}
 					.description {
@@ -478,9 +516,40 @@
   						text-overflow: ellipsis;
 					}
 					.title {
+						display: flex;
+						align-items: center;
+						.title-text {
+							text-wrap: nowrap;
+							overflow: hidden;
+							text-overflow: ellipsis;
+						}
+					}
+				}
+				// collapsible item (e.g. top-level item with annotations)
+				.item-with-children {
+					.children {
+						transition: max-height 0.3s ease;
 						overflow: hidden;
-						text-wrap: nowrap;
-						text-overflow: ellipsis;
+						max-height: calc(42px * var(--children-count)); // 42px is max height of a child item
+						// small padding at the top and bottom to make sure the focus-ring is not cutoff by the overflow:hidden.
+						// negative margin preserves spacing set by other components.
+						padding: 1px 0;
+						margin: -1px 0;
+						.item {
+							padding-inline-start: 36px;
+						}
+					}
+					&:not(.expanded) {
+						.children {
+							max-height: 0 !important; // important to override max-height above
+						}
+						.twisty {
+							transform: rotate(0deg);
+						}
+					}
+					.parent .description {
+						// additional 16px inline margin to account for twisty icon
+						margin-inline-start: 36px;
 					}
 				}
 				&.expandable {
@@ -521,8 +590,9 @@
 					}
 					// item container has no height when it is collapsed
 					.itemsContainer {
-						transition: height 0.3s ease;
+						transition: max-height 0.3s ease;
 						overflow: hidden;
+						max-height: calc(var(--children-count) * 42px); // 42px is max height of a child item
 						// add small padding at the top and bottom to make sure the focus-ring (if it appear) is not
 						// cutoff by the overflow:hidden. Negative margin is to preserve spacing set by other components.
 						padding: 1px 0;
@@ -530,7 +600,8 @@
 					}
 					&:not(.expanded) {
 						.itemsContainer {
-							height: 0 !important; // important to override inline height with items displayed
+							max-height: 0 !important; // important to override inline height with items displayed
+							padding: 0;
 						}
 					}
 				}

--- a/test/tests/searchTest.js
+++ b/test/tests/searchTest.js
@@ -513,6 +513,54 @@ describe("Zotero.Search", function() {
 					var matches = await s.search();
 					assert.lengthOf(matches, 0);
 				});
+
+				it("should include annotations if top-level item matches", async function () {
+					var item = await createDataObject('item', { title: Zotero.Utilities.randomString() });
+					var attachment = await importPDFAttachment(item);
+					var annotation = await createAnnotation('highlight', attachment);
+
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('title', 'contains', item.getDisplayTitle());
+					s.addCondition('includeParentsAndChildren', 'true');
+					var matches = await s.search();
+
+					assert.includeMembers(matches, [item.id, attachment.id, annotation.id]);
+				});
+
+				it("should include annotations if attachment item matches", async function () {
+					var item = await createDataObject('item');
+					var attachment = await importPDFAttachment(item);
+					var tag = Zotero.Utilities.randomString();
+					attachment.addTag(tag);
+					await attachment.saveTx();
+					var annotation = await createAnnotation('highlight', attachment);
+
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('tag', 'is', tag);
+					s.addCondition('includeParentsAndChildren', 'true');
+					var matches = await s.search();
+
+					assert.includeMembers(matches, [item.id, attachment.id, annotation.id]);
+				});
+
+				it("should include top-level item and attachment if annotation matches", async function () {
+					var item = await createDataObject('item');
+					var attachment = await importPDFAttachment(item);
+					var annotation = await createAnnotation('highlight', attachment);
+					var tag = Zotero.Utilities.randomString();
+					annotation.addTag(tag);
+					await annotation.saveTx();
+
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('tag', 'is', tag);
+					s.addCondition('includeParentsAndChildren', 'true');
+					var matches = await s.search();
+
+					assert.includeMembers(matches, [item.id, attachment.id, annotation.id]);
+				});
 			});
 			
 			describe("key", function () {


### PR DESCRIPTION
- update `EditorInstance` to allow creation of a note from annotations without saving the item to DB. When the image or ink annotations are being inserted, they cannot be added into the note via attachmentKey (since it would require to save entries to database). Instead, they are embedded as a src="data:image/..." string.
- `SearchHandler` will match annotations based on their content, as well as the top-level item. Same applies to notes, for consistency. The first two commits are minor search tweaks to allow that.
- returned child annotations will appear as child rows in list mode. Child rows can be hidden by collapsing the top-level item.
- in both list and library mode, one can select multiple annotations, which will all be added when the dialog is accepted. One can also select an attachment or top-level item, in which case all annotations that the item contains will be added.
- when displaying selected/open/cited items, only keep ones that have annotations

<img width="804" alt="Screenshot 2025-06-24 at 9 01 43 PM" src="https://github.com/user-attachments/assets/3ba36ed3-8639-4371-8eef-442bdd0ac26a" />
<img width="799" alt="Screenshot 2025-06-24 at 8 56 44 PM" src="https://github.com/user-attachments/assets/68ae0739-c2e1-46fd-90d9-9d72ea6fb8bf" />

Fixes: #5314