### PR TITLE
Related note to its previous attachment after converting from embedded to standalone

### DIFF
--- a/chrome/content/zotero/elements/attachmentBox.js
+++ b/chrome/content/zotero/elements/attachmentBox.js
@@ -706,8 +706,14 @@
 			newNote.libraryID = this.item.libraryID;
 			newNote.parentID = this.item.parentID;
 			newNote.setNote(this.item.note);
+			// Place new note into the same collections as the attachment
+			let collectionIDs = this.item.getCollections();
+			newNote.setCollections(collectionIDs);
+			// Relate new note and the item
+			newNote.addRelatedItem(this.item);
 			await newNote.saveTx();
 			this.item.setNote("");
+			this.item.addRelatedItem(newNote);
 			await this.item.saveTx();
 		}
 


### PR DESCRIPTION
When an embedded attachment note is converted to a standalone note, relate the standalone note to the attachment and place it in the same collections as the attachment.

Before:

https://github.com/user-attachments/assets/ebe42a89-bf69-47ae-a410-3a02fe9f57e0

After:


https://github.com/user-attachments/assets/e0b979dd-7936-4222-b307-d0b7480b994b

