### PR TITLE
Handle invalid path when launching/revealing on macOS

### DIFF
--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -5106,12 +5106,15 @@ var ZoteroPane = new function () {
 				return;
 			}
 			let fileExists;
+			let pathIsValid;
 			try {
 				fileExists = await IOUtils.exists(path);
+				pathIsValid = true;
 			}
 			catch (e) {
 				Zotero.logError(e);
 				fileExists = false;
+				pathIsValid = false;
 			}
 			
 			// If the file is an evicted iCloud Drive file, launch that to trigger a download.
@@ -5120,7 +5123,7 @@ var ZoteroPane = new function () {
 			// for the original file to exist and then continue with regular file opening below.
 			//
 			// To trigger eviction for testing, use Cirrus from https://eclecticlight.co/downloads/
-			if (!fileExists && Zotero.isMac && isLinkedFile) {
+			if (!fileExists && pathIsValid && Zotero.isMac && isLinkedFile) {
 				// Get the path to the .icloud file
 				let iCloudPath = Zotero.File.getEvictedICloudPath(path);
 				if (await IOUtils.exists(iCloudPath)) {
@@ -5381,10 +5384,21 @@ var ZoteroPane = new function () {
 		if (attachment.attachmentLinkMode == Zotero.Attachments.LINK_MODE_LINKED_URL) return;
 		
 		var path = attachment.getFilePath();
-		var fileExists = await IOUtils.exists(path);
+		
+		let fileExists;
+		let pathIsValid;
+		try {
+			fileExists = await IOUtils.exists(path);
+			pathIsValid = true;
+		}
+		catch (e) {
+			Zotero.logError(e);
+			fileExists = false;
+			pathIsValid = false;
+		}
 		
 		// If file doesn't exist but an evicted iCloud Drive file does, reveal that instead
-		if (!fileExists && Zotero.isMac && !attachment.isStoredFileAttachment()) {
+		if (!fileExists && pathIsValid && Zotero.isMac && !attachment.isStoredFileAttachment()) {
 			let iCloudPath = Zotero.File.getEvictedICloudPath(path);
 			if (await IOUtils.exists(iCloudPath)) {
 				path = iCloudPath;

--- a/test/tests/zoteroPaneTest.js
+++ b/test/tests/zoteroPaneTest.js
@@ -368,6 +368,25 @@ describe("ZoteroPane", function () {
 			await zp.viewAttachment(attachment.id);
 			assert.equal(attachment.attachmentContentType, 'application/epub+zip');
 		});
+
+		it("should handle Windows paths on macOS/Linux", async function () {
+			if (!Zotero.isMac && !Zotero.isLinux) {
+				this.skip();
+				return;
+			}
+			
+			let file = getTestDataDirectory();
+			file.append('test.pdf');
+			let attachment = await Zotero.Attachments.linkFromFile({ file });
+			attachment.attachmentPath = 'C:\\some\\windows\\path';
+			await attachment.saveTx();
+
+			let stub = sinon.stub(zp, 'showAttachmentNotFoundDialog');
+			await zp.viewAttachment(attachment.id);
+			assert.ok(stub.calledOnce);
+			assert.ok(stub.calledWith(attachment));
+			stub.restore();
+		});
 	})
 	
 	


### PR DESCRIPTION
(An error was only thrown on macOS, because `getEvictedICloudPath()` is currently the only method that throws on an invalid path that we call when the file doesn't exist, but the test runs on both macOS and Linux in case that changes.)

Fixes #5483