### PR TITLE
fx140: Fix Ctrl-Enter check

### DIFF
--- a/chrome/content/zotero/platformKeys.js
+++ b/chrome/content/zotero/platformKeys.js
@@ -96,15 +96,7 @@ document.addEventListener('DOMContentLoaded', (event) => {
 		var { getTargetElement, createContextMenuEvent } = ChromeUtils.importESModule("chrome://zotero/content/contextMenuUtils.sys.mjs");
 		let lastPreventedContextMenuTime = 0;
 		document.addEventListener('contextmenu', (event) => {
-			if (!(event.button === 2 && event.buttons === 0 && !event.ctrlKey)) {
-				return;
-			}
-			// Two-finger tap (on some machines?) generates an event that looks
-			// identical to the Ctrl-Enter event, except that the Ctrl-Enter event
-			// should always be exactly in the middle of the window.
-			if (event.mozInputSource === MouseEvent.MOZ_SOURCE_MOUSE
-					&& (event.clientX !== Math.floor(window.innerWidth / 2)
-						|| event.clientY !== Math.floor(window.innerHeight / 2))) {
+			if (!(event.button === 0 && event.buttons === 0 && !event.ctrlKey)) {
 				return;
 			}
 			


### PR DESCRIPTION
This turned out not to be a Sequoia change, but an fx140 change. (I couldn't find a relevant Firefox changeset, but there's a good chance it was something unrelated, like an accessibility improvement, that just happened to change Ctrl-Enter behavior.)

I tested the new check on Tahoe and Sequoia, and it does the right thing on tap, click, and Ctrl-Enter.

Fixes #5594