### PR TITLE
Display libraries and collections box for standalone notes and attachments

### DIFF
--- a/chrome/content/zotero/elements/librariesCollectionsBox.js
+++ b/chrome/content/zotero/elements/librariesCollectionsBox.js
@@ -46,7 +46,9 @@ import { getCSSIcon } from 'components/icons';
 		}
 
 		set item(item) {
-			if (item?.isRegularItem() && !item?.isFeedItem) {
+			let isRegularItem = item?.isRegularItem() && !item?.isFeedItem;
+			let isChildAttachment = item?.isAttachment() && !item.parentItemID;
+			if (isRegularItem || isChildAttachment) {
 				this.hidden = false;
 			}
 			else {

--- a/chrome/content/zotero/elements/librariesCollectionsBox.js
+++ b/chrome/content/zotero/elements/librariesCollectionsBox.js
@@ -47,8 +47,9 @@ import { getCSSIcon } from 'components/icons';
 
 		set item(item) {
 			let isRegularItem = item?.isRegularItem() && !item?.isFeedItem;
-			let isChildAttachment = item?.isAttachment() && !item.parentItemID;
-			if (isRegularItem || isChildAttachment) {
+			let isStandaloneAttachment = item?.isAttachment() && !item.parentItemID;
+			let isStandaloneNote = item?.isNote() && !item.parentItemID;
+			if (isRegularItem || isStandaloneAttachment || isStandaloneNote) {
 				this.hidden = false;
 			}
 			else {

--- a/chrome/content/zotero/elements/noteEditor.js
+++ b/chrome/content/zotero/elements/noteEditor.js
@@ -361,6 +361,7 @@
 				<html:div id="parent-value" class="value zotero-clicky" hidden="true"/>
 -->
 				<tags-box id="tags"/>
+				<libraries-collections-box id="libraries-collections"/>
 				<related-box id="related"/>
 			`, ['chrome://zotero/locale/zotero.dtd']);
 		}
@@ -388,6 +389,12 @@
 			this._item = val;
 			this._id('related').item = this._item;
 			this._id('tags').item = this._item;
+			if (this._item.parentItem) {
+				this._id('libraries-collections').hidden = true;
+			}
+			else {
+				this._id('libraries-collections').item = this._item;
+			}
 
 			this.refresh();
 		}


### PR DESCRIPTION
Display Libraries and Collections box in the itemPane for standalone notes and attachments.

Fixes: #5553