### PR TITLE
Fix "Next" button not appearing in conflict resolution dialog on linux and windows

### DIFF
--- a/chrome/content/zotero/merge.js
+++ b/chrome/content/zotero/merge.js
@@ -302,7 +302,7 @@ var Zotero_Merge_Window = new function () {
 			_wizard.getButton("finish").setAttribute("hidden", "true");
 		}
 		else {
-			let deck = document.querySelector(".wizard-next-deck");
+			let deck = _wizard.shadowRoot.querySelector(".wizard-next-deck");
 			deck.selectedIndex = 1;
 		}
 		
@@ -317,10 +317,9 @@ var Zotero_Merge_Window = new function () {
 			_wizard.getButton("next").setAttribute("hidden", "true");
 			finishButton.setAttribute("hidden", "false");
 		}
-		// Windows uses a deck to switch between the Next and Finish buttons
-		// TODO: check Linux
+		// Windows and Linux use a deck to switch between the Next and Finish buttons
 		else {
-			let deck = document.querySelector(".wizard-next-deck");
+			let deck = _wizard.shadowRoot.querySelector(".wizard-next-deck");
 			deck.selectedIndex = 0;
 		}
 		


### PR DESCRIPTION
Fixes: #5561

<img width="644" height="401" alt="Screenshot 2025-10-06 at 2 43 43 PM" src="https://github.com/user-attachments/assets/2bef9b88-eb86-4264-9184-f38a77ccf7a8" />

<img width="647" height="400" alt="Screenshot 2025-10-06 at 2 43 57 PM" src="https://github.com/user-attachments/assets/459439c4-df4a-4aba-8853-1274200d6510" />
