### PR TITLE
create new notes with related items from selected items

### DIFF
--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -124,7 +124,7 @@
 		<command id="cmd_zotero_newChildFileAttachment" oncommand="ZoteroPane.addAttachmentFromDialog(false, ZoteroPane.getSelectedItems()[0].id)"/>
 		<command id="cmd_zotero_newChildLinkedFileAttachment" oncommand="ZoteroPane.addAttachmentFromDialog(true, ZoteroPane.getSelectedItems()[0].id)"/>
 		<command id="cmd_zotero_newChildURLAttachment" oncommand="ZoteroPane.addAttachmentFromURI(true, ZoteroPane.getSelectedItems()[0].id)"/>
-		<command id="cmd_zotero_newStandaloneNote" oncommand="ZoteroPane_Local.newNote(event.shiftKey);"/>
+		<command id="cmd_zotero_newStandaloneNote" oncommand="ZoteroPane_Local.newNote(event.shiftKey, undefined, undefined, undefined, true);"/>
 		<command id="cmd_zotero_newChildNote" oncommand="ZoteroPane_Local.newChildNote(event.shiftKey);"/>
 		
 		<command id="cmd_zotero_showTabsMenu" oncommand="Zotero_Tabs.showTabsMenu()"/>
@@ -954,6 +954,7 @@
 			<menuitem class="menuitem-iconic zotero-menuitem-attach-note" label="&zotero.items.menu.attach.note;" oncommand="ZoteroPane_Local.newNote(false, this.parentNode.getAttribute('itemKey'))"/>
 			
 			<menuitem class="menuitem-iconic zotero-menuitem-create-note-from-annotations"/>
+			<menuitem class="menuitem-iconic zotero-menuitem-create-note-from-items"/>
 			
 			<menu class="menu-iconic zotero-menuitem-attach" label="&zotero.items.menu.attach;">
 				<menupopup id="zotero-add-attachment-popup">


### PR DESCRIPTION
- adds a new context menu item "Create Note From Items" which will create a new note with selected items as related items
- if multiple items are selected, the new note hotkey will create note from selected items