### PR TITLE
Fix misaligned text in the attachment box

### DIFF
--- a/scss/abstracts/_mixins.scss
+++ b/scss/abstracts/_mixins.scss
@@ -174,7 +174,6 @@
 			width: 0;
 			min-width: 100%;
 			display: flex;
-			align-items: baseline;
 
 			toolbarbutton {
 				margin-inline-start: 4px;
@@ -218,11 +217,13 @@
 			// needed to have the outline appear on all platforms
 			appearance: none;
 			-moz-appearance: none;
-			// Make all buttons tigher to not stretch the rows
+			// Make all buttons tighter to not stretch the rows
 			height: auto;
 			width: auto;
 			padding: 1px;
 			border-radius: 2px;
+			// Prevent the button from vertically stretching on multi-line fields (e.g., title)
+			align-self: baseline;
 		}
 	}
 }


### PR DESCRIPTION
Resolve #5627

<img width="324" height="119" alt="Screenshot 2025-11-13 at 15 50 55" src="https://github.com/user-attachments/assets/c953a05e-ef21-41bd-9e5a-ca5397ecb4e9" />

<img width="319" height="238" alt="Screenshot 2025-11-13 at 15 45 25" src="https://github.com/user-attachments/assets/4bec500c-c2ff-44e3-8268-6551bc2d7da6" />

<img width="323" height="217" alt="Screenshot 2025-11-13 at 15 45 35" src="https://github.com/user-attachments/assets/4d7dea1d-36c3-446a-864e-7f47ac307849" />
