### PR TITLE
Revised fix to failing 'should refresh on item update' test

### DIFF
--- a/test/tests/itemPaneTest.js
+++ b/test/tests/itemPaneTest.js
@@ -223,10 +223,11 @@ describe("Item pane", function () {
 			assert.exists(restoreButton);
 			assert.exists(win.document.querySelector('#zotero-item-message .custom-head .item-delete-button'));
 
+			let refreshTrashPromise = waitForNotifierEvent('refresh', 'trash');
 			await restoreButton.click();
 			let ids = await waitForItemEvent('modify');
+			await refreshTrashPromise;
 			assert.equal(ids.length, 2);
-			await waitForFrame();
 			
 			assert.notExists(win.document.querySelector('#zotero-item-message .custom-head .item-restore-button'));
 			


### PR DESCRIPTION
Another potential fix to the test failure. Earlier fix from 30784dd2413e39a3b38c017188f7873c47f13b98 seems to not have worked per https://github.com/zotero/zotero/pull/5595#issuecomment-3452466379.

My revised explanation for `should refresh on item update` failures is that the test before it (`should update custom header for items in the trash`) does not properly wait for the trash to refresh before trying to select the library. `refresh trash` fires when anything in trash changes after `modify` event on items that are restored, so it has to be waited for separately. If we don't wait for trash to refresh, collectionTree select event may still be be suppressed (by `collectionTree.refresh()`) when `selectLibrary` is called and library selection will not happen.

I finally managed to run into this error a few times locally by running `test/runtests.sh -s httpTest.js`, which is how I arrived at `refresh trash` event.

Hopefully fixes: #5584