### PR TITLE
Avoid reloading linked item each time it's fetched

### DIFF
--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -5802,7 +5802,7 @@ Zotero.Item.prototype.migrateExtraFields = function () {
 Zotero.Item.prototype.getLinkedItem = async function (libraryID, bidirectional) {
 	var item = await this._getLinkedObject(libraryID, bidirectional);
 	if (item) {
-		await item.loadAllData();
+		await Zotero.Items.loadDataTypes([item]);
 	}
 	return item;
 };


### PR DESCRIPTION
`item.loadAllData()` completely reloads all data and may clear unsaved changes. Instead, `Zotero.Items.loadDataTypes` will only load data once if it hasn't been loaded yet.

Followup to https://github.com/zotero/zotero/commit/fefad8a9e34a8f5e7d76fc125fe3175a8ab8d5ab per discussion in https://github.com/zotero/zotero/pull/5547#issuecomment-3373597427