### PR TITLE
ESMify feed processing code

### DIFF
--- a/resource/feeds/FeedProcessor.mjs
+++ b/resource/feeds/FeedProcessor.mjs
@@ -3,9 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 /* eslint-disable quote-props */
-/* globals SAXXMLReader */
 
-"use strict";
+const { SAXXMLReader } = ChromeUtils.importESModule("resource://zotero/feeds/SAXXMLReader.mjs");
 
 function LOG(str) {
 	Zotero.debug("Feed Processor: " + str);
@@ -973,7 +972,7 @@ function WrapperElementInfo(fieldName) {
 /** *** The Processor *****/
 // Implements nsIFeedProcessor, nsISAXContentHandler, nsISAXErrorHandler,
 //            nsIStreamListener, nsIRequestObserver
-function FeedProcessor() {
+export function FeedProcessor() {
 	this._reader = new SAXXMLReader();
 	this._buf = "";
 	this._feed = {};
@@ -1655,7 +1654,3 @@ FeedProcessor.prototype = {
 		this.endElement(uri, localName, qName);
 	},
 };
-
-if (typeof module == "object") {
-	module.exports = FeedProcessor;
-}

--- a/resource/feeds/SAXXMLReader.mjs
+++ b/resource/feeds/SAXXMLReader.mjs
@@ -23,8 +23,6 @@
     ***** END LICENSE BLOCK *****
 */
 
-"use strict";
-
 /**
  * This implements `nsISAXXMLReader` using content-accessible APIs, such as `DOMParser` and
  * `TreeWalker`. It should be usable in any web platform environment that supports those standard
@@ -39,7 +37,7 @@
  * Higher-level components are notified of XML content via the `nsISAXContentHandler` and
  * `nsISAXErrorHandler` interfaces as this reader walks through the XML content.
  */
-class SAXXMLReader {
+export class SAXXMLReader {
 	constructor() {
 		this.contentHandler = null;
 		this.errorHandler = null;
@@ -145,8 +143,4 @@ class SAXXMLReader {
 			this._walk();
 		}
 	}
-}
-
-if (typeof module == "object") {
-	module.exports = SAXXMLReader;
 }


### PR DESCRIPTION
And fully remove references to `hiddenDOMWindow`. We haven't needed to run this code in a DOM window since Z7 (it just needs `DOMParser` and `TreeWalker`, which are available in windowless contexts). This also has the very small benefit of allowing feeds to update when the main window is closed on macOS.