### PR TITLE
Unregister `Zotero_Tabs` observers when window is unloaded

### DIFF
--- a/chrome/content/zotero/tabs.js
+++ b/chrome/content/zotero/tabs.js
@@ -77,16 +77,21 @@ var Zotero_Tabs = new function () {
 	this._focusOptions = {};
 
 	// Keep track of item modifications to update the title
-	Zotero.Notifier.registerObserver(this, ['item'], 'tabs');
+	this._notifierID = Zotero.Notifier.registerObserver(this, ['item'], 'tabs');
 
 	// Update the title when pref of title format is changed
-	Zotero.Prefs.registerObserver('tabs.title.reader', async () => {
+	this._prefsObserverID = Zotero.Prefs.registerObserver('tabs.title.reader', async () => {
 		for (let tab of this._tabs) {
 			if (!tab.data.itemID) continue;
 			let item = Zotero.Items.get(tab.data.itemID);
 			let title = await item.getTabTitle();
 			this.rename(tab.id, title);
 		}
+	});
+	
+	window.addEventListener('unload', () => {
+		Zotero.Notifier.unregisterObserver(this._notifierID);
+		Zotero.Prefs.unregisterObserver(this._prefsObserverID);
 	});
 
 	this._unloadInterval = setInterval(() => {

--- a/chrome/content/zotero/xpcom/notifier.js
+++ b/chrome/content/zotero/xpcom/notifier.js
@@ -153,11 +153,17 @@ Zotero.Notifier = new function () {
 				continue;
 			}
 			
+			let ref = _observers[id].ref;
+			
+			if (Zotero.Debug.enabled && Zotero.Utilities.Internal.isObjectLeakingWindow(ref)) {
+				Zotero.warn(`Notifier observer with id '${id}' belongs to leaked window`);
+			}
+			
 			// Catch exceptions so all observers get notified even if
 			// one throws an error
 			try {
 				let t = new Date;
-				yield Zotero.Promise.resolve(_observers[id].ref.notify(event, type, ids, extraData));
+				yield Zotero.Promise.resolve(ref.notify(event, type, ids, extraData));
 				t = new Date - t;
 				if (t > 5) {
 					//Zotero.debug(id + " observer finished in " + t + " ms", 5);

--- a/chrome/content/zotero/xpcom/prefs.js
+++ b/chrome/content/zotero/xpcom/prefs.js
@@ -402,10 +402,14 @@ Zotero.Prefs = new function() {
 			return;
 		}
 		
-		var obs = _observers[data];
-		for (var i=0; i<obs.length; i++) {
+		var observersForPref = _observers[data];
+		for (let observer of observersForPref) {
+			if (Zotero.Debug.enabled && Zotero.Utilities.Internal.isObjectLeakingWindow(observer)) {
+				Zotero.warn(`Pref observer for '${data}' belongs to leaked window`);
+			}
+			
 			try {
-				obs[i](this.get(data, true));
+				observer(this.get(data, true));
 			}
 			catch (e) {
 				Zotero.debug("Error while executing preference observer handler for " + data);

--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -2561,6 +2561,21 @@ Zotero.Utilities.Internal = {
 		}
 
 		return textContent;
+	},
+
+	/**
+	 * Check whether an object belongs to a closed window, and is therefore
+	 * keeping it alive.
+	 *
+	 * @param {any} obj
+	 * @returns {boolean}
+	 */
+	isObjectLeakingWindow(obj) {
+		if (typeof obj !== 'object' || obj === null) {
+			return false;
+		}
+		let global = Cu.getGlobalForObject(obj);
+		return global.constructor.name === 'Window' && global.closed;
 	}
 };
 


### PR DESCRIPTION
And complain about observers that leak windows.

Can cherry-pick this to fx140. It matters more there because the event loop stops running on closed windows, meaning promises never resolve.