### PR TITLE
Enable support for Unicode features in file renaming by default

### DIFF
--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -2386,7 +2386,7 @@ Zotero.Attachments = new function () {
 		};
 
 
-		const common = (value, { start = false, truncate = false, prefix = '', suffix = '', match = '', replaceFrom = '', replaceTo = '', regexOpts = 'i', case: textCase = '' } = {}) => {
+		const common = (value, { start = false, truncate = false, prefix = '', suffix = '', match = '', replaceFrom = '', replaceTo = '', regexOpts = 'vi', case: textCase = '' } = {}) => {
 			if (value === '' || value === null || typeof value === 'undefined') {
 				return '';
 			}

--- a/test/tests/attachmentsTest.js
+++ b/test/tests/attachmentsTest.js
@@ -1673,7 +1673,7 @@ describe("Zotero.Attachments", function () {
 			);
 		});
 
-		it('should preserve unicode characters', async function () {
+		it('should work with unicode characters', async function () {
 			assert.equal(
 				Zotero.Attachments.getFileBaseNameFromItem(itemUnicode, { formatString: '{{ title case="camel" }}' }),
 				'金毛猎犬GoldenRetriever'
@@ -1685,6 +1685,16 @@ describe("Zotero.Attachments", function () {
 			assert.equal(
 				Zotero.Attachments.getFileBaseNameFromItem(itemUnicode, { formatString: '{{ title case="hyphen" }}' }),
 				'金毛猎犬-golden-retriever'
+			);
+			// By default we include `v flag` to support unicode features
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemUnicode, { formatString: '{{ title replaceFrom="(\\p{L}+)" replaceTo="Dog" }}' }),
+				'Dog - Golden Retriever'
+			);
+			// But it's possible to override regexOpts and disable unicode features
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemUnicode, { formatString: '{{ title replaceFrom="(\\p{L}+)" replaceTo="Dog" regexOpts="i" }}' }),
+				'金毛猎犬 - Golden Retriever'
 			);
 		});
 


### PR DESCRIPTION
This adds the `v` flag to enable support for Unicode features in regex in file renaming by default. I'll prep another PR with older `u` flag for 7.0

Resolve #5514