### PR TITLE
Ensure read-only fields don't save on blur

### DIFF
--- a/chrome/content/zotero/elements/abstractBox.js
+++ b/chrome/content/zotero/elements/abstractBox.js
@@ -89,9 +89,15 @@
 		}
 		
 		async save() {
-			if (this.item) {
-				this.item.setField('abstractNote', this._abstractField.value);
-				await this.item.saveTx();
+			if (!this.editable) {
+				return;
+			}
+			if (this._item) {
+				if (!this._item.itemID) {
+					throw new Error('Item has not been added to library');
+				}
+				this._item.setField('abstractNote', this._abstractField.value);
+				await this._item.saveTx();
 			}
 			this._forceRenderAll();
 		}

--- a/chrome/content/zotero/elements/itemPaneHeader.js
+++ b/chrome/content/zotero/elements/itemPaneHeader.js
@@ -180,7 +180,13 @@
 		}
 		
 		async save() {
+			if (!this.editable) {
+				return;
+			}
 			if (this._item) {
+				if (!this._item.itemID) {
+					throw new Error('Item has not been added to library');
+				}
 				this._item.setField(this._titleFieldID, this.titleField.value);
 				await this._item.saveTx();
 			}


### PR DESCRIPTION
Fixes tabbing out of Scaffold's abstract box causing the test item to be added to the user's library.