### PR TITLE
fix the  missing "yield" in line 158 of storageEngine.js

### DIFF
--- a/chrome/content/zotero/xpcom/storage/storageEngine.js
+++ b/chrome/content/zotero/xpcom/storage/storageEngine.js
@@ -155,7 +155,7 @@ Zotero.Sync.Storage.Engine.prototype.start = Zotero.Promise.coroutine(function* 
 			&& this.local.lastFullFileCheck[libraryID]
 			&& (this.local.lastFullFileCheck[libraryID]
 				+ (this.maxCheckAge * 1000)) > new Date().getTime()) {
-		let itemIDs = this.local.getFilesToCheck(libraryID, this.maxCheckAge);
+		let itemIDs = yield this.local.getFilesToCheck(libraryID, this.maxCheckAge);
 		yield this.local.checkForUpdatedFiles(libraryID, itemIDs);
 	}
 	// Otherwise check all files in library


### PR DESCRIPTION
Fix the issue where Zotero.Sync.Runner.sync({background: true}) cannot obtain the itemIDs

<img width="1517" height="480" alt="截图 2025-07-19 17-12-08" src="https://github.com/user-attachments/assets/5a5ca87b-40b5-47fd-8b1a-64eae682f2a7" />

<img width="1451" height="332" alt="截图 2025-07-19 17-10-21" src="https://github.com/user-attachments/assets/d1ad4bb2-ec86-4d7c-8360-4937ab26dc6e" />

