### PR TITLE
Expose tag split option in item tags box

### DIFF
--- a/chrome/content/zotero/elements/tagsBox.js
+++ b/chrome/content/zotero/elements/tagsBox.js
@@ -368,6 +368,15 @@
 				});
 				event.preventDefault();
 			}
+			let delimiters = [',', ';', '--'];
+			let interceptRegex = new RegExp(`\\w+\\s*(${delimiters.join('|')})\\s*\\w+`, 'i');
+			let match = str.match(interceptRegex);
+			if (match) {
+				event.preventDefault();
+				setTimeout(() => {
+					this.openTagSplitterWindow(str, match[1], textbox);
+				});
+			}
 		};
 
 		makeMultiline(editable, value) {
@@ -381,6 +390,30 @@
 		makeSingleLine(editable) {
 			editable.noWrap = true;
 			editable.multiline = false;
+		}
+
+		openTagSplitterWindow(tagString, delimiter, textbox) {
+			const dataIn = {
+				oldTag: tagString,
+				isLongTag: false,
+				delimiter
+			};
+			const dataOut = { result: null };
+
+			window.openDialog(
+				'chrome://zotero/content/longTagFixer.xhtml',
+				'',
+				'chrome,modal,centerscreen',
+				dataIn, dataOut
+			);
+
+			if (!dataOut.result) {
+				textbox.value = tagString;
+			}
+
+			if (dataOut?.result?.op === 'split') {
+				textbox.value = dataOut.result.tags.join('\n');
+			}
 		}
 
 		saveTag = async (event) => {

--- a/chrome/content/zotero/longTagFixer.js
+++ b/chrome/content/zotero/longTagFixer.js
@@ -26,12 +26,12 @@
 const HTML_NS = 'http://www.w3.org/1999/xhtml';
 
 var Zotero_Long_Tag_Fixer = new function () { // eslint-disable-line camelcase, no-unused-vars
-	const { oldTag, isLongTag } = window.arguments?.[0] ?? { isLongTag: true, oldTag: '' };
-	const dataOut = window.arguments?.[1] || {};
+	let { oldTag, isLongTag, delimiter } = window.arguments?.[0] ?? { isLongTag: true, oldTag: '' };
+	let dataOut = window.arguments?.[1] || {};
 	
 	this.init = function () {
 		const lastMode = Zotero.Prefs.get('lastLongTagMode') || 0;
-		const delimiter = Zotero.Prefs.get('lastLongTagDelimiter');
+		delimiter = delimiter ?? Zotero.Prefs.get('lastLongTagDelimiter');
 
 		this.dialog = document.getElementById('zotero-long-tag-fixer');
 		this.intro = document.getElementById('intro');

--- a/scss/components/_longTagFixer.scss
+++ b/scss/components/_longTagFixer.scss
@@ -127,6 +127,13 @@
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
+		margin-top: 0.5em;
+		
+		button {
+			@media (-moz-platform: macos) {
+				margin: unset; // restore space between buttons 
+			}
+		}
 	}
 
 	#zotero-new-tag-character-count {


### PR DESCRIPTION
In the item box tag input, if the pasted string matches the intercept regex—currently set to two words separated by one of three delimiters (`,`, `;`, or `--`)—Zotero will now open a tag splitter UI, with the delimiter automatically set to the one that was detected. Pressing **"Save Tags"** will save the selected tags from the list; pressing **"Cancel"** will save the tag as-is, without splitting.

Close #5323 

https://github.com/user-attachments/assets/38863c4b-e708-4439-a15c-44f7eb6fb7f3

