### PR TITLE
Tagsbox: fix quickly deleted tags reappearing

### DIFF
--- a/chrome/content/zotero/elements/tagsBox.js
+++ b/chrome/content/zotero/elements/tagsBox.js
@@ -241,7 +241,11 @@
 						this.remove(tagName);
 						try {
 							item.removeTag(tagName);
-							await item.saveTx();
+							// Save item after a debounce to avoid triggering multiple
+							// save operations. If there are many tags in the library,
+							// db transaction may not keep up with UI changes, and cause
+							// some deleted rows to reappear.
+							this._saveItemDebounced(item);
 						}
 						catch (e) {
 							this._forceRenderAll();
@@ -637,6 +641,10 @@
 				});
 			}
 		}
+
+		_saveItemDebounced = Zotero.Utilities.debounce(async (item) => {
+			await item.saveTx();
+		});
 
 		_id(id) {
 			return this.querySelector(`[id=${id}]`);


### PR DESCRIPTION
https://forums.zotero.org/discussion/110655/z7-beta-tags-reappear-after-quickly-deleting-them

If a library has many tags and one quickly clicks on "-" button to deleted multiple tags from an item, the database updates may not keep up with UI. To address this, avoid saving the item after every single tag removal - instead, do it once after a debounce.

This issue occurs in libraries with many tags (18,000 in the forums post or 70,000 for me). If there are significantly more tags (hundreds of thousands), all tag operations take a very long time due to tag selector rendering and this stops happening.

Fixes: #5410

Before:

https://github.com/user-attachments/assets/14b7ce67-7656-460d-870a-0e169a2e3c0c


After. Tags are removed synchronously.

https://github.com/user-attachments/assets/492f6924-f67b-435c-9bf7-34c82302949d


---
My understanding is that currently, when "-" buttons from tag rows are pressed quickly, tags are removed from the item synchronously and then async save operation is started:
https://github.com/zotero/zotero/blob/b3223dd94b5f1581b1e310504e52b384413aed92/chrome/content/zotero/elements/tagsBox.js#L243-L244
If this is called many times quickly, `item.saveTx` can take a while, so not after every `item.removeTag` the item will immediately be saved. At some point, something like this will happen: first `item.removeTag` -> first `item.saveTx` started -> second `item.removeTag` -> third `item.removeTag` -> first `item.saveTx` finished -> second `item.saveTx` started -> etc.

When a save operation runs, `_changedData` of tags is cleared:
https://github.com/zotero/zotero/blob/b3223dd94b5f1581b1e310504e52b384413aed92/chrome/content/zotero/xpcom/data/item.js#L2067-L2072

Which will lead to incorrect value of `this._getLatestField('tags')` in `setTags` during subsequent tag deletions:
https://github.com/zotero/zotero/blob/b3223dd94b5f1581b1e310504e52b384413aed92/chrome/content/zotero/xpcom/data/item.js#L4249-L4251

As a result, when the items is saved during tag deletions, sometimes it would have some tags to add into the item in `item._saveData`:
https://github.com/zotero/zotero/blob/b3223dd94b5f1581b1e310504e52b384413aed92/chrome/content/zotero/xpcom/data/item.js#L2078

