### PR TITLE
Fix zoteroSearch missing options for attachment type condition

### DIFF
--- a/chrome/content/zotero/elements/zoteroSearch.js
+++ b/chrome/content/zotero/elements/zoteroSearch.js
@@ -406,7 +406,7 @@
 			this.updateMenuCheckboxesRecursive(conditionsMenu, this.selectedCondition);
 			
 			// Display appropriate operators for condition
-			var selectThis;
+			var selectThis = null;
 			for (var i = 0, len = operatorsList.firstChild.childNodes.length; i < len; i++) {
 				var val = operatorsList.firstChild.childNodes[i].getAttribute('value');
 				var hidden = !operators[val];


### PR DESCRIPTION
Fix regression after 4d803fe2cdb8de7bb812f0dfeffac9b103d12cbd which caused the operator for condition to never get set.

Fixes: #5537

<img width="862" height="191" alt="Screenshot 2025-09-09 at 12 12 12 PM" src="https://github.com/user-attachments/assets/0babbb47-2f8c-402d-96c2-edcba624982c" />
