### PR TITLE
Fx140: update X icon for search cancel button

### DIFF
--- a/scss/components/_search.scss
+++ b/scss/components/_search.scss
@@ -35,7 +35,7 @@
 			margin-top: 2px;
 		}
 		cursor: default;
-		background: url(resource://content-accessible/searchfield-cancel.svg) no-repeat center/contain;
+		background: url(resource://content-accessible/close-12.svg) no-repeat center/contain;
 		background-size: unset;
 	}
 }


### PR DESCRIPTION
`searchfield-cancel.svg` no longer exists, use `close-12.svg` that is the same one used by search-textbox

Before:
<img width="296" height="39" alt="Screenshot 2025-07-28 at 4 47 38 PM" src="https://github.com/user-attachments/assets/8049e514-13b9-4340-a751-70321b49b703" />

After:
<img width="296" height="44" alt="Screenshot 2025-07-28 at 4 46 44 PM" src="https://github.com/user-attachments/assets/5ce81474-bd79-4681-b0c5-d45487e33c1a" />
