### PR TITLE
Align buttons with the top line of the field

### DIFF
--- a/chrome/content/zotero/elements/attachmentBox.js
+++ b/chrome/content/zotero/elements/attachmentBox.js
@@ -64,7 +64,7 @@
 						<html:div id="indexStatusRow" class="meta-row">
 							<html:div class="meta-label"><html:label id="index-status-label" class="key" data-l10n-id="attachment-info-index"/></html:div>
 							<html:div class="meta-data">
-								<html:label id="index-status"/>
+								<html:span id="index-status"/>
 								<toolbarbutton id="reindex" tabindex="0" oncommand="this.hidden = true; setTimeout(function () { ZoteroPane_Local.reindexItem(); }, 50)"/>
 							</html:div>
 						</html:div>

--- a/scss/abstracts/_mixins.scss
+++ b/scss/abstracts/_mixins.scss
@@ -115,7 +115,7 @@
 
 @mixin clicky-item {
 	display: flex;
-	align-items: flex-start;
+	align-items: baseline;
 	gap: 4px;
 	padding-inline-start: 4px;
 	overflow: hidden;
@@ -130,7 +130,7 @@
 	}
 
 	.icon {
-		height: calc(1.3333333333 * var(--zotero-font-size));
+		line-height: calc(1.3333333333 * var(--zotero-font-size));
 	}
 
 	.label {
@@ -140,9 +140,6 @@
 		width: 0; // Needed to allow the label to shrink for some reason
 		flex: 1;
 		overflow: hidden;
-	}
-	
-	.icon, .label {
 		padding-block: 2px;
 	}
 }
@@ -177,6 +174,8 @@
 			width: 0;
 			min-width: 100%;
 			display: flex;
+			align-items: baseline;
+
 			toolbarbutton {
 				margin-inline-start: 4px;
 			}

--- a/scss/elements/_attachmentBox.scss
+++ b/scss/elements/_attachmentBox.scss
@@ -23,8 +23,10 @@ attachment-box {
 		@include meta-table;
 
 		#index-status {
+			flex: 1 1 auto;
 			padding-inline: var(--editable-text-padding-inline);
 			margin-top: 2px;
+			
 			@include comfortable {
 				margin-top: 3px;
 			}
@@ -34,9 +36,9 @@ attachment-box {
 		{
 			height: 22px;
 			width: 22px;
-			padding: 1px;
+			padding: 4px;
 			margin-left: 4px;
-			@include svgicon-menu("sync", "universal", "20");
+			@include svgicon-menu("sync", "universal", "16");
 			&:not([disabled='true']) {
 				color: var(--fill-secondary);
 			}

--- a/scss/elements/_attachmentRow.scss
+++ b/scss/elements/_attachmentRow.scss
@@ -11,6 +11,7 @@ attachment-row {
 		display: flex;
 		align-items: center;
 		gap: 4px;
+		align-items: baseline;
 		
 		.clicky-item {
 			@include clicky-item;


### PR DESCRIPTION
(Screenshots below have significantly increased font size)

Metadata table:
<img width="381" height="274" alt="Screenshot 2025-10-29 at 15 18 25" src="https://github.com/user-attachments/assets/77337dbf-8694-4a6b-b96e-01ecbf493ee8" />

Attachments list:
<img width="379" height="246" alt="Screenshot 2025-10-29 at 15 18 38" src="https://github.com/user-attachments/assets/39508536-5f03-4352-97a9-c176a8033896" />

Tags list:
<img width="381" height="161" alt="Screenshot 2025-10-29 at 15 24 09" src="https://github.com/user-attachments/assets/323463bb-1c41-470b-bd0c-e6a621c329a1" />

"Re-index" icon tweaked size and position to match:
<img width="384" height="219" alt="Screenshot 2025-10-29 at 15 18 17" src="https://github.com/user-attachments/assets/aaf01fc8-9fa7-4b39-8914-dbc019820b3b" />


Close #5268