### PR TITLE
Fix Create Parent Dialog hanging if opened during search

### DIFF
--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -411,14 +411,12 @@ var ItemTree = class ItemTree extends LibraryTree {
 			
 			await this.runListeners('refresh');
 			
-			setTimeout(function () {
-				resolve();
-			});
+			await Zotero.Promise.delay();
+			resolve();
 		}
 		catch (e) {
-			setTimeout(function () {
-				reject(e);
-			});
+			await Zotero.Promise.delay();
+			reject(e);
 			throw e;
 		}
 	})


### PR DESCRIPTION
Fix `createParentDialog` hanging when opened during quicksearch or in saved search. After a parent item is added, `itemTree `is being refreshed. `_refreshPromise` is being resolved after a timeout, which means it will not complete until the modal dialog is closed. Instead, resolve `_refreshPromise` after `Zotero.Promise.delay`, which uses the XPCOM global timer unaffected by modals.

Fixes: #3026

Before:

https://github.com/user-attachments/assets/473b7166-4d7e-4d7a-995f-36c55ddec8dc

After:

https://github.com/user-attachments/assets/b97cef6b-9fd2-4a7f-aa32-78dd8cf68557


