### PR TITLE
fx140: fix collection tree toolbar color on Linux

### DIFF
--- a/scss/components/_toolbar.scss
+++ b/scss/components/_toolbar.scss
@@ -142,3 +142,8 @@ toolbox {
 		appearance: initial;
 	}
 }
+
+#zotero-toolbar-collection-tree {
+	// fx140: override default toolbar color on linux
+	background: var(--material-sidepane);
+}


### PR DESCRIPTION
Override default toolbar color set in https://searchfox.org/mozilla-esr140/source/toolkit/themes/linux/global/toolbar.css#12

Fixes #5439

Before: 
<img width="187" height="116" alt="Screenshot 2025-07-31 at 9 00 50 AM" src="https://github.com/user-attachments/assets/6bdad94c-d9b0-4408-9834-5dc9ccb4b009" />

After:
<img width="204" height="156" alt="Screenshot 2025-07-31 at 9 18 58 AM" src="https://github.com/user-attachments/assets/f235c6d1-ece3-4ced-92b2-79fe15c0f559" />
