### PR TITLE
Fix menuManager removedkeys.join is not function on plugin shundown

### DIFF
--- a/chrome/content/zotero/xpcom/pluginAPI/menuManager.js
+++ b/chrome/content/zotero/xpcom/pluginAPI/menuManager.js
@@ -285,8 +285,8 @@
 			};
 		}
 
-		_unregisterByPluginID(pluginID) {
-			let removedKeys = super._unregisterByPluginID(pluginID);
+		async _unregisterByPluginID(pluginID) {
+			let removedKeys = await super._unregisterByPluginID(pluginID);
 			if (!removedKeys) {
 				return [];
 			}

--- a/chrome/content/zotero/xpcom/pluginAPI/pluginAPIBase.mjs
+++ b/chrome/content/zotero/xpcom/pluginAPI/pluginAPIBase.mjs
@@ -340,7 +340,7 @@ class PluginAPIBase {
 	/**
 	 * Unregister all stored options by pluginID
 	 * @param {string} pluginID - PluginID
-	 * @returns {string[]} - The mainKeys of the unregistered options
+	 * @returns {Promise<string[]>} - The mainKeys of the unregistered options
 	 */
 	async _unregisterByPluginID(pluginID) {
 		let paneIDs = Object.keys(this._optionsCache).filter(


### PR DESCRIPTION
Fix follow error:

<img width="695" height="126" alt="7fc209df31f5fd6ef9d9cb23e3189820" src="https://github.com/user-attachments/assets/d28c58af-766b-4345-a95b-ecfcc2064a38" />
