### PR TITLE
Show warning on one-way or whole-library export

### DIFF
--- a/chrome/content/zotero/exportOptions.js
+++ b/chrome/content/zotero/exportOptions.js
@@ -31,7 +31,7 @@
 
 const OPTION_PREFIX = "export-option-";
 
-const IGNORE_IMPORT_ONLY = [
+const IGNORE_EXPORT_ONLY_TRANSLATORS = [
 	'b6e39b57-8942-4d11-8259-342c46ce395f', // BibLaTeX: Imported by BibTeX
 	'14763d25-8ba0-45df-8f52-b8d1108e7ac9', // Bibliontology RDF: Imported by RDF
 	'14763d24-8ba0-45df-8f52-b8d1108e7ac9', // Zotero RDF: Imported by RDF
@@ -228,7 +228,7 @@ var Zotero_File_Interface_Export = new function() {
 		
 		let warningCannotImport = document.getElementById('warning-cannot-import');
 		warningCannotImport.hidden = translator.translatorType & Zotero.Translator.TRANSLATOR_TYPES.import
-			|| IGNORE_IMPORT_ONLY.includes(translator.translatorID);
+			|| IGNORE_EXPORT_ONLY_TRANSLATORS.includes(translator.translatorID);
 		document.l10n.setArgs(warningCannotImport, { format: translator.label });
 		document.l10n.translateRoots().then(() => window.sizeToContent());
 		

--- a/chrome/content/zotero/exportOptions.js
+++ b/chrome/content/zotero/exportOptions.js
@@ -31,6 +31,13 @@
 
 const OPTION_PREFIX = "export-option-";
 
+const IGNORE_IMPORT_ONLY = [
+	'b6e39b57-8942-4d11-8259-342c46ce395f', // BibLaTeX: Imported by BibTeX
+	'14763d25-8ba0-45df-8f52-b8d1108e7ac9', // Bibliontology RDF: Imported by RDF
+	'14763d24-8ba0-45df-8f52-b8d1108e7ac9', // Zotero RDF: Imported by RDF
+	'6e372642-ed9d-4934-b5d1-c11ac758ebb7', // Unqualified Dublin Core RDF: Imported by RDF
+];
+
 // Class to provide options for export
 
 var Zotero_File_Interface_Export = new function() {
@@ -49,7 +56,7 @@ var Zotero_File_Interface_Export = new function() {
 		
 		var addedOptions = new Object();
 		
-		var { translators, exportingNotes } = window.arguments[0];
+		var { translators, exportingNotes, exportingLibrary } = window.arguments[0];
 		
 		// get format popup
 		var formatPopup = document.getElementById("format-popup");
@@ -138,6 +145,9 @@ var Zotero_File_Interface_Export = new function() {
 			exportingNotes ? "export.noteTranslatorSettings" : "export.translatorSettings"
 		));
 
+		var warningBackup = document.getElementById('warning-backup');
+		warningBackup.hidden = !exportingLibrary;
+
 		document.addEventListener('dialogaccept', () => this.accept());
 		document.addEventListener('dialogcancel', () => this.cancel());
 	}
@@ -148,7 +158,8 @@ var Zotero_File_Interface_Export = new function() {
 	this.updateOptions = function (optionString) {
 		// get selected translator
 		var index = document.getElementById("format-menu").selectedIndex;
-		var translatorOptions = window.arguments[0].translators[index].displayOptions;
+		var translator = window.arguments[0].translators[index];
+		var translatorOptions = translator.displayOptions;
 		
 		if(optionString) {
 			try {
@@ -214,6 +225,12 @@ var Zotero_File_Interface_Export = new function() {
 		} else {
 			document.getElementById("charset-box").hidden = true;
 		}
+		
+		let warningCannotImport = document.getElementById('warning-cannot-import');
+		warningCannotImport.hidden = translator.translatorType & Zotero.Translator.TRANSLATOR_TYPES.import
+			|| IGNORE_IMPORT_ONLY.includes(translator.translatorID);
+		document.l10n.setArgs(warningCannotImport, { format: translator.label });
+		document.l10n.translateRoots().then(() => window.sizeToContent());
 		
 		window.sizeToContent();
 	}

--- a/chrome/content/zotero/exportOptions.xhtml
+++ b/chrome/content/zotero/exportOptions.xhtml
@@ -7,7 +7,6 @@
 %zoteroDTD;
 ]>
 <window xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:html="http://www.w3.org/1999/xhtml"
 	title="&zotero.exportOptions.title;"
 	drawintitlebar-platforms="mac"
@@ -23,13 +22,15 @@
 	</script>
 	<script src="charsetMenu.js"/>
 	<script src="exportOptions.js"/>
-	<script type="application/javascript">
-	<![CDATA[
+	<script>
 		var observerService = Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService);
 		observerService.notifyObservers(null, "charsetmenu-selected", "other");
-	]]>
 	</script>
 
+	<linkset>
+		<html:link rel="localization" href="branding/brand.ftl"/>
+		<html:link rel="localization" href="zotero.ftl"/>
+	</linkset>
 	
 	<vbox id="zotero-export-options-container" flex="1">
 		<hbox align="center">
@@ -38,6 +39,7 @@
 				<menupopup id="format-popup"/>
 			</menulist>
 		</hbox>
+		<label id="warning-cannot-import" data-l10n-id="export-warning-cannot-import"/>
 		<groupbox id="translator-options">
 			<caption id="translator-options-label" label="&zotero.exportOptions.translatorOptions.label;"/>
 			
@@ -47,6 +49,9 @@
 				<menulist id="export-option-exportCharset" native="true"/>
 			</vbox>
 		</groupbox>
+		<label id="warning-backup" data-l10n-id="export-warning-backup">
+			<label class="zotero-text-link" is="zotero-text-link" href="https://www.zotero.org/support/zotero_data#backing_up_your_zotero_data" data-l10n-name="backup-help-link"/>
+		</label>
 	</vbox>
 </dialog>
 </window>

--- a/chrome/content/zotero/fileInterface.js
+++ b/chrome/content/zotero/fileInterface.js
@@ -103,7 +103,11 @@ Zotero_File_Exporter.prototype.save = async function () {
 	}
 	
 	// present options dialog
-	var io = { translators, exportingNotes };
+	var io = {
+		translators,
+		exportingNotes,
+		exportingLibrary: !!(this.libraryID && !this.collection && !this.items),
+	};
 	window.openDialog("chrome://zotero/content/exportOptions.xhtml",
 		"_blank", "chrome,modal,centerscreen,resizable=no", io);
 	if(!io.selectedTranslator) {

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -278,6 +278,9 @@ import-online-new =
 import-mendeley-username = Username
 import-mendeley-password = Password
 
+export-warning-cannot-import = { -app-name } cannot import data in { $format }. Only exports are supported using this format.
+export-warning-backup = You may lose data if you attempt to back up your entire library this way. <label data-l10n-name="backup-help-link">Learn more.</label>
+
 general-error = Error
 file-interface-import-error = An error occurred while trying to import the selected file. Please ensure that the file is valid and try again.
 file-interface-import-complete = Import Complete

--- a/scss/components/_exportOptions.scss
+++ b/scss/components/_exportOptions.scss
@@ -13,4 +13,23 @@
 	checkbox[native][disabled="true"] {
 		color: unset;
 	}
+	
+	#warning-cannot-import, #warning-backup {
+		max-width: 300px;
+		white-space: wrap;
+	}
+	
+	#warning-cannot-import {
+		color: var(--fill-secondary);
+		padding-inline-start: 8px;
+		padding-bottom: 2px;
+	}
+	
+	#warning-backup {
+		color: var(--accent-red);
+		
+		.zotero-text-link {
+			margin: 0;
+		}
+	}
 }


### PR DESCRIPTION
These are both sources of confusion - people think they need to do a whole-library export to transfer their data to a new computer, and people export to export-only formats without realizing that they won't easily be able to get that data back into Zotero later. Maybe a couple warning messages will help.

Closes #5639