### PR TITLE
Disable find-as-you-type on 0 keypress in itemTree

### DIFF
--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -997,7 +997,9 @@ var ItemTree = class ItemTree extends LibraryTree {
 			// When 0 is pressed, remove all colored tags
 			if (position == -1) {
 				let items = this.getSelectedItems();
-				return Zotero.Tags.removeColoredTagsFromItems(items);
+				Zotero.Tags.removeColoredTagsFromItems(items);
+				// Disable find-as-you-type for 0 keypress
+				return false;
 			}
 			let colorData = Zotero.Tags.getColorByPosition(libraryID, position);
 			// If a color isn't assigned to this number or any


### PR DESCRIPTION
`0` keypress in itemTree is meant to remove all colored tags, so it should not trigger find-as-you-type.

https://forums.zotero.org/discussion/107895/zotero-7-beta-jumping-selected-item-after-pressing-0-on-the-keyboard