### PR TITLE
Enable support for Unicode features in file renaming by default (for 7.0)

### DIFF
--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -2386,7 +2386,7 @@ Zotero.Attachments = new function () {
 		};
 
 
-		const common = (value, { start = false, truncate = false, prefix = '', suffix = '', match = '', replaceFrom = '', replaceTo = '', regexOpts = 'i', case: textCase = '' } = {}) => {
+		const common = (value, { start = false, truncate = false, prefix = '', suffix = '', match = '', replaceFrom = '', replaceTo = '', regexOpts = 'ui', case: textCase = '' } = {}) => {
 			if (value === '' || value === null || typeof value === 'undefined') {
 				return '';
 			}

--- a/test/tests/attachmentsTest.js
+++ b/test/tests/attachmentsTest.js
@@ -1674,7 +1674,7 @@ describe("Zotero.Attachments", function() {
 			);
 		});
 
-		it('should preserve unicode characters', async function () {
+		it('should work with unicode characters', async function () {
 			assert.equal(
 				Zotero.Attachments.getFileBaseNameFromItem(itemUnicode, { formatString: '{{ title case="camel" }}' }),
 				'金毛猎犬GoldenRetriever'
@@ -1686,6 +1686,16 @@ describe("Zotero.Attachments", function() {
 			assert.equal(
 				Zotero.Attachments.getFileBaseNameFromItem(itemUnicode, { formatString: '{{ title case="hyphen" }}' }),
 				'金毛猎犬-golden-retriever'
+			);
+			// By default we include `u flag` to support unicode features
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemUnicode, { formatString: '{{ title replaceFrom="(\\p{L}+)" replaceTo="Dog" }}' }),
+				'Dog - Golden Retriever'
+			);
+			// But it's possible to override regexOpts and disable unicode features
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(itemUnicode, { formatString: '{{ title replaceFrom="(\\p{L}+)" replaceTo="Dog" regexOpts="i" }}' }),
+				'金毛猎犬 - Golden Retriever'
 			);
 		});
 


### PR DESCRIPTION
This adds the `u` flag to enable support for Unicode features in regex in file renaming by default. This is a PR for 7.0 where `v` flag could not be supported yet.