### PR TITLE
fx140: fix cutoff progressWindow on linux

### DIFF
--- a/chrome/content/zotero/progressWindow.xhtml
+++ b/chrome/content/zotero/progressWindow.xhtml
@@ -47,6 +47,5 @@
 	<script>
         var { Zotero } = ChromeUtils.importESModule("chrome://zotero/content/zotero.mjs");
         Services.scriptloader.loadSubScript("chrome://zotero/content/titlebar.js", this);
-		window.addEventListener("DOMContentLoaded", () => window.sizeToContent())
 	</script>
 </window>

--- a/chrome/content/zotero/xpcom/progressWindow.js
+++ b/chrome/content/zotero/xpcom/progressWindow.js
@@ -473,6 +473,8 @@ Zotero.ProgressWindow = function (options = {}) {
 		_deferredUntilWindowLoad = [];
 		_deferredUntilWindowLoadThis = [];
 		_deferredUntilWindowLoadArgs = [];
+
+		_progressWindow.sizeToContent();
 	}
 	
 	function _move() {


### PR DESCRIPTION
Resize the window to fit content on `load` after the header is rendered. If the window is resized on
`DOMContentLoaded`, nothing is rendered yet and the window will look cutoff on Linux.

Addresses #5453