### PR TITLE
An option to persist quick search across collections

### DIFF
--- a/chrome/content/zotero/elements/quickSearchTextbox.js
+++ b/chrome/content/zotero/elements/quickSearchTextbox.js
@@ -132,10 +132,21 @@
 				popup.append(item);
 			}
 			
+			// "Apply to All Collections"
+			let separatorOne = document.createXULElement('menuseparator');
+			popup.append(separatorOne);
+			let retainAcrossCollections = document.createXULElement('menuitem');
+			retainAcrossCollections.label = Zotero.getString("quicksearch-apply-to-all");
+			retainAcrossCollections.addEventListener("command", () => {
+				let current = Zotero.Prefs.get("search.quicksearch-apply-to-all");
+				Zotero.Prefs.set("search.quicksearch-apply-to-all", !current);
+			});
+			popup.append(retainAcrossCollections);
+
 			// Add Advanced Search menu item in main window
 			if (document.documentElement.getAttribute('windowtype') === 'navigator:browser') {
-				let separator = document.createXULElement('menuseparator');
-				popup.append(separator);
+				let separatorTwo = document.createXULElement('menuseparator');
+				popup.append(separatorTwo);
 				let advancedSearchOption = document.createXULElement('menuitem');
 				advancedSearchOption.label = Zotero.getString("zotero.toolbar.advancedSearch");
 				advancedSearchOption.addEventListener("command", () => {
@@ -143,6 +154,11 @@
 				});
 				popup.append(advancedSearchOption);
 			}
+
+			// Set some checked states when the popup appears
+			popup.addEventListener('popupshowing', () => {
+				retainAcrossCollections.setAttribute("checked", Zotero.Prefs.get("search.quicksearch-apply-to-all"));
+			});
 			
 			return this._searchModePopup = popup;
 		}

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -1160,6 +1160,9 @@ var ItemTree = class ItemTree extends LibraryTree {
 			return this.clearItemsPaneMessage();
 		}
 		Zotero.debug(`itemTree.changeCollectionTreeRow(): ${collectionTreeRow.id}`);
+		if (!skipRefresh) {
+			this._itemTreeLoadingDeferred = Zotero.Promise.defer();
+		}
 		this.setItemsPaneMessage(Zotero.getString('pane.items.loading'));
 		let newId = "item-tree-" + this.props.id;
 		if (collectionTreeRow.visibilityGroup) {
@@ -1180,7 +1183,6 @@ var ItemTree = class ItemTree extends LibraryTree {
 		// Sometimes (e.g. if there is an active quick search), we skip the refresh
 		// to avoid blinking because there will be another one triggered right after.
 		if (skipRefresh) return;
-		this._itemTreeLoadingDeferred = Zotero.Promise.defer();
 
 		this.selection.clearSelection();
 		this.selection.focused = 0;

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -1142,7 +1142,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 		];
 	}
 	
