### PR TITLE
Enhance copying between libraries and linked collections

### DIFF
--- a/chrome/content/zotero/collectionTree.jsx
+++ b/chrome/content/zotero/collectionTree.jsx
@@ -112,6 +112,7 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 		this._expandedRowsOnDrag = new Set();
 		this._expandRowOnHoverTimer = null;
 		this._collapseExpandedRowsTimer = null;
+		this._linkedToSelected = [];
 		
 		this.onLoad = this.createEventBinding('load', true, true);
 	}
@@ -231,6 +232,9 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 				}
 			}
 		}
+		// when selection changes, highlight collections linked to the one currently selected
+		this.highlightLinkedCollections();
+
 		if (shouldDebounce) {
 			this._onSelectionChangeDebounced();
 		}
@@ -1071,12 +1075,31 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 		return promise;
 	}
 
+
+	// highlight collections linked to the currently selected collection
+	async highlightLinkedCollections() {
+		let treeRow = this.getRow(this.selection.focused);
+		// when selection changes, highlight collections linked to the one currently selected
+		if (treeRow.isCollection()) {
+			treeRow.ref.getAllLinkedCollections(true).then((linkedCols) => {
+				this._linkedToSelected = linkedCols.filter(col => col).map(col => "C" + col.id);
+				this.setHighlightedRows(this._linkedToSelected, { color: "var(--accent-blue10)", dontEnsureVisible: true });
+			});
+		}
+		// if not a collection is selected, clear the highlight
+		else {
+			this.setHighlightedRows();
+		}
+	}
+
 	/**
 	 * Set the rows that should be highlighted
 	 *
 	 * @param ids {String[]} list of row ids to be highlighted
+	 * @param options.dontEnsureVisible {Boolean} do not expand collections and scroll the itemTree
+	 * @param options.color {String} CSS color for the highlight
 	 */
