### PR TITLE
Fix misaligned sync reset options radio button labels

### DIFF
--- a/scss/preferences/_sync_reset.scss
+++ b/scss/preferences/_sync_reset.scss
@@ -61,10 +61,6 @@
 	margin-top: 1em;
 }
 
-#sync-reset-radiogroup > div radio .radio-check {
-	margin-inline-end: 1.05em;
-}
-
 #sync-reset-radiogroup > div[disabled] span {
 	color: gray;
 }


### PR DESCRIPTION
Keeping the spacing between the radio buttons and the description text below.

Fixes: #5580

Before:

<img width="434" height="119" alt="Screenshot 2025-10-20 at 1 37 32 PM" src="https://github.com/user-attachments/assets/06ec7161-3d9a-43f0-85f5-042c781bbc3e" />

After:

<img width="454" height="116" alt="Screenshot 2025-10-20 at 1 36 45 PM" src="https://github.com/user-attachments/assets/8c59b842-5650-4036-8d9e-88c765e261d5" />
