### PR TITLE
Close more leftover windows in tests

### DIFF
--- a/test/tests/hyphenationTest.js
+++ b/test/tests/hyphenationTest.js
@@ -1,8 +1,14 @@
 describe("Hyphenation", function () {
+	let win;
+
+	after(function() {
+		win.close();
+	});
+	
 	it("should not cause a segfault", async function () {
 		// Files in test/tests/data/ (resources://) can't be parsed as XUL/XHTML, so the data for this test is in
 		// test/content/ (chrome://), which can
-		window.openDialog('chrome://zotero-unit/content/hyphenationTest.xhtml', 'test', 'chrome');
+		win = window.openDialog('chrome://zotero-unit/content/hyphenationTest.xhtml', 'test', 'chrome');
 		await Zotero.Promise.delay(200);
 	});
 });

--- a/test/tests/preferences_syncTest.js
+++ b/test/tests/preferences_syncTest.js
@@ -122,9 +122,6 @@ describe("Sync Preferences", function () {
 			
 			it("should clear sync errors from the toolbar after logging in", async function () {
 				let win = await loadZoteroPane();
-				after(function () {
-					win.close();
-				});
 				
 				let syncError = win.document.getElementById('zotero-tb-sync-error');
 				
@@ -134,6 +131,8 @@ describe("Sync Preferences", function () {
 				getAPIKeyFromCredentialsStub.resolves(apiResponse);
 				await setCredentials("Username", "correctPassword");
 				assert.isTrue(syncError.hidden);
+
+				win.close();
 			});
 		})
 	})

--- a/test/tests/readerTest.js
+++ b/test/tests/readerTest.js
@@ -9,6 +9,7 @@ describe("Reader", function () {
 	});
 
 	after(function () {
+		win.Zotero_Tabs.closeAll();
 		win.close();
 	});
 


### PR DESCRIPTION
- close `hyphenationTest window.
- properly close `zoteroPane` window in `preferences_syncTest`. `after()` hook inside of the test would not close the window until the very end of the entire test run. Without this, during subsequent tests that open their own `zoteroPane` window, there are two instances of `zoteroPane` open at the same time.
- close open tabs in `readerTest` cleanup, since subsequent tests expect library tab to be selected.

Followup to https://github.com/zotero/zotero/pull/5444#issuecomment-3141879892