### PR TITLE
Send deleted annotations to trash

### DIFF
--- a/chrome/content/zotero/collectionViewItemTree.jsx
+++ b/chrome/content/zotero/collectionViewItemTree.jsx
@@ -537,6 +537,12 @@ class CollectionViewItemTreeRowProvider extends ItemTreeRowProvider {
 			// applied to rows carried over from the previous view
 			this._sort(options.forceSortAll || this._groupedByLibrary ? null : [...addedItemIDs]);
 			
+			// Set the new search state before refreshing open containers, so that
+			// getChildItems() filters child rows (e.g. non-matching annotations)
+			// against the new search results rather than the previous view's
+			this._searchMode = newSearchMode;
+			this._searchItemIDs = newSearchItemIDs; // items matching the search
+
 			// Toggle all open containers closed and open to refresh child items
 			var t = new Date();
 			for (let i = this.rows.length - 1; i >= 0; i--) {
@@ -552,8 +558,6 @@ class CollectionViewItemTreeRowProvider extends ItemTreeRowProvider {
 				this.refreshRowMap();
 			}
 
-			this._searchMode = newSearchMode;
-			this._searchItemIDs = newSearchItemIDs; // items matching the search
 			this.itemTree.invalidateRowCache(true);
 				
 			if (this.viewMode != 'publications') {
@@ -709,28 +713,29 @@ class CollectionViewItemTreeRowProvider extends ItemTreeRowProvider {
 
 			// For a refresh on an item in the trash, check if the item hadn't been restored
 			if (type == 'item' && this.viewMode == 'trash') {
-				let rows = [];
+				let rows = new Set();
 				for (let id of ids) {
 					let row = this.getRowIndexByID(id);
 					if (row === false) continue;
 					let item = Zotero.Items.get(id);
-					let isParentTrashed = item.parentItemID
-						? Zotero.Items.get(item.parentItemID).deleted
-						: false;
-					// Remove parent row if it isn't deleted, its parent isn't deleted, and it
-					// doesn't have any deleted children (shown by numChildren including deleted
-					// being the same as numChildren not including deleted)
-					if (!item.deleted && !isParentTrashed
-							&& (!item.isRegularItem() || item.numChildren(true) == item.numChildren(false))) {
-						rows.push(row);
+					if (!item) continue;
+					let topLevelItem = item.topLevelItem;
+					let isAnythingDeleted = topLevelItem.deleted
+						|| topLevelItem.getAllDescendents(true).length > topLevelItem.getAllDescendents(false).length;
+					// Remove the top-level item's row if neither it nor any of its
+					// descendents remain trashed
+					if (!isAnythingDeleted) {
+						let topLevelRow = this.getRowIndexByID(topLevelItem.treeViewID);
+						if (topLevelRow === false) continue;
+						rows.add(topLevelRow);
 						// And all its children in the tree
-						for (let child = row + 1; child < this.getRowCount() && this.itemTree.getLevel(child) > this.itemTree.getLevel(row); child++) {
-							rows.push(child);
+						for (let child = topLevelRow + 1; child < this.getRowCount() && this.itemTree.getLevel(child) > this.itemTree.getLevel(topLevelRow); child++) {
+							rows.add(child);
 						}
 					}
 				}
-				if (rows.length) {
-					this._removeRows(rows);
+				if (rows.size) {
+					this._removeRows([...rows]);
 					rowsToInvalidate = true; // all rows
 					this.runListeners('update', true);
 					this.itemTree.runListeners('rowCountChange');
@@ -766,9 +771,30 @@ class CollectionViewItemTreeRowProvider extends ItemTreeRowProvider {
 				// Row might already be gone (e.g. if this is a child and
 				// 'modify' was sent to parent)
 				let row = this._rowMap[ids[i]];
+				// A hidden child (e.g. an annotation of a collapsed attachment) can
+				// still change how its parent renders when trashed -- an attachment
+				// whose only annotation is trashed stops being an expandable
+				// container -- so re-render the parent's row
+				if (push && row === undefined && action == 'trash') {
+					let trashedItem = Zotero.Items.get(ids[i]);
+					if (trashedItem && trashedItem.parentItemID) {
+						let parentRowIndex = this._rowMap[trashedItem.parentItemID];
+						if (parentRowIndex !== undefined) {
+							this.itemTree.invalidateRowCache([trashedItem.parentItemID]);
+							this.itemTree.tree?.invalidateRow(parentRowIndex);
+						}
+					}
+				}
 				if (push && row !== undefined) {
 					// Don't remove child items from collections, because it's handled by 'modify'
 					if (action == 'remove' && this.itemTree.getParentIndex(row) != -1) {
+						continue;
+					}
+					// When viewing the trash, a trashed item belongs in the view, so
+					// don't remove its rows (which can be visible as context rows).
+					// The accompanying 'modify' event triggers a refresh that
+					// re-renders them as regular trash rows.
+					if (action == 'trash' && this.viewMode == 'trash') {
 						continue;
 					}
 					rows.push(row);
@@ -900,6 +926,15 @@ class CollectionViewItemTreeRowProvider extends ItemTreeRowProvider {
 					if (parentItemRowIndex === undefined) continue;
 					if (this.isContainerOpen(parentItemRowIndex)) {
 						this._refreshContainer(parentItemRowIndex);
+						madeChanges = true;
+					}
+					// If the parent is collapsed, the restored child can still change how
+					// its row renders -- e.g. a restored annotation makes an attachment
+					// with no other visible children an expandable container again --
+					// so re-render the parent's row
+					else {
+						this.itemTree.invalidateRowCache([item.parentItemID]);
+						this.itemTree.tree?.invalidateRow(parentItemRowIndex);
 					}
 				}
 
@@ -2050,12 +2085,8 @@ class CollectionViewItemTree extends ItemTree {
 
 			let collectionTreeRows = this.collectionTreeRows;
 
-			// If all selected items are annotations, for now erase them skipping trash
-			if (selectedItems.length && selectedItems.every(item => item.isAnnotation())) {
-				await Zotero.Items.erase(selectedItemIDs);
-			}
-			else if (this.viewMode == 'bucket') {
-				collectionTreeRows[0].ref.deleteItems(ids);
+			if (this.viewMode == 'bucket') {
+				collectionTreeRows[0].ref.deleteItems(selectedItemIDs);
 			}
 			else if (this.viewMode == 'trash') {
 				let [trashedCollectionIDs, trashedSearches] = [[], []];

--- a/chrome/content/zotero/collectionViewItemTree.jsx
+++ b/chrome/content/zotero/collectionViewItemTree.jsx
@@ -721,7 +721,7 @@ class CollectionViewItemTreeRowProvider extends ItemTreeRowProvider {
 					if (!item) continue;
 					let topLevelItem = item.topLevelItem;
 					let isAnythingDeleted = topLevelItem.deleted
-						|| topLevelItem.getAllDescendents(true).length > topLevelItem.getAllDescendents(false).length;
+						|| topLevelItem.getDescendantItems({ includeTrashed: true }).length > topLevelItem.getDescendantItems().length;
 					// Remove the top-level item's row if neither it nor any of its
 					// descendents remain trashed
 					if (!isAnythingDeleted) {

--- a/chrome/content/zotero/integration/citationDialog/searchHandler.mjs
+++ b/chrome/content/zotero/integration/citationDialog/searchHandler.mjs
@@ -260,12 +260,7 @@ export class CitationDialogSearchHandler {
 	
 	isItemWithAnnotations(item) {
 		if (item.isAnnotation()) return true;
-		if (item.isFileAttachment() && item.getAnnotations().length) return true;
-		if (item.isRegularItem()) {
-			let attachments = Zotero.Items.get(item.getAttachments());
-			return attachments.some(att => att.isFileAttachment() && att.getAnnotations().length);
-		}
-		return false;
+		return item.getDescendantItems().some(descendent => descendent.isAnnotation());
 	}
 
 	isItemWithNotes(item) {
@@ -279,10 +274,7 @@ export class CitationDialogSearchHandler {
 
 	getAllAnnotations(item) {
 		if (item.isAnnotation()) return [item];
-		if (item.isFileAttachment()) return item.getAnnotations();
-		let attachmentIDs = item.getAttachments();
-		let attachments = Zotero.Items.get(attachmentIDs).filter(item => item.isFileAttachment());
-		let annotations = attachments.flatMap(attachment => attachment.getAnnotations());
+		let annotations = item.getDescendantItems().filter(descendent => descendent.isAnnotation());
 		annotations.sort((a, b) => {
 			if (a.parentItemID !== b.parentItemID) return 0;
 			return (a.annotationSortIndex > b.annotationSortIndex) - (a.annotationSortIndex < b.annotationSortIndex);

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -3887,7 +3887,10 @@ var ItemTree = class ItemTree extends LibraryTree {
 				this.selection.select(this._rowMap[itemID]);
 				focusedSet = true;
 			}
-			else {
+			// If the item is already selected (e.g. when expandCollapsedParents == false,
+			// and the item is a collapsed parent of a previously selected item),
+			// do not toggle selection on it, since it would un-select it.
+			else if (!this.selection.isSelected(this._rowMap[itemID])) {
 				this.selection.toggleSelect(this._rowMap[itemID]);
 			}
 		}).bind(this);
@@ -3915,8 +3918,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 							toggleSelect(selection[i].treeViewID);
 						}
 						else {
-							!this.selection.isSelected(this._rowMap[parent]) &&
-								toggleSelect(parent);
+							toggleSelect(parent);
 						}
 					}
 				}

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -554,17 +554,14 @@ var ItemTree = class ItemTree extends LibraryTree {
 					let row = this.getRowIndexByID(id);
 					if (row === false) continue;
 					let item = Zotero.Items.get(id);
-					let isParentTrashed = item.parentItemID
-						? Zotero.Items.get(item.parentItemID).deleted
-						: false;
-					// Remove parent row if it isn't deleted, its parent isn't deleted, and it
-					// doesn't have any deleted children (shown by numChildren including deleted
-					// being the same as numChildren not including deleted)
-					if (!item.deleted && !isParentTrashed
-							&& (!item.isRegularItem() || item.numChildren(true) == item.numChildren(false))) {
-						rows.push(row);
+					let topLevelItem = item.topLevelItem;
+					let isAnythingDeleted = topLevelItem.getAllDescendents(true).length > topLevelItem.getAllDescendents(false).length;
+					// Remove top level item row if it is not trashed and has no trashed descendents
+					if (!topLevelItem.deleted && !isAnythingDeleted) {
+						let topLevelRow = this.getRowIndexByID(topLevelItem.id);
+						rows.push(topLevelRow);
 						// And all its children in the tree
-						for (let child = row + 1; child < this.rowCount && this.getLevel(child) > this.getLevel(row); child++) {
+						for (let child = topLevelRow + 1; child < this.rowCount && this.getLevel(child) > this.getLevel(topLevelRow); child++) {
 							rows.push(child);
 						}
 					}
@@ -629,6 +626,11 @@ var ItemTree = class ItemTree extends LibraryTree {
 				if (push && row !== undefined) {
 					// Don't remove child items from collections, because it's handled by 'modify'
 					if (action == 'remove' && this.getParentIndex(row) != -1) {
+						continue;
+					}
+					// Don't remove visible context child rows from trash.
+					// After 'modify', they will be refreshed as non-context rows.
+					if (action == 'trash' && this.collectionTreeRow.isTrash() && this.getParentIndex(row) != -1) {
 						continue;
 					}
 					rows.push(row);
@@ -1723,7 +1725,8 @@ var ItemTree = class ItemTree extends LibraryTree {
 		var annotations = [];
 
 		if (item.isFileAttachment()) {
-			annotations = item.getAnnotations();
+			let includeTrashed = this.collectionTreeRow.isTrash();
+			annotations = item.getAnnotations(includeTrashed);
 		}
 		var newRows = [];
 		if (attachments.length && notes.length) {
@@ -1905,11 +1908,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 
 			let collectionTreeRow = this.collectionTreeRow;
 
-			// If all selected items are annotations, for now erase them skipping trash
-			if (selectedItems.length && selectedItems.every(item => item.isAnnotation())) {
-				await Zotero.Items.erase(selectedItemIDs);
-			}
-			else if (collectionTreeRow.isBucket()) {
+			if (collectionTreeRow.isBucket()) {
 				collectionTreeRow.ref.deleteItems(ids);
 			}
 			else if (collectionTreeRow.isTrash()) {
@@ -2100,7 +2099,8 @@ var ItemTree = class ItemTree extends LibraryTree {
 
 		var item = this.getRow(index).ref;
 		if (item.isFileAttachment()) {
-			return item.numAnnotations() == 0;
+			let includeTrashed = this.collectionTreeRow.isTrash();
+			return item.numAnnotations(includeTrashed) == 0;
 		}
 		if (!item.isRegularItem()) {
 			return true;

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -2774,7 +2774,10 @@ var ItemTree = class ItemTree extends LibraryTree {
 				this.selection.select(this._rowMap[itemID]);
 				focusedSet = true;
 			}
-			else {
+			// If the row is already selected (e.g. a collapsed parent that was
+			// selected as the fallback for a previously restored child), don't
+			// toggle selection on it, since that would un-select it
+			else if (!this.selection.isSelected(this._rowMap[itemID])) {
 				this.selection.toggleSelect(this._rowMap[itemID]);
 			}
 		}).bind(this);
@@ -2791,7 +2794,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 					// Try selecting the parent (child gone in this view)
 					var parent = selection[i].parentItemID;
 
-					if (parent && this._rowMap[parent] !== undefined && !this.selection.isSelected(this._rowMap[parent])) {
+					if (parent && this._rowMap[parent] !== undefined) {
 						toggleSelect(parent);
 					}
 				}

--- a/chrome/content/zotero/itemTreeRow.js
+++ b/chrome/content/zotero/itemTreeRow.js
@@ -461,12 +461,12 @@ class FileItemTreeRow extends ZoteroItemTreeRow {
 		return true;
 	}
 
-	isContainerEmpty() {
-		return this.ref.numAnnotations() == 0;
+	isContainerEmpty({ includeTrashed } = {}) {
+		return this.ref.numAnnotations(includeTrashed) == 0;
 	}
 
-	getChildItems({ searchMode, searchItemIDs } = {}) {
-		let annotations = this.ref.getAnnotations();
+	getChildItems({ searchMode, searchItemIDs, includeTrashed } = {}) {
+		let annotations = this.ref.getAnnotations(includeTrashed);
 		// With "Hide Non-Matching Annotations" enabled, if any of the attachment's
 		// annotations match a search, show only those and hide the rest. If none match,
 		// show them all, since otherwise the attachment couldn't be expanded to browse its

--- a/chrome/content/zotero/standalone/standalone.js
+++ b/chrome/content/zotero/standalone/standalone.js
@@ -237,52 +237,11 @@ const ZoteroStandalone = new function () {
 		this.updateQuickCopyOptions();
 		// goUpdateGlobalEditMenuItems(true) is necessary to update Edit menu when contenteditable is focused
 		window.goUpdateGlobalEditMenuItems(true);
-		this._updateUndoRedoLabels();
+		Zotero.UndoHistory.updateMenuItems(document);
 
 		this.onUpdateCustomMenus(event, 'edit');
 	};
 
-	this._updateUndoRedoLabels = function () {
-		let undoItem = document.getElementById('menu_undo');
-		let redoItem = document.getElementById('menu_redo');
-		if (!undoItem || !redoItem) return;
-
-		// When a native text-editing controller handles undo/redo
-		// (e.g. focused input), show generic labels and let it take over
-		let nativeUndo = Zotero.UndoHistory.hasNativeUndo(document);
-		let nativeRedo = Zotero.UndoHistory.hasNativeRedo(document);
-
-		let undoAction = !nativeUndo && Zotero.UndoHistory.getUndoAction();
-		if (undoAction) {
-			let actionLabel = Zotero.ftl.formatValueSync(
-				undoAction.action, undoAction.actionArgs || undefined
-			);
-			let fullLabel = Zotero.ftl.formatValueSync(
-				'menu-edit-undo-action', { action: actionLabel }
-			);
-			undoItem.removeAttribute('data-l10n-id');
-			undoItem.setAttribute('label', fullLabel);
-		}
-		else {
-			document.l10n.setAttributes(undoItem, 'text-action-undo');
-		}
-
-		let redoAction = !nativeRedo && Zotero.UndoHistory.getRedoAction();
-		if (redoAction) {
-			let actionLabel = Zotero.ftl.formatValueSync(
-				redoAction.action, redoAction.actionArgs || undefined
-			);
-			let fullLabel = Zotero.ftl.formatValueSync(
-				'menu-edit-redo-action', { action: actionLabel }
-			);
-			redoItem.removeAttribute('data-l10n-id');
-			redoItem.setAttribute('label', fullLabel);
-		}
-		else {
-			document.l10n.setAttributes(redoItem, 'text-action-redo');
-		}
-	};
-	
 	/**
 	 * Builds new item menu
 	 */

--- a/chrome/content/zotero/xpcom/data/dataObjectUtilities.js
+++ b/chrome/content/zotero/xpcom/data/dataObjectUtilities.js
@@ -741,6 +741,7 @@ Zotero.DataObjectUtilities = {
 		isRegularItem: () => false, // Should be false to prevent items dropped into deleted searches
 		getNotes: () => [],
 		getAttachments: () => [],
+		getDescendantItems: () => [],
 		isFileAttachment: () => false,
 		isTopLevelItem: () => false,
 		getField: function (field, _) {

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -2167,6 +2167,29 @@ Zotero.Item.prototype.numChildren = function (includeTrashed) {
 	return this.numNotes(includeTrashed) + this.numAttachments(includeTrashed);
 }
 
+/**
+ * Get all descendents of an item.
+ * @param	{Boolean}	includeTrashed		Include trashed items
+ * @return	{Zotero.Item[]} Array of Zotero.Item objects, whose parent, or parent's parent, is this item
+ */
+Zotero.Item.prototype.getAllDescendents = function (includeTrashed) {
+	let attachments = [];
+	let notes = [];
+	let annotations = [];
+	if (this.isRegularItem()) {
+		attachments = Zotero.Items.get(this.getAttachments(includeTrashed));
+		notes = Zotero.Items.get(this.getNotes(includeTrashed));
+		for (let attachment of attachments) {
+			if (!attachment.isFileAttachment()) continue;
+			annotations = annotations.concat(attachment.getAnnotations(includeTrashed));
+		}
+	}
+	else if (this.isFileAttachment()) {
+		annotations = this.getAnnotations(includeTrashed);
+	}
+	return [...attachments, ...notes, ...annotations];
+};
+
 
 /**
  * @return	{String|FALSE}	 Key of the parent item for an attachment or note, or FALSE if none

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -2460,28 +2460,30 @@ Zotero.Item.prototype.numChildren = function (includeTrashed) {
 
 
 /**
- * Get all descendents of an item -- child notes and attachments of a regular item,
- * annotations of its file attachments, and annotations of a standalone file attachment
+ * Get descendant items -- child notes and attachments of a regular item, plus
+ * annotations of its file attachments; annotations of a standalone file attachment
  *
- * @param	{Boolean}	includeTrashed		Include trashed items
- * @return	{Zotero.Item[]}
+ * @param {Object} [options]
+ * @param {Boolean} [options.includeTrashed=false] Include trashed items
+ * @param {Boolean} [options.includeAnnotations=true] Include annotations of file attachments
+ * @return {Zotero.Item[]}
  */
-Zotero.Item.prototype.getAllDescendents = function (includeTrashed) {
-	let attachments = [];
-	let notes = [];
-	let annotations = [];
+Zotero.Item.prototype.getDescendantItems = function ({ includeTrashed = false, includeAnnotations = true } = {}) {
+	let descendents = [];
 	if (this.isRegularItem()) {
-		attachments = Zotero.Items.get(this.getAttachments(includeTrashed));
-		notes = Zotero.Items.get(this.getNotes(includeTrashed));
-		for (let attachment of attachments) {
-			if (!attachment.isFileAttachment()) continue;
-			annotations.push(...attachment.getAnnotations(includeTrashed));
+		let attachments = Zotero.Items.get(this.getAttachments(includeTrashed));
+		descendents.push(...attachments, ...Zotero.Items.get(this.getNotes(includeTrashed)));
+		if (includeAnnotations) {
+			for (let attachment of attachments) {
+				if (!attachment.isFileAttachment()) continue;
+				descendents.push(...attachment.getAnnotations(includeTrashed));
+			}
 		}
 	}
-	else if (this.isFileAttachment()) {
-		annotations = this.getAnnotations(includeTrashed);
+	else if (includeAnnotations && this.isFileAttachment()) {
+		descendents.push(...this.getAnnotations(includeTrashed));
 	}
-	return [...attachments, ...notes, ...annotations];
+	return descendents;
 };
 
 

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -2460,6 +2460,32 @@ Zotero.Item.prototype.numChildren = function (includeTrashed) {
 
 
 /**
+ * Get all descendents of an item -- child notes and attachments of a regular item,
+ * annotations of its file attachments, and annotations of a standalone file attachment
+ *
+ * @param	{Boolean}	includeTrashed		Include trashed items
+ * @return	{Zotero.Item[]}
+ */
+Zotero.Item.prototype.getAllDescendents = function (includeTrashed) {
+	let attachments = [];
+	let notes = [];
+	let annotations = [];
+	if (this.isRegularItem()) {
+		attachments = Zotero.Items.get(this.getAttachments(includeTrashed));
+		notes = Zotero.Items.get(this.getNotes(includeTrashed));
+		for (let attachment of attachments) {
+			if (!attachment.isFileAttachment()) continue;
+			annotations.push(...attachment.getAnnotations(includeTrashed));
+		}
+	}
+	else if (this.isFileAttachment()) {
+		annotations = this.getAnnotations(includeTrashed);
+	}
+	return [...attachments, ...notes, ...annotations];
+};
+
+
+/**
  * @return	{String|FALSE}	 Key of the parent item for an attachment or note, or FALSE if none
  */
 Zotero.Item.prototype.getSourceKey = function () {

--- a/chrome/content/zotero/xpcom/data/items.js
+++ b/chrome/content/zotero/xpcom/data/items.js
@@ -1336,7 +1336,7 @@ Zotero.Items = function () {
 				
 				// Remove all child items too
 				if (item.isRegularItem()) {
-					allItems.push(...this.get(item.getNotes(true).concat(item.getAttachments(true))));
+					allItems.push(...item.getDescendantItems({ includeTrashed: true, includeAnnotations: false }));
 				}
 				
 				allItems.push(item);

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -2151,8 +2151,10 @@ class Reader {
 						}
 					}
 					else if (event === 'delete') {
-						// Annotations are removed from the reader when they are trashed
-						// so 'delete' requires no extra handling after
+						// Annotations are already removed from the reader - it happens when they are trashed.
+						// If annotation is erased, just ensure it cannot be restored from the reader.
+						let annotationKeys = Object.keys(extraData || {}).map(id => extraData[id].key);
+						reader.clearAnnotationsEditHistory(Components.utils.cloneInto(annotationKeys, reader._iframeWindow));
 					}
 					else {
 						if (['add', 'modify'].includes(event)) {

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -46,6 +46,16 @@ const READ_ALOUD_VOICE_DEFAULTS_PATH = PathUtils.join(Zotero.Profile.dir, 'readA
 // Whether the Read Aloud audio cache has been pruned of stale versions this session
 let readAloudCachePruned = false;
 
+// Fluent messages for the undoable actions the reader reports
+const UNDO_ACTIONS = {
+	'add-annotations': 'undo-action-add-annotation',
+	'update-annotations': 'undo-action-edit-annotation',
+	'delete-annotations': 'undo-action-delete-annotation',
+	'convert-annotations': 'undo-action-convert-annotation',
+	'merge-annotations': 'undo-action-merge-annotations',
+};
+const UNDO_ACTION_FALLBACK = 'undo-action-edit-annotation';
+
 class ReaderInstance {
 	constructor(options) {
 		this.stateFileName = '.zotero-reader-state';
@@ -404,6 +414,11 @@ class ReaderInstance {
 			onChangeSidebarView: (view) => {
 				Zotero.Prefs.set('reader.lastSidebarTab', view);
 			},
+			// Passing this hands undo/redo over to us, so leave it out when the
+			// undo history is disabled and let the reader keep handling its own
+			onChangeUndoHistory: Zotero.UndoHistory.isEnabled()
+				? history => this._updateUndoHistory(history)
+				: undefined,
 			onSetPopupPosition: (id, position) => {
 				this._setPopupPosition(id, position);
 			},
@@ -647,6 +662,8 @@ class ReaderInstance {
 			},
 		}, this._iframeWindow, { cloneFunctions: true }));
 
+		this._registerUndoHistoryProvider();
+
 		this._resolveInitPromise();
 		// Set title once again, because `ReaderWindow` isn't loaded the first time
 		this.updateTitle();
@@ -692,11 +709,62 @@ class ReaderInstance {
 		};
 	}
 
+	/**
+	 * Take part in the app-wide undo history, which owns the Undo/Redo commands
+	 * and interleaves the reader's annotation changes with changes made
+	 * elsewhere. The reader keeps its own annotation snapshots, so it does the
+	 * stepping itself and only reports what its history looks like.
+	 */
+	_registerUndoHistoryProvider() {
+		if (this._isTransient() || !Zotero.UndoHistory.isEnabled()) {
+			return;
+		}
+		Zotero.UndoHistory.registerProvider(this._instanceID, {
+			libraryID: this._item.libraryID,
+			window: this._iframeWindow,
+			undo: () => this._internalReader.undo(),
+			redo: () => this._internalReader.redo(),
+			reveal: () => this.reveal()
+		});
+	}
+
+	_updateUndoHistory(history) {
+		if (this._isTransient()) {
+			return;
+		}
+		try {
+			let { undoSteps, redoSteps } = JSON.parse(JSON.stringify(history));
+			Zotero.UndoHistory.setProviderSteps(this._instanceID, {
+				undoSteps: undoSteps.map(step => this._toUndoHistoryStep(step)),
+				redoSteps: redoSteps.map(step => this._toUndoHistoryStep(step))
+			});
+		}
+		catch (e) {
+			// Never let a problem here interfere with annotation editing
+			Zotero.logError(e);
+		}
+	}
+
+	_toUndoHistoryStep({ id, revision, action, count }) {
+		return {
+			id,
+			revision,
+			action: UNDO_ACTIONS[action] || UNDO_ACTION_FALLBACK,
+			actionArgs: { count }
+		};
+	}
+
+	/**
+	 * Bring this reader into view.
+	 */
+	reveal() {}
+
 	uninit() {
 		if (this._isUninitialized) {
 			return;
 		}
 		this._isUninitialized = true;
+		Zotero.UndoHistory.unregisterProvider(this._instanceID);
 		if (this._customEventHandler && this._iframeWindow) {
 			try {
 				this._iframeWindow.removeEventListener('customEvent', this._customEventHandler);
@@ -2075,6 +2143,16 @@ class ReaderTab extends ReaderInstance {
 		}
 	}
 
+	reveal() {
+		if (this._isTabClosed) {
+			return;
+		}
+		this._window.Zotero_Tabs.select(this.tabID);
+		if (Services.focus.activeWindow !== this._window) {
+			this._window.focus();
+		}
+	}
+
 	_handleLoad = (event) => {
 		if (this._iframe && this._iframe.contentWindow && this._iframe.contentWindow.document === event.target) {
 			this._window.removeEventListener('DOMContentLoaded', this._handleLoad);
@@ -2222,6 +2300,12 @@ class ReaderWindow extends ReaderInstance {
 				this._window.onViewMenuOpen = this._onViewMenuOpen.bind(this);
 				this._window.onWindowMenuOpen = this._onWindowMenuOpen.bind(this);
 				this._window.reader = this;
+				// Register a window controller for undo/redo, as the main window
+				// does. Appending (rather than inserting at 0) ensures
+				// text-editing controllers take priority.
+				this._window.controllers.appendController(
+					Zotero.UndoHistory.getController(this._window.document)
+				);
 				this._iframe = this._window.document.getElementById('reader');
 				this._iframe.docShell.windowDraggingAllowed = true;
 			}
@@ -2251,6 +2335,10 @@ class ReaderWindow extends ReaderInstance {
 		this.uninit();
 		this._window.close();
 		this._onClose();
+	}
+
+	reveal() {
+		this._window.focus();
 	}
 
 	_setTitleValue(title) {
@@ -2292,6 +2380,7 @@ class ReaderWindow extends ReaderInstance {
 			return;
 		}
 		this._window.goUpdateGlobalEditMenuItems(true);
+		Zotero.UndoHistory.updateMenuItems(this._window.document);
 
 		this.onUpdateCustomMenus(event, 'edit', popup);
 	}
@@ -2882,7 +2971,7 @@ class Reader {
 	getByTabID(tabID) {
 		return this._readers.find(r => (r instanceof ReaderTab) && r.tabID === tabID);
 	}
-	
+
 	getWindowStates() {
 		return this._readers
 			.filter(r => r instanceof ReaderWindow)

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -50,7 +50,7 @@ let readAloudCachePruned = false;
 const UNDO_ACTIONS = {
 	'add-annotations': 'undo-action-add-annotation',
 	'update-annotations': 'undo-action-edit-annotation',
-	'delete-annotations': 'undo-action-delete-annotation',
+	'delete-annotations': 'undo-action-trash-annotation',
 	'convert-annotations': 'undo-action-convert-annotation',
 	'merge-annotations': 'undo-action-merge-annotations',
 };
@@ -250,6 +250,8 @@ class ReaderInstance {
 			location,
 			readOnly: this._isReadOnly(),
 			preview,
+			// Deleted annotations are sent to the trash rather than erased
+			trashesAnnotations: true,
 			authorName: this._item.library.libraryType === 'group' ? Zotero.Users.getCurrentName() : '',
 			showContextPaneToggle: this._showContextPaneToggle,
 			sidebarWidth: this._sidebarWidth,
@@ -319,6 +321,12 @@ class ReaderInstance {
 						}
 						// Save annotation, and save image to cache
 						else {
+							// Trashed annotations never appear in the reader's annotations array,
+							// so a save for a trashed item can only mean the reader undid the
+							// trashing (see onDeleteAnnotations), and the item should be restored
+							if (item && item.deleted) {
+								item.deleted = false;
+							}
 							// Delete authorName to prevent setting annotationAuthorName unnecessarily
 							delete annotation.authorName;
 							let savedAnnotation = await Zotero.Annotations.saveFromJSON(attachment, annotation, saveOptions);
@@ -348,14 +356,18 @@ class ReaderInstance {
 				let libraryID = attachment.libraryID;
 				let notifierQueue = new Zotero.Notifier.Queue();
 				try {
-					for (let key of keys) {
-						let annotation = Zotero.Items.getByLibraryAndKey(libraryID, key);
-						// Make sure the annotation actually belongs to the current PDF
-						if (annotation && annotation.isAnnotation() && annotation.parentID === this._item.id) {
-							this.annotationItemIDs = this.annotationItemIDs.filter(id => id !== annotation.id);
-							await annotation.eraseTx({ notifierQueue });
+					// Deleted annotations are sent to the trash
+					await Zotero.DB.executeTransaction(async () => {
+						for (let key of keys) {
+							let annotation = Zotero.Items.getByLibraryAndKey(libraryID, key);
+							// Make sure the annotation actually belongs to the current PDF
+							if (annotation && annotation.isAnnotation() && annotation.parentID === this._item.id) {
+								this.annotationItemIDs = this.annotationItemIDs.filter(id => id !== annotation.id);
+								annotation.deleted = true;
+								await annotation.save({ notifierQueue });
+							}
 						}
-					}
+					});
 				}
 				catch (e) {
 					this.displayError(e);
@@ -814,6 +826,12 @@ class ReaderInstance {
 
 	unsetAnnotations(keys) {
 		this._internalReader.unsetAnnotations(Components.utils.cloneInto(keys, this._iframeWindow));
+	}
+
+	// Drop reader history points referencing permanently deleted annotations,
+	// so they can't be recreated with the same keys by undo/redo
+	clearAnnotationsHistory(keys) {
+		this._internalReader.clearAnnotationsHistory?.(Components.utils.cloneInto(keys, this._iframeWindow));
 	}
 
 	async navigate(location) {
@@ -2923,11 +2941,30 @@ class Reader {
 					if (event === 'trash' && (ids.includes(item.id) || ids.includes(item.parentItemID))) {
 						reader.close();
 					}
+					else if (event === 'trash') {
+						// Trashed annotations are removed from the reader
+						let trashedKeys = item.getAnnotations(true)
+							.filter(annotation => ids.includes(annotation.id))
+							.map(annotation => annotation.key);
+						if (trashedKeys.length) {
+							reader.annotationItemIDs = item.getAnnotations().map(x => x.id);
+							reader.unsetAnnotations(trashedKeys);
+						}
+					}
 					else if (event === 'delete') {
 						let disappearedIDs = reader.annotationItemIDs.filter(x => ids.includes(x));
 						if (disappearedIDs.length) {
 							let keys = disappearedIDs.map(id => extraData[id].key);
 							reader.unsetAnnotations(keys);
+						}
+						// Permanently deleted annotations must not be recreatable by
+						// replaying reader history.
+						let erasedKeys = ids
+							.map(id => extraData?.[id])
+							.filter(data => data && data.libraryID === item.libraryID)
+							.map(data => data.key);
+						if (erasedKeys.length) {
+							reader.clearAnnotationsHistory(erasedKeys);
 						}
 					}
 					else {

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -360,7 +360,7 @@ class ReaderInstance {
 					await Zotero.DB.executeTransaction(async () => {
 						for (let key of keys) {
 							let annotation = Zotero.Items.getByLibraryAndKey(libraryID, key);
-							// Make sure the annotation actually belongs to the current PDF
+							// Make sure the annotation actually belongs to the current attachment
 							if (annotation && annotation.isAnnotation() && annotation.parentID === this._item.id) {
 								this.annotationItemIDs = this.annotationItemIDs.filter(id => id !== annotation.id);
 								annotation.deleted = true;

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -824,14 +824,14 @@ class ReaderInstance {
 		}
 	}
 
-	unsetAnnotations(keys) {
-		this._internalReader.unsetAnnotations(Components.utils.cloneInto(keys, this._iframeWindow));
-	}
-
-	// Drop reader history points referencing permanently deleted annotations,
-	// so they can't be recreated with the same keys by undo/redo
-	clearAnnotationsHistory(keys) {
-		this._internalReader.clearAnnotationsHistory?.(Components.utils.cloneInto(keys, this._iframeWindow));
+	// Pass permanentlyDeleted for annotations that were erased rather than
+	// trashed, so the reader also drops its history points referencing them
+	// and undo/redo can't recreate them with the same keys
+	unsetAnnotations(keys, permanentlyDeleted) {
+		this._internalReader.unsetAnnotations(
+			Components.utils.cloneInto(keys, this._iframeWindow),
+			permanentlyDeleted
+		);
 	}
 
 	async navigate(location) {
@@ -2952,19 +2952,14 @@ class Reader {
 						}
 					}
 					else if (event === 'delete') {
-						let disappearedIDs = reader.annotationItemIDs.filter(x => ids.includes(x));
-						if (disappearedIDs.length) {
-							let keys = disappearedIDs.map(id => extraData[id].key);
-							reader.unsetAnnotations(keys);
-						}
-						// Permanently deleted annotations must not be recreatable by
-						// replaying reader history.
+						// Erased non-annotation keys can't match anything in the reader,
+						// so all keys deleted from the library can be passed as is
 						let erasedKeys = ids
 							.map(id => extraData?.[id])
 							.filter(data => data && data.libraryID === item.libraryID)
 							.map(data => data.key);
 						if (erasedKeys.length) {
-							reader.clearAnnotationsHistory(erasedKeys);
+							reader.unsetAnnotations(erasedKeys, true);
 						}
 					}
 					else {

--- a/chrome/content/zotero/xpcom/undoHistory.js
+++ b/chrome/content/zotero/xpcom/undoHistory.js
@@ -40,6 +40,11 @@
  * stageAction is opt-in via save({ undoAction, undoActionArgs }) or by an
  * outer caller invoking Zotero.UndoHistory.stageAction() directly inside
  * the transaction.
+ *
+ * Components that maintain their own history of undoable changes participate
+ * via registerProvider() and setProviderSteps(). Their steps are interleaved
+ * with the entries captured here. Providers are responsible for
+ * undoing/reapplying their changes themselves.
  */
 Zotero.UndoHistory = {
 	_undoStack: [],
@@ -47,6 +52,7 @@ Zotero.UndoHistory = {
 	_pendingEntry: null,
 	_maxSteps: 100,
 	_opQueue: Promise.resolve(),
+	_providers: new Map(),
 
 	init() {
 		// default (100) when unset or non-numeric. 0 (or less) disables undo/redo entirely.
@@ -73,9 +79,155 @@ Zotero.UndoHistory = {
 	 * @param {Integer} libraryID
 	 */
 	clearForLibrary(libraryID) {
-		let affectsLibrary = entry => entry.changes.some(change => change.libraryID === libraryID);
+		let affectsLibrary = entry => (entry.providerID
+			? entry.libraryID === libraryID
+			: entry.changes.some(change => change.libraryID === libraryID));
 		if (this._undoStack.some(affectsLibrary) || this._redoStack.some(affectsLibrary)) {
 			this.clear();
+		}
+	},
+
+	/**
+	 * Register a component that keeps its own history of undoable changes and
+	 * wants those changes to take part in the app-wide undo/redo commands.
+	 *
+	 * The provider reports its history with setProviderSteps() and does the
+	 * actual work in undo() and redo(), each of which steps the provider's
+	 * own history by one and returns whether it did so.
+	 *
+	 * @param {String} providerID
+	 * @param {Object} options
+	 * @param {Integer} options.libraryID Library the provider's changes belong to
+	 * @param {Function} options.undo () => boolean | Promise<boolean>
+	 * @param {Function} options.redo () => boolean | Promise<boolean>
+	 * @param {Function} [options.reveal] Bring the provider into view after a step
+	 * @param {Window} [options.window] Frame the provider's changes are made in,
+	 *     which therefore shouldn't be left to handle undo/redo itself
+	 */
+	registerProvider(providerID, { libraryID, undo, redo, reveal, window }) {
+		this._providers.set(providerID,
+			{ libraryID, undo, redo, reveal, window, lastStepID: 0 });
+	},
+
+	/**
+	 * Unregister a provider and discard its entries, since nothing can apply
+	 * them anymore
+	 *
+	 * @param {String} providerID
+	 */
+	unregisterProvider(providerID) {
+		if (this._providers.delete(providerID)) {
+			this._filterEntries(entry => entry.providerID !== providerID);
+		}
+	},
+
+	/**
+	 * Bring a provider's entries in line with the provider's own history.
+	 *
+	 * Steps are ordered oldest first and identified by an id that increases
+	 * monotonically, plus a revision that changes when a step absorbs a later
+	 * change (e.g., continued typing in an annotation comment). Steps the
+	 * provider no longer has are dropped; steps newer than any we've seen are
+	 * pushed onto the undo stack; and a step whose revision changed moves back
+	 * to the top of the stack, since it now covers the most recent change.
+	 *
+	 * @param {String} providerID
+	 * @param {Object} history
+	 * @param {{ id, revision, action, actionArgs }[]} history.undoSteps
+	 * @param {{ id, revision, action, actionArgs }[]} history.redoSteps
+	 */
+	setProviderSteps(providerID, { undoSteps = [], redoSteps = [] }) {
+		let provider = this._providers.get(providerID);
+		if (!provider || !this.isEnabled()) {
+			return;
+		}
+		let stepIDs = new Set([...undoSteps, ...redoSteps].map(step => step.id));
+		this._filterEntries(
+			entry => entry.providerID !== providerID || stepIDs.has(entry.stepID)
+		);
+		let added = false;
+		for (let step of undoSteps) {
+			if (step.id > provider.lastStepID) {
+				this._undoStack.push({
+					providerID,
+					stepID: step.id,
+					revision: step.revision,
+					libraryID: provider.libraryID,
+					action: step.action,
+					actionArgs: step.actionArgs || null
+				});
+				added = true;
+				continue;
+			}
+			let index = this._undoStack.findIndex(
+				entry => entry.providerID === providerID && entry.stepID === step.id);
+			if (index !== -1 && this._undoStack[index].revision !== step.revision) {
+				let [entry] = this._undoStack.splice(index, 1);
+				entry.revision = step.revision;
+				this._undoStack.push(entry);
+			}
+		}
+		provider.lastStepID = Math.max(provider.lastStepID, ...stepIDs);
+		if (added) {
+			this._redoStack = [];
+			this._trimUndoStack();
+		}
+	},
+
+	_filterEntries(keep) {
+		this._undoStack = this._undoStack.filter(keep);
+		this._redoStack = this._redoStack.filter(keep);
+	},
+
+	/**
+	 * Bring the context a change was made in back into view, so the user can see
+	 * what an undo or redo did. Providers know how to reveal themselves; for
+	 * entries we manage, focus the tab where the change was made.
+	 *
+	 * @param {Object} entry
+	 */
+	_revealEntry(entry) {
+		try {
+			if (entry.providerID) {
+				let provider = this._providers.get(entry.providerID);
+				if (provider && provider.reveal) {
+					provider.reveal();
+				}
+				return;
+			}
+			this._revealTab(entry.tabID);
+		}
+		catch (e) {
+			// A change that can't be revealed has still been applied
+			Zotero.logError(e);
+		}
+	},
+
+	/**
+	 * Select a tab in the main window, bringing the window itself forward if
+	 * it's not the one in front (e.g. when undoing from a reader window)
+	 *
+	 * @param {String} tabID
+	 */
+	_revealTab(tabID) {
+		let win = Zotero.getMainWindow();
+		// The tab may have been closed since the change was made
+		if (!tabID || !win?.Zotero_Tabs?._getTab(tabID).tab) {
+			return;
+		}
+		win.Zotero_Tabs.select(tabID);
+		if (Services.focus.activeWindow !== win) {
+			win.focus();
+		}
+	},
+
+	_getSelectedTabID() {
+		return Zotero.getMainWindow()?.Zotero_Tabs?.selectedID || null;
+	},
+
+	_trimUndoStack() {
+		if (this._undoStack.length > this._maxSteps) {
+			this._undoStack.splice(0, this._undoStack.length - this._maxSteps);
 		}
 	},
 
@@ -146,17 +298,22 @@ Zotero.UndoHistory = {
 	},
 
 	_hasNativeCommand(doc, cmd) {
-		// If focus is in a child window (e.g. note-editor or reader iframe),
-		// it handles its own undo/redo internally
+		// If focus is in a child frame, it handles its own undo/redo internally
+		// (e.g. the note editor)... unless it has a provider here, in which case
+		// its changes are ours to undo and only text editing within it wins
 		let focusedWindow = doc.commandDispatcher.focusedWindow;
 		if (focusedWindow && focusedWindow !== doc.defaultView) {
-			return true;
+			if (!this._getProviderForWindow(focusedWindow)) {
+				return true;
+			}
+			return this._isTextBoxFocused(focusedWindow);
 		}
 		let el = doc.commandDispatcher.focusedElement;
 		if (!el) return false;
-		// Iframes (note-editor, reader) handle their own undo/redo
-		// internally but don't expose XUL controllers for it
-		if (el.tagName === 'iframe' || el.tagName === 'IFRAME') return true;
+		if (['iframe', 'browser'].includes(el.localName)
+				&& !this._getProviderForWindow(el.contentWindow)) {
+			return true;
+		}
 		let controllers;
 		try {
 			controllers = el.controllers;
@@ -172,6 +329,40 @@ Zotero.UndoHistory = {
 			}
 		}
 		return false;
+	},
+
+	/**
+	 * The provider that records the changes made in a given frame, if any
+	 *
+	 * @param {Window} win
+	 * @return {Object|undefined}
+	 */
+	_getProviderForWindow(win) {
+		// Collect the frame and its ancestors, since focus may be in a frame
+		// nested inside the provider's own (e.g., a reader's view iframe)
+		let frames = [];
+		for (; win && !frames.includes(win); win = win.parent) {
+			frames.push(win);
+		}
+		for (let provider of this._providers.values()) {
+			if (provider.window && frames.includes(provider.window)) {
+				return provider;
+			}
+		}
+		return undefined;
+	},
+
+	/**
+	 * Whether the focused element in a frame is a text box, meaning native text
+	 * editing owns undo/redo for it
+	 *
+	 * @param {Window} win
+	 * @return {Boolean}
+	 */
+	_isTextBoxFocused(win) {
+		let el = win.document.activeElement;
+		return !!el
+			&& (el.isContentEditable || ['input', 'textarea'].includes(el.localName));
 	},
 
 	/**
@@ -239,6 +430,9 @@ Zotero.UndoHistory = {
 	async _apply({ fromStack, toStack, staleSide, applySide, label }) {
 		let entry = this[fromStack].pop();
 		if (!entry) return false;
+		if (entry.providerID) {
+			return this._applyProviderEntry(entry, { toStack, label });
+		}
 		let stale = false;
 		try {
 			await Zotero.DB.executeTransaction(async () => {
@@ -267,6 +461,7 @@ Zotero.UndoHistory = {
 				return false;
 			}
 			this[toStack].push(entry);
+			this._revealEntry(entry);
 			return true;
 		}
 		catch (e) {
@@ -281,6 +476,43 @@ Zotero.UndoHistory = {
 		}
 	},
 
+	/**
+	 * Hand an entry back to the provider that recorded it. The provider holds
+	 * the snapshots and does its own staleness checking, so all that's left
+	 * here is to step it and move the entry to the opposite stack.
+	 *
+	 * A provider that declines (or is gone) is out of step with us, so we drop
+	 * the rest of its entries rather than risk applying them out of order.
+	 * Entries captured here are self-contained, so the stacks are otherwise
+	 * left alone.
+	 *
+	 * @param {Object} entry
+	 * @param {Object} opts
+	 * @param {String} opts.toStack -- name of the stack to push the entry to on success
+	 * @param {String} opts.label -- 'undo' or 'redo'
+	 * @return {Promise<Boolean>} -- true if the entry was applied
+	 */
+	async _applyProviderEntry(entry, { toStack, label }) {
+		let provider = this._providers.get(entry.providerID);
+		let applied = false;
+		try {
+			if (provider) {
+				applied = !!(await (label === 'undo' ? provider.undo() : provider.redo()));
+			}
+		}
+		catch (e) {
+			Zotero.debug(`UndoHistory: ${label} failed for provider ${entry.providerID}: ` + e);
+		}
+		if (!applied) {
+			Zotero.debug(`UndoHistory: declining ${label} entry for provider ${entry.providerID}`);
+			this._filterEntries(other => other.providerID !== entry.providerID);
+			return false;
+		}
+		this[toStack].push(entry);
+		this._revealEntry(entry);
+		return true;
+	},
+
 	// -- Transaction lifecycle callbacks --
 
 	_onTransactionBegin(_id) {
@@ -293,15 +525,32 @@ Zotero.UndoHistory = {
 		if (this._pendingEntry && this._pendingEntry.changes.length && this._pendingEntry.action) {
 			this._undoStack.push(this._pendingEntry);
 			this._redoStack = [];
-			if (this._undoStack.length > this._maxSteps) {
-				this._undoStack.splice(0, this._undoStack.length - this._maxSteps);
-			}
+			this._trimUndoStack();
 		}
 		this._pendingEntry = null;
 	},
 
 	_onTransactionRollback(_id) {
 		this._pendingEntry = null;
+	},
+
+	/**
+	 * The entry being staged by the current transaction, created on first use.
+	 * It records the tab the change is being made in, so that undoing it later
+	 * from somewhere else can bring the user back.
+	 *
+	 * @return {Object}
+	 */
+	_ensurePendingEntry() {
+		if (!this._pendingEntry) {
+			this._pendingEntry = {
+				changes: [],
+				action: null,
+				actionArgs: null,
+				tabID: this._getSelectedTabID()
+			};
+		}
+		return this._pendingEntry;
 	},
 
 	/**
@@ -321,11 +570,9 @@ Zotero.UndoHistory = {
 			return;
 		}
 		Zotero.DB.requireTransaction();
-		if (!this._pendingEntry) {
-			this._pendingEntry = { changes: [], action: null, actionArgs: null };
-		}
-		this._pendingEntry.action = action;
-		this._pendingEntry.actionArgs = actionArgs || null;
+		let entry = this._ensurePendingEntry();
+		entry.action = action;
+		entry.actionArgs = actionArgs || null;
 	},
 
 	/**
@@ -351,6 +598,40 @@ Zotero.UndoHistory = {
 	},
 
 	/**
+	 * Update the Undo/Redo items in a window's Edit menu to name the action
+	 * they would apply (e.g. "Undo Add Tag")
+	 *
+	 * @param {Document} doc
+	 */
+	updateMenuItems(doc) {
+		// When a native text-editing controller handles undo/redo (e.g. focused
+		// input), show generic labels and let it take over
+		this._updateMenuItem(doc, 'menu_undo', 'text-action-undo', 'menu-edit-undo-action',
+			!this.hasNativeUndo(doc) && this.getUndoAction());
+		this._updateMenuItem(doc, 'menu_redo', 'text-action-redo', 'menu-edit-redo-action',
+			!this.hasNativeRedo(doc) && this.getRedoAction());
+	},
+
+	_updateMenuItem(doc, id, genericMessageID, actionMessageID, action) {
+		let menuitem = doc.getElementById(id);
+		if (!menuitem) {
+			return;
+		}
+		if (action) {
+			let actionLabel = Zotero.ftl.formatValueSync(
+				action.action, action.actionArgs || undefined
+			);
+			menuitem.removeAttribute('data-l10n-id');
+			menuitem.setAttribute('label', Zotero.ftl.formatValueSync(
+				actionMessageID, { action: actionLabel }
+			));
+		}
+		else {
+			doc.l10n.setAttributes(menuitem, genericMessageID);
+		}
+	},
+
+	/**
 	 * Stage a change record. Must be called inside a transaction; without
 	 * a matching stageAction() in the same transaction, the record is
 	 * discarded at commit.
@@ -367,9 +648,7 @@ Zotero.UndoHistory = {
 			return;
 		}
 		Zotero.DB.requireTransaction();
-		if (!this._pendingEntry) {
-			this._pendingEntry = { changes: [], action: null, actionArgs: null };
-		}
+		this._ensurePendingEntry();
 		let existing = this._pendingEntry.changes.find(
 			c => c.objectType === changeRecord.objectType && c.id === changeRecord.id);
 		if (existing) {

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -2436,16 +2436,20 @@ var ZoteroPane = new function () {
 					if (!parent.isNote()) {
 						childIDs.push(...parent.getNotes(true));
 					}
-					if (!parent.isAttachment()) {
-						let attachmentIDs = parent.getAttachments(true);
-						childIDs.push(...attachmentIDs);
-						// Include annotations of attachments
-						for (let attachmentID of attachmentIDs) {
-							let attachment = Zotero.Items.get(attachmentID);
-							if (attachment.isFileAttachment()) {
-								let annotations = attachment.getAnnotations(true);
-								childIDs.push(...annotations.map(a => a.id));
-							}
+					let attachmentIDs = [];
+					if (parent.isRegularItem()) {
+						attachmentIDs = parent.getAttachments(true);
+					}
+					else if (parent.isAttachment()) {
+						attachmentIDs = [parent.id];
+					}
+					childIDs.push(...attachmentIDs);
+					// Include annotations of attachments
+					for (let attachmentID of attachmentIDs) {
+						let attachment = Zotero.Items.get(attachmentID);
+						if (attachment.isFileAttachment()) {
+							let annotations = attachment.getAnnotations(true);
+							childIDs.push(...annotations.map(a => a.id));
 						}
 					}
 				}

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -4057,8 +4057,8 @@ var ZoteroPane = new function () {
 		}
 
 		// Only keep annotation-specific options if annotations are selected
-		let annotationsSelected = items.some(item => item.isAnnotation());
-		if (annotationsSelected) {
+		let selectedAnnotations = items.filter(item => item.isAnnotation());
+		if (selectedAnnotations.length) {
 			let menuItemsForAnnotations = [
 				'createNoteFromAnnotations',
 				'deleteFromLibrary',
@@ -4068,6 +4068,10 @@ var ZoteroPane = new function () {
 			for (let i in m) {
 				if (menuItemsForAnnotations.includes(i)) continue;
 				show.delete(m[i]);
+			}
+			// Cannot trash external annotations or annotations made by other users
+			if (selectedAnnotations.some(item => !item.isEditable() || item.annotationIsExternal)) {
+				disable.add(m.moveToTrash);
 			}
 		}
 
@@ -4099,7 +4103,7 @@ var ZoteroPane = new function () {
 		}
 
 		// No locate menu options if annotations are selected
-		if (annotationsSelected) return;
+		if (selectedAnnotations.length) return;
 
 		// add locate menu options
 		await Zotero_LocateMenu.buildContextMenu(menu, true);

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -2859,7 +2859,7 @@ var ZoteroPane = new function () {
 				}
 
 				let parent = this.itemsView.getRow(row).ref;
-				let childIDs = [];
+				let childItems = [];
 				let subcollections = [];
 				if (parent instanceof Zotero.Collection) {
 					// If the restored item is a collection, restore its subcollections too
@@ -2868,26 +2868,8 @@ var ZoteroPane = new function () {
 					}
 				}
 				else {
-					if (!parent.isNote()) {
-						childIDs.push(...parent.getNotes(true));
-					}
-					// Include annotations of the item's file attachments, or of the item
-					// itself for a standalone file attachment
-					let fileAttachments = [];
-					if (parent.isRegularItem()) {
-						let attachmentIDs = parent.getAttachments(true);
-						childIDs.push(...attachmentIDs);
-						fileAttachments = Zotero.Items.get(attachmentIDs)
-							.filter(attachment => attachment.isFileAttachment());
-					}
-					else if (parent.isFileAttachment()) {
-						fileAttachments = [parent];
-					}
-					for (let attachment of fileAttachments) {
-						childIDs.push(...attachment.getAnnotations(true).map(a => a.id));
-					}
+					childItems = parent.getDescendantItems({ includeTrashed: true });
 				}
-				let childItems = Zotero.Items.get(childIDs);
 				if (isSelected(parent)) {
 					if (parent.deleted) {
 						parent.deleted = false;

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -2529,12 +2529,14 @@ var ZoteroPane = new function () {
 		else if (collectionTreeRows[0].isShare()) {
 			return false;
 		}
-		// If multiple items are selected and only some are annotations, disallow delete unless we
-		// are in the trash, in which case any selected item can be erased
-		let selected = this.itemsView.getSelectedItems();
-		if (!selected.every(item => item.isAnnotation())
-			&& selected.some(item => item.isAnnotation())) {
-			return collectionTreeRows[0].isTrash();
+		// Outside the trash, disallow if the selection includes annotations that can't be
+		// trashed -- ones made by other users or stored externally in the file
+		if (!collectionTreeRows[0].isTrash()) {
+			let selected = this.itemsView.getSelectedItems();
+			if (selected.some(item => item.isAnnotation()
+					&& (!item.isEditable() || item.annotationIsExternal))) {
+				return false;
+			}
 		}
 		return true;
 	};
@@ -2586,11 +2588,7 @@ var ZoteroPane = new function () {
 			return;
 		}
 		var prompt;
-		// Backspace on annotation items = prompt to erase
-		if (this.itemsView.getSelectedItems().every(item => item.isAnnotation())) {
-			prompt = toDelete;
-		}
-		else if (collectionTreeRows[0].isPublications()) {
+		if (collectionTreeRows[0].isPublications()) {
 			let toRemoveFromPublications = {
 				title: Zotero.getString('pane.items.removeFromPublications.title'),
 				text: Zotero.getString(
@@ -2873,8 +2871,20 @@ var ZoteroPane = new function () {
 					if (!parent.isNote()) {
 						childIDs.push(...parent.getNotes(true));
 					}
-					if (!parent.isAttachment()) {
-						childIDs.push(...parent.getAttachments(true));
+					// Include annotations of the item's file attachments, or of the item
+					// itself for a standalone file attachment
+					let fileAttachments = [];
+					if (parent.isRegularItem()) {
+						let attachmentIDs = parent.getAttachments(true);
+						childIDs.push(...attachmentIDs);
+						fileAttachments = Zotero.Items.get(attachmentIDs)
+							.filter(attachment => attachment.isFileAttachment());
+					}
+					else if (parent.isFileAttachment()) {
+						fileAttachments = [parent];
+					}
+					for (let attachment of fileAttachments) {
+						childIDs.push(...attachment.getAnnotations(true).map(a => a.id));
 					}
 				}
 				let childItems = Zotero.Items.get(childIDs);
@@ -4623,15 +4633,21 @@ var ZoteroPane = new function () {
 		}
 
 		// Only keep annotation-specific options if annotations are selected
-		let annotationsSelected = items.some(item => item.isAnnotation());
-		if (annotationsSelected) {
+		let selectedAnnotations = items.filter(item => item.isAnnotation());
+		if (selectedAnnotations.length) {
 			let menuItemsForAnnotations = [
 				'createNoteFromAnnotations',
-				'deleteFromLibrary'
+				'deleteFromLibrary',
+				'restoreToLibrary',
+				'moveToTrash'
 			];
 			for (let i in m) {
 				if (menuItemsForAnnotations.includes(i)) continue;
 				show.delete(m[i]);
+			}
+			// Cannot trash external annotations or annotations made by other users
+			if (selectedAnnotations.some(item => !item.isEditable() || item.annotationIsExternal)) {
+				disable.add(m.moveToTrash);
 			}
 		}
 
@@ -4662,7 +4678,7 @@ var ZoteroPane = new function () {
 		}
 
 		// No locate menu options if annotations are selected
-		if (annotationsSelected) return;
+		if (selectedAnnotations.length) return;
 
 		// add locate menu options
 		await Zotero_LocateMenu.buildContextMenu(menu, true);

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -1270,9 +1270,9 @@ undo-action-edit-annotation = { $count ->
     [one] Edit Annotation
    *[other] Edit { $count } Annotations
 }
-undo-action-delete-annotation = { $count ->
-    [one] Delete Annotation
-   *[other] Delete { $count } Annotations
+undo-action-trash-annotation = { $count ->
+    [one] Trash Annotation
+   *[other] Trash { $count } Annotations
 }
 undo-action-convert-annotation = { $count ->
     [one] Convert Annotation

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -1262,6 +1262,26 @@ undo-action-merge-items = { $count ->
     [one] Merge Item
    *[other] Merge { $count } Items
 }
+undo-action-add-annotation = { $count ->
+    [one] Add Annotation
+   *[other] Add { $count } Annotations
+}
+undo-action-edit-annotation = { $count ->
+    [one] Edit Annotation
+   *[other] Edit { $count } Annotations
+}
+undo-action-delete-annotation = { $count ->
+    [one] Delete Annotation
+   *[other] Delete { $count } Annotations
+}
+undo-action-convert-annotation = { $count ->
+    [one] Convert Annotation
+   *[other] Convert { $count } Annotations
+}
+undo-action-merge-annotations = { $count ->
+    [one] Merge Annotation
+   *[other] Merge { $count } Annotations
+}
 menu-edit-undo-action = Undo { $action }
 menu-edit-redo-action = Redo { $action }
 

--- a/test/tests/collectionViewItemTreeTest.js
+++ b/test/tests/collectionViewItemTreeTest.js
@@ -2080,6 +2080,222 @@ describe("CollectionViewItemTree", function () {
 					assert.isFalse(zp.itemsView.getRowIndexByID(o3.treeViewID));
 				})
 			}
+
+			describe("Annotations", function () {
+				async function createItemWithAnnotation() {
+					let item = await createDataObject('item');
+					let attachment = await importFileAttachment('test.pdf', { parentItemID: item.id });
+					let annotation = await createAnnotation('highlight', attachment);
+					return { item, attachment, annotation };
+				}
+
+				it("should trash annotation row on delete in library view", async function () {
+					let { item, attachment, annotation } = await createItemWithAnnotation();
+
+					await selectLibrary(win);
+					await waitForItemsLoad(win);
+					itemsView = zp.itemsView;
+					await itemsView.selectItems([annotation.id]);
+					await itemsView.deleteSelection();
+
+					// The annotation is trashed, not erased, and its row is gone
+					assert.isTrue(annotation.deleted);
+					assert.isFalse(itemsView.getRowIndexByID(annotation.id));
+					assert.isNumber(itemsView.getRowIndexByID(attachment.id));
+					assert.isNumber(itemsView.getRowIndexByID(item.id));
+				});
+
+				it("should show trashed annotation under context rows in the trash", async function () {
+					let { item, attachment, annotation } = await createItemWithAnnotation();
+					annotation.deleted = true;
+					await annotation.saveTx();
+
+					await selectTrash(win);
+					itemsView = zp.itemsView;
+
+					// Untrashed ancestors are shown as context rows
+					assert.isNumber(itemsView.getRowIndexByID(item.id));
+					itemsView.expandAllRows(true);
+					let annotationRow = itemsView.getRowIndexByID(annotation.id);
+					assert.isNumber(annotationRow);
+					assert.equal(itemsView.getRow(annotationRow).type, 'annotation');
+					assert.isNumber(itemsView.getRowIndexByID(attachment.id));
+				});
+
+				it("should remove context rows when the last trashed annotation is restored", async function () {
+					let { item, attachment, annotation } = await createItemWithAnnotation();
+					annotation.deleted = true;
+					await annotation.saveTx();
+
+					await selectTrash(win);
+					itemsView = zp.itemsView;
+					await zp.selectItems([annotation.id]);
+					await zp.restoreSelectedItems();
+
+					assert.isFalse(annotation.deleted);
+					assert.isFalse(itemsView.getRowIndexByID(annotation.id));
+					assert.isFalse(itemsView.getRowIndexByID(attachment.id));
+					assert.isFalse(itemsView.getRowIndexByID(item.id));
+				});
+
+				it("should keep context rows when other trashed annotations remain", async function () {
+					let { item, attachment, annotation } = await createItemWithAnnotation();
+					let annotation2 = await createAnnotation('highlight', attachment);
+					annotation.deleted = true;
+					await annotation.saveTx();
+					annotation2.deleted = true;
+					await annotation2.saveTx();
+
+					await selectTrash(win);
+					itemsView = zp.itemsView;
+					await zp.selectItems([annotation.id]);
+					await zp.restoreSelectedItems();
+
+					assert.isFalse(annotation.deleted);
+					assert.isTrue(annotation2.deleted);
+					assert.isNumber(itemsView.getRowIndexByID(item.id));
+					itemsView.expandAllRows(true);
+					assert.isNumber(itemsView.getRowIndexByID(annotation2.id));
+				});
+
+				it("shouldn't remove context annotation row when it is trashed while viewing the trash", async function () {
+					// Show non-matching annotations so the untrashed annotation
+					// appears as a context row
+					Zotero.Prefs.set("hideContextAnnotationRows", false);
+
+					let { attachment, annotation } = await createItemWithAnnotation();
+					let annotation2 = await createAnnotation('highlight', attachment);
+					annotation.deleted = true;
+					await annotation.saveTx();
+
+					await selectTrash(win);
+					itemsView = zp.itemsView;
+					itemsView.expandAllRows(true);
+					// The untrashed annotation is visible as a context row
+					assert.isNumber(itemsView.getRowIndexByID(annotation2.id));
+
+					// Trash it from outside the view (e.g. the reader or another window)
+					annotation2.deleted = true;
+					await annotation2.saveTx();
+
+					// The row remains, now as a regular trash row
+					assert.isTrue(annotation2.deleted);
+					assert.isNumber(itemsView.getRowIndexByID(annotation2.id));
+
+					Zotero.Prefs.clear("hideContextAnnotationRows");
+				});
+
+				it("should erase annotation permanently when deleted from the trash", async function () {
+					let { annotation } = await createItemWithAnnotation();
+					annotation.deleted = true;
+					await annotation.saveTx();
+
+					await selectTrash(win);
+					itemsView = zp.itemsView;
+					await itemsView.selectItems([annotation.id]);
+					await itemsView.deleteSelection();
+
+					assert.isFalse(Zotero.Items.get(annotation.id));
+				});
+
+				it("should hide non-matching context annotations on first render of the trash", async function () {
+					Zotero.Prefs.set("hideContextAnnotationRows", true);
+
+					let attachment = await importFileAttachment('test.pdf');
+					let annotation1 = await createAnnotation('highlight', attachment);
+					let annotation2 = await createAnnotation('highlight', attachment);
+
+					// Expand the standalone attachment in the library view, so its
+					// open row is carried over into the trash view's row rebuild
+					await waitForItemsLoad(win);
+					itemsView = zp.itemsView;
+					itemsView.expandAllRows(true);
+					assert.isNumber(itemsView.getRowIndexByID(annotation1.id));
+
+					await Zotero.Items.trashTx([annotation1.id]);
+
+					await selectTrash(win);
+					itemsView = zp.itemsView;
+					// Only the trashed annotation is shown; the non-matching context
+					// annotation is hidden from the very first render
+					assert.isNumber(itemsView.getRowIndexByID(annotation1.id));
+					assert.isFalse(itemsView.getRowIndexByID(annotation2.id));
+
+					Zotero.Prefs.clear("hideContextAnnotationRows");
+				});
+
+				it("should render restored annotation row after undoing trash", async function () {
+					let collection = await createDataObject('collection');
+					await select(win, collection);
+					itemsView = zp.itemsView;
+					let item = await createDataObject('item', { collections: [collection.id] });
+					let attachment = await importFileAttachment('test.pdf', { parentItemID: item.id });
+					let annotation = await createAnnotation('highlight', attachment, { comment: "undoTrashUniqueComment" });
+					// A second annotation keeps the attachment container non-empty (and
+					// so expanded) while the first annotation is in the trash
+					await createAnnotation('highlight', attachment);
+					await waitForItemsLoad(win);
+
+					itemsView.expandAllRows(true);
+					assert.isNumber(itemsView.getRowIndexByID(annotation.id));
+
+					await Zotero.Items.trashTx([annotation.id]);
+					assert.isFalse(itemsView.getRowIndexByID(annotation.id));
+
+					// Undo (as via Cmd-Z)
+					await Zotero.UndoHistory.undo();
+					assert.isFalse(annotation.deleted);
+					assert.isNumber(itemsView.getRowIndexByID(annotation.id));
+					// The row is rendered again without any further interaction
+					await waitForCallback(
+						() => [...win.document.querySelectorAll('#zotero-items-tree .annotation-comment')]
+							.some(el => el.textContent.includes("undoTrashUniqueComment")),
+						50, 3
+					);
+				});
+
+				it("should re-render collapsed attachment's twisty when its annotation is restored", async function () {
+					let collection = await createDataObject('collection');
+					await select(win, collection);
+					itemsView = zp.itemsView;
+					let item = await createDataObject('item', { collections: [collection.id] });
+					let attachment = await importFileAttachment('test.pdf', {
+						title: 'twistyRestoreUnique.pdf', parentItemID: item.id
+					});
+					let annotation = await createAnnotation('highlight', attachment);
+					// A note keeps the item's container non-empty (and so expanded)
+					// while the attachment is in the trash
+					await createDataObject('item', { itemType: 'note', parentID: item.id });
+					await waitForItemsLoad(win);
+
+					itemsView.expandAllRows(true);
+					assert.isNumber(itemsView.getRowIndexByID(annotation.id));
+
+					await Zotero.Items.trashTx([annotation.id]);
+					await Zotero.Items.trashTx([attachment.id]);
+					assert.isFalse(itemsView.getRowIndexByID(attachment.id));
+
+					// Undo trashing the attachment: its row is back, rendered as a
+					// non-container since its only annotation is still trashed
+					await Zotero.UndoHistory.undo();
+					assert.isFalse(attachment.deleted);
+					let attachmentRowIndex = itemsView.getRowIndexByID(attachment.id);
+					assert.isNumber(attachmentRowIndex);
+					assert.isTrue(itemsView.isContainerEmpty(attachmentRowIndex));
+
+					// Undo trashing the annotation: the attachment is a container
+					// again and its row gets a twisty without further interaction
+					await Zotero.UndoHistory.undo();
+					assert.isFalse(annotation.deleted);
+					assert.isFalse(itemsView.isContainerEmpty(itemsView.getRowIndexByID(attachment.id)));
+					await waitForCallback(
+						() => [...win.document.querySelectorAll('#zotero-items-tree .row')]
+							.some(rowEl => rowEl.textContent.includes('twistyRestoreUnique')
+								&& rowEl.querySelector('.twisty')),
+						50, 3
+					);
+				});
+			});
 		});
 		
 		describe("My Publications", function () {
@@ -3373,6 +3589,23 @@ describe("CollectionViewItemTree", function () {
 			assert.isFalse(itemsView.getRowIndexByID(childAttachment.id));
 			assert.sameMembers(itemsView.getSelectedItems(true), [parentItem.id]);
 		});
+
+		it("should keep collapsed parent selected when a missing child precedes it in the selection", async function () {
+			let parentItem = await createDataObject('item', { title: 'Parent Item' });
+			let childAttachment = await importFileAttachment('test.png', { parentItemID: parentItem.id });
+			await waitForItemsLoad(win);
+
+			let parentRow = itemsView.getRowIndexByID(parentItem.id);
+			itemsView.rowProvider._closeContainer(parentRow);
+			assert.isFalse(itemsView.isContainerOpen(itemsView.getRowIndexByID(parentItem.id)));
+
+			itemsView.selection.clearSelection();
+			// The missing child selects the parent as a fallback; the parent
+			// itself must not toggle that selection back off
+			await itemsView._restoreSelection([childAttachment, parentItem], false, false);
+
+			assert.sameMembers(itemsView.getSelectedItems(true), [parentItem.id]);
+		});
 	});
 
 	describe("primary cell rendering", function () {
@@ -3503,17 +3736,18 @@ describe("CollectionViewItemTree", function () {
 			assert.deepEqual(rowIDs, zp.itemsView._rows.map(row => row.id));
 		});
 
-		it("should erase annotation on escape when row is selected", async () => {
+		it("should trash annotation row on forced delete", async () => {
 			zp.itemsView.expandAllRows(true);
 
-			// Select and delete ink annotation
+			// Select and trash ink annotation
 			let inkID = ink.id;
 			await zp.itemsView.selectItems([inkID]);
 
-			await zp.itemsView.deleteSelection();
+			await zp.itemsView.deleteSelection(true);
 
-			// Make sure it is deleted and the row is gone
-			assert.isFalse(Zotero.Items.get(inkID));
+			// Make sure it is trashed, not erased, and the row is gone
+			let inkItem = Zotero.Items.get(inkID);
+			assert.isTrue(inkItem.deleted);
 			assert.isFalse(zp.itemsView.getRowIndexByID(inkID));
 		});
 

--- a/test/tests/itemTreeTest.js
+++ b/test/tests/itemTreeTest.js
@@ -1721,6 +1721,20 @@ describe("Zotero.ItemTree", function () {
 			zp.itemsView._restoreSelection(selection);
 			assert.lengthOf(zp.itemsView.getSelectedObjects(), 2);
 		});
+
+		it("should reselect collapsed parent item if child is selected before parent", async function () {
+			let item = await createDataObject('item');
+			let child = await importFileAttachment('test.pdf', { title: 'PDF', parentItemID: item.id });
+			await zp.itemsView.selectItems([child.id, item.id]);
+
+			let itemRowIndex = zp.itemsView.getRowIndexByID(item.id);
+			await zp.itemsView._closeContainer(itemRowIndex, false, true);
+
+			assert.isFalse(zp.itemsView.isContainerOpen(itemRowIndex));
+			let selection = zp.itemsView.getSelectedObjects();
+			let selectedIDs = selection.map(obj => obj.id);
+			assert.sameMembers(selectedIDs, [item.id]);
+		});
 	});
 
 	describe("#_renderPrimaryCell()", function () {

--- a/test/tests/itemTreeTest.js
+++ b/test/tests/itemTreeTest.js
@@ -1809,18 +1809,36 @@ describe("Zotero.ItemTree", function () {
 			assert.deepEqual(rowIDs, zp.itemsView._rows.map(row => row.id));
 		});
 
-		it("should erase annotation on escape when row is selected", async () => {
+		it("should trash annotation row", async () => {
 			zp.itemsView.expandAllRows();
 
-			// Select and delete ink annotation
+			// Select and trash ink annotation
 			let inkID = ink.id;
 			await zp.itemsView.selectItems([inkID]);
-
 			await zp.itemsView.deleteSelection();
 
-			// Make sure it is deleted and the row is gone
-			assert.isFalse(Zotero.Items.get(inkID));
+			// Make sure it is trashed and the row is now gone
+			let inkItem = await Zotero.Items.getAsync(inkID);
+			assert.isTrue(inkItem.deleted);
 			assert.isFalse(zp.itemsView.getRowIndexByID(inkID));
+		});
+
+		it("should restore annotation row from trash", async () => {
+			// Trash ink annotation
+			ink.deleted = true;
+			await ink.saveTx();
+
+			// Select the trash
+			await zp.collectionsView.selectByID("T" + attachment.libraryID);
+
+			// Restore to library
+			await zp.itemsView.selectItems([ink.id]);
+			await zp.restoreSelectedItems();
+
+			// Make sure the row is no longer trashed
+			let inkItem = await Zotero.Items.getAsync(ink.id);
+			assert.isFalse(inkItem.deleted);
+			assert.isFalse(zp.itemsView.getRowIndexByID(ink.id));
 		});
 
 		it("should add note from selected annotation rows of the same parent item", async () => {

--- a/test/tests/readerTest.js
+++ b/test/tests/readerTest.js
@@ -242,15 +242,17 @@ describe("Reader", function () {
 					Zotero.UndoHistory.getUndoAction().action, 'undo-action-add-annotation'
 				);
 
-				// Undoing from outside the reader should remove the annotation
+				// Undoing from outside the reader should move the annotation to the trash
 				assert.isTrue(await Zotero.UndoHistory.undo());
-				await waitForItemEvent('delete');
+				await waitForItemEvent('trash');
 				assert.lengthOf(attachment.getAnnotations(), 0);
+				assert.lengthOf(attachment.getAnnotations(true), 1);
 
-				// Redoing should bring it back (with a new key, to avoid sync conflicts)
+				// Redoing should restore it from the trash with the same key
 				assert.isTrue(await Zotero.UndoHistory.redo());
-				await waitForItemEvent('add');
+				await waitForItemEvent('modify');
 				assert.lengthOf(attachment.getAnnotations(), 1);
+				assert.equal(attachment.getAnnotations()[0].key, annotation.id);
 
 				// An edit should be undoable as its own step
 				annotationManager.updateAnnotations(
@@ -301,7 +303,7 @@ describe("Reader", function () {
 
 				win.Zotero_Tabs.select('zotero-pane');
 				assert.isTrue(await Zotero.UndoHistory.undo());
-				await waitForItemEvent('delete');
+				await waitForItemEvent('trash');
 				assert.equal(win.Zotero_Tabs.selectedID, reader.tabID);
 			}
 			finally {
@@ -368,7 +370,7 @@ describe("Reader", function () {
 				assert.isFalse(Zotero.UndoHistory.hasNativeUndo(win.document));
 				// As the Edit menu and key_undo do
 				win.goDoCommand('cmd_undo');
-				await waitForItemEvent('delete');
+				await waitForItemEvent('trash');
 				assert.lengthOf(attachment.getAnnotations(), 0);
 			}
 			finally {
@@ -571,6 +573,144 @@ describe("Reader", function () {
 						action: Zotero.ftl.formatValueSync('undo-action-add-annotation', { count: 1 })
 					})
 				);
+			}
+			finally {
+				await cleanupReaders(reader);
+			}
+		});
+
+		it('should trash annotation deleted in the reader and restore it on reader undo', async function () {
+			let attachment = await importFileAttachment('test.pdf');
+			let highlight = await createAnnotation('highlight', attachment);
+			let reader = await Zotero.Reader.open(attachment.itemID);
+			try {
+				await reader._initPromise;
+				let annotationManager = reader._internalReader._annotationManager;
+				annotationManager._skipAnnotationSavingDebounce = true;
+
+				// Delete annotation from the reader
+				annotationManager.deleteAnnotations(
+					Components.utils.cloneInto([highlight.key], reader._iframeWindow)
+				);
+				await waitForItemEvent('trash');
+
+				// The item is trashed, not erased, and removed from the reader
+				assert.isTrue(highlight.deleted);
+				assert.notInclude(annotationManager._annotations.map(x => x.id), highlight.key);
+
+				// Undoing in the reader restores the same item from the trash
+				annotationManager.undo();
+				await waitForItemEvent('modify');
+				assert.isFalse(highlight.deleted);
+				assert.include(annotationManager._annotations.map(x => x.id), highlight.key);
+			}
+			finally {
+				await cleanupReaders(reader);
+			}
+		});
+
+		it('should restore annotation trashed in the reader when undoing from the library', async function () {
+			let attachment = await importFileAttachment('test.pdf');
+			let highlight = await createAnnotation('highlight', attachment);
+			let reader = await Zotero.Reader.open(attachment.itemID);
+			try {
+				await reader._initPromise;
+				let annotationManager = reader._internalReader._annotationManager;
+				annotationManager._skipAnnotationSavingDebounce = true;
+				Zotero.UndoHistory.clear();
+
+				annotationManager.deleteAnnotations(
+					Components.utils.cloneInto([highlight.key], reader._iframeWindow)
+				);
+				await waitForItemEvent('trash');
+				assert.isTrue(highlight.deleted);
+
+				// The reader's delete step is mirrored into the app-wide history
+				// as a single entry
+				assert.equal(
+					Zotero.UndoHistory.getUndoAction().action, 'undo-action-trash-annotation'
+				);
+				assert.isTrue(await Zotero.UndoHistory.undo());
+				await waitForItemEvent('modify');
+				assert.isFalse(highlight.deleted);
+				assert.isFalse(Zotero.UndoHistory.canUndo());
+				assert.include(annotationManager._annotations.map(x => x.id), highlight.key);
+			}
+			finally {
+				await cleanupReaders(reader);
+			}
+		});
+
+		it('should remove annotation from the reader when trashed from the library', async function () {
+			let attachment = await importFileAttachment('test.pdf');
+			let highlight = await createAnnotation('highlight', attachment);
+			let reader = await Zotero.Reader.open(attachment.itemID);
+			try {
+				await reader._initPromise;
+				let annotationManager = reader._internalReader._annotationManager;
+				assert.include(annotationManager._annotations.map(x => x.id), highlight.key);
+
+				await Zotero.Items.trashTx([highlight.id]);
+
+				assert.notInclude(annotationManager._annotations.map(x => x.id), highlight.key);
+				assert.notInclude(reader.annotationItemIDs, highlight.id);
+			}
+			finally {
+				await cleanupReaders(reader);
+			}
+		});
+
+		it('should re-add annotation to the reader when restored from the trash', async function () {
+			let attachment = await importFileAttachment('test.pdf');
+			let highlight = await createAnnotation('highlight', attachment);
+			highlight.deleted = true;
+			await highlight.saveTx();
+
+			let reader = await Zotero.Reader.open(attachment.itemID);
+			try {
+				await reader._initPromise;
+				let annotationManager = reader._internalReader._annotationManager;
+				// Trashed annotations aren't loaded
+				assert.notInclude(annotationManager._annotations.map(x => x.id), highlight.key);
+
+				highlight.deleted = false;
+				await highlight.saveTx();
+
+				// setAnnotations() conversion is async, so poll for the row to appear
+				await waitForCallback(
+					() => annotationManager._annotations.map(x => x.id).includes(highlight.key),
+					50, 3
+				);
+				assert.include(reader.annotationItemIDs, highlight.id);
+			}
+			finally {
+				await cleanupReaders(reader);
+			}
+		});
+
+		it('should not restore annotation from reader history after it is erased from the trash', async function () {
+			let attachment = await importFileAttachment('test.pdf');
+			let highlight = await createAnnotation('highlight', attachment);
+			let reader = await Zotero.Reader.open(attachment.itemID);
+			try {
+				await reader._initPromise;
+				let annotationManager = reader._internalReader._annotationManager;
+				annotationManager._skipAnnotationSavingDebounce = true;
+
+				// Trash from the reader, leaving a delete point in its history
+				annotationManager.deleteAnnotations(
+					Components.utils.cloneInto([highlight.key], reader._iframeWindow)
+				);
+				await waitForItemEvent('trash');
+				assert.isTrue(annotationManager.canUndo);
+
+				// Permanently delete from the trash
+				await Zotero.Items.erase([highlight.id]);
+
+				// The reader history points referencing the annotation are dropped,
+				// so it can't be recreated with the same key
+				assert.isFalse(annotationManager.canUndo);
+				assert.isFalse(Zotero.Items.getByLibraryAndKey(attachment.libraryID, highlight.key));
 			}
 			finally {
 				await cleanupReaders(reader);

--- a/test/tests/readerTest.js
+++ b/test/tests/readerTest.js
@@ -214,6 +214,192 @@ describe("Reader", function () {
 			}
 		}
 
+		it('should record annotation changes in the app-wide undo history', async function () {
+			let attachment = await importFileAttachment('test.pdf');
+			let reader = await Zotero.Reader.open(attachment.itemID);
+			try {
+				await reader._initPromise;
+				let annotationManager = reader._internalReader._annotationManager;
+				annotationManager._skipAnnotationSavingDebounce = true;
+				Zotero.UndoHistory.clear();
+
+				let annotation = annotationManager.addAnnotation(
+					Components.utils.cloneInto({
+						type: 'highlight',
+						color: '#ffd400',
+						sortIndex: '00000|003305|00000',
+						position: {
+							pageIndex: 0,
+							rects: [[0, 0, 100, 100]]
+						},
+						text: 'test'
+					}, reader._iframeWindow)
+				);
+				await waitForItemEvent('add');
+				assert.equal(attachment.getAnnotations()[0].key, annotation.id);
+				assert.isTrue(Zotero.UndoHistory.canUndo());
+				assert.equal(
+					Zotero.UndoHistory.getUndoAction().action, 'undo-action-add-annotation'
+				);
+
+				// Undoing from outside the reader should remove the annotation
+				assert.isTrue(await Zotero.UndoHistory.undo());
+				await waitForItemEvent('delete');
+				assert.lengthOf(attachment.getAnnotations(), 0);
+
+				// Redoing should bring it back (with a new key, to avoid sync conflicts)
+				assert.isTrue(await Zotero.UndoHistory.redo());
+				await waitForItemEvent('add');
+				assert.lengthOf(attachment.getAnnotations(), 1);
+
+				// An edit should be undoable as its own step
+				annotationManager.updateAnnotations(
+					Components.utils.cloneInto([{
+						id: attachment.getAnnotations()[0].key,
+						text: 'test2'
+					}], reader._iframeWindow)
+				);
+				await waitForItemEvent('modify');
+				assert.equal(
+					Zotero.UndoHistory.getUndoAction().action, 'undo-action-edit-annotation'
+				);
+				assert.isTrue(await Zotero.UndoHistory.undo());
+				await waitForItemEvent('modify');
+				assert.equal(attachment.getAnnotations()[0].annotationText, 'test');
+			}
+			finally {
+				await cleanupReaders(reader);
+			}
+
+			// A closed reader can't apply its steps anymore
+			assert.isFalse(Zotero.UndoHistory.canUndo());
+			assert.isFalse(Zotero.UndoHistory.canRedo());
+		});
+
+		it('should select the reader tab when undoing an annotation change from the library', async function () {
+			let attachment = await importFileAttachment('test.pdf');
+			let reader = await Zotero.Reader.open(attachment.itemID);
+			try {
+				await reader._initPromise;
+				let annotationManager = reader._internalReader._annotationManager;
+				annotationManager._skipAnnotationSavingDebounce = true;
+				Zotero.UndoHistory.clear();
+
+				annotationManager.addAnnotation(
+					Components.utils.cloneInto({
+						type: 'highlight',
+						color: '#ffd400',
+						sortIndex: '00000|003305|00000',
+						position: {
+							pageIndex: 0,
+							rects: [[0, 0, 100, 100]]
+						},
+						text: 'test'
+					}, reader._iframeWindow)
+				);
+				await waitForItemEvent('add');
+
+				win.Zotero_Tabs.select('zotero-pane');
+				assert.isTrue(await Zotero.UndoHistory.undo());
+				await waitForItemEvent('delete');
+				assert.equal(win.Zotero_Tabs.selectedID, reader.tabID);
+			}
+			finally {
+				await cleanupReaders(reader);
+			}
+		});
+
+		it('should select the library tab when undoing a library change from a reader', async function () {
+			let reader;
+			try {
+				win.Zotero_Tabs.select('zotero-pane');
+				let collection = await createDataObject('collection', { name: 'Original' });
+				Zotero.UndoHistory.clear();
+				collection.name = 'Modified';
+				await collection.saveTx({ undoAction: 'undo-action-rename-collection' });
+
+				let attachment = await importFileAttachment('test.pdf');
+				reader = await Zotero.Reader.open(attachment.itemID);
+				await reader._initPromise;
+				assert.equal(win.Zotero_Tabs.selectedID, reader.tabID);
+
+				assert.isTrue(await Zotero.UndoHistory.undo());
+				assert.equal(collection.name, 'Original');
+				assert.equal(win.Zotero_Tabs.selectedID, 'zotero-pane');
+			}
+			finally {
+				await cleanupReaders(reader);
+			}
+		});
+
+		it('should run undo commands from the app-wide history while a reader view has focus', async function () {
+			let attachment = await importFileAttachment('test.pdf');
+			let reader = await Zotero.Reader.open(attachment.itemID);
+			try {
+				await reader._initPromise;
+				let annotationManager = reader._internalReader._annotationManager;
+				annotationManager._skipAnnotationSavingDebounce = true;
+				Zotero.UndoHistory.clear();
+
+				annotationManager.addAnnotation(
+					Components.utils.cloneInto({
+						type: 'highlight',
+						color: '#ffd400',
+						sortIndex: '00000|003305|00000',
+						position: {
+							pageIndex: 0,
+							rects: [[0, 0, 100, 100]]
+						},
+						text: 'test'
+					}, reader._iframeWindow)
+				);
+				await waitForItemEvent('add');
+
+				await reader.focus();
+				await Zotero.Promise.delay(100);
+				// Focus only moves into the reader while its window is active.
+				// It lands in a view iframe, whose frame tree is rooted at the
+				// reader itself.
+				if (win.document.commandDispatcher.focusedWindow?.top !== reader._iframeWindow) {
+					Zotero.debug("Skipping test -- reader couldn't be focused");
+					this.skip();
+				}
+
+				assert.isFalse(Zotero.UndoHistory.hasNativeUndo(win.document));
+				// As the Edit menu and key_undo do
+				win.goDoCommand('cmd_undo');
+				await waitForItemEvent('delete');
+				assert.lengthOf(attachment.getAnnotations(), 0);
+			}
+			finally {
+				await cleanupReaders(reader);
+			}
+		});
+
+		it('should leave undo to text editing while a reader text box has focus', async function () {
+			let attachment = await importFileAttachment('test.pdf');
+			let reader = await Zotero.Reader.open(attachment.itemID);
+			try {
+				await reader._initPromise;
+				await reader._internalReader._primaryView.initializedPromise;
+				let doc = reader._iframeWindow.document;
+				let pageNumberInput = doc.getElementById('pageNumber');
+				pageNumberInput.focus();
+				await Zotero.Promise.delay(100);
+				// Focus only moves into the reader while its window is active
+				if (win.document.commandDispatcher.focusedWindow !== reader._iframeWindow
+						|| doc.activeElement !== pageNumberInput) {
+					Zotero.debug("Skipping test -- reader text box couldn't be focused");
+					this.skip();
+				}
+
+				assert.isTrue(Zotero.UndoHistory.hasNativeUndo(win.document));
+			}
+			finally {
+				await cleanupReaders(reader);
+			}
+		});
+
 		it('should reopen a reader whose tab closes during a notifier transaction', async function () {
 			let reader, reopenedReader;
 			let title = Zotero.Promise.defer();
@@ -349,6 +535,45 @@ describe("Reader", function () {
 					win.Zotero_Tabs.close(unloadedTabID);
 				}
 				await cleanupReaders(reader, windowReader);
+			}
+		});
+
+		it('should name the undone action in a reader window Edit menu', async function () {
+			let attachment = await importFileAttachment('test.pdf');
+			let reader = await Zotero.Reader.open(attachment.id, null, { openInWindow: true });
+			try {
+				await reader._initPromise;
+				let annotationManager = reader._internalReader._annotationManager;
+				annotationManager._skipAnnotationSavingDebounce = true;
+				Zotero.UndoHistory.clear();
+
+				annotationManager.addAnnotation(
+					Components.utils.cloneInto({
+						type: 'highlight',
+						color: '#ffd400',
+						sortIndex: '00000|003305|00000',
+						position: {
+							pageIndex: 0,
+							rects: [[0, 0, 100, 100]]
+						},
+						text: 'test'
+					}, reader._iframeWindow)
+				);
+				await waitForItemEvent('add');
+
+				let doc = reader._window.document;
+				Zotero.UndoHistory.updateMenuItems(doc);
+				let undoItem = doc.getElementById('menu_undo');
+				assert.isFalse(undoItem.hasAttribute('data-l10n-id'));
+				assert.equal(
+					undoItem.getAttribute('label'),
+					Zotero.ftl.formatValueSync('menu-edit-undo-action', {
+						action: Zotero.ftl.formatValueSync('undo-action-add-annotation', { count: 1 })
+					})
+				);
+			}
+			finally {
+				await cleanupReaders(reader);
 			}
 		});
 

--- a/test/tests/undoHistoryTest.js
+++ b/test/tests/undoHistoryTest.js
@@ -1577,6 +1577,237 @@ describe("Zotero.UndoHistory", function () {
 		});
 	});
 
+	describe("external providers", function () {
+		// Stands in for a reader instance: keeps its own stack of steps, reports
+		// it after every change, and steps it on request
+		function createProvider(providerID) {
+			let provider = {
+				id: providerID,
+				undoSteps: [],
+				redoSteps: [],
+				revealCount: 0,
+				_lastStepID: 0,
+
+				register() {
+					Zotero.UndoHistory.registerProvider(this.id, {
+						libraryID: Zotero.Libraries.userLibraryID,
+						undo: () => this.undo(),
+						redo: () => this.redo(),
+						reveal: () => this.revealCount++
+					});
+					return this;
+				},
+
+				addStep(action = 'undo-action-edit-annotation', count = 1) {
+					let step = {
+						id: ++this._lastStepID,
+						revision: 0,
+						action,
+						actionArgs: { count }
+					};
+					this.undoSteps.push(step);
+					this.redoSteps = [];
+					this.report();
+					return step;
+				},
+
+				// A change joined into the newest step, as continued typing is
+				reviseNewestStep() {
+					this.undoSteps[this.undoSteps.length - 1].revision++;
+					this.redoSteps = [];
+					this.report();
+				},
+
+				// An outside change invalidating everything up to and including
+				// the given step
+				invalidateThrough(step) {
+					this.undoSteps = this.undoSteps.slice(this.undoSteps.indexOf(step) + 1);
+					this.report();
+				},
+
+				undo() {
+					let step = this.undoSteps.pop();
+					if (!step) {
+						return false;
+					}
+					this.redoSteps.push(step);
+					this.report();
+					return true;
+				},
+
+				redo() {
+					let step = this.redoSteps.pop();
+					if (!step) {
+						return false;
+					}
+					this.undoSteps.push(step);
+					this.report();
+					return true;
+				},
+
+				report() {
+					Zotero.UndoHistory.setProviderSteps(this.id, {
+						undoSteps: this.undoSteps,
+						redoSteps: this.redoSteps
+					});
+				}
+			};
+			return provider;
+		}
+
+		var provider;
+
+		beforeEach(function () {
+			provider = createProvider('provider-' + Zotero.Utilities.randomString()).register();
+		});
+
+		afterEach(function () {
+			Zotero.UndoHistory.unregisterProvider(provider.id);
+		});
+
+		it("should undo and redo a provider step", async function () {
+			provider.addStep('undo-action-add-annotation');
+			assert.isTrue(Zotero.UndoHistory.canUndo());
+			assert.deepEqual(
+				Zotero.UndoHistory.getUndoAction(),
+				{ action: 'undo-action-add-annotation', actionArgs: { count: 1 } }
+			);
+
+			assert.isTrue(await Zotero.UndoHistory.undo());
+			assert.lengthOf(provider.undoSteps, 0);
+			assert.lengthOf(provider.redoSteps, 1);
+			assert.isFalse(Zotero.UndoHistory.canUndo());
+			assert.equal(
+				Zotero.UndoHistory.getRedoAction().action, 'undo-action-add-annotation'
+			);
+
+			assert.isTrue(await Zotero.UndoHistory.redo());
+			assert.lengthOf(provider.undoSteps, 1);
+			assert.isTrue(Zotero.UndoHistory.canUndo());
+			assert.isFalse(Zotero.UndoHistory.canRedo());
+		});
+
+		it("should ask the provider to reveal itself after applying a step", async function () {
+			provider.addStep();
+
+			await Zotero.UndoHistory.undo();
+			assert.equal(provider.revealCount, 1);
+
+			await Zotero.UndoHistory.redo();
+			assert.equal(provider.revealCount, 2);
+		});
+
+		it("should not reveal a provider that declined to step", async function () {
+			provider.addStep();
+			provider.undoSteps = [];
+
+			assert.isFalse(await Zotero.UndoHistory.undo());
+			assert.equal(provider.revealCount, 0);
+		});
+
+		it("should interleave provider steps with captured changes", async function () {
+			let collection = await createDataObject('collection', { name: 'Original' });
+			Zotero.UndoHistory.clear();
+
+			collection.name = 'Modified';
+			await collection.saveTx({ undoAction: 'undo-action-rename-collection' });
+			provider.addStep('undo-action-add-annotation');
+
+			// The provider step came last, so it goes first
+			assert.isTrue(await Zotero.UndoHistory.undo());
+			assert.lengthOf(provider.undoSteps, 0);
+			assert.equal(collection.name, 'Modified');
+
+			assert.isTrue(await Zotero.UndoHistory.undo());
+			assert.equal(collection.name, 'Original');
+		});
+
+		it("should move a revised step back to the top of the stack", async function () {
+			let collection = await createDataObject('collection', { name: 'Original' });
+			Zotero.UndoHistory.clear();
+
+			provider.addStep();
+			collection.name = 'Modified';
+			await collection.saveTx({ undoAction: 'undo-action-rename-collection' });
+			// The provider's step now covers a change made after the rename
+			provider.reviseNewestStep();
+
+			assert.isTrue(await Zotero.UndoHistory.undo());
+			assert.lengthOf(provider.undoSteps, 0);
+			assert.equal(collection.name, 'Modified');
+		});
+
+		it("should clear the redo stack when a provider records a new step", async function () {
+			let collection = await createDataObject('collection', { name: 'Original' });
+			Zotero.UndoHistory.clear();
+
+			collection.name = 'Modified';
+			await collection.saveTx({ undoAction: 'undo-action-rename-collection' });
+			await Zotero.UndoHistory.undo();
+			assert.isTrue(Zotero.UndoHistory.canRedo());
+
+			provider.addStep();
+			assert.isFalse(Zotero.UndoHistory.canRedo());
+		});
+
+		it("should drop entries for steps the provider no longer has", async function () {
+			let firstStep = provider.addStep();
+			provider.addStep();
+			provider.invalidateThrough(firstStep);
+
+			assert.isTrue(await Zotero.UndoHistory.undo());
+			assert.isFalse(await Zotero.UndoHistory.undo());
+		});
+
+		it("should not restore steps that were already discarded", async function () {
+			provider.addStep();
+			Zotero.UndoHistory.clear();
+
+			// Reporting the older step again along with a new one shouldn't
+			// bring the cleared entry back
+			provider.addStep();
+			assert.isTrue(await Zotero.UndoHistory.undo());
+			assert.isFalse(await Zotero.UndoHistory.undo());
+		});
+
+		it("should discard a provider's entries when it declines to step", async function () {
+			let collection = await createDataObject('collection', { name: 'Original' });
+			Zotero.UndoHistory.clear();
+
+			collection.name = 'Modified';
+			await collection.saveTx({ undoAction: 'undo-action-rename-collection' });
+			provider.addStep();
+			provider.addStep();
+			// Provider has lost track of its own history
+			provider.undoSteps = [];
+
+			assert.isFalse(await Zotero.UndoHistory.undo());
+			// The remaining provider entry is gone, but the captured change isn't
+			assert.isTrue(await Zotero.UndoHistory.undo());
+			assert.equal(collection.name, 'Original');
+		});
+
+		it("should discard entries when a provider is unregistered", async function () {
+			provider.addStep();
+			assert.isTrue(Zotero.UndoHistory.canUndo());
+
+			Zotero.UndoHistory.unregisterProvider(provider.id);
+			assert.isFalse(Zotero.UndoHistory.canUndo());
+		});
+
+		it("should discard provider entries for an erased library", async function () {
+			provider.addStep();
+			Zotero.UndoHistory.clearForLibrary(Zotero.Libraries.userLibraryID);
+			assert.isFalse(Zotero.UndoHistory.canUndo());
+		});
+
+		it("should ignore steps from an unregistered provider", function () {
+			Zotero.UndoHistory.unregisterProvider(provider.id);
+			provider.addStep();
+			assert.isFalse(Zotero.UndoHistory.canUndo());
+		});
+	});
+
 	describe("step limit pref", function () {
 		afterEach(function () {
 			Zotero.Prefs.clear('undoHistory.steps');

--- a/test/tests/undoHistoryTest.js
+++ b/test/tests/undoHistoryTest.js
@@ -92,6 +92,38 @@ describe("Zotero.UndoHistory", function () {
 			assert.isFalse(item2.deleted);
 			assert.isFalse(Zotero.UndoHistory.canUndo());
 		});
+
+		it("should undo and redo trashing an annotation", async function () {
+			let attachment = await importFileAttachment('test.pdf');
+			let annotation = await createAnnotation('highlight', attachment);
+			Zotero.UndoHistory.clear();
+
+			await Zotero.Items.trashTx([annotation.id]);
+			assert.isTrue(annotation.deleted);
+			assert.isTrue(Zotero.UndoHistory.canUndo());
+
+			await Zotero.UndoHistory.undo();
+			assert.isFalse(annotation.deleted);
+
+			await Zotero.UndoHistory.redo();
+			assert.isTrue(annotation.deleted);
+		});
+
+		it("should undo trashing multiple annotations as a single step", async function () {
+			let attachment = await importFileAttachment('test.pdf');
+			let annotation1 = await createAnnotation('highlight', attachment);
+			let annotation2 = await createAnnotation('note', attachment);
+			Zotero.UndoHistory.clear();
+
+			await Zotero.Items.trashTx([annotation1.id, annotation2.id]);
+			assert.isTrue(annotation1.deleted);
+			assert.isTrue(annotation2.deleted);
+
+			await Zotero.UndoHistory.undo();
+			assert.isFalse(annotation1.deleted);
+			assert.isFalse(annotation2.deleted);
+			assert.isFalse(Zotero.UndoHistory.canUndo());
+		});
 	});
 
 	describe("item metadata field edit", function () {

--- a/test/tests/zoteroPaneTest.js
+++ b/test/tests/zoteroPaneTest.js
@@ -1475,6 +1475,92 @@ describe("ZoteroPane", function () {
 			assert.isFalse(attachment2.deleted);
 			assert.isFalse(attachment3.deleted);
 		});
+
+		it("should restore selected trashed annotation", async function () {
+			let item1 = await createDataObject('item');
+			let attachment1 = await importFileAttachment('test.pdf', { parentItemID: item1.id });
+			let annotation1 = await createAnnotation('highlight', attachment1);
+			annotation1.deleted = true;
+			await annotation1.saveTx();
+
+			var userLibraryID = Zotero.Libraries.userLibraryID;
+			await zp.collectionsView.selectByID('T' + userLibraryID);
+			await zp.selectItems([annotation1.id]);
+			await zp.restoreSelectedItems();
+
+			assert.isFalse(annotation1.deleted);
+		});
+
+		it("should restore selected trashed annotation of a standalone attachment", async function () {
+			let attachment1 = await importFileAttachment('test.pdf');
+			let annotation1 = await createAnnotation('highlight', attachment1);
+			annotation1.deleted = true;
+			await annotation1.saveTx();
+
+			var userLibraryID = Zotero.Libraries.userLibraryID;
+			await zp.collectionsView.selectByID('T' + userLibraryID);
+			await zp.selectItems([annotation1.id]);
+			await zp.restoreSelectedItems();
+
+			assert.isFalse(annotation1.deleted);
+			assert.isFalse(attachment1.deleted);
+		});
+
+		it("should restore annotations when trashed standalone attachment is restored", async function () {
+			let attachment1 = await importFileAttachment('test.pdf');
+			let annotation1 = await createAnnotation('highlight', attachment1);
+			annotation1.deleted = true;
+			await annotation1.saveTx();
+			attachment1.deleted = true;
+			await attachment1.saveTx();
+
+			var userLibraryID = Zotero.Libraries.userLibraryID;
+			await zp.collectionsView.selectByID('T' + userLibraryID);
+			await zp.selectItems([attachment1.id]);
+			await zp.restoreSelectedItems();
+
+			assert.isFalse(attachment1.deleted);
+			assert.isFalse(annotation1.deleted);
+		});
+
+		it("should restore annotations when trashed top-level item is restored", async function () {
+			let item1 = await createDataObject('item', { deleted: true });
+			let attachment1 = await importFileAttachment('test.pdf', { parentItemID: item1.id });
+			let annotation1 = await createAnnotation('highlight', attachment1);
+			attachment1.deleted = true;
+			await attachment1.saveTx();
+			annotation1.deleted = true;
+			await annotation1.saveTx();
+
+			var userLibraryID = Zotero.Libraries.userLibraryID;
+			await zp.collectionsView.selectByID('T' + userLibraryID);
+			await zp.selectItems([item1.id]);
+			await zp.restoreSelectedItems();
+
+			assert.isFalse(item1.deleted);
+			assert.isFalse(attachment1.deleted);
+			assert.isFalse(annotation1.deleted);
+		});
+
+		it("should restore only selected annotation when it is selected along with its top-level item", async function () {
+			let item1 = await createDataObject('item', { deleted: true });
+			let attachment1 = await importFileAttachment('test.pdf', { parentItemID: item1.id });
+			let annotation1 = await createAnnotation('highlight', attachment1);
+			let annotation2 = await createAnnotation('highlight', attachment1);
+			annotation1.deleted = true;
+			await annotation1.saveTx();
+			annotation2.deleted = true;
+			await annotation2.saveTx();
+
+			var userLibraryID = Zotero.Libraries.userLibraryID;
+			await zp.collectionsView.selectByID('T' + userLibraryID);
+			await zp.selectItems([item1.id, annotation1.id]);
+			await zp.restoreSelectedItems();
+
+			assert.isFalse(item1.deleted);
+			assert.isFalse(annotation1.deleted);
+			assert.isTrue(annotation2.deleted);
+		});
 	});
 
 	describe("#checkForLinkedFilesToRelink()", function () {


### PR DESCRIPTION
Annotations will be sent to trash instead of being immediately erased, similar to other item types. That is the case when deleting from both `itemTree` and the reader. From trash, annotations can be permanently deleted or restored. `Reader.AnnotationManager.undo` will also restore annotations from trash.

Needs: https://github.com/zotero/reader/pull/173
Fixes: #5466