### PR TITLE
fx140: a11y fix voiceover not reading out menulist labels

### DIFF
--- a/chrome/content/zotero/customElements.js
+++ b/chrome/content/zotero/customElements.js
@@ -241,8 +241,8 @@ Services.scriptloader.loadSubScript('chrome://zotero/content/elements/itemTreeMe
 						this.removeAttribute("aria-hidden");
 					});
 				});
-				// Fx140: set the menulist role to 'combobox' to fix Voiceover no longer announcing
-				// menulist's label. Combobox is already menulist's implicit role, so it's not clear why this helps.
+				// Fx140: set the menulist role to 'combobox' to fix VoiceOver no longer announcing
+				// menulist's label. combobox is already menulist's implicit role, so it's not clear why this helps.
 				// Handle this here instead of connectedCallback of menulist because that doesn't get called
 				// if menulist exists in the initial .xhtml (vs inserted dynamically)
 				if (this.parentElement && this.parentElement.localName == 'menulist') {


### PR DESCRIPTION
Post-fx140, `menulist` labels in chrome windows are not announced by VoiceOver. There are not many `menulist`s in chrome windos left in Firefox 140.3.0esr but one that I found has the same issue (
Open application menu > History > Manage history > Right click on a history entry > Bookmark page > "Location" label on menulist is not announced). This is, however, working as expected with menulists inside of a `<browser>`, for example "Default font" label is properly announced for the font dropdown in Firefox preferences.

Setting the `menulist`'s role to 'combobox' addresses this and gets VoiceOver to announce the labels again. This is interesting because 'combobox' is supposedly `menulist`'s implicit role, so it's not clear why this helps.

It does slightly change the way VoiceOver announces `menulist`s: it announces "combobox" instead of "popup button", but semantically combobox is still appropriate per https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-select-only, and other screen readers already announce them as such.

Fixes: #5424

Before. Note that "Language" and "Item Pane Header" are not announced.

https://github.com/user-attachments/assets/2262ba9e-c935-4c2d-9a52-c05ac49f21d2

After.

https://github.com/user-attachments/assets/ef82825e-35c1-4fd1-bf33-3943248269df