-	async setHighlightedRows(ids) {
+	async setHighlightedRows(ids, options = {}) {
 		if (this._editing) return;
 		try {
 			this._highlightedRows = new Set();
@@ -1086,12 +1109,15 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 			}
 			
 			// Make sure all highlighted collections are shown
-			for (let id of ids) {
-				if (id[0] == 'C') {
-					await this.expandToCollection(parseInt(id.substr(1)));
+			if (!options.dontEnsureVisible) {
+				for (let id of ids) {
+					if (id[0] == 'C') {
+						await this.expandToCollection(parseInt(id.substr(1)));
+					}
 				}
 			}
-			
+			// Set highlight color
+			this.domEl.style.setProperty('--highlight-color', options.color);
 			// Highlight rows
 			var rows = [];
 			for (let id of ids) {
@@ -1105,7 +1131,7 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 			// Select first collection
 			// TODO: This is slightly annoying if some subsequent
 			// but not the first row is visible
-			if (rows.length) {
+			if (rows.length && !options.dontEnsureVisible) {
 				this.ensureRowIsVisible(rows[0]);
 			}
 		} finally {
@@ -1388,7 +1414,7 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 	getSelectedGroup(asID) {
 		if (this.getRow(this.selection.focused)) {
 			var group = this.getRow(this.selection.focused);
-			if (group && group.isGroup()) {
+			if (group && (group.isGroup() || group.isLibrary())) {
 				return asID ? group.ref.id : group.ref;
 			}
 		}
@@ -1785,6 +1811,13 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 					}
 				}
 				
+				// Dragging to a different library
+				let linkedCollections = this._linkedToSelected.map(col => Zotero.Collections.get(col.substr(1)));
+				let linkedCollection = linkedCollections.find(col => col.libraryID == treeRow.ref.libraryID);
+				// If the library has a linked collection, only allow dropping into that collection
+				if (linkedCollection && linkedCollection.id !== treeRow.ref.id) {
+					return false;
+				}
 				return true;
 			}
 		}
@@ -1886,265 +1919,6 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 		return true;
 	}
 
-	/**
-	 * Copy a given item into another library. Used when we need to create a copy of a collection
-	 * in another library if collection is drag-dropped into a group it is not a part of.
-	 */
-	async _copyItem({ item, targetLibraryID, targetTreeRow, options }) {
-		// Check if there's already a copy of this item in the library
-		var linkedItem = await item.getLinkedItem(targetLibraryID, true);
-		if (linkedItem) {
-			return linkedItem.id;
-			
-			/*
-			// TODO: support tags, related, attachments, etc.
-			
-			// Overlay source item fields on unsaved clone of linked item
-			var newItem = item.clone(false, linkedItem.clone(true));
-			newItem.setField('dateAdded', item.dateAdded);
-			newItem.setField('dateModified', item.dateModified);
-			
-			var diff = newItem.diff(linkedItem, false, ["dateAdded", "dateModified"]);
-			if (!diff) {
-				// Check if creators changed
-				var creatorsChanged = false;
-				
-				var creators = item.getCreators();
-				var linkedCreators = linkedItem.getCreators();
-				if (creators.length != linkedCreators.length) {
-					Zotero.debug('Creators have changed');
-					creatorsChanged = true;
-				}
-				else {
-					for (var i=0; i<creators.length; i++) {
-						if (!creators[i].ref.equals(linkedCreators[i].ref)) {
-							Zotero.debug('changed');
-							creatorsChanged = true;
-							break;
-						}
-					}
-				}
-				if (!creatorsChanged) {
-					Zotero.debug("Linked item hasn't changed -- skipping conflict resolution");
-					continue;
-				}
-			}
-			toReconcile.push([newItem, linkedItem]);
-			continue;
-			*/
-		}
-		
-		// Standalone attachment
-		if (item.isAttachment()) {
-			var linkMode = item.attachmentLinkMode;
-			
-			// Skip linked files
-			if (linkMode == Zotero.Attachments.LINK_MODE_LINKED_FILE) {
-				Zotero.debug("Skipping standalone linked file attachment on drag");
-				return false;
-			}
-			
-			if (!targetTreeRow.filesEditable) {
-				Zotero.debug("Skipping standalone file attachment on drag");
-				return false;
-			}
-			
-			let newAttachment = await Zotero.Attachments.copyAttachmentToLibrary(item, targetLibraryID);
-			if (options.annotations) {
-				await Zotero.Items.copyChildItems(item, newAttachment);
-			}
-			
-			return newAttachment.id;
-		}
-		
-		// Create new clone item in target library
-		var newItem = item.clone(targetLibraryID, { skipTags: !options.tags });
-		
-		var newItemID = await newItem.save({
-			skipSelect: true
-		});
-		
-		// Record link
-		await newItem.addLinkedItem(item);
-		
-		if (item.isNote()) {
-			if (Zotero.Libraries.get(newItem.libraryID).filesEditable) {
-				await Zotero.Notes.copyEmbeddedImages(item, newItem);
-			}
-			return newItemID;
-		}
-		
-		// For regular items, add child items if prefs and permissions allow
-		
-		// Child notes
-		if (options.childNotes) {
-			var noteIDs = item.getNotes();
-			var notes = Zotero.Items.get(noteIDs);
-			for (let note of notes) {
-				let newNote = note.clone(targetLibraryID, { skipTags: !options.tags });
-				newNote.parentID = newItemID;
-				await newNote.save({
-					skipSelect: true
-				})
-
-				if (Zotero.Libraries.get(newNote.libraryID).filesEditable) {
-					await Zotero.Notes.copyEmbeddedImages(note, newNote);
-				}
-				await newNote.addLinkedItem(note);
-			}
-		}
-		
-		// Child attachments
-		if (options.childLinks || options.childFileAttachments) {
-			var attachmentIDs = item.getAttachments();
-			var attachments = Zotero.Items.get(attachmentIDs);
-			for (let attachment of attachments) {
-				var linkMode = attachment.attachmentLinkMode;
-				
-				// Skip linked files
-				if (linkMode == Zotero.Attachments.LINK_MODE_LINKED_FILE) {
-					Zotero.debug("Skipping child linked file attachment on drag");
-					continue;
-				}
-				
-				// Skip imported files if we don't have pref and permissions
-				if (linkMode == Zotero.Attachments.LINK_MODE_LINKED_URL) {
-					if (!options.childLinks) {
-						Zotero.debug("Skipping child link attachment on drag");
-						continue;
-					}
-				}
-				else {
-					if (!options.childFileAttachments
-							|| (!targetTreeRow.filesEditable && !targetTreeRow.isPublications())) {
-						Zotero.debug("Skipping child file attachment on drag");
-						continue;
-					}
-				}
-				let newAttachment = await Zotero.Attachments.copyAttachmentToLibrary(
-					attachment, targetLibraryID, newItemID
-				);
-				
-				if (options.annotations) {
-					await Zotero.Items.copyChildItems(attachment, newAttachment);
-				}
-			}
-		}
-		
-		return newItemID;
-	}
-	
-	/**
-	 * Helper function used by executeCollectionCopy to recursively copy collections from one library
-	 * into another, or from one collection to another within the same library.
-	 */
-	async _copyCollections({ descendents, parentID, addItems, targetLibraryID, targetTreeRow, copyOptions }) {
-		for (var desc of descendents) {
-			// Collections
-			if (desc.type == 'collection') {
-				var c = await Zotero.Collections.getAsync(desc.id);
-				let newCollection = c.clone(targetLibraryID);
-				// set the parent collection if provided or null if copying to root library
-				newCollection.parentID = parentID || null;
-				var collectionID = await newCollection.save();
-				
-				// Record link only if copying to a different library
-				if (targetLibraryID !== c.libraryID) {
-					await newCollection.addLinkedCollection(c);
-				}
-				
-				// Recursively copy subcollections
-				if (desc.children.length) {
-					await this._copyCollections({
-						descendents: desc.children,
-						parentID: collectionID,
-						addItems,
-						targetLibraryID,
-						targetTreeRow,
-						copyOptions
-					});
-				}
-			}
-			// Items
-			else {
-				var item = await Zotero.Items.getAsync(desc.id);
-				let id = desc.id;
-				// Actually copy items only if moving to another library
-				if (item.libraryID !== targetLibraryID) {
-					id = await this._copyItem({
-						item,
-						targetLibraryID,
-						targetTreeRow,
-						options: copyOptions
-					});
-					// Standalone attachments might not get copied
-					if (!id) {
-						continue;
-					}
-				}
-				// Mark copied item for adding to collection
-				if (parentID) {
-					let parentItems = addItems.get(parentID);
-					if (!parentItems) {
-						parentItems = [];
-						addItems.set(parentID, parentItems);
-					}
-					
-					// If source item is a top-level non-regular item (which can exist in a
-					// collection) but target item is a child item (which can't), add
-					// target item's parent to collection instead
-					if (!item.isRegularItem()) {
-						let targetItem = await Zotero.Items.getAsync(id);
-						let targetItemParentID = targetItem.parentItemID;
-						if (targetItemParentID) {
-							id = targetItemParentID;
-						}
-					}
-					
-					parentItems.push(id);
-				}
-			}
-		}
-	}
-
-	/**
-	 * Copy a given collection into another library, or duplicate it within the same library
-	 *
-	 * Used for drag-and-drop and the "Copy To" context menu option
-	 *
-	 * @param {Zotero.Collection} collection - collection to copy
-	 * @param {String} targetCollectionID - id of the collection to copy to
-	 * @param {String} targetLibraryID - id of the library to copy to
-	 * @param {Zotero.CollectionTreeRow } targetTreeRow - tree row of the target
-	 * @param {Object} copyOptions - options how to perform the copy - see onDrop for an example
-	*/
-	async executeCollectionCopy({ collection, targetCollectionID, targetLibraryID, targetTreeRow, copyOptions }) {
-		await Zotero.DB.executeTransaction(async () => {
-			var collections = [{
-				id: collection.id,
-				children: collection.getDescendents(true),
-				type: 'collection'
-			}];
-			
-			var addItems = new Map();
-			await this._copyCollections({
-				descendents: collections,
-				parentID: targetCollectionID,
-				addItems,
-				targetLibraryID,
-				targetTreeRow,
-				copyOptions
-			});
-			for (let [collectionID, items] of addItems.entries()) {
-				let collection = await Zotero.Collections.getAsync(collectionID);
-				await collection.addItems(items);
-			}
-			
-			// TODO: add subcollections and subitems, if they don't already exist,
-			// and display a warning if any of the subcollections already exist
-		});
-	}
-
 	async onDrop(event, index) {
 		const treeRow = this.getRow(index);
 		this._dropRow = null;
@@ -2211,12 +1985,8 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 			var droppedCollection = await Zotero.Collections.getAsync(data[0]);
 			// Collection drag between libraries
 			if (targetLibraryID != droppedCollection.libraryID) {
-				await this.executeCollectionCopy({
-					collection: droppedCollection,
-					targetCollectionID,
-					targetLibraryID,
-					targetTreeRow,
-					copyOptions
+				await Zotero.DB.executeTransaction(async () => {
+					await Zotero.Collections.copy(droppedCollection, targetTreeRow.ref);
 				});
 			}
 			// Collection drag within a library
@@ -2310,12 +2080,7 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 						return Zotero.DB.executeTransaction(async () => {
 							let copiedItemIDs = [];
 							for (let item of chunk) {
-								var id = await this._copyItem({
-									item,
-									targetLibraryID,
-									targetTreeRow,
-									options: copyOptions
-								});
+								var id = await Zotero.Items.copyToLibrary(item, targetTreeRow.ref.libraryID);
 								// Standalone attachments might not get copied
 								if (!id) {
 									continue;

--- a/chrome/content/zotero/collectionTree.jsx
+++ b/chrome/content/zotero/collectionTree.jsx
@@ -1985,9 +1985,7 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 			var droppedCollection = await Zotero.Collections.getAsync(data[0]);
 			// Collection drag between libraries
 			if (targetLibraryID != droppedCollection.libraryID) {
-				await Zotero.DB.executeTransaction(async () => {
-					await Zotero.Collections.copy(droppedCollection, targetTreeRow.ref);
-				});
+				await Zotero.Collections.copy(droppedCollection, targetTreeRow.ref);
 			}
 			// Collection drag within a library
 			else {

--- a/chrome/content/zotero/preferences/preferences_general.xhtml
+++ b/chrome/content/zotero/preferences/preferences_general.xhtml
@@ -304,6 +304,7 @@
 				<checkbox label="&zotero.preferences.groups.annotations;" preference="extensions.zotero.groups.copyAnnotations" native="true"/>
 				<checkbox label="&zotero.preferences.groups.childLinks;" preference="extensions.zotero.groups.copyChildLinks" native="true"/>
 				<checkbox label="&zotero.preferences.groups.tags;" preference="extensions.zotero.groups.copyTags" native="true"/>
+				<checkbox data-l10n-id="preferences-groups-copy-related-items" preference="extensions.zotero.groups.copyRelatedItems" native="true"/>
 			</vbox>
 		</groupbox>
 	</vbox>

--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -3075,14 +3075,14 @@ Zotero.Attachments = new function () {
 	 *
 	 * @return {Zotero.Item} - The new attachment
 	 */
-	this.copyAttachmentToLibrary = async function (attachment, libraryID, parentItemID) {
+	this.copyAttachmentToLibrary = async function (attachment, libraryID, parentItemID, skipTags) {
 		if (attachment.libraryID == libraryID) {
 			throw new Error("Attachment is already in library " + libraryID);
 		}
 		
 		Zotero.DB.requireTransaction();
 		
-		var newAttachment = attachment.clone(libraryID);
+		var newAttachment = attachment.clone(libraryID, { skipTags });
 		if (attachment.isStoredFileAttachment()) {
 			// Attachment path isn't copied over by clone() if libraryID is different
 			newAttachment.attachmentPath = attachment.attachmentPath;

--- a/chrome/content/zotero/xpcom/data/collections.js
+++ b/chrome/content/zotero/xpcom/data/collections.js
@@ -262,11 +262,6 @@ Zotero.Collections = function () {
 			throw new Error("Can only replace a non-deleted linked collection");
 		}
 
-		// If source collection is top-level, ensure linked collection is too
-		if (!collectionToCopy.parentID && linkedColToSource.parentID) {
-			linkedColToSource.parentID = null;
-			await linkedColToSource.saveTx();
-		}
 		// Update the name
 		if (linkedColToSource.name !== collectionToCopy.name) {
 			linkedColToSource.name = collectionToCopy.name;
@@ -320,7 +315,6 @@ Zotero.Collections = function () {
 			...linkedColToSource.getChildItems(),
 			...childCollectionsOfLinked.flatMap(c => c.getChildItems())
 		];
-		itemsOfLinkedCollection = itemsOfLinkedCollection.flatMap(item => [item, ...item.getChildren()]);
 		await Zotero.Utilities.Internal.forEachChunkAsync(itemsOfLinkedCollection, 50, (chunk) => {
 			return Zotero.DB.executeTransaction(async () => {
 				for (let itemInLinkedGroup of chunk) {

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -3838,6 +3838,25 @@ Zotero.Item.prototype.getAttachments = function (includeTrashed) {
 	return ids;
 }
 
+/**
+ * Return all descendant items of this item, including annotations.
+ */
+Zotero.Item.prototype.getChildren = function () {
+	this._requireData('childItems');
+
+	if (this.isFileAttachment()) {
+		return Zotero.Items.get(this.getAnnotations());
+	}
+
+	if (this.isRegularItem()) {
+		let notes = Zotero.Items.get(this.getNotes());
+		let attachments = Zotero.Items.get(this.getAttachments());
+		let annotations = attachments.filter(att => att.isFileAttachment()).flatMap(att => Zotero.Items.get(att.getAnnotations()));
+		return [...notes, ...attachments, ...annotations];
+	}
+	return [];
+};
+
 
 /**
  * Looks for attachment in the following order: oldest PDF attachment matching parent URL,
@@ -4844,6 +4863,8 @@ Zotero.Item.prototype.multiDiff = function (otherItems, ignoreFields) {
  * @param {Number} [libraryID] - libraryID of the new item, or the same as original if omitted
  * @param {Boolean} [options.skipTags=false] - Skip tags
  * @param {Boolean} [options.includeCollections=false] - Add new item to all collections
+ * @param {Zotero.Item} [options.shouldReplaceItem] - If provided, data will be cloned INTO this item, instead of creating a new one.
+ * This is used to "sync" data of item in one library with linked item in another library.
  * @return {Zotero.Item}
  */
 Zotero.Item.prototype.clone = function (libraryID, options = {}) {
@@ -4858,7 +4879,7 @@ Zotero.Item.prototype.clone = function (libraryID, options = {}) {
 	}
 	var sameLibrary = libraryID == this.libraryID;
 	
-	var newItem = new Zotero.Item;
+	var newItem = options.shouldReplaceItem || (new Zotero.Item);
 	newItem.libraryID = libraryID;
 	newItem.setType(this.itemTypeID);
 	

--- a/chrome/content/zotero/xpcom/data/items.js
+++ b/chrome/content/zotero/xpcom/data/items.js
@@ -122,7 +122,8 @@ Zotero.Items = function () {
 		if (onlyTopLevel) {
 			sql += ' LEFT JOIN itemNotes B USING (itemID) '
 			+ 'LEFT JOIN itemAttachments C ON (C.itemID=A.itemID) '
-			+ 'WHERE B.parentItemID IS NULL AND C.parentItemID IS NULL';
+			+ 'WHERE B.parentItemID IS NULL AND C.parentItemID IS NULL'
+			+ ' AND A.itemID NOT IN (SELECT itemID FROM itemAnnotations)'; // exclude annotations that are never top-level
 		}
 		else {
 			sql += " WHERE 1";
@@ -850,34 +851,240 @@ Zotero.Items = function () {
 	 *
 	 * Requires a transaction
 	 */
-	this.copyChildItems = async function (fromItem, toItem) {
+	this.copyChildItems = async function (fromItem, toItem, options = {}) {
 		Zotero.DB.requireTransaction();
 		
 		var fromGroup = fromItem.library.isGroup;
 		
 		// Annotations on files
 		if (fromItem.isFileAttachment()) {
-			let annotations = fromItem.getAnnotations();
-			for (let annotation of annotations) {
+			let fromAnnotations = fromItem.getAnnotations();
+			let toAnnotations = toItem.getAnnotations();
+			await Zotero.Items.loadDataTypes(toAnnotations);
+			
+			for (let annotation of fromAnnotations) {
 				// Don't copy embedded PDF annotations
 				if (annotation.annotationIsExternal) {
 					continue;
 				}
-				let newAnnotation = annotation.clone(toItem.libraryID);
-				newAnnotation.parentItemID = toItem.id;
+				let targetAnnotation;
+				if (options.mergeAnnotations) {
+					// Try to see if the destination item already has an annotation at the same
+					// position as where this annotation would be added
+					targetAnnotation = toAnnotations.find(a =>
+						a.annotationPosition == annotation.annotationPosition
+						&& a.annotationType == annotation.annotationType
+					);
+					if (targetAnnotation) {
+						// If the annotation exits, update its comment and add tags
+						if (annotation.annotationComment) {
+							targetAnnotation.annotationComment = annotation.annotationComment;
+						}
+						for (let { tag } of annotation.getTags()) {
+							targetAnnotation.addTag(tag);
+						}
+					}
+				}
+				// If the target annotation wasn't found above, create a copy
+				if (!targetAnnotation) {
+					targetAnnotation = annotation.clone(toItem.libraryID);
+					targetAnnotation.parentItemID = toItem.id;
+				}
+
 				// If there's no explicit author and we're copying an annotation created by another
 				// user from a group, set the author to the creating user
 				if (fromGroup
 						&& !annotation.annotationAuthorName
 						&& annotation.createdByUserID != Zotero.Users.getCurrentUserID()) {
-					newAnnotation.annotationAuthorName =
+					targetAnnotation.annotationAuthorName =
 						Zotero.Users.getName(annotation.createdByUserID);
 				}
-				await newAnnotation.save();
+				await targetAnnotation.save();
 			}
 		}
 		
 		// TODO: Other things as necessary
+	};
+
+	/**
+	 * Copy a given item and its descendants into another library, and link the
+	 * copy to the new item.
+	 * If the linked item already exists, it will not be updated but not-linked child items
+	 * will still be added (including annotations).
+	 * This is a purely additive operation that does not overwrite any data or delete anything.
+	 * When annotations are copied, we try to merge them based on their position and type to avoid
+	 * creating unnecessary duplicates. See copyChildItems above for details.
+	 * @param {Zotero.Item} item - Item to copy
+	 * @param {Number} targetLibraryID - Library where item is copied
+	 * @return {Zotero.Item} - Item in target library linked to given item
+	 */
+	this.copyToLibrary = async function (item, targetLibraryID) {
+		if (!(item.isRegularItem() || item.isNote() || item.isAttachment())) {
+			throw new Error("Can only copy regular items, notes, or attachments");
+		}
+		let targetLibrary = Zotero.Libraries.get(targetLibraryID);
+		Zotero.DB.requireTransaction();
+		
+		let copyPrefs = {
+			tags: Zotero.Prefs.get('groups.copyTags'),
+			childNotes: Zotero.Prefs.get('groups.copyChildNotes'),
+			childLinks: Zotero.Prefs.get('groups.copyChildLinks'),
+			childFileAttachments: Zotero.Prefs.get('groups.copyChildFileAttachments'),
+			annotations: Zotero.Prefs.get('groups.copyAnnotations'),
+		};
+
+		let copyAttachment = async (attachment, parentID) => {
+			var linkMode = attachment.attachmentLinkMode;
+
+			// Skip linked files
+			if (linkMode == Zotero.Attachments.LINK_MODE_LINKED_FILE) {
+				Zotero.debug("Cross-library item copy: Skipping linked file attachment");
+				return false;
+			}
+			// Skip imported files if we don't have pref and permissions
+			if (linkMode == Zotero.Attachments.LINK_MODE_LINKED_URL && !copyPrefs.childLinks) {
+				Zotero.debug("Cross-library item copy: Skipping imported file attachment");
+				return false;
+			}
+			// Skip if target library doesn't allow file editing
+			if (!(targetLibrary.editable && targetLibrary.filesEditable)) {
+				Zotero.debug("Cross-library item copy: Skipping attachment - not editable target");
+				return false;
+			}
+			// Skip child file attachments if pref not set
+			if (!copyPrefs.childFileAttachments && attachment.parentItemID) {
+				Zotero.debug("Cross-library item copy: Skipping child file attachment");
+				return false;
+			}
+
+			// Check if the attachment already has a linked item in the library
+			let copiedAttachment = await attachment.getLinkedItem(targetLibrary.libraryID, true);
+			if (copiedAttachment) {
+				// Ensure parent item is correct
+				if (copiedAttachment.parentID !== parentID) {
+					copiedAttachment.parentID = parentID;
+					await copiedAttachment.save();
+				}
+			}
+			else {
+				// If not - create a new copy
+				copiedAttachment = await Zotero.Attachments.copyAttachmentToLibrary(
+					attachment, targetLibrary.libraryID, parentID, !copyPrefs.tags
+				);
+			}
+			// If specified, copy annotations
+			if (copyPrefs.annotations) {
+				await Zotero.Items.copyChildItems(attachment, copiedAttachment, { mergeAnnotations: true });
+			}
+			return copiedAttachment;
+		};
+
+		let copyNote = async (note, parentID) => {
+			// Skip if the note already has a linked item in the library
+			// and we are not updating its content
+			let copiedNote = await note.getLinkedItem(targetLibrary.libraryID, true);
+			if (copiedNote) {
+				// Ensure parent item is correct
+				if (copiedNote.parentID !== parentID) {
+					copiedNote.parentID = parentID;
+					await copiedNote.save();
+				}
+				return copiedNote;
+			}
+			// Create new copy of note and record the link
+			let newNote = note.clone(targetLibrary.libraryID, { skipTags: !copyPrefs.tags, shouldReplaceItem: copiedNote });
+			newNote.parentID = parentID;
+			await newNote.save({ skipSelect: true });
+			if (Zotero.Libraries.get(newNote.libraryID).filesEditable) {
+				await Zotero.Notes.copyEmbeddedImages(note, newNote);
+			}
+			await newNote.addLinkedItem(note);
+			return newNote;
+		};
+
+		// Copy standalone file attachments
+		if (item.isAttachment()) {
+			let result = await copyAttachment(item, false);
+			return result;
+		}
+
+		// Copy standalone notes
+		if (item.isNote()) {
+			let result = await copyNote(item);
+			return result;
+		}
+		
+		// Check if linked item already exists
+		let copiedItem = await item.getLinkedItem(targetLibrary.libraryID, true);
+		if (!copiedItem) {
+			// Create a linked item if it does not yet exist
+			copiedItem = item.clone(targetLibrary.libraryID, { skipTags: !copyPrefs.tags });
+			await copiedItem.save({ skipSelect: true });
+			await copiedItem.addLinkedItem(item);
+		}
+		
+		// Child notes of the regular item
+		if (copyPrefs.childNotes) {
+			var noteIDs = item.getNotes();
+			var notes = Zotero.Items.get(noteIDs);
+			for (let note of notes) {
+				await copyNote(note, copiedItem.id);
+			}
+		}
+		
+		// Child attachments of the regular item
+		if (copyPrefs.childLinks || copyPrefs.childFileAttachments) {
+			var attachmentIDs = item.getAttachments();
+			var attachments = Zotero.Items.get(attachmentIDs);
+			for (let attachment of attachments) {
+				await copyAttachment(attachment, copiedItem.id);
+			}
+		}
+		
+		return copiedItem;
+	};
+
+
+	/**
+	 * Make a given item with its descendants in target library have the same data
+	 * as its linked item in another library. This operation is destructive: it can change
+	 * item's metadata, remove child items, add/remove item from collections, etc.
+	 * The goal is to have this item identical to the linked item.
+	 * If the linked item does not exist, this item is trashed.
+	 * @param {Zotero.Item} item - Item to change
+	 * @param {Number} libraryID - Library with linked item whose state needs to be replicated
+	 */
+	this.pullLinkedItemData = async function (item, libraryID) {
+		Zotero.DB.requireTransaction();
+		
+		let linkedItemInLibrary = await item.getLinkedItem(libraryID, true);
+		// If an item in the collection is not linked is not linked to source
+		// library, send it to trash
+		if (!linkedItemInLibrary) {
+			item.deleted = true;
+			await item.save();
+			return;
+		}
+
+		// Update metadata
+		item = linkedItemInLibrary.clone(item.libraryID, { shouldReplaceItem: item, skipTags: !Zotero.Prefs.get('groups.copyTags') });
+		await item.save({ skipSelect: true });
+
+		let shouldSave = false;
+		// Check all collections of the remaining items, and make sure
+		// all collections this item belong to are linked to collections
+		// that the linked item in source library belongs to
+		for (let col of Zotero.Collections.get(item.getCollections())) {
+			let colInSource = await col.getLinkedCollection(libraryID, true);
+			let isSourceItemInCol = colInSource && linkedItemInLibrary.inCollection(colInSource.id);
+			if (!isSourceItemInCol) {
+				item.removeFromCollection(col.id);
+				shouldSave = true;
+			}
+		}
+		if (shouldSave) {
+			await item.save();
+		}
 	};
 	
 	

--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -1712,6 +1712,32 @@ Zotero.Utilities.Internal = {
 		return menu;
 	},
 	
+	/**
+	 * Shortcut to create iconic menus or menuitems.
+	 * @param {Document} doc - document to create element in
+	 * @param {String} nodeType - "menu" or "menuitem"
+	 * @param {Zotero.Library|Zotero.Collection} object - library or collection of this menu component
+	 * @returns {XULElement} - the created menu or menuitem
+	 */
+	createIconicMenuNode: function (doc, nodeType, object) {
+		if (!["menu", "menuitem"].includes(nodeType)) {
+			throw new Error("Invalid nodeType -- must be menu menuitem");
+		}
+		if (!(object instanceof Zotero.Library || object instanceof Zotero.Collection)) {
+			throw new Error("Invalid object -- must be Library or Collection");
+		}
+		let node = doc.createXULElement(nodeType);
+		node.classList.add("menuitem-iconic");
+		node.setAttribute("value", object.treeViewID);
+		node.setAttribute("label", object.name);
+		node.setAttribute("image", object.treeViewImage);
+		if (nodeType == "menu") {
+			let menupopup = doc.createXULElement("menupopup");
+			node.appendChild(menupopup);
+		}
+		return node;
+	},
+	
 	openPreferences: function (paneID, options = {}) {
 		if (typeof options == 'string') {
 			throw new Error("openPreferences() now takes an 'options' object -- update your code");

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -938,6 +938,10 @@
 			<menuitem class="zotero-menuitem-create-report"/>
 			<menuitem class="zotero-menuitem-delete-from-lib" label="&zotero.toolbar.emptyTrash.label;"/>
 			<menuitem class="zotero-menuitem-removeLibrary"/>
+			<menu class="menu-iconic zotero-menuitem-copy-library">
+				<menupopup id="zotero-copy-library-popup" onpopupshowing="ZoteroPane_Local.buildCopyLibraryMenu(event)">
+				</menupopup>
+			</menu>
 		</menupopup>
 		<menupopup id="zotero-itemmenu">
 			<!-- Keep order in sync with buildItemContextMenu -->

--- a/chrome/locale/en-US/zotero/preferences.ftl
+++ b/chrome/locale/en-US/zotero/preferences.ftl
@@ -120,3 +120,6 @@ preferences-sync-reset-restore-to-server-checkbox-label = { $remoteItemsDeletedC
     }
 preferences-sync-reset-restore-to-server-confirmation-text = delete online library
 preferences-sync-reset-restore-to-server-yes = Replace Data in Online Library
+
+preferences-groups-copy-related-items =
+    .label = related items

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -174,6 +174,19 @@ collections-menu-move-collection =
     .label = Move To
 collections-menu-copy-collection =
     .label = Copy To
+collections-menu-copy-collection-additive =
+    .label = Transfer New Items and Collections
+collections-menu-copy-collection-destructive =
+    .label = Replace Existing Items and Collections
+collection-replicate-dialog-title = Replace linked collection's content?
+collection-replicate-dialog-text = This will delete all items and subcollections in the linked collection and replace them with copies of subcollections and items in the selected collection.
+collection-replicate-dialog-checkbox = I understand
+collection-replicate-dialog-accept = Accept
+
+library-replicate-dialog-title = Replace all content of the target library?
+library-replicate-dialog-text = This will completely replace all items and collections in the selected library and replace them with data from the selected collection.
+library-replicate-dialog-checkbox = I understand
+library-replicate-dialog-accept = Accept
 
 item-creator-moveDown =
     .label = Move Down


### PR DESCRIPTION
- allow one to copy a linked collection of one library into another linked collection after the first copy. This will add new subcollections and items (including child attachments, notes, and annotations) into the linked collection without editing already linked items. This is a fairly safe options that one can use regularly to sync most of items between collections without risking that any data is going to be changed or lost.
- provide a new option to "replicate" a collection in another library that will not only copy new items
and subcollections but also update metadata of items, rearrange subcollections to match those in the source library and delete items (including children) and collections that are not linked. It allows one to essentially sync the state of one collection with another. This is a destructive operation that has to be confirmed via a hard confirmation dialog.
- when a linked collection exists, context menu of collection tree "Copy to" will only show the menu of that linked collection. It has two menuitem options - to copy collection or to fully replicate it
- allow one to copy a library into another library, as well as to replicate it, same way as with collections above
- when a collection is selected, highlight the linked collections in other libraries with faint blue, so that there is some indication which collections are linked
- refactoring to move the logic of copying collections/items between libraries from collectionTree into dedicated methods in Zotero.Libraries, Zotero.Collections and Zotero.Items.

Fixes: #3045

---
Marking it as a draft to allow for additional testing and to write additional tests.

Copy collection:

https://github.com/user-attachments/assets/dd5093e6-85f2-493b-923d-3df2393d1676

Copy library:

https://github.com/user-attachments/assets/d117b5da-7be2-414a-9a82-b5699b575c60

Replicate collection:


https://github.com/user-attachments/assets/d4f240bc-39c9-4e19-aa17-cb33ec3f6170



Replicate library:

https://github.com/user-attachments/assets/5660a513-4aab-429c-91e1-5291b348b86b


