### PR TITLE
Fix trashed collection sometimes treated as an item row

### DIFF
--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -276,7 +276,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 						|| item.isRegularItem();
 				});
 			}
-			let newSearchItemIDs = new Set(newSearchItems.map(item => item.id));
+			let newSearchItemIDs = new Set(newSearchItems.map(item => item.treeViewID));
 			// Find the items that aren't yet in the tree
 			let itemsToAdd = newSearchItems.filter(item => this._rowMap[item.treeViewID] === undefined);
 			// Find the parents of search matches
@@ -318,7 +318,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 						skipChildren = false;
 					}
 					// Skip items that don't match the search and don't have children that do
-					if (!newSearchItemIDs.has(row.ref.id) && !isSearchParent) {
+					if (!newSearchItemIDs.has(row.ref.treeViewID) && !isSearchParent) {
 						continue;
 					}
 				}

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -1949,7 +1949,7 @@ var ZoteroPane = new function()
 			// Check if selection has actually changed. The onselect event that calls this
 			// can be called in various situations where the selection didn't actually change,
 			// such as whenever selectEventsSuppressed is set to false.
-			var ids = selectedItems.map(item => item.id);
+			var ids = selectedItems.map(item => item.treeViewID);
 			ids.sort();
 			if (ids.length && Zotero.Utilities.arrayEquals(_lastSelectedItems, ids)) {
 				return false;


### PR DESCRIPTION
If the id of the collection happens to be the same as an id of an existing item, those objects may end up being used interchangeably in `itemTree`. The trashed collection could appear in "My Library" instead of the item, or the not-deleted item could appear in the trash instead of the collection. This is addressed by using `.treeViewID` instead of the `.id` of the objects in `ItemTree.refresh` and `ZoteroPane.itemSelected`.

@AbeJellinek, does this fix the issue of weird trashed collections behavior for you?