### PR TITLE
Add Relate Items to context menu

### DIFF
--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -2324,6 +2324,29 @@ var ZoteroPane = new function () {
 	};
 	
 	
+	this.relateSelectedItems = async function () {
+		if (!this.canEdit()) {
+			this.displayCannotEditLibraryMessage();
+			return;
+		}
+		
+		let selectedItems = this.getSelectedItems();
+		await Zotero.DB.executeTransaction(async () => {
+			for (let index1 = 0; index1 < selectedItems.length; index1++) {
+				for (let index2 = index1 + 1; index2 < selectedItems.length; index2++) {
+					let item1 = selectedItems[index1];
+					let item2 = selectedItems[index2];
+
+					item1.addRelatedItem(item2);
+					item2.addRelatedItem(item1);
+					await item1.save();
+					await item2.save();
+				}
+			}
+		});
+	};
+	
+	
 	this.deleteSelectedCollection = function (deleteItems) {
 		var collectionTreeRow = this.getCollectionTreeRow();
 		
@@ -3617,6 +3640,7 @@ var ZoteroPane = new function () {
 			'moveToTrash',
 			'deleteFromLibrary',
 			'mergeItems',
+			'relateItems',
 			'sep4',
 			'exportItems',
 			'createBib',
@@ -3679,6 +3703,7 @@ var ZoteroPane = new function () {
 				var multiple =  '.multiple';
 				
 				var canMerge = true,
+					showRelate = true, canRelate = true,
 					canIndex = true,
 					canRecognize = true,
 					canUnrecognize = true,
@@ -3686,10 +3711,18 @@ var ZoteroPane = new function () {
 				var canMarkRead = collectionTreeRow.isFeedsOrFeed();
 				var markUnread = true;
 				
-				for (let i = 0; i < items.length; i++) {
-					let item = items[i];
+				for (let item of items) {
 					if (canMerge && (!item.isRegularItem() || item.isFeedItem || collectionTreeRow.isDuplicates())) {
 						canMerge = false;
+					}
+					
+					if (showRelate) {
+						if (item.isFeedItem) {
+							showRelate = false;
+						}
+						else if (canRelate && items.every(otherItem => otherItem === item || otherItem.relatedItems.includes(item.key))) {
+							canRelate = false;
+						}
 					}
 					
 					if (canIndex && !((await Zotero.Fulltext.canReindex(item)))) {
@@ -3716,6 +3749,13 @@ var ZoteroPane = new function () {
 				
 				if (canMerge) {
 					show.add(m.mergeItems);
+				}
+
+				if (showRelate) {
+					show.add(m.relateItems);
+					if (!canRelate) {
+						disable.add(m.relateItems);
+					}
 				}
 				
 				if (canIndex) {

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -988,6 +988,7 @@
 			<menuitem class="menuitem-iconic zotero-menuitem-move-to-trash" oncommand="ZoteroPane_Local.deleteSelectedItems(true, true);"/>
 			<menuitem class="menuitem-iconic zotero-menuitem-delete-from-lib" oncommand="ZoteroPane_Local.deleteSelectedItems(false, true)"/>
 			<menuitem class="menuitem-iconic zotero-menuitem-merge-items" label="&zotero.items.menu.mergeItems;" oncommand="ZoteroPane_Local.mergeSelectedItems();"/>
+			<menuitem class="menuitem-iconic zotero-menuitem-relate-items" data-l10n-id="item-menu-relate-items" oncommand="ZoteroPane_Local.relateSelectedItems();"/>
 			<menuseparator/>
 			<menuitem class="menuitem-iconic zotero-menuitem-export" oncommand="Zotero_File_Interface.exportItems();"/>
 			<menuitem class="menuitem-iconic zotero-menuitem-create-bibliography" oncommand="Zotero_File_Interface.bibliographyFromItems();"/>

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -202,6 +202,8 @@ item-menu-add-url =
      .label = Web Link
 item-menu-change-parent-item =
      .label = Change Parent Item…
+item-menu-relate-items =
+    .label = Relate Items
 
 view-online = View Online
 item-menu-option-view-online =


### PR DESCRIPTION
We show the Relate Items option for all non-feed items, but disable it when all selected items are already related. That keeps things consistent with the UI we use for Add to Collection, and I think it's a little less confusing than hiding the menu item entirely based on a non-obvious condition (relations between all selected items).

Will throw on mixed multi-selections in the trash until #5497 is merged.

Closes #5477