### PR TITLE
Improve attachments section test

### DIFF
--- a/chrome/content/zotero/elements/attachmentPreview.js
+++ b/chrome/content/zotero/elements/attachmentPreview.js
@@ -302,6 +302,22 @@
 		}
 
 		/**
+		 * Clear all pending tasks and reset processing states.
+		 */
+		_clearPendingTasks() {
+			try {
+				this._lastTask = null;
+				this._isProcessingTask = false;
+				this._isRendering = false;
+				this._isDiscarding = false;
+			}
+			catch (e) {
+				// Ignore errors during cleanup to prevent cascading failures
+				this._debug(`Error during task cleanup: ${e.message}`);
+			}
+		}
+
+		/**
 		 * Process the most recent task
 		 * @returns {Promise<void>}
 		 */


### PR DESCRIPTION
Cancel pending discard to avoid race condition
Cancel pending render/discard after tests

This should fix the unstable `should discard attachments pane preview after becoming invisible` test.

After extensive debugging, it is clear that the failure is due to render tasks sometimes being queued by the previous test. These tasks can execute after the previous test finishes, updating the preview unexpectedly. When the current test attempts to discard the preview, the condition check finds that the preview is newer than the one it was asked to discard. As a result, the discard operation is skipped and the test fails.
