### PR TITLE
Display the number of items that would be deleted when replacing the online library

### DIFF
--- a/chrome/content/zotero/hardConfirmationDialog.xhtml
+++ b/chrome/content/zotero/hardConfirmationDialog.xhtml
@@ -34,6 +34,7 @@
 
 <window xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
 		xmlns:html="http://www.w3.org/1999/xhtml"
+		id="zotero-hardConfirmationDialog"
 		title=""
 		onload="Zotero.HardConfirmationDialog.init(); sizeToContent();"
 		style="display: flex;">

--- a/chrome/content/zotero/preferences/preferences_sync.jsx
+++ b/chrome/content/zotero/preferences/preferences_sync.jsx
@@ -833,6 +833,7 @@ Zotero_Preferences.Sync = {
 			
 			case 'restore-to-server': {
 				const CHECKBOX_THRESHOLD = 10;
+				const CONFIRMATION_TEXT_MAX_ITEMS = 5;
 				
 				let apiKey = await Zotero.Sync.Data.Local.getAPIKey();
 				let client = Zotero.Sync.Runner.getAPIClient({ apiKey });
@@ -840,29 +841,45 @@ Zotero_Preferences.Sync = {
 				let { keys: remoteKeysArray } = await client.getKeys('user', keyInfo.userID, { target: 'items', itemType: '-annotation' });
 				let remoteKeys = new Set(remoteKeysArray);
 				let localItems = await Zotero.Items.getAll(Zotero.Libraries.userLibraryID, false, false, false);
+				let localItemsCount = localItems.length;
 				let localKeys = new Set(localItems
 					.filter(item => item.isRegularItem() || item.isNote() || item.isAttachment())
 					.map(item => item.key));
 				let remoteButNotLocal = remoteKeys.difference(localKeys); // NOTE: `difference` requires FF 127
 				let remoteItemsDeletedCount = remoteButNotLocal.size;
 				
-				let [title, text, warning, checkboxLabel, yes] = await document.l10n.formatValues([
+				let [title, text, warning1, warning2, checkboxLabel, yes] = await document.l10n.formatValues([
 					'general-warning',
 					{ id: 'preferences-sync-reset-restore-to-server-body', args: { libraryName: library.name, domain: ZOTERO_CONFIG.DOMAIN_NAME } },
-					{ id: 'preferences-sync-reset-restore-to-server-warning', args: { remoteItemsDeletedCount } },
+					{ id: 'preferences-sync-reset-restore-to-server-deleted-items-text', args: { remoteItemsDeletedCount } },
+					{ id: 'preferences-sync-reset-restore-to-server-remaining-items-text', args: { localItemsCount } },
 					{ id: 'preferences-sync-reset-restore-to-server-checkbox-label', args: { remoteItemsDeletedCount } },
 					'preferences-sync-reset-restore-to-server-yes',
 				]);
+				let confirmationText;
 				
-				text = remoteItemsDeletedCount > 0 ? `${text}\n\n${warning}` : text;
+				text = remoteItemsDeletedCount > 0 ? `${text}\n\n${warning1}` : text;
+				
 				if (remoteItemsDeletedCount < CHECKBOX_THRESHOLD) {
 					checkboxLabel = null;
+				}
+				else if (localItemsCount < CONFIRMATION_TEXT_MAX_ITEMS) {
+					text += warning2;
+					checkboxLabel = null;
+					confirmationText = await document.l10n.formatValue(
+						'preferences-sync-reset-restore-to-server-confirmation-text',
+					)
+					text += "\n\n" + await document.l10n.formatValue(
+						'general-type-to-continue',
+						{ text: confirmationText}
+					);
 				}
 				var io = {
 					title,
 					text,
 					acceptLabel: yes,
-					checkboxLabel
+					checkboxLabel,
+					confirmationText
 				};
 				window.openDialog("chrome://zotero/content/hardConfirmationDialog.xhtml", "",
 					"chrome,dialog,dependent,modal,centerscreen", io);

--- a/chrome/locale/en-US/zotero/preferences.ftl
+++ b/chrome/locale/en-US/zotero/preferences.ftl
@@ -105,11 +105,17 @@ preferences-advanced-default-data-dir =
     .aria-label = Default location
 
 preferences-sync-reset-restore-to-server-body = { -app-name } will replace “{ $libraryName }” on { $domain } with data from this computer.
-preferences-sync-reset-restore-to-server-warning = { $remoteItemsDeletedCount } { $remoteItemsDeletedCount ->
+preferences-sync-reset-restore-to-server-deleted-items-text = { $remoteItemsDeletedCount } { $remoteItemsDeletedCount ->
         [one] item
         *[other] items
-} in the online library will be permanently deleted.
+    } in the online library will be permanently deleted.
+preferences-sync-reset-restore-to-server-remaining-items-text = { general-sentence-separator }{ $localItemsCount ->
+        [0] The library on this computer and the online library will be empty.
+        [one] 1 item will remain on this computer and in the online library.
+        *[other] { $localItemsCount } items will remain on this computer and in the online library.
+    }
 preferences-sync-reset-restore-to-server-checkbox-label = { $remoteItemsDeletedCount ->
         *[other] Delete { $remoteItemsDeletedCount } items
-}
+    }
+preferences-sync-reset-restore-to-server-confirmation-text = delete online library
 preferences-sync-reset-restore-to-server-yes = Replace Data in Online Library

--- a/chrome/locale/en-US/zotero/preferences.ftl
+++ b/chrome/locale/en-US/zotero/preferences.ftl
@@ -104,9 +104,12 @@ preferences-advanced-default-data-dir =
     .value = (Default: { $directory })
     .aria-label = Default location
 
-preferences-sync-reset-restore-to-server-body = { -app-name } will replace data in “{ $libraryName }” on { $domain } with data from this computer.
-preferences-sync-reset-restore-to-server-warning = { $remoteItemsDeletedCount } { $remoteItemsDeletedCount -> 
-        [1] item
+preferences-sync-reset-restore-to-server-body = { -app-name } will replace “{ $libraryName }” on { $domain } with data from this computer.
+preferences-sync-reset-restore-to-server-warning = { $remoteItemsDeletedCount } { $remoteItemsDeletedCount ->
+        [one] item
         *[other] items
 } in the online library will be deleted.
+preferences-sync-reset-restore-to-server-checkbox-label = { $remoteItemsDeletedCount ->
+        *[other] Delete { $remoteItemsDeletedCount } items
+}
 preferences-sync-reset-restore-to-server-yes = Replace Data in Online Library

--- a/chrome/locale/en-US/zotero/preferences.ftl
+++ b/chrome/locale/en-US/zotero/preferences.ftl
@@ -103,3 +103,10 @@ preferences-advanced-custom-data-dir =
 preferences-advanced-default-data-dir =
     .value = (Default: { $directory })
     .aria-label = Default location
+
+preferences-sync-reset-restore-to-server-body = { -app-name } will replace data in “{ $libraryName }” on { $domain } with data from this computer.
+preferences-sync-reset-restore-to-server-warning = { $remoteItemsDeletedCount } { $remoteItemsDeletedCount -> 
+        [1] item
+        *[other] items
+} in the online library will be deleted.
+preferences-sync-reset-restore-to-server-yes = Replace Data in Online Library

--- a/chrome/locale/en-US/zotero/preferences.ftl
+++ b/chrome/locale/en-US/zotero/preferences.ftl
@@ -108,7 +108,7 @@ preferences-sync-reset-restore-to-server-body = { -app-name } will replace “{ 
 preferences-sync-reset-restore-to-server-warning = { $remoteItemsDeletedCount } { $remoteItemsDeletedCount ->
         [one] item
         *[other] items
-} in the online library will be deleted.
+} in the online library will be permanently deleted.
 preferences-sync-reset-restore-to-server-checkbox-label = { $remoteItemsDeletedCount ->
         *[other] Delete { $remoteItemsDeletedCount } items
 }

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -58,6 +58,7 @@ general-et-al = et al.
 general-previous = Previous
 general-next = Next
 general-learn-more = Learn More
+general-warning = Warning
 
 general-red = Red
 general-orange = Orange

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -1,3 +1,5 @@
+general-sentence-separator = { " " }
+
 general-key-control = Control
 general-key-shift = Shift
 general-key-alt = Alt
@@ -59,6 +61,7 @@ general-previous = Previous
 general-next = Next
 general-learn-more = Learn More
 general-warning = Warning
+general-type-to-continue = Type “{ $text }” to continue.
 
 general-red = Red
 general-orange = Orange

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -718,8 +718,6 @@ zotero.preferences.sync.reset.userInfoMissing			= You must enter a username and 
 zotero.preferences.sync.reset.restoreFromServer			= All data in this copy of Zotero will be erased and replaced with data belonging to user '%S' on the Zotero server.
 zotero.preferences.sync.reset.replaceLocalData			= Replace Local Data
 zotero.preferences.sync.reset.restartToComplete			= Firefox must be restarted to complete the restore process.
-zotero.preferences.sync.reset.restoreToServer          = %1$S will replace data in “%2$S” on %3$S with data from this computer.
-zotero.preferences.sync.reset.restoreToServer.button   = Replace Data in Online Library
 zotero.preferences.sync.reset.fileSyncHistory          = On the next sync, %1$S will check all attachment files in “%2$S” against the storage service. Any remote attachment files that are missing locally will be downloaded, and local attachment files missing remotely will be uploaded.\n\nThis option is not necessary during normal usage.
 zotero.preferences.sync.reset.fileSyncHistory.cleared  = The file sync history for “%S” has been cleared.
 

--- a/chrome/skin/default/zotero/hardConfirmationDialog.css
+++ b/chrome/skin/default/zotero/hardConfirmationDialog.css
@@ -9,3 +9,7 @@
 #infoContainer {
 	margin-bottom: 6px;
 }
+
+#zotero-hardConfirmationDialog-textbox {
+	font-size: 12px;
+}


### PR DESCRIPTION
This compares item keys in the remote library with those in the local DB and prints an additional warning if at least one remote key is not found locally. In a fully synced library, there is no change in behaviour, but if I remove `zotero.sqlite`, I’ll now see:

![Screenshot 2025-06-26 at 14 24 46](https://github.com/user-attachments/assets/213a2797-e338-4d3a-a8fd-97bf3ba136ee)

Few notes:

* I've added `asKeys` to `getAll` in `items.js` as an optimisation. If we don't want to affect the core API for this, I can retrieve all items and map them to keys instead.
* We probably need a spinner in the Preferences window to provide feedback while remote keys are being fetched.

Fix #5078