### PR TITLE
Fix post-merge item having a relation to itself

### DIFF
--- a/chrome/content/zotero/xpcom/data/items.js
+++ b/chrome/content/zotero/xpcom/data/items.js
@@ -1341,7 +1341,12 @@ Zotero.Items = function () {
 		// Add relations to toItem
 		let oldRelations = fromItem.getRelations();
 		for (let pred in oldRelations) {
-			oldRelations[pred].forEach(obj => toItem.addRelation(pred, obj));
+			oldRelations[pred].forEach((obj) => {
+				// Avoid adding a relation to self
+				if (obj !== toURI) {
+					toItem.addRelation(pred, obj);
+				}
+			});
 		}
 		
 		// Remove merge-tracking relations from fromItem, so that there aren't two
@@ -1362,6 +1367,8 @@ Zotero.Items = function () {
 			// so those will follow the merge-tracking relations and can optimize their
 			// path if they're resaved.
 			if (rel.subject.libraryID != toItem.libraryID) continue;
+			// Do not add a relation to self
+			if (rel.subject.id == toItem.id) continue;
 			rel.subject.removeRelation(rel.predicate, fromURI);
 			rel.subject.addRelation(rel.predicate, toURI);
 			await rel.subject.save();

--- a/test/tests/duplicatesTest.js
+++ b/test/tests/duplicatesTest.js
@@ -81,5 +81,33 @@ describe("Duplicate Items", function () {
 			assert.isTrue(collection1.hasItem(item1.id));
 			assert.isTrue(collection2.hasItem(item1.id));
 		});
+
+		it("should not create a relation to self if related items are merged", async function () {
+			// Create 3 items related to each other
+			// item1 <-> item2, item2 <-> item3
+			var item1 = await createDataObject('item', { setTitle: true });
+			var item2 = item1.clone();
+			var item3 = item1.clone();
+			await item2.saveTx();
+			await item3.saveTx();
+
+			item1.addRelatedItem(item2);
+			item2.addRelatedItem(item1);
+			
+			item2.addRelatedItem(item3);
+			item3.addRelatedItem(item2);
+
+			await item1.saveTx();
+			await item2.saveTx();
+			await item3.saveTx();
+
+			// Merge all 3 items into item1
+			await merge(item1.id);
+			
+			// Item 1 should now be related to item2 and item3
+			assert.sameMembers(item1.relatedItems, [item2.key, item3.key]);
+			assert.sameMembers(item2.relatedItems, [item1.key]);
+			assert.sameMembers(item3.relatedItems, [item1.key]);
+		});
 	});
 });


### PR DESCRIPTION
When copying over relations during merge of items that are related to one another, avoid relating the chosen main item to itself.

Fixes: #5487