### PR TITLE
Fix missing labels for options under “Display citations as”

### DIFF
--- a/chrome/content/zotero/elements/styleConfigurator.js
+++ b/chrome/content/zotero/elements/styleConfigurator.js
@@ -228,6 +228,11 @@
 			return this.querySelector('#display-as').value;
 		}
 
+		connectedCallback() {
+			super.connectedCallback();
+			MozXULElement.insertFTLIfNeeded("integration.ftl");
+		}
+
 		async init() {
 			let styleSelector = document.createXULElement('style-selector');
 			styleSelector.id = 'style-selector';


### PR DESCRIPTION
Resolves #5617