### PR TITLE
Fix relations to erased items re-appearing after sync

### DIFF
--- a/chrome/content/zotero/xpcom/sync/syncEngine.js
+++ b/chrome/content/zotero/xpcom/sync/syncEngine.js
@@ -1094,7 +1094,7 @@ Zotero.Sync.Data.Engine.prototype._startUpload = async function () {
 				objectType, objectDeletions[objectType], libraryVersion
 			);
 		}
-
+		
 		Zotero.debug(JSON.stringify(objectIDs));
 		for (let objectType in objectIDs) {
 			this._statusCheck();

--- a/chrome/content/zotero/xpcom/sync/syncEngine.js
+++ b/chrome/content/zotero/xpcom/sync/syncEngine.js
@@ -1086,21 +1086,21 @@ Zotero.Sync.Data.Engine.prototype._startUpload = async function () {
 	}
 	
 	try {
-		Zotero.debug(JSON.stringify(objectIDs));
-		for (let objectType in objectIDs) {
-			this._statusCheck();
-			
-			libraryVersion = await this._uploadObjects(
-				objectType, objectIDs[objectType], libraryVersion
-			);
-		}
-		
 		Zotero.debug(JSON.stringify(objectDeletions));
 		for (let objectType in objectDeletions) {
 			this._statusCheck();
 			
 			libraryVersion = await this._uploadDeletions(
 				objectType, objectDeletions[objectType], libraryVersion
+			);
+		}
+
+		Zotero.debug(JSON.stringify(objectIDs));
+		for (let objectType in objectIDs) {
+			this._statusCheck();
+			
+			libraryVersion = await this._uploadObjects(
+				objectType, objectIDs[objectType], libraryVersion
 			);
 		}
 	}

--- a/test/tests/syncEngineTest.js
+++ b/test/tests/syncEngineTest.js
@@ -3537,6 +3537,78 @@ describe("Zotero.Sync.Data.Engine", function () {
 			assert.ok(Zotero.Items.get(item1.id));
 			assert.isFalse(Zotero.Items.get(item2.id));
 		});
+
+		it("should not return relation to a deleted item in response", async function () {
+			({ engine, client, caller } = await setup());
+
+			let library = Zotero.Libraries.userLibrary;
+			let libraryVersion = 5;
+			library.libraryVersion = libraryVersion;
+			await library.saveTx();
+
+			var itemOne = await createDataObject('item');
+			var itemTwo = await createDataObject('item');
+			itemOne.addRelatedItem(itemTwo);
+			itemTwo.addRelatedItem(itemOne);
+			await itemOne.saveTx();
+			await itemTwo.saveTx();
+
+			// Simulate response object that would come from the dataserver.
+			let responseObj = {};
+			responseObj["0"] = itemOne.toResponseJSON();
+			responseObj["0"].version = libraryVersion + 1;
+			responseObj["1"] = itemTwo.toResponseJSON();
+			responseObj["1"].version = libraryVersion + 1;
+
+			server.respond(async function (req) {
+				if (req.method == "DELETE") {
+					// On delete, the data for the second item is deleted and it
+					// is removed from the relations of the first item.
+					delete responseObj["1"];
+					responseObj["0"].data.relations = {};
+					req.respond(
+						204,
+						{
+							"Last-Modified-Version": ++libraryVersion
+						},
+					)
+				}
+				else if (req.method == "POST") {
+					// Only respond with data on items that are in the request body
+					let body = JSON.parse(req.requestBody);
+					let keys = body.map(o => o.key);
+					let responseToSend = {};
+					for (let index of Object.keys(responseObj)) {
+						if (keys.includes(responseObj[index].key)) {
+							responseToSend[index] = responseObj[index];
+						}
+					}
+
+					req.respond(
+						200,
+						{
+							"Content-Type": "application/json",
+							"Last-Modified-Version": ++libraryVersion
+						},
+						JSON.stringify({
+							successful: responseToSend,
+							unchanged: {},
+							failed: {}
+						})
+					);
+				}
+			});
+
+			// Sync to send the items to the dataserver
+			await engine._startUpload();
+			// Erase one item and sync again
+			await itemTwo.eraseTx();
+			await engine._startUpload();
+
+			// Make sure that the server does not send a relation to the
+			// deleted item in the response
+			assert.equal(itemOne.relatedItems.length, 0);
+		});
 	});
 	
 	


### PR DESCRIPTION
Fix ghost relations to erased items re-appearing after sync. The dataserver ensures that `dc:relation` relations are bidirectional. On the client side, a simple way to verify this is to remove relation from one item, save it, sync - the relation will be restored. When a related item is erased, syncing would first upload the update to the remaining related item (where the relation is removed), followed by the deletions. While handling update upload, the dataserver would return the old, should-be-removed, `dc:relation` entry for that item because it does not know that the other item is erased.

To handle this, swap the order of operations during sync: upload deletion first and then upload updates after. Then, when the dataserver handles the update of the non-erased item, there is no related item to enforce bidirectional relations to.

Fixes: #5481