### PR TITLE
Citation dialog: warn about cross-library citations

### DIFF
--- a/chrome/content/zotero/collectionTree.jsx
+++ b/chrome/content/zotero/collectionTree.jsx
@@ -348,12 +348,12 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 		// The arrow on macOS is a full icon's width.
 		// For non-userLibrary/feed items that are drawn under headers
 		// we do not draw the arrow and need to move all items 1 level up
-		if (Zotero.isMac && !treeRow.isHeader() && !treeRow.isFeed() && treeRow.ref
-			&& treeRow.ref.libraryID != Zotero.Libraries.userLibraryID) {
+		if (Zotero.isMac && !treeRow.isHeader() && !treeRow.isFeed()
+			&& treeRow.ref && treeRow.ref.libraryID != Zotero.Libraries.userLibraryID) {
 			depth--;
 		}
-		// Ensures the feeds and separator rows have no padding
-		if (treeRow.isFeeds() || treeRow.isSeparator()) {
+		// Ensures the feeds row has no padding
+		if (treeRow.isFeeds()) {
 			depth = 0;
 		}
 		div.style.paddingInlineStart = (CHILD_INDENT * depth) + 'px';
@@ -548,7 +548,6 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 			var added = 0;
 			this._filterResultsCache = {};
 			let libraryIncluded, groupsIncluded, feedsIncluded;
-
 			//
 			// Add "My Library"
 			//
@@ -556,8 +555,8 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 			if (libraryIncluded) {
 				newRows.splice(added++, 0,
 					new Zotero.CollectionTreeRow(this, 'library', Zotero.Libraries.userLibrary));
-				newRows[added - 1].isOpen = true;
-				added += await this._expandRow(newRows, added ? added - 1 : 0);
+				newRows[0].isOpen = true;
+				added += await this._expandRow(newRows, 0);
 			}
 			
 			// Add groups
@@ -1465,9 +1464,6 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 			case 'header':
 				if (treeRow.ref.id == 'group-libraries-header') {
 					icon = 'groups';
-				}
-				if (treeRow.ref.id == 'top-group-header') {
-					icon = 'groups'; // to change
 				}
 				break;
 			case 'separator':

--- a/chrome/content/zotero/collectionTree.jsx
+++ b/chrome/content/zotero/collectionTree.jsx
@@ -114,6 +114,7 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 		this._collapseExpandedRowsTimer = null;
 		
 		this._citedGroupLibraryIDs = new Set();
+		this._citedGroupsLoading = false;
 		
 		this.onLoad = this.createEventBinding('load', true, true);
 	}
@@ -143,9 +144,11 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 	 * Set cited groups to display at the top of the groups section
 	 *
 	 * @param {Array<number>} groupLibraryIDs - Array of group library IDs to show at the top of groups
+	 * @param {boolean} isLoading - If true, cited badge on group rows will display a spinner
 	 */
-	async setCitedGroup(groupLibraryIDs) {
+	async setCitedGroup(groupLibraryIDs, isLoading = false) {
 		this._citedGroupLibraryIDs = new Set(groupLibraryIDs);
+		this._citedGroupsLoading = !!isLoading;
 		for (let [index, row] of this._rows.entries()) {
 			if (row.isLibrary(true) && !this._citedGroupLibraryIDs.has(row.ref.libraryID) && row.isOpen) {
 				await this.toggleOpenState(index);
@@ -435,7 +438,12 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 		// Add "Cited" badge for cited groups
 		if (treeRow.isLibrary(true) && treeRow.ref && this._citedGroupLibraryIDs.has(treeRow.ref.libraryID)) {
 			let citedBadge = document.createElement('span');
-			citedBadge.className = 'cited-badge';
+			citedBadge.className = 'cited-badge has-title';
+			// Add a spinner and tooltip explaining that the library is not confirmed as cited
+			if (this._citedGroupsLoading) {
+				citedBadge.classList.add('loading');
+				citedBadge.setAttribute('title', Zotero.getString('integration-citationDialog-cited-title-loading'));
+			}
 			citedBadge.textContent = Zotero.getString('integration-citationDialog-cited-label');
 			cell.appendChild(citedBadge);
 		}

--- a/chrome/content/zotero/collectionTree.jsx
+++ b/chrome/content/zotero/collectionTree.jsx
@@ -436,7 +436,7 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 		if (treeRow.isLibrary(true) && treeRow.ref && this._citedGroupLibraryIDs.has(treeRow.ref.libraryID)) {
 			let citedBadge = document.createElement('span');
 			citedBadge.className = 'cited-badge';
-			document.l10n.setAttributes(citedBadge, 'integration-citationDialog-cited-label');
+			citedBadge.textContent = Zotero.getString('integration-citationDialog-cited-label');
 			cell.appendChild(citedBadge);
 		}
 		

--- a/chrome/content/zotero/components/virtualized-table.jsx
+++ b/chrome/content/zotero/components/virtualized-table.jsx
@@ -936,7 +936,7 @@ class VirtualizedTable extends React.Component {
 	_handleMouseOver = (event) => {
 		let elem = event.target;
 		let cell = elem.closest('.cell');
-		if (!cell || elem.classList.contains('cell-icon')) return;
+		if (!cell || elem.classList.contains('cell-icon') || elem.classList.contains('has-title')) return;
 		let textElem = elem.querySelector('.label, .cell-text');
 		// .label is used in the header, .cell-text on primary cells,
 		// otherwise the .cell element if its immediate child is a text node

--- a/chrome/content/zotero/integration/citationDialog.js
+++ b/chrome/content/zotero/integration/citationDialog.js
@@ -59,6 +59,16 @@ async function onLoad() {
 	}
 	ioReadyPromise.then(() => ioIsReady = true);
 	isCitingNotes = !!io.isCitingNotes;
+	// set default cited libraries info, if not provided
+	if (!io.getCitedLibraryInfo) {
+		io.getCitedLibraryInfo = () => {
+			return {
+				citedLibrariesURIs: [],
+				citedLibrariesNames: [],
+				citedLibrariesIDs: []
+			};
+		};
+	}
 	window.isPristine = true;
 
 	Zotero.debug("Citation Dialog: initializing");

--- a/chrome/content/zotero/integration/citationDialog.js
+++ b/chrome/content/zotero/integration/citationDialog.js
@@ -679,7 +679,7 @@ class LibraryLayout extends Layout {
 		// Move cited groups to the top
 		let { citedLibrariesIDs } = io.getCitedLibraryInfo();
 		if (citedLibrariesIDs.length) {
-			await libraryLayout.collectionsView.setCitedGroup(citedLibrariesIDs);
+			await libraryLayout.collectionsView.setCitedGroup(citedLibrariesIDs, !ioIsReady);
 		}
 		// Add aria-description with instructions on what this collection tree is for
 		// Voiceover announces the description placed on the actual tree when focus enters it
@@ -859,7 +859,13 @@ class ListLayout extends Layout {
 			let { citedLibrariesIDs } = io.getCitedLibraryInfo();
 			if (citedLibrariesIDs.includes(parseInt(libraryID))) {
 				let citedBadge = Helpers.createNode("span", {}, "cited-badge");
-				document.l10n.setAttributes(citedBadge, "integration-citationDialog-cited-label");
+				citedBadge.textContent = Zotero.getString('integration-citationDialog-cited-label');
+				// Untill the cited items are fetched, add a spinner to the cited badge to indicate
+				// that the library is not confirmed as cited
+				if (!ioIsReady) {
+					citedBadge.classList.add("loading");
+					citedBadge.setAttribute('title', Zotero.getString('integration-citationDialog-cited-title-loading'));
+				}
 				section.querySelector(".header").appendChild(citedBadge);
 			}
 		}

--- a/chrome/content/zotero/integration/citationDialog/popupHandler.mjs
+++ b/chrome/content/zotero/integration/citationDialog/popupHandler.mjs
@@ -235,6 +235,32 @@ export class CitationDialogPopupsHandler {
 		return true;
 	}
 
+	// Display a warning when citing from a new library
+	showCrossLibraryCitationWarning = function (citedLibraryNames) {
+		var ps = Services.prompt;
+		var buttonFlags = ps.BUTTON_POS_0 * ps.BUTTON_TITLE_IS_STRING
+			+ ps.BUTTON_POS_1 * ps.BUTTON_TITLE_CANCEL;
+		var title = Zotero.getString("integration-citationDialog-cross-lib-warning-title");
+		var text = Zotero.getString("integration-citationDialog-cross-lib-warning-line1") + ` ${citedLibraryNames.join(",")}.`;
+		text += `\n\n${Zotero.getString("integration-citationDialog-cross-lib-warning-line2")}`;
+		var result = ps.confirmEx(
+			null,
+			title,
+			text,
+			buttonFlags,
+			Zotero.getString('general.continue'),
+			null, null, null, {}
+		);
+
+		// Cancel
+		if (result == 1) {
+			return false;
+		}
+
+		// Cross-library citations allowed
+		return true;
+	};
+
 	_getNode(selector) {
 		return this.doc.querySelector(selector);
 	}

--- a/chrome/content/zotero/integration/citationDialog/searchHandler.mjs
+++ b/chrome/content/zotero/integration/citationDialog/searchHandler.mjs
@@ -135,6 +135,12 @@ export class CitationDialogSearchHandler {
 			if (!aIsCited && bIsCited) return 1;
 			return b.group.length - a.group.length;
 		});
+		// record which libraries are cited
+		for (let libraryItem of libraryItems) {
+			if (citedLibrariesIDs.includes(libraryItem.libraryID)) {
+				libraryItem.isCited = true;
+			}
+		}
 		result.push(...libraryItems);
 
 		return result;

--- a/chrome/content/zotero/integration/citationDialog/searchHandler.mjs
+++ b/chrome/content/zotero/integration/citationDialog/searchHandler.mjs
@@ -124,8 +124,17 @@ export class CitationDialogSearchHandler {
 			library.group.sort(itemComparator);
 		});
 	
-		// sort libraries by the number of items
-		libraryItems.sort((a, b) => b.group.length - a.group.length);
+		// sort libraries by the number of items, placing cited libraries first
+		let { citedLibrariesIDs } = this.io.getCitedLibraryInfo();
+		libraryItems.sort((a, b) => {
+			let aGroupID = Zotero.Libraries.get(a.key).libraryID;
+			let bGroupID = Zotero.Libraries.get(b.key).libraryID;
+			let aIsCited = citedLibrariesIDs.includes(aGroupID);
+			let bIsCited = citedLibrariesIDs.includes(bGroupID);
+			if (aIsCited && !bIsCited) return -1;
+			if (!aIsCited && bIsCited) return 1;
+			return b.group.length - a.group.length;
+		});
 		result.push(...libraryItems);
 
 		return result;

--- a/chrome/content/zotero/xpcom/integration.js
+++ b/chrome/content/zotero/xpcom/integration.js
@@ -2687,12 +2687,11 @@ Zotero.Integration.DocumentData.prototype.serialize = function () {
 	}
 	// Store cited libraries URI and their group name separated by '='
 	// See refreshCitedLibraries comments for info on why both are needed.
-	let citedLibraries = Object.entries(this.citedLibraryURIs).map(([uri, name]) => `${uri}=${name}`);
-	
+	let citedLibraries = Object.entries(this.citedLibraryURIs).map(([uri, name]) => `${uri}=${name}`).join(",");
 	return '<data data-version="'+Zotero.Utilities.htmlSpecialChars(`${DATA_VERSION}`)+'" '+
-		'zotero-version="'+Zotero.Utilities.htmlSpecialChars(Zotero.version)+'"'+
-		' cited-libraries="' + Zotero.Utilities.htmlSpecialChars(citedLibraries.join(',')) + '"' + '>'
-			+ '<session id="'+Zotero.Utilities.htmlSpecialChars(this.sessionID)+'"/>'+
+		'zotero-version="'+Zotero.Utilities.htmlSpecialChars(Zotero.version)+'">'+
+		'<cited libraries="' + Zotero.Utilities.htmlSpecialChars(citedLibraries) + '"/>' +
+		'<session id="'+Zotero.Utilities.htmlSpecialChars(this.sessionID)+'"/>'+
 		'<style id="'+Zotero.Utilities.htmlSpecialChars(this.style.styleID)+'" '+
 			(this.style.locale ? 'locale="' + Zotero.Utilities.htmlSpecialChars(this.style.locale) + '" ': '') +
 			'hasBibliography="'+(this.style.hasBibliography ? "1" : "0")+'" '+
@@ -2708,8 +2707,8 @@ Zotero.Integration.DocumentData.prototype.unserializeXML = function (xmlData) {
 		doc = parser.parseFromString(xmlData, "application/xml");
 	
 	this.sessionID = Zotero.Utilities.xpathText(doc, '/data/session[1]/@id');
-	let citedLibraryURIsAttr = Zotero.Utilities.xpathText(doc, '/data/@cited-libraries');
-	this.citedLibraryURIs = citedLibraryURIsAttr.split(",").reduce((obj, pair) => {
+	let citedLibraryURIsAttr = Zotero.Utilities.xpathText(doc, '/data/cited/@libraries');
+	this.citedLibraryURIs = (citedLibraryURIsAttr || "").split(",").reduce((obj, pair) => {
 		let [uri, name] = pair.split("=");
 		obj[uri] = name;
 		return obj;

--- a/chrome/content/zotero/xpcom/uri.js
+++ b/chrome/content/zotero/xpcom/uri.js
@@ -375,6 +375,31 @@ Zotero.URI = new function () {
 	};
 	
 	
+	// Fetch library and its name based on the provided URL.
+	// If url is for a group, return group and its name.
+	// If url is for a user, user's name and, if it is the current user, "My Library"
+	this.getLibraryInfoFromURI = function (uri) {
+		if (uri.includes("/groups/")) {
+			let groupID = uri.split("/groups/")[1];
+			let group = Zotero.Groups.get(groupID);
+			if (group) {
+				return { name: group.name, library: group };
+			}
+		}
+		else if (uri.includes("/users/")) {
+			let userID = uri.split("/users/")[1];
+			let result = {
+				name: Zotero.Users.getName(userID),
+				library: null
+			};
+			if (userID == `${Zotero.Users.getCurrentUserID()}`) {
+				result.library = Zotero.Libraries.userLibrary;
+			}
+			return result;
+		}
+		return null;
+	};
+	
 	/**
 	 * Convert an object URI into an object containing libraryID and key
 	 *

--- a/chrome/locale/en-US/zotero/integration.ftl
+++ b/chrome/locale/en-US/zotero/integration.ftl
@@ -87,6 +87,7 @@ integration-citationDialog-collapse-section =
     .title = Collapse section
 integration-citationDialog-bubble-empty = (no title)
 integration-citationDialog-add-to-citation = Add to Citation
+integration-citationDialog-cited-label = Cited
 integration-citationDialog-cross-lib-warning-title = Confirm citation from a new group?
 integration-citationDialog-cross-lib-warning-line1 = All items currently cited in this document belong to:
 integration-citationDialog-cross-lib-warning-line2 = You are about to cite an item from a different library. It is generally not recommended and may cause issues if some collaborators do not have access to all libraries cited in the document.

--- a/chrome/locale/en-US/zotero/integration.ftl
+++ b/chrome/locale/en-US/zotero/integration.ftl
@@ -87,6 +87,10 @@ integration-citationDialog-collapse-section =
     .title = Collapse section
 integration-citationDialog-bubble-empty = (no title)
 integration-citationDialog-add-to-citation = Add to Citation
+integration-citationDialog-cross-lib-warning-title = Confirm citation from a new group?
+integration-citationDialog-cross-lib-warning-line1 = All items currently cited in this document belong to:
+integration-citationDialog-cross-lib-warning-line2 = You are about to cite an item from a different library. It is generally not recommended and may cause issues if some collaborators do not have access to all libraries cited in the document.
+integration-citationDialog-cross-lib-warning-unknown-lib = [Unknown library]
 
 integration-prefs-displayAs-label = Display Citations As:
 integration-prefs-footnotes =

--- a/chrome/locale/en-US/zotero/integration.ftl
+++ b/chrome/locale/en-US/zotero/integration.ftl
@@ -88,6 +88,7 @@ integration-citationDialog-collapse-section =
 integration-citationDialog-bubble-empty = (no title)
 integration-citationDialog-add-to-citation = Add to Citation
 integration-citationDialog-cited-label = Cited
+integration-citationDialog-cited-title-loading = Fetching citations from word processor
 integration-citationDialog-cross-lib-warning-title = Confirm citation from a new group?
 integration-citationDialog-cross-lib-warning-line1 = All items currently cited in this document belong to:
 integration-citationDialog-cross-lib-warning-line2 = You are about to cite an item from a different library. It is generally not recommended and may cause issues if some collaborators do not have access to all libraries cited in the document.

--- a/chrome/skin/default/zotero/8/universal/spinner-8.svg
+++ b/chrome/skin/default/zotero/8/universal/spinner-8.svg
@@ -1,0 +1,3 @@
+<svg width="8" height="8" viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4 1C2.34315 1 1 2.34315 1 4C1 5.65685 2.34315 7 4 7C5.65685 7 7 5.65685 7 4H8C8 6.20914 6.20914 8 4 8C1.79086 8 0 6.20914 0 4C0 1.79086 1.79086 0 4 0V1Z" fill="context-fill"/>
+</svg>

--- a/scss/components/_citationDialog.scss
+++ b/scss/components/_citationDialog.scss
@@ -378,6 +378,16 @@
 						align-items: center;
 						height: 17px;
 					}
+					.cited-badge {
+						margin-left: 8px;
+						padding: 1px 4px;
+						border-radius: 5px;
+						background: var(--accent-blue50);
+						white-space: nowrap;
+						font-size: 0.85em;
+						font-weight: 500;
+						color: var(--fill-primary);
+					}
 				}
 				.item {
 					@include focus-ring(true);

--- a/scss/components/_citationDialog.scss
+++ b/scss/components/_citationDialog.scss
@@ -379,14 +379,7 @@
 						height: 17px;
 					}
 					.cited-badge {
-						margin-left: 8px;
-						padding: 1px 4px;
-						border-radius: 5px;
-						background: var(--accent-blue50);
-						white-space: nowrap;
-						font-size: 0.85em;
 						font-weight: 500;
-						color: var(--fill-primary);
 					}
 				}
 				.item {
@@ -649,6 +642,33 @@
 			#z-icon {
 				margin: 0 !important;
 			}
+		}
+	}
+}
+
+.cited-badge {
+	display: flex;
+	align-items: center;
+	margin-left: 8px;
+	padding: 1px 4px;
+	border-radius: 5px;
+	background: var(--accent-blue30);
+	white-space: nowrap;
+	font-size: 0.85em;
+	&.loading {
+		background-color: var(--fill-tertiary);
+		color: var(--fill-secondary);
+		&::before {
+			background: url("chrome://zotero/skin/8/universal/spinner-8.svg");
+			fill: currentColor;
+			-moz-context-properties: fill,fill-opacity;
+			width: 8px;
+			height: 8px;
+			content: "";
+			display: inline-block;
+			animation: rotating 1s linear infinite;
+			margin-inline-end: 3px;
+			color: var(--fill-tertiary);
 		}
 	}
 }

--- a/scss/components/_collection-tree.scss
+++ b/scss/components/_collection-tree.scss
@@ -124,6 +124,11 @@ $icons: (
 		.cell-icon {
 			min-width: 16px;
 		}
+
+		&.bottom-border {
+			border-bottom: 1px solid var(--color-panedivider);
+			margin-bottom: 4px;
+		}
 	}
 }
 

--- a/scss/components/_collection-tree.scss
+++ b/scss/components/_collection-tree.scss
@@ -124,15 +124,6 @@ $icons: (
 		.cell-icon {
 			min-width: 16px;
 		}
-
-		.cited-badge {
-			margin-left: 8px;
-			padding: 1px 4px;
-			border-radius: 5px;
-			background: var(--accent-blue50);
-			white-space: nowrap;
-			font-size: 0.85em;
-		}
 	}
 }
 

--- a/scss/components/_collection-tree.scss
+++ b/scss/components/_collection-tree.scss
@@ -125,9 +125,13 @@ $icons: (
 			min-width: 16px;
 		}
 
-		&.bottom-border {
-			border-bottom: 1px solid var(--color-panedivider);
-			margin-bottom: 4px;
+		.cited-badge {
+			margin-left: 8px;
+			padding: 1px 4px;
+			border-radius: 5px;
+			background: var(--accent-blue50);
+			white-space: nowrap;
+			font-size: 0.85em;
 		}
 	}
 }

--- a/test/tests/integrationTest.js
+++ b/test/tests/integrationTest.js
@@ -1090,7 +1090,7 @@ describe("Zotero.Integration", function () {
 	
 	describe("DocumentData", function () {
 		it('should properly unserialize old XML document data', function () {
-			var serializedXMLData = `<data data-version="3" zotero-version="5.0.SOURCE"><session id="F0NFmZ32"/><style id="${styleID}" hasBibliography="1" bibliographyStyleHasBeenSet="1"/><prefs><pref name="fieldType" value="ReferenceMark"/><pref name="automaticJournalAbbreviations" value="true"/><pref name="noteType" value="0"/></prefs></data>`;
+			var serializedXMLData = `<data data-version="3" zotero-version="5.0.SOURCE"><cited libraries="http://zotero.org/groups/6295613=sample-zoter0-group"/><session id="F0NFmZ32"/><style id="${styleID}" hasBibliography="1" bibliographyStyleHasBeenSet="1"/><prefs><pref name="fieldType" value="ReferenceMark"/><pref name="automaticJournalAbbreviations" value="true"/><pref name="noteType" value="0"/></prefs></data>`;
 			var data = new Zotero.Integration.DocumentData(serializedXMLData);
 			var expectedData = {
 				style: {
@@ -1103,6 +1103,9 @@ describe("Zotero.Integration", function () {
 					fieldType: 'ReferenceMark',
 					automaticJournalAbbreviations: true,
 					noteType: 0
+				},
+				citedLibraryURIs: {
+					'http://zotero.org/groups/6295613': 'sample-zoter0-group'
 				},
 				sessionID: 'F0NFmZ32',
 				zoteroVersion: '5.0.SOURCE',
@@ -1125,6 +1128,9 @@ describe("Zotero.Integration", function () {
 					automaticJournalAbbreviations: false,
 					noteType: 0
 				},
+				citedLibraryURIs: {
+					'http://zotero.org/groups/6295613': 'sample-zoter0-group'
+				},
 				sessionID: 'owl-sesh',
 				zoteroVersion: '5.0.SOURCE',
 				dataVersion: 4
@@ -1135,6 +1141,7 @@ describe("Zotero.Integration", function () {
 		});
 		
 		it('should properly serialize document data to XML (data ver 3)', function () {
+			console.log(" ---- ");
 			sinon.spy(Zotero, 'debug');
 			var data = new Zotero.Integration.DocumentData();
 			data.sessionID = "owl-sesh";
@@ -1150,6 +1157,9 @@ describe("Zotero.Integration", function () {
 				noteType: 1,
 				fieldType: "Field",
 				automaticJournalAbbreviations: true
+			};
+			data.citedLibraryURIs = {
+				'http://zotero.org/groups/6295613': 'sample-zoter0-group'
 			};
 			
 			var serializedData = data.serialize();


### PR DESCRIPTION
When a new item is added into the citation, and all other cited items are all from another library, display a warning saying that cross-library citations are not recommended. If the document has cited items from multiple libraries, no warning is shown.

If there are many cited items, and `io` is still loading, the warning will appear if needed as soon as `io` is ready.

If the user clicks "Cancel" in the warning dialog, all added items from other libraries are removed.

Fixes: #5631

---

For reference:

https://github.com/user-attachments/assets/0667ee52-0c7c-4ebc-ad70-7c79fb4408b5

If io takes a long time to load, and the user adds some items and clicks `Accept`, the warning will be shown before the dialog is accepted:

https://github.com/user-attachments/assets/f04800e5-9826-4c5c-9c49-e761ce714b68




I wasn't sure about the use case for the pref to not show this warning in this document again, as mentioned in the linked issue. Once the user adds at least one citation from another library, next time the dialog is used, all cited items will not belong to a single library, so the warning won't be shown already.