### PR TITLE
Close ProgressQueueDialog after connector server tests

### DIFF
--- a/test/tests/server_connectorTest.js
+++ b/test/tests/server_connectorTest.js
@@ -47,6 +47,10 @@ describe("Connector Server", function () {
 	});
 	
 	afterEach(function* () {
+		for (let win of getWindows("chrome://zotero/content/progressQueueDialog.xhtml")) {
+			win.close();
+		}
+		
 		var defer = Zotero.Promise.defer();
 		httpd.stop(() => defer.resolve());
 		yield defer.promise;


### PR DESCRIPTION
Since some operations trigger recognition

This is probably a better fix for the tags box test failures than #5444.