### PR TITLE
Fix item sometimes not added to collection on cross-library drag-drop

### DIFF
--- a/chrome/content/zotero/collectionTree.jsx
+++ b/chrome/content/zotero/collectionTree.jsx
@@ -2310,7 +2310,7 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 					100,
 					function (chunk) {
 						return Zotero.DB.executeTransaction(async () => {
-							let createdBatch = [];
+							let copiedItemIDs = [];
 							for (let item of chunk) {
 								var id = await this._copyItem({
 									item,
@@ -2322,11 +2322,11 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 								if (!id) {
 									continue;
 								}
-								createdBatch.push(id);
+								copiedItemIDs.push(id);
 							}
 							// Add copied items to target collection
 							if (targetCollectionID) {
-								for (let itemID of createdBatch) {
+								for (let itemID of copiedItemIDs) {
 									let item = Zotero.Items.get(itemID);
 									if (item.isTopLevelItem()) {
 										item.addToCollection(targetCollectionID);

--- a/chrome/content/zotero/collectionTree.jsx
+++ b/chrome/content/zotero/collectionTree.jsx
@@ -2327,7 +2327,7 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 							// Add copied items to target collection
 							if (targetCollectionID) {
 								for (let itemID of createdBatch) {
-									let item = await Zotero.Items.getAsync(itemID);
+									let item = Zotero.Items.get(itemID);
 									if (item.isTopLevelItem()) {
 										item.addToCollection(targetCollectionID);
 										await item.save({ skipSelect: true });


### PR DESCRIPTION
When drag-dropping items into a collection in another library, perform the addition to collection in the same transaction as creating a new item in the target library. This way, the notifier event does not fire until the item is copied to the group AND added to the collection.

When the `librariesCollectionsBox` refreshes on the `modify` event when a newly created group item is linked to the selected item, it re-loads the data of the linked item via `item.loadAllData()`. This could happen after the item is added to the collection but before this change is saved. In that case, `item._changed.collections` would be cleared, and when the item is saved, there would be no changes to collections to save. More details on this scenario: https://github.com/zotero/zotero/issues/5539#issuecomment-3294238047

Fixes: #5539

Also, cleanup leftover unused logic of restoring linked item from trash on drop that was removed in 2dd16b44d654669255463cb7342055708b92c593