-	async changeCollectionTreeRow(collectionTreeRow) {
+	async changeCollectionTreeRow(collectionTreeRow, skipRefresh) {
 		// When used outside the Zotero Pane, "collectionTreeRow" is not an actual
 		// tree row being passed in, but rather a simple object that defines necessary properties.
 		// So we need to supplement other CollectionTreeRow properties so that itemTree code
@@ -1160,7 +1160,6 @@ var ItemTree = class ItemTree extends LibraryTree {
 			return this.clearItemsPaneMessage();
 		}
 		Zotero.debug(`itemTree.changeCollectionTreeRow(): ${collectionTreeRow.id}`);
-		this._itemTreeLoadingDeferred = Zotero.Promise.defer();
 		this.setItemsPaneMessage(Zotero.getString('pane.items.loading'));
 		let newId = "item-tree-" + this.props.id;
 		if (collectionTreeRow.visibilityGroup) {
@@ -1177,6 +1176,11 @@ var ItemTree = class ItemTree extends LibraryTree {
 		this.collectionTreeRow.view.itemTreeView = this;
 		// Ensures that an up to date this._columns is set
 		this._getColumns();
+
+		// Sometimes (e.g. if there is an active quick search), we skip the refresh
+		// to avoid blinking because there will be another one triggered right after.
+		if (skipRefresh) return;
+		this._itemTreeLoadingDeferred = Zotero.Promise.defer();
 
 		this.selection.clearSelection();
 		this.selection.focused = 0;

--- a/chrome/content/zotero/selectItemsDialog.js
+++ b/chrome/content/zotero/selectItemsDialog.js
@@ -155,7 +155,15 @@ var onCollectionSelected = async function () {
 		await library.waitForDataLoad('item');
 	}
 	
-	await itemsView.changeCollectionTreeRow(collectionTreeRow);
+	let searchValue = document.getElementById('zotero-tb-search-textbox').value;
+	await itemsView.changeCollectionTreeRow(collectionTreeRow, true);
+	if (Zotero.Prefs.get("search.quicksearch-apply-to-all") && searchValue) {
+		itemsView.setFilter('search', searchValue);
+	}
+	else {
+		document.getElementById('zotero-tb-search-textbox').value = "";
+		itemsView.setFilter('search', "");
+	}
 	
 	itemsView.clearItemsPaneMessage();
 };

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -1810,15 +1810,10 @@ var ZoteroPane = new function () {
 		// Rename tab
 		Zotero_Tabs.rename('zotero-pane', collectionTreeRow.getName());
 		
-		let type = Zotero.Libraries.get(collectionTreeRow.ref.libraryID).libraryType;
-		
-		// Clear quick search and tag selector when switching views
-		document.getElementById('zotero-tb-search-textbox').value = "";
 		if (ZoteroPane.tagSelector) {
 			ZoteroPane.tagSelector.clearTagSelection();
 		}
 		
-		collectionTreeRow.setSearch('');
 		if (ZoteroPane.tagSelector) {
 			collectionTreeRow.setTags(ZoteroPane.tagSelector.getTagSelection());
 		}
@@ -1846,7 +1841,20 @@ var ZoteroPane = new function () {
 			}
 		}
 		
-		this.itemsView.changeCollectionTreeRow(collectionTreeRow);
+		let hasSearch = document.getElementById('zotero-tb-search-textbox').value;
+		if (Zotero.Prefs.get("search.quicksearch-apply-to-all") && hasSearch) {
+			// If there is an active search, change collection tree row without refreshing.
+			// Then rerun the search in the new collection which will refresh the itemTree.
+			this.itemsView.changeCollectionTreeRow(collectionTreeRow, true);
+			this.search();
+		}
+		else {
+			// If there is no search persisting across collections, clear the quickSearch
+			// and change collectionRow with refresh.
+			document.getElementById('zotero-tb-search-textbox').value = "";
+			collectionTreeRow.setSearch('');
+			this.itemsView.changeCollectionTreeRow(collectionTreeRow);
+		}
 		
 		Zotero.Prefs.set('lastViewedFolder', collectionTreeRow.id);
 	});

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -649,6 +649,7 @@ quicksearch-input =
     .aria-label = Quick Search
     .placeholder = { $placeholder }
     .aria-description = { $placeholder }
+quicksearch-apply-to-all = Apply to All Collections
 
 item-pane-header-view-as =
     .label = View As

--- a/defaults/preferences/zotero.js
+++ b/defaults/preferences/zotero.js
@@ -100,6 +100,7 @@ pref("extensions.zotero.keys.toggleRead", "`");
 pref("extensions.zotero.keys.showTabsMenu", ";");
 
 pref("extensions.zotero.search.quicksearch-mode", "fields");
+pref("extensions.zotero.search.quicksearch-apply-to-all", false);
 
 // Fulltext indexing
 pref("extensions.zotero.fulltext.textMaxLength", 500000);


### PR DESCRIPTION
- added a new `menuitem` to quick search `dropdown` "Apply to all collections"
- when checked, quick search will not be cleared when switching collections
- if "Apply all collections" is checked, when a new collection is selected, `collectionTreeRow` will be updated without triggering the refresh of the `itemTree`. Then, it will run the search, which will refresh the `itemTree`. This way, the tree is not refreshed twice over a short period of time, which can look like flickering.

Fixes: #2936

https://github.com/user-attachments/assets/4b068c03-94b5-46a5-b07f-f93bbdc72a60

