### PR TITLE
Fix `should discard attachment pane preview after becoming invisible`

### DIFF
--- a/test/tests/itemPaneTest.js
+++ b/test/tests/itemPaneTest.js
@@ -1745,9 +1745,9 @@ describe("Item pane", function () {
 			await waitForScrollToPane(itemDetails, 'related');
 
 			// Wait for the intersection observer to trigger discard and the discard process to complete
-			await waitForCallback(() => !attachmentBox._preview._isReaderInitialized);
+			await waitForCallback(() => !attachmentBox._preview?._isReaderInitialized);
 
-			assert.isFalse(attachmentBox._preview._isReaderInitialized);
+			assert.isFalse(!!attachmentBox._preview?._isReaderInitialized);
 
 			attachmentBox._discardPreviewTimeout = currentDiscardTimeout;
 		});


### PR DESCRIPTION
fix: #5624

(need to run more rounds to test)