### PR TITLE
fx140: use the correct build folder on linux in runtest.sh depending on x86 vs arm

### DIFF
--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -19,12 +19,13 @@ if [ -z "$Z_EXECUTABLE" ]; then
 	if [ "`uname`" == "Darwin" ]; then
 		Z_EXECUTABLE="$ROOT_DIR/app/staging/Zotero.app/Contents/MacOS/zotero"
 	else
-		ARCH="$(uname -m)"
-		if [ "$ARCH" = "aarch64" ]; then
-			Z_EXECUTABLE="$ROOT_DIR/app/staging/Zotero_linux-arm64/zotero"
+		arch=""
+		if [ "$(uname -m)" = "aarch64" ]; then
+			arch="arm64"
 		else
-			Z_EXECUTABLE="$ROOT_DIR/app/staging/Zotero_linux-x86_64/zotero"
+			arch="x86_64"
 		fi
+		Z_EXECUTABLE="$ROOT_DIR/app/staging/Zotero_linux-$arch/zotero"
 	fi
 fi
 

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -19,7 +19,12 @@ if [ -z "$Z_EXECUTABLE" ]; then
 	if [ "`uname`" == "Darwin" ]; then
 		Z_EXECUTABLE="$ROOT_DIR/app/staging/Zotero.app/Contents/MacOS/zotero"
 	else
-		Z_EXECUTABLE="$ROOT_DIR/app/staging/Zotero_linux-x86_64/zotero"
+		ARCH="$(uname -m)"
+		if [ "$ARCH" = "aarch64" ]; then
+			Z_EXECUTABLE="$ROOT_DIR/app/staging/Zotero_linux-arm64/zotero"
+		else
+			Z_EXECUTABLE="$ROOT_DIR/app/staging/Zotero_linux-x86_64/zotero"
+		fi
 	fi
 fi
 


### PR DESCRIPTION
Choose the build folder depending on the x86 vs arm architecture. Otherwise, if you call `runtest.sh` on arm linux, it tried to run zotero from `Zotero_linux-x86_64`.