### PR TITLE
Enforce `annotationSortIndex` format by type

### DIFF
--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -4075,11 +4075,30 @@ for (let name of ['type', 'authorName', 'text', 'comment', 'color', 'pageLabel',
 					}
 					break;
 				
-				case 'sortIndex':
-					if (!/^(\d{5}\|\d{6}\|\d{5}|\d{5}\|\d{8}|\d{7,8})$/.test(value)) {
+				case 'sortIndex': {
+					let parentItem = this.parentItem;
+					if (parentItem?.isPDFAttachment()) {
+						if (!/^\d{5}\|\d{6}\|\d{5}$/.test(value)) {
+							throw new Error(`Invalid sortIndex '${value}'`);
+						}
+					}
+					else if (parentItem?.isEPUBAttachment()) {
+						if (!/^\d{5}\|\d{8}$/.test(value)) {
+							throw new Error(`Invalid sortIndex '${value}' for EPUB annotation`);
+						}
+					}
+					// TODO: Use isSnapshotAttachment() once that matches all annotatable HTML attachments
+					else if (parentItem?.attachmentContentType === 'text/html') {
+						if (!/^\d{7,8}$/.test(value)) {
+							throw new Error(`Invalid sortIndex '${value}' for HTML annotation`);
+						}
+					}
+					// Otherwise, allow any supported sortIndex format
+					else if (!/^(\d{5}\|\d{6}\|\d{5}|\d{5}\|\d{8}|\d{7,8})$/.test(value)) {
 						throw new Error(`Invalid sortIndex '${value}'`);
 					}
 					break;
+				}
 				
 				case 'isExternal':
 					if (typeof value != 'boolean') {

--- a/test/tests/itemTest.js
+++ b/test/tests/itemTest.js
@@ -1556,6 +1556,47 @@ describe("Zotero.Item", function () {
 			});
 		});
 		
+		describe("#annotationSortIndex", function () {
+			let sortIndexPDF = '12345|123456|12345';
+			let sortIndexEPUB = '12345|12345678';
+			let sortIndexHTML = '1234567';
+			let sortIndexInvalid = '1';
+
+			it("should enforce the parent attachment's sortIndex format", async function () {
+				let file = getTestDataDirectory();
+				file.append('stub.epub');
+				let attachmentEPUB = await Zotero.Attachments.linkFromFile({ file });
+
+				file = getTestDataDirectory();
+				file.append('test.html');
+				let attachmentHTML = await Zotero.Attachments.linkFromFile({ file });
+
+				let annotation = await createAnnotation('highlight', attachment);
+				assert.doesNotThrow(() => annotation.annotationSortIndex = sortIndexPDF);
+				assert.throws(() => annotation.annotationSortIndex = sortIndexEPUB);
+				assert.throws(() => annotation.annotationSortIndex = sortIndexHTML);
+
+				annotation = await createAnnotation('highlight', attachmentEPUB);
+				assert.throws(() => annotation.annotationSortIndex = sortIndexPDF);
+				assert.doesNotThrow(() => annotation.annotationSortIndex = sortIndexEPUB);
+				assert.throws(() => annotation.annotationSortIndex = sortIndexHTML);
+
+				annotation = await createAnnotation('highlight', attachmentHTML);
+				assert.throws(() => annotation.annotationSortIndex = sortIndexPDF);
+				assert.throws(() => annotation.annotationSortIndex = sortIndexEPUB);
+				assert.doesNotThrow(() => annotation.annotationSortIndex = sortIndexHTML);
+			});
+			
+			it("should allow any sortIndex format when there is no parent attachment", async function () {
+				let annotation = await createAnnotation('highlight', attachment);
+				annotation.parentItemID = null;
+				for (let sortIndex of [sortIndexPDF, sortIndexEPUB, sortIndexHTML]) {
+					assert.doesNotThrow(() => annotation.annotationSortIndex = sortIndex);
+				}
+				assert.throws(() => annotation.annotationSortIndex = sortIndexInvalid);
+			});
+		});
+		
 		describe("#saveTx()", function () {
 			it("should save a highlight annotation", async function () {
 				var annotation = new Zotero.Item('annotation');


### PR DESCRIPTION
This isn't perfect because `annotationSortIndex` could be set before `parentItemID`, but it should catch most of these errors.

https://forums.zotero.org/discussion/128228/sync-error-invalid-sortindex-for-non-existent-items-report-id-1343152414