### PR TITLE
Cache CiteProc Engine instances, pre-cache for Quick Copy

### DIFF
--- a/chrome/content/zotero/fileInterface.js
+++ b/chrome/content/zotero/fileInterface.js
@@ -827,7 +827,7 @@ var Zotero_File_Interface = new function() {
 		
 		clipboardService.setData(transferable, null, Components.interfaces.nsIClipboard.kGlobalClipboard);
 		
-		Zotero.debug(`Copied bibliography to clipboard in ${new Date() - d} ms}`);
+		Zotero.debug(`Copied bibliography to clipboard in ${new Date() - d} ms`);
 	}
 	
 	

--- a/chrome/content/zotero/xpcom/integration.js
+++ b/chrome/content/zotero/xpcom/integration.js
@@ -2300,8 +2300,7 @@ Zotero.Integration.Session.prototype.restoreProcessorState = function() {
 	if (!Zotero.Prefs.get('cite.useCiteprocRs')) {
 		// Due to a bug in citeproc-js there are disambiguation issues after changing items in Zotero library
 		// and rebuilding the processor state, so we reinitialize the processor altogether
-		let style = Zotero.Styles.get(this.data.style.styleID);
-		this.style = style.getCiteProc(this.data.style.locale, this.outputFormat, this.data.prefs.automaticJournalAbbreviations);
+		this.style.restoreProcessorState();
 	}
 	this.style.rebuildProcessorState(citations, this.outputFormat, uncited);
 }

--- a/chrome/content/zotero/xpcom/integration.js
+++ b/chrome/content/zotero/xpcom/integration.js
@@ -2298,8 +2298,12 @@ Zotero.Integration.Session.prototype.restoreProcessorState = function() {
 		}
 	}
 	if (!Zotero.Prefs.get('cite.useCiteprocRs')) {
-		// Due to a bug in citeproc-js there are disambiguation issues after changing items in Zotero library
-		// and rebuilding the processor state, so we reinitialize the processor altogether
+		// Due to a bug in citeproc-js there are disambiguation issues after
+		// modifying items in Zotero, even after calling rebuildProcessorState(),
+		// because rebuildProcessorState() doesn't reset three properties of the
+		// processor (registry, tmp, and disambiguate) used for disambiguation.
+		// Call the deprecated restoreProcessorState(), which resets everything.
+		// Revisit if restoreProcessorState() is removed.
 		this.style.restoreProcessorState();
 	}
 	this.style.rebuildProcessorState(citations, this.outputFormat, uncited);

