### PR TITLE
Clean plugin cache on re-install

### DIFF
--- a/chrome/content/zotero/xpcom/plugins.js
+++ b/chrome/content/zotero/xpcom/plugins.js
@@ -636,6 +636,10 @@ Zotero.Plugins = new function () {
 				}
 				await _callMethod(existingAddon, 'uninstall', reason);
 				Services.obs.notifyObservers(null, "startupcache-invalidate");
+				unregisterLocales(existingAddon);
+				clearDefaultPrefs(existingAddon);
+				_unloadScope(existingAddon.id);
+				addonVersions.delete(existingAddon.id);
 			}
 		},
 		


### PR DESCRIPTION
## description

When reinstalling the same plugin (upgrading or downgrading), `bootstrap` is not destroyed, resulting in the new plugin still using the old `bootstrap.js`.

## example

`bootstrap.js` version 1

```js
function install(data, reason) {}

async function startup({ id, version, resourceURI, rootURI }, reason) {
  await Zotero.initializationPromise;
  /**
   * Global variables for plugin code.
   * The `_globalThis` is the global root variable of the plugin sandbox environment
   * and all child variables assigned to it is globally accessible.
   * See `src/index.ts` for details.
   */
  const ctx = {
    rootURI,
  };
  ctx._globalThis = ctx;

  Services.scriptloader.loadSubScript(`${rootURI}/content/scripts/__addonRef__.js`, ctx);
  // Zotero.__addonInstance__.hooks.onStartup();
  Zotero.debug("Plugin started - 1");
}

async function onMainWindowLoad({ window }, reason) {
  Zotero.__addonInstance__?.hooks.onMainWindowLoad(window);
}

async function onMainWindowUnload({ window }, reason) {
  Zotero.__addonInstance__?.hooks.onMainWindowUnload(window);
}

function shutdown({ id, version, resourceURI, rootURI }, reason) {
  Zotero.debug("Plugin shundowning - 1");
}

function uninstall(data, reason) {}
```


`bootstrap.js` version 2

```diff js
function install(data, reason) {}

async function startup({ id, version, resourceURI, rootURI }, reason) {
  await Zotero.initializationPromise;
  /**
   * Global variables for plugin code.
   * The `_globalThis` is the global root variable of the plugin sandbox environment
   * and all child variables assigned to it is globally accessible.
   * See `src/index.ts` for details.
   */
  const ctx = {
    rootURI,
  };
  ctx._globalThis = ctx;

  Services.scriptloader.loadSubScript(`${rootURI}/content/scripts/__addonRef__.js`, ctx);
  // Zotero.__addonInstance__.hooks.onStartup();
---  Zotero.debug("Plugin started - 1");
+++  Zotero.debug("Plugin started - 2");
}

async function onMainWindowLoad({ window }, reason) {
  Zotero.__addonInstance__?.hooks.onMainWindowLoad(window);
}

async function onMainWindowUnload({ window }, reason) {
  Zotero.__addonInstance__?.hooks.onMainWindowUnload(window);
}

function shutdown({ id, version, resourceURI, rootURI }, reason) {
---  Zotero.debug("Plugin shundowning - 1");
+++  Zotero.debug("Plugin shundowning - 2");
}

function uninstall(data, reason) {}
```

log:

```plain 
----------------------------------------------------------------------------------
action: install version 1
----------------------------------------------------------------------------------

(3)(+0012595): Installing plugin zotero-format-metadata@northword.cn

(3)(+0000001): Calling bootstrap method 'shutdown' for plugin zotero-format-metadata@northword.cn version 1.24.5 with reason ADDON_UPGRADE

(3)(+0000000): Plugin shundowning - 1

(3)(+0000000): Calling bootstrap method 'uninstall' for plugin zotero-format-metadata@northword.cn version 1.24.5 with reason ADDON_UPGRADE

(3)(+0000019): Installed plugin zotero-format-metadata@northword.cn

(3)(+0000006): Calling bootstrap method 'install' for plugin zotero-format-metadata@northword.cn version 1.24.5 with reason ADDON_UPGRADE

(3)(+0000001): Calling bootstrap method 'startup' for plugin zotero-format-metadata@northword.cn version 1.24.5 with reason ADDON_UPGRADE

(3)(+0000165): Plugin started - 1

(3)(+0007205): Starting full-text content processor

(4)(+0000000): Registering notifier observer 'fulltext_C7' for [sync]


----------------------------------------------------------------------------------
action: install version 2
----------------------------------------------------------------------------------

(3)(+0003859): Installing plugin zotero-format-metadata@northword.cn

(3)(+0000001): Calling bootstrap method 'shutdown' for plugin zotero-format-metadata@northword.cn version 1.24.5 with reason ADDON_UPGRADE

(3)(+0000000): Plugin shundowning - 1             // expected 'Plugin shundowning - 1'

(3)(+0000000): Calling bootstrap method 'uninstall' for plugin zotero-format-metadata@northword.cn version 1.24.5 with reason ADDON_UPGRADE

(3)(+0000009): Installed plugin zotero-format-metadata@northword.cn

(3)(+0000003): Calling bootstrap method 'install' for plugin zotero-format-metadata@northword.cn version 1.24.5 with reason ADDON_UPGRADE

(3)(+0000000): Calling bootstrap method 'startup' for plugin zotero-format-metadata@northword.cn version 1.24.5 with reason ADDON_UPGRADE

(3)(+0000150): Plugin started - 1             // expected 'Plugin started - 2' but got 'Plugin started - 1'

----------------------------------------------------------------------------------
action: install version 2
----------------------------------------------------------------------------------

(3)(+0004277): Installing plugin zotero-format-metadata@northword.cn

(3)(+0000001): Calling bootstrap method 'shutdown' for plugin zotero-format-metadata@northword.cn version 1.24.5 with reason ADDON_UPGRADE

(3)(+0000000): Plugin shundowning - 1             // expected 'Plugin shundowning - 2' but got 'Plugin shundowning - 1'

(3)(+0000000): Calling bootstrap method 'uninstall' for plugin zotero-format-metadata@northword.cn version 1.24.5 with reason ADDON_UPGRADE

(3)(+0000013): Installed plugin zotero-format-metadata@northword.cn

(3)(+0000007): Calling bootstrap method 'install' for plugin zotero-format-metadata@northword.cn version 1.24.5 with reason ADDON_UPGRADE

(3)(+0000000): Calling bootstrap method 'startup' for plugin zotero-format-metadata@northword.cn version 1.24.5 with reason ADDON_UPGRADE

(3)(+0000206): Plugin started - 1             // expected 'Plugin started - 2' but got 'Plugin started - 1'
```

## note

1. I didn't test the changes to see if they took effect because I had some problems building Zotero on my local Windows.
2. This is the reason we tried to use `Cu.unload` earlier (even though it really didn't seem to do the trick) ref: https://groups.google.com/g/zotero-dev/c/uQhEGkJEzYs/m/Hjqr13PwBwAJ