### PR TITLE
Keep Zotero in the User-Agent, add Firefox

### DIFF
--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -2046,26 +2046,17 @@ Zotero.VersionHeader = {
 	},
 	
 	/**
-	 * Replace Zotero/[version] with Firefox/[version] in the default user agent
+	 * Append Firefox/[version] to the default user agent
 	 *
 	 * @param {String} ua - User Agent
-	 * @param {String} [testAppName] - App name to look for (necessary in tests, which are
-	 *     currently run in Firefox)
 	 */
-	update: function (ua, testAppName) {
+	update: function (ua) {
 		var info = Services.appinfo;
-		var appName = testAppName || info.name;
+		var appName = info.name;
 		
-		var pos = ua.indexOf(appName + '/');
-		var appPart = ua.substr(pos);
-		
-		// Default UA (not a faked UA from the connector
-		if (pos != -1) {
-			ua = ua.slice(0, pos) + `Firefox/${info.platformVersion.match(/^\d+/)[0]}.0`;
-			// To fix cloudflare bot detection. rv frozen to avoid some websites
-			// detecting us as IE11. See https://bugzilla.mozilla.org/show_bug.cgi?id=1806690
-			// For some reason we are note getting this from the Firefox base.
-			ua = ua.replace('rv:115', 'rv:109');
+		// Default UA (not a faked UA from the connector)
+		if (ua.includes(appName + '/')) {
+			ua += ` Firefox/${info.platformVersion.match(/^\d+/)[0]}.0`;
 		}
 		
 		return ua;

--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -2046,7 +2046,7 @@ Zotero.VersionHeader = {
 	},
 	
 	/**
-	 * Append Firefox/[version] to the default user agent
+	 * Add Firefox/[version] to the default user agent
 	 *
 	 * @param {String} ua - User Agent
 	 */
@@ -2054,9 +2054,11 @@ Zotero.VersionHeader = {
 		var info = Services.appinfo;
 		var appName = info.name;
 		
+		var pos = ua.indexOf(appName + '/');
+		
 		// Default UA (not a faked UA from the connector)
-		if (ua.includes(appName + '/')) {
-			ua += ` Firefox/${info.platformVersion.match(/^\d+/)[0]}.0`;
+		if (pos != -1) {
+			ua = ua.substring(0, pos) + `Firefox/${info.platformVersion.match(/^\d+/)[0]}.0 ` + ua.substring(pos);
 		}
 		
 		return ua;

--- a/test/tests/zoteroTest.js
+++ b/test/tests/zoteroTest.js
@@ -12,18 +12,18 @@ describe("Zotero", function() {
 			it("should replace app name with Firefox", function () {
 				var platformVersion = Services.appinfo.platformVersion.match(/^\d+/)[0] + '.0';
 				var ua1 = `Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:60.0) Gecko/20100101 ${Zotero.clientName}/${Zotero.version}`;
-				var ua2 = `Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:60.0) Gecko/20100101 Firefox/${platformVersion}`;
-				assert.equal(Zotero.VersionHeader.update(ua1, ZOTERO_CONFIG.CLIENT_NAME), ua2);
+				var ua2 = `${ua1} Firefox/${platformVersion}`;
+				assert.equal(Zotero.VersionHeader.update(ua1), ua2);
 			});
 			
 			it("should show Chrome user agent unchanged", function () {
 				var ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.139 Safari/537.36';
-				assert.equal(Zotero.VersionHeader.update(ua, ZOTERO_CONFIG.CLIENT_NAME), ua);
+				assert.equal(Zotero.VersionHeader.update(ua), ua);
 			});
 				
 			it("should show Firefox user agent unchanged", function () {
 				var ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:60.0) Gecko/20100101 Firefox/60.0';
-				assert.equal(Zotero.VersionHeader.update(ua, ZOTERO_CONFIG.CLIENT_NAME), ua);
+				assert.equal(Zotero.VersionHeader.update(ua), ua);
 			});
 		});
 	});

--- a/test/tests/zoteroTest.js
+++ b/test/tests/zoteroTest.js
@@ -12,7 +12,7 @@ describe("Zotero", function() {
 			it("should replace app name with Firefox", function () {
 				var platformVersion = Services.appinfo.platformVersion.match(/^\d+/)[0] + '.0';
 				var ua1 = `Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:60.0) Gecko/20100101 ${Zotero.clientName}/${Zotero.version}`;
-				var ua2 = `${ua1} Firefox/${platformVersion}`;
+				var ua2 = `Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:60.0) Gecko/20100101 Firefox/${platformVersion} ${Zotero.clientName}/${Zotero.version}`;
 				assert.equal(Zotero.VersionHeader.update(ua1), ua2);
 			});
 			


### PR DESCRIPTION
And:
- Remove `rv:` replacement after fx140 upgrade
- Remove special handling for tests, since we now run tests in Zotero