--- a/chrome/content/zotero/xpcom/quickCopy.js
+++ b/chrome/content/zotero/xpcom/quickCopy.js
@@ -279,8 +279,7 @@ Zotero.QuickCopy = new function() {
 		else if (format.mode == 'bibliography') {
 			items = items.filter(item => !item.isNote());
 			
-			// determine locale preference
-			var locale = format.locale ? format.locale : Zotero.Prefs.get('export.quickCopy.locale');
+			var locale = _getLocale(format);
 			
 			// Copy citations if shift key pressed
 			if (modified) {
@@ -390,7 +389,19 @@ Zotero.QuickCopy = new function() {
 			translator.cacheCode = true;
 			await Zotero.Translators.getCodeForTranslator(translator);
 		}
+		else if (format.mode === 'bibliography') {
+			let style = Zotero.Styles.get(format.id);
+			let locale = _getLocale(format);
+			// Cache CiteProc instances for HTML and text
+			style.getCiteProc(locale, 'html');
+			style.getCiteProc(locale, 'text');
+		}
 	};
+	
+	
+	function _getLocale(format) {
+		return format.locale || Zotero.Prefs.get('export.quickCopy.locale');
+	}
 	
 	
 	var _loadFormattedNames = Zotero.Promise.coroutine(function* () {

--- a/chrome/content/zotero/xpcom/style.js
+++ b/chrome/content/zotero/xpcom/style.js
@@ -213,7 +213,7 @@ Zotero.Styles = new function() {
 	/**
 	 * Gets a style with a given ID
 	 * @param {String} id
-	 * @param {Boolean} skipMappings Don't automatically return renamed style
+	 * @param {Boolean} [skipMappings] Don't automatically return renamed style
 	 */
 	this.get = function (id, skipMappings) {
 		if (!_initialized) {
@@ -699,8 +699,8 @@ Zotero.Style = function (style, path) {
 /**
  * Get a citeproc-js CSL.Engine instance
  * @param {String} locale Locale code
- * @param {String} format Output format one of [rtf, html, text]
- * @param {Boolean} automaticJournalAbbreviations Whether to automatically abbreviate titles
+ * @param {String} [format] Output format one of [rtf, html, text]
+ * @param {Boolean} [automaticJournalAbbreviations] Whether to automatically abbreviate titles
  */
 Zotero.Style.prototype.getCiteProc = function(locale, format, automaticJournalAbbreviations) {
 	locale = locale || Zotero.locale || 'en-US';

--- a/chrome/content/zotero/xpcom/style.js
+++ b/chrome/content/zotero/xpcom/style.js
@@ -716,6 +716,12 @@ Zotero.Style.prototype.getCiteProc = function(locale, format, automaticJournalAb
 		: null;
 	if (cacheKey && this._cachedEngines.has(cacheKey)) {
 		let engine = this._cachedEngines.get(cacheKey);
+		// Due to a bug in citeproc-js there are disambiguation issues after
+		// modifying items in Zotero. The lighter-weight rerebuildProcessorState()
+		// doesn't reset three properties of the processor (registry, tmp, and
+		// disambiguate) used for disambiguation, so we need to call the
+		// deprecated restoreProcessorState(), which resets everything.
+		// Revisit if restoreProcessorState() is removed.
 		engine.restoreProcessorState();
 		return engine;
 	}

--- a/chrome/content/zotero/xpcom/style.js
+++ b/chrome/content/zotero/xpcom/style.js
@@ -709,7 +709,7 @@ Zotero.Style.prototype.getCiteProc = function(locale, format, automaticJournalAb
 
 	let useCiteprocRs = Zotero.Prefs.get('cite.useCiteprocRs');
 	
-	// We can cache the Engine instance if we aren't using CiteprocRs
+	// We can cache the Engine instance if we aren't using citeproc-rs
 	// and this is an installed style
 	let cacheKey = !useCiteprocRs && this.path
 		? JSON.stringify({ locale, format, automaticJournalAbbreviations })
@@ -785,6 +785,7 @@ Zotero.Style.prototype.getCiteProc = function(locale, format, automaticJournalAb
 	
 	try {
 		var citeproc;
+		var engineDesc;
 		if (useCiteprocRs) {
 			citeproc = new Zotero.CiteprocRs.Engine(
 				new Zotero.Cite.System({
@@ -797,6 +798,7 @@ Zotero.Style.prototype.getCiteProc = function(locale, format, automaticJournalAb
 				format == 'text' ? 'plain' : format,
 				overrideLocale
 			);
+			engineDesc = 'CiteprocRs';
 		}
 		else {
 			citeproc = new Zotero.CiteProc.CSL.Engine(
@@ -813,12 +815,13 @@ Zotero.Style.prototype.getCiteProc = function(locale, format, automaticJournalAb
 			citeproc.opt.development_extensions.wrap_url_and_doi = true;
 			// Don't try to parse author names. We parse them in itemToCSLJSON
 			citeproc.opt.development_extensions.parse_names = false;
+			engineDesc = 'CSL';
 		}
 		
 		// Cache the Engine instance if allowed
 		if (cacheKey) {
 			this._cachedEngines.set(cacheKey, citeproc);
-			Zotero.debug(`Caching Engine instance for ${cacheKey} on ${this.styleID}`);
+			Zotero.debug(`Caching ${engineDesc}.Engine instance with ${cacheKey} for ${this.styleID}`);
 		}
 
 		return citeproc;

--- a/chrome/content/zotero/xpcom/style.js
+++ b/chrome/content/zotero/xpcom/style.js
@@ -38,6 +38,19 @@ Zotero.Styles = new function() {
 	};
 
 	this.CSL_VALIDATOR_URL = "resource://zotero/csl-validator.js";
+
+	this._memoryPressureObserver = {
+		observe: (subject, topic) => {
+			if (topic !== 'memory-pressure') {
+				return;
+			}
+			for (let style of Object.values(this.getAll())) {
+				style.clearEngineCache();
+			}
+		},
+		QueryInterface: ChromeUtils.generateQI(['nsISupportsWeakReference']),
+	};
+	Services.obs.addObserver(this._memoryPressureObserver, 'memory-pressure', /* ownsWeak */ true);
 	
 	
 	/**
@@ -679,6 +692,8 @@ Zotero.Style = function (style, path) {
 	if(this.source === this.styleID) {
 		throw new Error("Style with ID "+this.styleID+" references itself as source");
 	}
+	
+	this._cachedEngines = new Map();
 }
 
 /**
@@ -688,13 +703,22 @@ Zotero.Style = function (style, path) {
  * @param {Boolean} automaticJournalAbbreviations Whether to automatically abbreviate titles
  */
 Zotero.Style.prototype.getCiteProc = function(locale, format, automaticJournalAbbreviations) {
-	if(!locale) {
-		var locale = Zotero.locale;
-		if(!locale) {
-			var locale = 'en-US';
-		}
-	}
+	locale = locale || Zotero.locale || 'en-US';
 	format = format || 'text';
+	automaticJournalAbbreviations = !!automaticJournalAbbreviations;
+
+	let useCiteprocRs = Zotero.Prefs.get('cite.useCiteprocRs');
+	
+	// We can cache the Engine instance if we aren't using CiteprocRs
+	// and this is an installed style
+	let cacheKey = !useCiteprocRs && this.path
+		? JSON.stringify({ locale, format, automaticJournalAbbreviations })
+		: null;
+	if (cacheKey && this._cachedEngines.has(cacheKey)) {
+		let engine = this._cachedEngines.get(cacheKey);
+		engine.restoreProcessorState();
+		return engine;
+	}
 	
 	// APA and some similar styles capitalize the first word of subtitles
 	var uppercaseSubtitlesRE = /^apa($|-)|^academy-of-management($|-)|^(freshwater-science)/;
@@ -761,7 +785,7 @@ Zotero.Style.prototype.getCiteProc = function(locale, format, automaticJournalAb
 	
 	try {
 		var citeproc;
-		if (Zotero.Prefs.get('cite.useCiteprocRs')) {
+		if (useCiteprocRs) {
 			citeproc = new Zotero.CiteprocRs.Engine(
 				new Zotero.Cite.System({
 					automaticJournalAbbreviations,
@@ -791,11 +815,22 @@ Zotero.Style.prototype.getCiteProc = function(locale, format, automaticJournalAb
 			citeproc.opt.development_extensions.parse_names = false;
 		}
 		
+		// Cache the Engine instance if allowed
+		if (cacheKey) {
+			this._cachedEngines.set(cacheKey, citeproc);
+			Zotero.debug(`Caching Engine instance for ${cacheKey} on ${this.styleID}`);
+		}
+
 		return citeproc;
-	} catch(e) {
+	}
+	catch (e) {
 		Zotero.logError(e);
 		throw e;
 	}
+};
+
+Zotero.Style.prototype.clearEngineCache = function () {
+	this._cachedEngines.clear();
 };
 
 /**


### PR DESCRIPTION
Uncached:
```
zotero(3)(+0022127): Keyboard shortcut: copySelectedItemsToClipboard

zotero(3)(+0004691): Caching Engine instance for {"locale":"en-US","format":"html","automaticJournalAbbreviations":false} on http://www.zotero.org/styles/chicago-notes-bibliography

zotero(3)(+0004567): Caching Engine instance for {"locale":"en-US","format":"text","automaticJournalAbbreviations":false} on http://www.zotero.org/styles/chicago-notes-bibliography

zotero(3)(+0000013): Copied bibliography to clipboard in 9270 ms
```

Cached:
```
zotero(3)(+0005101): Keyboard shortcut: copySelectedItemsToClipboard

zotero(3)(+0000030): Copied bibliography to clipboard in 28 ms
```

A mere 331x speedup! (For some reason subsequent Engine instantiations for the same style are especially bad - first-time instantiations, like the ones we now do in `_preloadFormat()`, only take about half a second. But still!)

This doesn't affect 4a475ff3aa9b73d010a532ecb41cb5fa7793c0e9, since that was added before `getCiteProc()` took a format argument. These days the first call passes 'html' and the second passes 'text', so two separate Engine instances are cached.