### PR TITLE
fx140: fix separators appearance on linux

### DIFF
--- a/chrome/content/zotero-platform/unix/overlay.css
+++ b/chrome/content/zotero-platform/unix/overlay.css
@@ -22,13 +22,3 @@ tab:where([visuallyselected="true"]) {
 #zotero-prefs .numberbox-input-box{
 	-moz-appearance: textfield;
 }
-
-#zotero-tags-splitter:not([state=collapsed]) {
-	min-height: 5px;
-}
-
-#zotero-context-splitter-stacked {
-	-moz-appearance: none;
-	background-color: #ececec;
-	border-top: 1px solid hsla(0, 0%, 0%, 0.2);
-}


### PR DESCRIPTION
- fix transparent gap between tag selector and separator
- remove double border below separator of context pane in stacked mode

Fixes: #5430

Before (double border above stacked context pane):
<img width="1101" height="455" alt="before_context" src="https://github.com/user-attachments/assets/2aa89c61-2023-44d5-937b-ed88755e7d90" />

Before (transparent gap):
<img width="251" height="81" alt="before_tag" src="https://github.com/user-attachments/assets/75ca2d91-48ba-4294-8a11-67b394a1de5f" />

After (context pane):
<img width="1004" height="295" alt="after_context" src="https://github.com/user-attachments/assets/b509ecd1-82fd-4954-af8f-b93e74bba95b" />
After (tag selector):
<img width="249" height="94" alt="Screenshot 2025-07-30 at 3 49 04 PM" src="https://github.com/user-attachments/assets/483b0e00-2d36-4e29-9752-52bdfa35716a" />

