### PR TITLE
Fix errors when multi-selection contains collections in trash

### DIFF
--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -3671,12 +3671,12 @@ var ZoteroPane = new function () {
 			show.add(m.loadReport);
 		}
 		
-		var items = this.getSelectedObjects();
+		var items = this.getSelectedItems();
 		
 		if (items.length > 0) {
 			// Multiple items selected
 			if (items.length > 1) {
-				var multiple =  '.multiple';
+				multiple = '.multiple';
 				
 				var canMerge = true,
 					canIndex = true,


### PR DESCRIPTION
By using `getSelectedItems()` instead of `getSelectedObjects()`. The code below all assumes that `items` contains items, and we handle general (item or collection) options above, so this seems more correct.

And fix duplicate var.

Fixes #5496