### PR TITLE
Don't merge into a missing snapshot attachment

### DIFF
--- a/chrome/content/zotero/xpcom/data/items.js
+++ b/chrome/content/zotero/xpcom/data/items.js
@@ -1124,6 +1124,11 @@ Zotero.Items = function () {
 
 		let masterAttachments = (await this.getAsync(item.getAttachments(true)))
 			.filter(attachment => attachment.isWebAttachment());
+		let masterAttachmentFilesExist = await Promise.all(masterAttachments.map(
+			attachment => attachment.attachmentLinkMode === Zotero.Attachments.LINK_MODE_LINKED_URL
+				|| attachment.fileExists()
+		));
+		masterAttachments = masterAttachments.filter((_, i) => masterAttachmentFilesExist[i]);
 
 		for (let otherItem of otherItems) {
 			for (let otherAttachment of await this.getAsync(otherItem.getAttachments(true))) {
@@ -1195,6 +1200,7 @@ Zotero.Items = function () {
 			.filter(attachment => attachment.isFileAttachment());
 		let hashes = new Map();
 		await Promise.all(attachments.map(async (attachment) => {
+			// attachmentHash and _hashAttachmentText() implicitly check file existence
 			let hash = hashType === 'bytes'
 				? await attachment.attachmentHash
 				: await this._hashAttachmentText(attachment);

--- a/test/content/support.js
+++ b/test/content/support.js
@@ -1027,13 +1027,37 @@ function importFileAttachment(filename, options = {}) {
 }
 
 
-function importTextAttachment() {
-	return importFileAttachment('test.txt', { contentType: 'text/plain', charset: 'utf-8' });
+function importTextAttachment(parentItem, options = {}) {
+	return importFileAttachment('test.txt', {
+		contentType: 'text/plain',
+		charset: 'utf-8',
+		parentID: parentItem ? parentItem.id : null,
+		title: options.title
+	});
 }
 
 
-function importHTMLAttachment() {
-	return importFileAttachment('test.html', { contentType: 'text/html', charset: 'utf-8' });
+function importHTMLAttachment(parentItem, options = {}) {
+	return importFileAttachment('test.html', {
+		contentType: 'text/html',
+		charset: 'utf-8',
+		parentID: parentItem ? parentItem.id : null,
+		title: options.title
+	});
+}
+
+
+function importSnapshotAttachment(parentItem, options = {}) {
+	let file = getTestDataDirectory();
+	file.append('test.html');
+	return Zotero.Attachments.importSnapshotFromFile({
+		title: options.title || 'Snapshot',
+		url: 'http://example.com',
+		file,
+		contentType: 'text/html',
+		charset: 'utf-8',
+		parentItemID: parentItem ? parentItem.id : null,
+	});
 }
 
 


### PR DESCRIPTION
PDFs: Behavior unchanged. Attachments are always left alone if their files are missing. A master-item attachment with a missing file never has anything else merged into it, and a non-master-item attachment with a missing file is never merged into anything else. This is because we don't know if the missing PDF is a different version or has external annotations.

Snapshots: Previously, a master-item attachment with a missing file could have other attachments from non-master items merged into it. That was a bug. Now a master-item attachment with a missing file never has anything else merged into it, but we _do_ allow a non-master attachment with a missing file to be merged into a matching master attachment. In other words, we're OK deleting a missing snapshot from the non-master item, as long it's from the same page as a snapshot on the master item that exists on disk. This is because we can be reasonably confident that two snapshots of the same page are equivalent, and a snapshot file is unlikely to be modified.

(And it enables the workflow described in [the report](https://forums.zotero.org/discussion/comment/496598/#Comment_496598), which seems like a reasonable use case for merging, though they should figure out why they're ending up with so many missing snapshots.)

Also:

- Add tests
- Add `importSnapshotAttachment()` test support function and add `parentItem` and `options` parameters to all `import*Attachment()` functions

Fixes #5458 