### PR TITLE
Filter out trashed items in relatedBox

### DIFF
--- a/chrome/content/zotero/elements/relatedBox.js
+++ b/chrome/content/zotero/elements/relatedBox.js
@@ -85,17 +85,7 @@ import { getCSSItemTypeIcon } from 'components/icons';
 			body.replaceChildren();
 
 			if (this._item) {
-				let relatedKeys = this._item.relatedItems;
-				
-				let relatedItems = relatedKeys.map((key) => {
-					let item = Zotero.Items.getByLibraryAndKey(this._item.libraryID, key);
-					if (!item) {
-						Zotero.debug(`Related item ${this._item.libraryID}/${key} not found `
-							+ `for item ${this._item.libraryKey}`, 2);
-					}
-					return item;
-				}).filter(Boolean);
-				
+				let relatedItems = this._getRelatedItems();
 				// Sort by display title
 				var collation = Zotero.getLocaleCollation();
 				var titles = new Map();
@@ -225,12 +215,31 @@ import { getCSSItemTypeIcon } from 'components/icons';
 		}
 
 		_updateCount() {
-			let count = this._item.relatedItems.length;
+			let count = this._getRelatedItems().length;
 			this._section.setCount(count);
 		}
 
 		_id(id) {
 			return this.querySelector(`[id=${id}]`);
+		}
+
+		_getRelatedItems() {
+			let relatedKeys = this._item.relatedItems;
+			
+			let relatedItems = relatedKeys.map((key) => {
+				let item = Zotero.Items.getByLibraryAndKey(this._item.libraryID, key);
+				if (!item) {
+					Zotero.debug(`Related item ${this._item.libraryID}/${key} not found `
+						+ `for item ${this._item.libraryKey}`, 2);
+				}
+				return item;
+			}).filter(Boolean);
+
+			// Unless the item itself is trashed, filter out trashed related items
+			if (!this._item.deleted) {
+				relatedItems = relatedItems.filter(item => !item.deleted);
+			}
+			return relatedItems;
 		}
 
 		receiveKeyboardFocus(_direction) {

--- a/test/tests/relatedboxTest.js
+++ b/test/tests/relatedboxTest.js
@@ -114,6 +114,32 @@ describe("Related Box", function () {
 		while (relatedbox.querySelector('.body').innerHTML.includes(title1));
 	});
 	
+	it("should exclude trashed related items", async function () {
+		var item1 = await createDataObject('item');
+		var item2 = await createDataObject('item');
+		var item3 = await createDataObject('item');
+		await relateItems(item1, item2, item3);
+
+		item3.deleted = true;
+		await item3.saveTx();
+
+		await win.ZoteroPane.selectItem(item1.id);
+
+		var relatedbox = doc.getElementById('zotero-editpane-related');
+		
+		// Wait for relations list to populate
+		do {
+			await Zotero.Promise.delay(50);
+		}
+		while (!relatedbox.querySelectorAll('.row').length);
+
+		// Ensure only non-trashed item is displayed
+		var rows = [...relatedbox.querySelectorAll('.row')];
+		assert.lengthOf(rows, 1);
+		assert.equal(rows[0].textContent, item2.getDisplayTitle());
+		assert.equal(relatedbox._getRelatedItems().length, 1);
+	});
+	
 	describe("Add button", function () {
 		it("should add a related item", async function () {
 			var item1 = await createDataObject('item');


### PR DESCRIPTION
If the item itself is trashed, all related items are displayed (trashed or not).

Fixes: #1780