### PR TITLE
Style configurator: Handle invalid locales

### DIFF
--- a/chrome/content/zotero/elements/styleConfigurator.js
+++ b/chrome/content/zotero/elements/styleConfigurator.js
@@ -107,6 +107,15 @@
 		}
 
 		set value(val) {
+			try {
+				// eslint-disable-next-line no-new
+				new Intl.Locale(val);
+			}
+			catch (e) {
+				Zotero.logError(e);
+				val = '';
+			}
+			
 			this._value = val;
 			const styleData = this._style ? Zotero.Styles.get(this._style) : null;
 			this.localeListEl.value = styleData && styleData.locale || this._value;


### PR DESCRIPTION
- Don't use string interpolation to build custom element XUL. This was rather dangerous, and it caused the document preferences window to fail to render when interpolated values created invalid XML syntax (like when they included `"` characters).
- When initializing the locale menu, check that the current setting is at least a valid language tag. If it isn't, log an error and discard it.

Fixes #5572