### PR TITLE
Fixes for CSL.Engine pre-caching issues and race conditions

### DIFF
--- a/chrome/content/zotero/elements/itemPaneHeader.js
+++ b/chrome/content/zotero/elements/itemPaneHeader.js
@@ -83,7 +83,9 @@
 			];
 			
 			this._bibEntryCache = new LRUCache();
-			this._cacheCSLEngine();
+			if (Zotero.Prefs.get(PREF_HEADER_MODE) === 'bibEntry') {
+				this._cacheCSLEngine();
+			}
 			
 			this.title = this.querySelector('.title');
 			this.titleField = this.title.querySelector('editable-text');

--- a/chrome/content/zotero/xpcom/quickCopy.js
+++ b/chrome/content/zotero/xpcom/quickCopy.js
@@ -43,13 +43,14 @@ Zotero.QuickCopy = new function () {
 		_initialized = true;
 
 		// Make sure export translator code is loaded whenever the output format changes
-		this._prefObserverID = Zotero.Prefs.registerObserver(
-			"export.quickCopy.setting", _loadOutputFormat
-		);
-		
-		this._prefObserverID = Zotero.Prefs.registerObserver(
-			"export.noteQuickCopy.setting", _loadNoteOutputFormat
-		);
+		this._prefObserverIDs = [
+			Zotero.Prefs.registerObserver(
+				"export.quickCopy.setting", _loadOutputFormat
+			),
+			Zotero.Prefs.registerObserver(
+				"export.noteQuickCopy.setting", _loadNoteOutputFormat
+			),
+		];
 		
 		Zotero.Schema.schemaUpdatePromise.then(async () => {
 			// Avoid random translator initialization during tests, which can result in timeouts
@@ -70,7 +71,7 @@ Zotero.QuickCopy = new function () {
 	this.uninit = function () {
 		_initialized = false;
 		_initCancelled = true;
-		Zotero.Prefs.unregisterObserver(this._prefObserverID);
+		this._prefObserverIDs.forEach(id => Zotero.Prefs.unregisterObserver(id));
 	};
 	
 	

--- a/chrome/content/zotero/xpcom/translation/translators.js
+++ b/chrome/content/zotero/xpcom/translation/translators.js
@@ -271,7 +271,7 @@ Zotero.Translators = new function () {
 		await this.init(Object.assign({}, options, { reinit: true }));
 		this._translatorsHash = null;
 		this._sortedTranslatorHash = null;
-		await Zotero.QuickCopy.init();
+		Zotero.QuickCopy.init();
 	};
 	
 	

--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -748,7 +748,7 @@ const { CommandLineOptions } = ChromeUtils.importESModule("chrome://zotero/conte
 			
 			Zotero.Items.startEmptyTrashTimer();
 			
-			await Zotero.QuickCopy.init();
+			Zotero.QuickCopy.init();
 			Zotero.addShutdownListener(() => Zotero.QuickCopy.uninit());
 			
 			Zotero.Feeds.init();


### PR DESCRIPTION
1. Don't bother pre-caching a CSL.Engine for the item pane header if it isn't initially set to `bibEntry` mode. Initializing the engine takes a couple hundred milliseconds (synchronously!) for some styles, so best to avoid when it isn't needed.

2. Fix a nasty Quick Copy `init` race condition:

   `QuickCopy.init()` calls `Style#getCiteProc()`, and a side effect of citeproc-js locale initialization could cause a recursive call back to `QuickCopy.init()`, which would again call `Style#getCiteProc()` (after it had checked its cache but before it had added the new engine to it), leading to an extra, unnecessary CSL.Engine initialization on launch. Now we correctly check whether we've already been initialized, eliminating the race condition.

   Separately, remove `async` keyword from `init()`. It never actually was async - even before Bluebird removal, it didn't await anything or return a promise. And we can't make it await its pre-caching work because `schemaUpdatePromise` won't resolve until `init()` resolves/returns.

3. Fix a Quick Copy pref leak. This would cause some duplicate work to stack up over time when translators are reset.