### PR TITLE
Add column in item tree to display attachment size

### DIFF
--- a/chrome/content/zotero/itemTreeColumns.jsx
+++ b/chrome/content/zotero/itemTreeColumns.jsx
@@ -340,6 +340,15 @@ const COLUMNS = [
 		zoteroPersist: ["hidden", "sortDirection"]
 	},
 	{
+		dataKey: "attachmentSize",
+		defaultIn: ["default"],
+		disabledIn: ["feeds", "feed"],
+		showInColumnPicker: true,
+		label: "zotero.tabs.attachmentSize.label",
+		flex: 0.25,
+		zoteroPersist: ["hidden", "sortDirection"]
+	},
+	{
 		dataKey: "numNotes",
 		disabledIn: ["feeds", "feed"],
 		showInColumnPicker: true,

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -3914,7 +3914,11 @@ Zotero.Item.prototype.getBestAttachmentState = async function () {
 	}
 	var exists = await item.fileExists();
 	let key = item.key;
-	return this._bestAttachmentState = { type, exists, key };
+        let size = 0;
+        if (exists) {
+                 size = await Zotero.Attachments.getTotalFileSize(item);
+        }
+        return this._bestAttachmentState = { type, exists, key, size };
 };
 
 

--- a/chrome/locale/en-US/zotero/zotero.dtd
+++ b/chrome/locale/en-US/zotero/zotero.dtd
@@ -49,6 +49,7 @@
 <!-- Used for columnpicker until the tree supports Fluent strings -->
 <!ENTITY zotero.tabs.notes.label                                               "Notes">
 <!ENTITY zotero.tabs.attachments.label                                 "Attachments">
+<!ENTITY zotero.tabs.attachmentSize.label                                 "Attachment Size">
 
 <!ENTITY zotero.toolbar.duplicate.label				"Show Duplicates">
 <!ENTITY zotero.collections.showUnfiledItems			"Show Unfiled Items">


### PR DESCRIPTION
Add a column to show the attachment size. Useful when Zotero storage starts to run out.

I realized after implementing this that there was already an open PR with the same feature: https://github.com/zotero/zotero/pull/2338. However, it seems like it hasn't been touched since 2022, so I'm still submitting this PR in case it is easier to merge, and to bump the other one.