### PR TITLE
Fix broken new collection dialog opened from context menu of a group

### DIFF
--- a/chrome/content/zotero/customElements.js
+++ b/chrome/content/zotero/customElements.js
@@ -126,7 +126,7 @@ Services.scriptloader.loadSubScript('chrome://zotero/content/elements/itemTreeMe
 		// event with <menuitem> as target in event.sourceEvent.
 		// This is the event we want to work with, since we do not expect events with .sourceEvent
 		// and <command> has no menupopup ancestor.
-		if (originalTarget.tagName === "command" && event.sourceEvent?.type === "command") {
+		if (originalTarget.localName === "command" && event.sourceEvent?.type === "command") {
 			event = event.sourceEvent;
 			originalTarget = event.target;
 		}


### PR DESCRIPTION
Fix new collection dialog appearing broken when opened via "New Collection" option of context menu on "My Library" or a group in collection tree.

On macOS, the popup of collections would never leave and on windows, subcollection would never appear.

https://github.com/user-attachments/assets/fae27dcd-2b49-4409-b147-758de40788ec



This is a followup to https://github.com/zotero/zotero/pull/5409 that fixed this issue for all collections. The reason why it didn't work for groups is that the command event would fire not on the `menuitem` but on the [command](https://github.com/zotero/zotero/blob/5b82a38383ee2689b959c656713beb3e8accdea6/chrome/content/zotero/zoteroPane.xhtml#L117) node, which is not what the workaround expects (e.g. `command` as a target node does not have the `menupopup`, and etc.). Instead of tweaking the workaround (that was already hacky enough), I thought it's best to just skip the `command` node for this specific option, which solves this on my end. 