### PR TITLE
Citation dialog: fix locators listed out of order in non-english locales

### DIFF
--- a/chrome/content/zotero/integration/citationDialog/popupHandler.mjs
+++ b/chrome/content/zotero/integration/citationDialog/popupHandler.mjs
@@ -106,12 +106,18 @@ export class CitationDialogPopupsHandler {
 
 		// add locator labels if they don't exist yet
 		if (this._getNode("#label").childElementCount == 0) {
-			let locators = Zotero.Cite.labels;
-			for (var locator of locators) {
-				let locatorLabel = Zotero.Cite.getLocatorString(locator);
+			let locators = Zotero.Cite.labels.map((locator) => {
+				return {
+					label: Zotero.Cite.getLocatorString(locator),
+					value: locator
+				};
+			});
+			// Sort locators alphabetically by their label (for non-english locales)
+			locators.sort((a, b) => a.label.localeCompare(b.label));
+			for (var { label, value } of locators) {
 				var option = this.doc.createElement("option");
-				option.value = locator;
-				option.label = locatorLabel;
+				option.value = value;
+				option.label = label;
 				this._getNode("#label").appendChild(option);
 			}
 		}


### PR DESCRIPTION
Sort the locators alphabetically by their label after constructing the popup.

https://forums.zotero.org/discussion/comment/497495/#Comment_497495

For reference, list of locators in Spanish.
Left - before (note "Libro" and "Canon" out of order). Right - after.


<img width="146" height="613" alt="Screenshot 2025-08-29 at 12 02 32 PM" src="https://github.com/user-attachments/assets/4612ad34-42a2-456c-b68a-f1b07689cf95" />
<img width="145" height="615" alt="Screenshot 2025-08-29 at 12 11 10 PM" src="https://github.com/user-attachments/assets/76c9724f-d0e5-4d3a-aab7-758b325fc9dc" />
