### PR TITLE
Persist the state of the Reader sidebar

### DIFF
--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -240,6 +240,7 @@ class ReaderInstance {
 			autoDisableNoteTool: Zotero.Prefs.get('reader.autoDisableTool.note'),
 			autoDisableTextTool: Zotero.Prefs.get('reader.autoDisableTool.text'),
 			autoDisableImageTool: Zotero.Prefs.get('reader.autoDisableTool.image'),
+			sidebarView: Zotero.Prefs.get('reader.lastSidebarTab'),
 			onOpenContextMenu: () => {
 				// Functions can only be passed over wrappedJSObject (we call back onClick for context menu items)
 				this._openContextMenu(this._iframeWindow.wrappedJSObject.contextMenuParams);
@@ -372,6 +373,9 @@ class ReaderInstance {
 				if (this._onChangeSidebarWidthCallback) {
 					this._onChangeSidebarWidthCallback(width);
 				}
+			},
+			onChangeSidebarView: (view) => {
+				Zotero.Prefs.set('reader.lastSidebarTab', view);
 			},
 			onFocusContextPane: () => {
 				if (this instanceof ReaderWindow || !this._window.ZoteroContextPane.focus()) {

--- a/defaults/preferences/zotero.js
+++ b/defaults/preferences/zotero.js
@@ -235,6 +235,7 @@ pref("extensions.zotero.reader.ebookHyphenate", true);
 pref("extensions.zotero.reader.autoDisableTool.note", true);
 pref("extensions.zotero.reader.autoDisableTool.text", true);
 pref("extensions.zotero.reader.autoDisableTool.image", true);
+pref("extensions.zotero.reader.lastSidebarTab", "annotations");
 
 // Set color scheme to auto by default
 pref("browser.theme.toolbar-theme", 2);


### PR DESCRIPTION
Use a new pref named `reader.sidebarView` to persist the most recently selected sidebar tab in the Reader.

Close #5489