### PR TITLE
Fix Find Full Text failing on ProQuest

### DIFF
--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -2197,6 +2197,13 @@ Zotero.Attachments = new function () {
 								nextURL = refreshURL;
 								continue;
 							}
+							// ProQuest does a JS redirect back to the original page after authenticating
+							// Simulate that ourselves
+							else if (responseURL === 'https://www.proquest.com/intermediateredirectforezproxy') {
+								doc = null;
+								nextURL = pageURL;
+								continue;
+							}
 						}
 						
 						// Don't try this page URL again

--- a/chrome/content/zotero/xpcom/cookieSandbox.js
+++ b/chrome/content/zotero/xpcom/cookieSandbox.js
@@ -28,10 +28,10 @@
  *
  * @constructor
  * @param {browser} [browser] Hidden browser object
- * @param {String|nsIURI} uri URI of page to manage cookies for (cookies for domains that are not
+ * @param {String|nsIURI} [uri] URI of page to manage cookies for (cookies for domains that are not
  *                     subdomains of this URI are ignored)
- * @param {String} cookieData Cookies with which to initiate the sandbox
- * @param {String} userAgent User agent to use for sandboxed requests
+ * @param {String} [cookieData] Cookies with which to initiate the sandbox
+ * @param {String} [userAgent] User agent to use for sandboxed requests
  */
 Zotero.CookieSandbox = function (browser, uri, cookieData, userAgent) {
 	this._cookies = {};
@@ -51,9 +51,6 @@ Zotero.CookieSandbox = function (browser, uri, cookieData, userAgent) {
 	}
 	
 	if (userAgent) this.userAgent = userAgent;
-
-	this._observerService = Components.classes["@mozilla.org/observer-service;1"].
-	getService(Components.interfaces.nsIObserverService);
 
 	if (browser) {
 		this.attachToBrowser(browser);

--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -1343,11 +1343,13 @@ Zotero.Utilities.Internal = {
 	 * Run translation on a Document to try to find a PDF URL
 	 *
 	 * @param {doc} Document
+	 * @param {Zotero.CookieSandbox} cookieSandbox
 	 * @return {{ title: string, url: string } | false} - PDF attachment title and URL, or false if none found
 	 */
-	getFileFromDocument: async function (doc) {
+	getFileFromDocument: async function (doc, { cookieSandbox } = {}) {
 		let translate = new Zotero.Translate.Web();
 		translate.setDocument(doc);
+		translate.setCookieSandbox(cookieSandbox);
 		var translators = await translate.getTranslators();
 		// TEMP: Until there's a generic webpage translator
 		if (!translators.length) {

--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -1342,7 +1342,7 @@ Zotero.Utilities.Internal = {
 	/**
 	 * Run translation on a Document to try to find a PDF URL
 	 *
-	 * @param {doc} Document
+	 * @param {Document} doc
 	 * @param {Zotero.CookieSandbox} cookieSandbox
 	 * @return {{ title: string, url: string } | false} - PDF attachment title and URL, or false if none found
 	 */


### PR DESCRIPTION
And probably some other sites with auth redirects that set cookies.

- Wrap Find Full Text requests and translation in a CookieSandbox
	- Pre-fx115, our XHRs would've implicitly used global cookies. Now system XHRs [are anonymous](https://bugzilla.mozilla.org/show_bug.cgi?id=1881800) (`mozAnon`) by default, so we need to use a CookieSandbox in order to track cookies between requests. (Redirects are separate requests here because we handle them manually.)
- ProQuest-specific: When you first connect to ProQuest using a proxy/VPN, it sends you through https://www.proquest.com/intermediateredirectforezproxy, which uses a JS redirect to bring you back to the page you originally requested. We can't detect that, so just treat a 200 response from `/immediateredirectforezproxy` like a redirect back to the original URL.
- Fix JSDoc comment, remove unused variable

Fixes #5442