### PR TITLE
Restore the arrow in the guidance panel

### DIFF
--- a/chrome/content/zotero/elements/guidancePanel.js
+++ b/chrome/content/zotero/elements/guidancePanel.js
@@ -25,6 +25,16 @@
 
 "use strict";
 
+
+const clamp = (number, min, max) => Math.max(min, Math.min(number, max));
+
+const getAnchorOffset = (anchorEl, popoverEl, padding = 5) => {
+	const anchorRect = anchorEl.getBoundingClientRect();
+	const popoverRect = popoverEl.getBoundingClientRect();
+
+	return clamp(anchorRect.left - popoverRect.left, padding, popoverRect.width - padding);
+};
+
 {
 	class GuidancePanel extends XULElementBase {
 		content = MozXULElement.parseXULToFragment(`
@@ -135,6 +145,10 @@
 				
 				this.panel.openPopup(forEl, position || "after_start",
 					x ? parseInt(x, 10) : 0, y ? parseInt(y, 10) : 0);
+
+				const anchorOffset = getAnchorOffset(forEl, this.panel);
+				this.panel.style.setProperty('--anchor-x', `${anchorOffset}px`);
+
 				if (pref) {
 					Zotero.Prefs.set(pref, true);
 				}

--- a/scss/elements/_guidancePanel.scss
+++ b/scss/elements/_guidancePanel.scss
@@ -1,4 +1,23 @@
 guidance-panel {
+	panel[side="top"] {
+		&::part(content) {
+			margin-top: 9px;
+		}
+		
+		&::before {
+			-moz-context-properties: fill, stroke;
+			background: url("chrome://global/skin/arrow/panelarrow-vertical.svg") no-repeat left 9px;
+			content: "";
+			fill: var(--color-toolbar);
+			height: 20px;
+			position: absolute;
+			stroke: var(--color-border);
+			top: -9px;
+			width: 20px;
+			left: var(--anchor-x);
+		}
+	}
+		
 	.panel-container {
 		width: 400px;
 		display: flex;
@@ -9,7 +28,6 @@ guidance-panel {
 			padding: 8px;
 		}
 	}
-	
 	#nav-buttons {
 		-moz-box-align: end;
 		-moz-box-pack: end;


### PR DESCRIPTION
It appears that the arrow in the panel component was removed around FF 87. This PR restores it for the guidance panel only.

Resolve #4110