### PR TITLE
Potential fix to test 'should refresh on item update' failing sometimes

### DIFF
--- a/test/tests/itemPaneTest.js
+++ b/test/tests/itemPaneTest.js
@@ -230,8 +230,13 @@ describe("Item pane", function () {
 			
 			assert.notExists(win.document.querySelector('#zotero-item-message .custom-head .item-restore-button'));
 			
-			await item1.eraseTx();
-			await item2.eraseTx();
+			let promise = waitForItemEvent('delete');
+			await Zotero.DB.executeTransaction(async function () {
+				await item1.erase();
+				await item2.erase();
+			});
+			await promise;
+
 			await selectLibrary(win);
 		});
 	});


### PR DESCRIPTION
"should refresh on item update" test would sometimes fail, most likely due to the library sometimes not getting re-selected in the previous test 'should update custom header for items in the trash'.

A likely explanation is that the selection event in collectionTree would still be suppressed when selectLibrary is called, so make sure to wait for item deletion to go through before trying to re-select the library. More context: https://github.com/zotero/zotero/issues/5584#issuecomment-3438330589

Fixes: #5584