### PR TITLE
Unify styles for headers of similar custom elements

### DIFF
--- a/chrome/content/zotero/elements/itemPaneHeader.js
+++ b/chrome/content/zotero/elements/itemPaneHeader.js
@@ -199,7 +199,7 @@
 			if (this._item.isAttachment()) {
 				headerMode = 'title';
 			}
-			
+
 			this.title.hidden = true;
 			this.creatorYear.hidden = true;
 			this.bibEntry.hidden = true;

--- a/scss/abstracts/_mixins.scss
+++ b/scss/abstracts/_mixins.scss
@@ -406,3 +406,30 @@
 		visibility: visible;
 	}
 }
+
+@mixin elements-custom-head {
+	.custom-head {
+		display: flex;
+		flex-direction: row;
+		align-self: stretch;
+		gap: 8px;
+		padding: 6px 8px;
+		background: var(--material-sidepane);
+		border-bottom: var(--material-panedivider);
+		height: 28px;
+		align-items: center;
+
+		&:empty {
+			display: none;
+		}
+
+		button {
+			height: 26px;
+			margin: 0;
+			@media (-moz-platform: macos) {
+				margin: 0px -2px;
+			}
+			flex-grow: 1;
+		}
+	}
+}

--- a/scss/elements/_itemMessagePane.scss
+++ b/scss/elements/_itemMessagePane.scss
@@ -2,30 +2,7 @@ item-message-pane {
 	display: flex;
 	flex-direction: column;
 
-	.custom-head {
-		display: flex;
-		flex-direction: row;
-		align-self: stretch;
-		gap: 8px;
-		padding: 6px 8px;
-		background: var(--material-toolbar);
-		border-bottom: var(--material-panedivider);
-		height: 28px;
-		align-items: center;
-
-		&:empty {
-			display: none;
-		}
-
-		button {
-			height: 26px;
-			margin: 0;
-			@media (-moz-platform: macos) {
-				margin: 0px -2px;
-			}
-			flex-grow: 1;
-		}
-	}
+	@include elements-custom-head;
 
 	#zotero-item-pane-groupbox {
 		flex: 1;

--- a/scss/elements/_itemPaneAnnotations.scss
+++ b/scss/elements/_itemPaneAnnotations.scss
@@ -1,32 +1,8 @@
 annotation-items-pane {
-
 	display: flex;
 	flex-direction: column;
 	
-	.custom-head {
-		display: flex;
-		flex-direction: row;
-		align-self: stretch;
-		gap: 8px;
-		padding: 6px 8px;
-		background: var(--material-sidepane);
-		border-bottom: var(--material-panedivider);
-		height: 28px;
-		align-items: center;
-
-		&:empty {
-			display: none;
-		}
-
-		button {
-			height: 26px;
-			margin: 0;
-			@media (-moz-platform: macos) {
-				margin: 0px -2px;
-			}
-			flex-grow: 1;
-		}
-	}
+	@include elements-custom-head;
 
 	// Make sure the summary containing name of top-level item is always visible
 	// and titles are cut off by letter and not by word

--- a/scss/elements/_itemPaneHeader.scss
+++ b/scss/elements/_itemPaneHeader.scss
@@ -7,6 +7,7 @@ item-pane-header {
 	padding: 8px;
 	border-bottom: 1px solid var(--fill-quinary);
 	
+	min-height: 41px;
 	max-height: 25%;
 	overflow-y: auto;
 	scrollbar-color: var(--color-scrollbar) var(--color-scrollbar-background);
@@ -57,65 +58,10 @@ item-pane-header {
 				overflow-wrap: anywhere;
 			}
 		}
-
-		.custom-head {
-			display: flex;
-			flex-direction: row;
-			align-self: stretch;
-			gap: 8px;
-
-			@media (-moz-platform: macos) {
-				// The extent of the button is about 2px wider than its optical width
-				// need to compensate for that
-				gap: 4px;
-			}
-
-			&:empty {
-				display: none;
-			}
-
-			button {
-				// Allow the button to grow/shrink to fit the container
-				width: 0;
-				margin: 0;
-				flex-grow: 1;
-
-				padding: 2px 6px;
-
-				@media (-moz-platform: macos) {
-					height: 24px;
-					padding: 3px 0px 1px 0px;
-
-					&:is(.split-menu-button) {
-						padding: 3px 2px 1px 3px;
-					}
-				}
-
-				.button-text {
-					width: 0;
-					flex-grow: 1;
-					justify-content: center;
-
-					&::before {
-						overflow: hidden;
-						white-space: nowrap;
-						text-overflow: ellipsis;
-					}
-				}
-
-				&:is(.no-shrink-button) {
-					width: auto;
-					flex-shrink: 0;
-
-					.button-text {
-						width: auto;
-					}
-				}
-			}
-		}
 	}
 
 	&.no-title-head {
+		min-height: auto;
 		&:not(.has-custom-head) {
 			padding: 0;
 			border: none;
@@ -124,5 +70,12 @@ item-pane-header {
 		.title-head {
 			display: none;
 		}
+	}
+
+	@include elements-custom-head;
+	.custom-head {
+		padding: 0;
+		border: none;
+		height: 24px;
 	}
 }

--- a/scss/elements/_noteEditor.scss
+++ b/scss/elements/_noteEditor.scss
@@ -1,26 +1,8 @@
 note-editor {
+	display: flex;
 	flex-direction: column;
 
-	.custom-head {
-		display: flex;
-		flex-direction: row;
-		align-self: stretch;
-		gap: 8px;
-		padding: 6px 8px;
-		background: var(--material-toolbar);
-		border-bottom: var(--material-panedivider);
-		height: 28px;
-
-		&:empty {
-			display: none;
-		}
-
-		button {
-			height: 26px;
-			margin: 0;
-			flex-grow: 1;
-		}
-	}
+	@include elements-custom-head;
 }
 
 links-box {


### PR DESCRIPTION
Unify very similar styles used by four different custom elements and move the shared code into a mixin.

The most noticeable improvements are:

* Buttons no longer "jump around" (see video in #5372)
* The background colour remains consistent — previously, some elements used the toolbar background, while others used the sidepane background.

@windingwind I've removed some of your styles to fix buttons "jumping around" (`button` and `.button-text` in `scss/elements/_itemPaneHeader.scss`). If you believe this breaks something, please let me know.

Before:

https://github.com/user-attachments/assets/c3f1c7f5-c6b6-4855-8d6d-00fa2a421af1

After:

https://github.com/user-attachments/assets/498a4a59-774f-47fc-80a5-d3d833223050

I've also tested on Windows, where this issue is also present (though perhaps slightly less noticeable).

Close #5372