### PR TITLE
Itembox: restore unsaved input value after refresh

### DIFF
--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -60,6 +60,7 @@
 			this._initialVisibleCreators = 5;
 			this._draggedCreator = false;
 			this._selectField = null;
+			this._selectFieldValue = null;
 			this._selectFieldSelection = null;
 			this._addCreatorRow = false;
 			this._switchedModeOfCreator = null;
@@ -2522,7 +2523,7 @@
 			// Save the field ID
 			this._selectField = fieldID;
 
-			// Save selection inside inputs
+			// Save selection and value inside inputs
 			let targetInput = activeElement.closest("input, textarea");
 			if (targetInput) {
 				this._selectFieldSelection = [
@@ -2530,12 +2531,15 @@
 					targetInput.selectionEnd,
 					targetInput.selectionDirection,
 				];
+				// Save the value in case it was changed but not saved
+				this._selectFieldValue = targetInput.value;
 			}
 		}
 		
 		_clearSavedFieldFocus() {
 			this._selectField = null;
 			this._selectFieldSelection = null;
+			this._selectFieldValue = null;
 		}
 
 		_restoreFieldFocus() {
@@ -2565,6 +2569,11 @@
 			if (this._selectFieldSelection) {
 				let input = refocusField.querySelector("input, textarea");
 				if (input) {
+					// Restore the potentially unsaved value
+					if (this._selectFieldValue) {
+						refocusField.value = this._selectFieldValue;
+					}
+					// Restore the selection
 					input.setSelectionRange(...this._selectFieldSelection);
 				}
 			}

--- a/test/tests/itemPaneTest.js
+++ b/test/tests/itemPaneTest.js
@@ -648,6 +648,27 @@ describe("Item pane", function () {
 			await waitForNotifierEvent('modify', 'item');
 			assert.equal(itemOne.getDisplayTitle(), "Updated title");
 		});
+
+		it("should retain unsaved value between refreshes", async function () {
+			let itemOne = new Zotero.Item('book');
+			await ZoteroPane.selectItem(itemOne.id);
+
+			let itemDetails = ZoteroPane.itemPane._itemDetails;
+			let infoBox = itemDetails.getPane("info");
+
+			// Type something into the series field without saving it
+			let seriesField = infoBox.querySelector("#itembox-field-value-series");
+			seriesField.focus();
+			seriesField.value = "Series name";
+			
+			// Trigger a refresh
+			infoBox._renderInternal();
+			await waitForFrame();
+
+			// Ensure the field is still focused AND has the yet-unsaved text
+			assert.equal(doc.activeElement.parentNode.id, "itembox-field-value-series");
+			assert.equal(doc.activeElement.value, "Series name");
+		});
 	});
 
 	describe("Libraries and collections pane", function () {


### PR DESCRIPTION
If `itemBox` refresh happens when an input is focused and has some unsaved changes, restore the value of the input after the refresh.

Potential solution for:
https://forums.zotero.org/discussion/126273/bug-data-that-is-input-is-not-saved-and-needs-to-be-entered-again

---

I have not been able to naturally reproduce the issue from the forums post above. However, I do see the following in the debug log: `Showing editor for publisher ... Showing editor for publisher ... Hiding editor for publisher`.  One `Hiding editor for publisher` is missing. That means that if you have some changes typed in after the first `Showing editor for publisher`, on the second `Showing editor for publisher` (which is refresh and refocusing of the previously focused field), those changes are just discarded. We already restore focus and selection, so perhaps it's also worth trying to restore the value for cases like this.

A simple way I mocked this is by running in the console `setTimeout(() => {document.querySelector("info-box")._renderInternal();console.log("Refresh")}, 5000)` to simulate an unexpected refresh. Then, I would focus the field, type something, wait for the refresh to happen, Tab - and then the edits were gone.

This situation happens, I think, due to the fact that right before the first `Showing editor for publisher`, a new DB transaction is started. Once it finishes, the itemBox is refreshed. So ... maybe that's just what can happen if transactions take a while to run?



