### PR TITLE
Warn users running non-ARM version on ARM CPU on Linux

### DIFF
--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -1420,7 +1420,7 @@ const { CommandLineOptions } = ChromeUtils.importESModule("chrome://zotero/conte
 		}
 	}
 
-	this.isLinux64EmulatedOnArm = async function () {
+	this.isLinux64EmulatedOnArm = function () {
 		if (!this.isLinux) {
 			return false;
 		}

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -6590,7 +6590,7 @@ var ZoteroPane = new function () {
 		}
 		
 		const isWow64 = (await Services.sysinfo.processInfo).isWow64;
-		const isX64OnArm = Zotero.isWin64EmulatedOnArm() || await Zotero.isLinux64EmulatedOnArm();
+		const isX64OnArm = Zotero.isWin64EmulatedOnArm() || Zotero.isLinux64EmulatedOnArm();
 		
 		if ((Zotero.isWin && isWow64) || isX64OnArm) {
 			let panel = document.getElementById('architecture-warning-container');

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -6590,9 +6590,9 @@ var ZoteroPane = new function () {
 		}
 		
 		const isWow64 = (await Services.sysinfo.processInfo).isWow64;
-		const isX64OnArm = Zotero.isWin64EmulatedOnArm();
+		const isX64OnArm = Zotero.isWin64EmulatedOnArm() || await Zotero.isLinux64EmulatedOnArm();
 		
-		if (Zotero.isWin && (isWow64 || isX64OnArm)) {
+		if ((Zotero.isWin && isWow64) || isX64OnArm) {
 			let panel = document.getElementById('architecture-warning-container');
 			let action = document.getElementById('architecture-warning-action');
 			let close = document.getElementById('architecture-warning-close');


### PR DESCRIPTION
I wasn't able to test it as a whole - I set up a Parallels VM running Ubuntu with the Rosetta layer for this and jumped through some hoops trying to get it to work, but the x64 binary segfaults on that system (7.x does as well).

Resolve #5448