### PR TITLE
Citation dialog: updates to locators shortcuts

### DIFF
--- a/chrome/content/zotero/elements/bubbleInput.js
+++ b/chrome/content/zotero/elements/bubbleInput.js
@@ -432,7 +432,6 @@
 			// Handle drag-drop of items from the citationDialog into bubble-input to add them
 			if (itemIDs) {
 				itemIDs = itemIDs.split(",");
-				console.log(itemIDs);
 				let newIndex = 0;
 				if (this.dragOver) {
 					newIndex = [...this.bubbleInput.querySelectorAll(".bubble")].findIndex(node => this.dragOver == node);
@@ -587,6 +586,11 @@
 			this.bubbleInput._body.appendChild(span);
 			let spanWidth = span.getBoundingClientRect().width;
 			span.remove();
+			// set min-width of 1px if the input is focused to ensure
+			// that the cursor is always visible
+			if (document.activeElement == input && !spanWidth) {
+				spanWidth = 1;
+			}
 			return spanWidth;
 		},
 

--- a/chrome/content/zotero/integration/citationDialog/helpers.mjs
+++ b/chrome/content/zotero/integration/citationDialog/helpers.mjs
@@ -195,6 +195,25 @@ export class CitationDialogHelpers {
 	// so page10-15 in 'history of the US page10-15 and something else' will not be treated as a locator.
 	extractLocator(string) {
 		string = string.trim();
+		// special case: colon followed by numbers (e.g. "History of the US: 10" or just ":10")
+		// counts as a page locator
+		let colonRegex = /^(.*):\s*(\d+(?:[\s,-]*\d*)*)(?:\s*)$/;
+		let colonMatch = colonRegex.exec(string);
+		if (colonMatch) {
+			let beforeColon = colonMatch[1].trim();
+			let pageNumbers = colonMatch[2].trim();
+			// extract the actual colon and whitespace portion from the original string
+			let colonIndex = string.indexOf(':');
+			let pageNumbersIndex = string.indexOf(pageNumbers, colonIndex);
+			let fullLocatorString = string.substring(colonIndex, pageNumbersIndex + pageNumbers.length);
+			return {
+				label: "page",
+				locator: pageNumbers,
+				onlyLocator: beforeColon.length === 0,
+				fullLocatorString
+			};
+		}
+		
 		let words = string.split(" ");
 		let locatorLabel, locatorLabelString, locatorValue;
 		let wordLocatorIndex = 0;
@@ -269,6 +288,11 @@ export class CitationDialogHelpers {
 			onlyLocator: fullLocatorString.length == string.length,
 			fullLocatorString
 		};
+	}
+
+	// Check if a given string is a number, potentially with whitespace, commas, colons, or hyphens
+	isOnlyNumberLocator(string) {
+		return /^[\d\s,:-]*\d[\d\s,:-]*$/.test(string);
 	}
 
 	// calculate the height of the #search-row accounting for margins and border

--- a/scss/elements/_bubbleInput.scss
+++ b/scss/elements/_bubbleInput.scss
@@ -74,6 +74,8 @@ bubble-input {
 		position: relative;
 		cursor: pointer;
 		background-color: var(--fill-quinary);
+		// don't let the bubble with a very long locator stretch bubble-input
+		overflow-x: hidden;
 		
 		&:hover:not(.showingDetails) {
 			background-color: var(--fill-quarternary);


### PR DESCRIPTION
- after a new bubble is added to the citation, it is recorded as a just-added bubble. The next locator typed without any additional search query and accepted via Enter will go to that item, instead of going to the bubble right before where the locator was typed.
- just-added bubble is visually marked, so it is more apparent why a locator would go into that bubble.
- the record of just-added bubbles is cleared on `focusout` or` keypress` of an arrow key. That way, it's discarded if the user is almost certainly not intending to immediately type a locator.
- added a special case to recognize a numeric value as a page locator if it is typed right after a bubble is added
- added a special case to recognize ":<number>" as a locator in the same circumstances that "page <number>" is currently recognized

Also, minor refactoring of `cleanSearchQuery` to make it less likely that relevant punctuation (e.g. colon for locators) is removed.

---

In the demo below, I add a page locator to the bubble before the input by typing ":10-15". Then I add a bubble and add a page locator to that newly added bubble by typing a number. Then I type a number 2019 meaning to search by a year - the search does not happen because it is initially treated as a locator. I press ArrowRight, which clears the record of a just-added bubble, and the 2019 is then treated as a search query.

https://github.com/user-attachments/assets/8d55dace-ca8a-4180-853c-f723069da445

Comments:
- I added the visual border around a last-added bubble because I thought it could be helpful to indicate what is happening with the locators. I also found it useful to show which bubbles were just added because it is not always apparent after sorting which bubbles came from the items one clicked on. This is not essential, so if it just makes it busy, we can remove it.
- In QuickFormat dialog, the locators would be added immediately after you type them. Now that we support more locators, including ones that can be quite long (e.g. `chapter "some title of the chapter"`), to apply the locator one needs to press Enter. The same applies to newly added numeric locators for consistency.
- just-added bubbles are cleared if you press arrow keys. This covers navigation through the list of items while the focus remains in the input. I also thought it's an effective to "cancel" the effect of just-added bubble on numeric input without necessarily moving the cursor from the input (as in the demo). We could use something else instead, such as whitespace, for example.
- we briefly discussed adding Cmd/Ctrl-Z to undo a locator going into the bubble and return it into the input. I am not sure how useful it would be with the current setup, given that it's pretty easy to "cancel" the just-added status of a bubble, as in the demo. But let me know if it is something we would still want.
