### PR TITLE
Citation dialog: fix row cutoff in list mode on linux after resize

### DIFF
--- a/chrome/content/zotero/integration/citationDialog.js
+++ b/chrome/content/zotero/integration/citationDialog.js
@@ -878,6 +878,13 @@ class ListLayout extends Layout {
 		
 		// set min height and resize the window
 		let autoHeight = bubbleInputHeight + sectionsHeight + sectionsWrapperPadding + bottomHeight + marginOfError;
+		// window.resizeTo(X,Y) resizes the window so that it's outerHeight == Y. On mac and windows,
+		// innerHeight and outerHeight are the same. On linux, the outerHeight > innerHeight, perhaps
+		// outerHeight there includes chrome, borders, etc. This difference is accounted for below, so that the dialog
+		// itself (not the outer window) ends up with the desired height.
+		if (Zotero.isLinux) {
+			autoHeight += (window.outerHeight - window.innerHeight);
+		}
 		let minHeight = bubbleInputHeight + bottomHeight;
 		doc.documentElement.style.minHeight = `${minHeight}px`;
 		

--- a/test/tests/citationDialogTest.js
+++ b/test/tests/citationDialogTest.js
@@ -415,6 +415,10 @@ describe("Citation Dialog", function () {
 		it("should perform search in list mode", async function () {
 			IOManager.toggleDialogMode("list");
 
+			// Wait for search triggered after switching dialog modes to finish
+			while (SearchHandler.searching) {
+				await Zotero.Promise.delay(10);
+			}
 			// Search for "one"
 			await dialog.currentLayout.search("one", { skipDebounce: true });
 			// Selected items should have both "one_selected" and "one_selected_open"
@@ -442,6 +446,10 @@ describe("Citation Dialog", function () {
 		it("should perform search in library mode", async function () {
 			IOManager.toggleDialogMode("library");
 
+			// Wait for search triggered after switching dialog modes to finish
+			while (SearchHandler.searching) {
+				await Zotero.Promise.delay(10);
+			}
 			// Search for "one"
 			await dialog.currentLayout.search("one", { skipDebounce: true });
 			// Selected items should have both "one_selected" and "one_selected_open"


### PR DESCRIPTION
Fix bottom row in list mode getting cutoff after auto-resizing on linux. The height of the window seems to include the titlebar (even though it's invisible), so we have to account for that when calculating the new height for the dialog.

Fixes: #5502

Dialog after auto-resizing with 2 rows before:

<img width="641" height="134" alt="before" src="https://github.com/user-attachments/assets/0ea05f06-c3ba-49f7-866b-564e5814b864" />

After:

<img width="644" height="178" alt="after" src="https://github.com/user-attachments/assets/fee38fa8-65b6-4e4e-8476-b254fdbdcc5c" />

