### PR TITLE
Plugin: Correctly clear default preferences without losing user-modified sub-prefs

### DIFF
--- a/chrome/content/zotero/xpcom/plugins.js
+++ b/chrome/content/zotero/xpcom/plugins.js
@@ -389,7 +389,7 @@ Zotero.Plugins = new function () {
 		var obj = {
 			pref(pref, _value) {
 				if (!branch.prefHasUserValue(pref)) {
-					branch.deleteBranch(pref);
+					branch.clearUserPref(pref);
 				}
 			}
 		};


### PR DESCRIPTION
## Description

When a plugin is disabled, certain user preferences are unexpectedly cleared. This specific behavior manifests under the following conditions:

There are two default preferences defined in `prefs.js`:

```javascript
pref("extensions.zotero.test-plugin.feature-1", true);
pref("extensions.zotero.test-plugin.feature-1.option-1a", "");
```

If:
1.  `extensions.zotero.test-plugin.feature-1` has **not been modified** by the user.
2.  `extensions.zotero.test-plugin.feature-1.option-1a` **has been modified** by the user.

Upon disabling the plugin, `extensions.zotero.test-plugin.feature-1.option-1a` is unexpectedly cleared, causing the loss of the user's custom setting.

## Minimal Reproduction Repository

https://github.com/northword/zotero-clear-user-pref-on-shundown

## Investigation

After a brief investigation, I've identified that this issue arises because Zotero calls `Zotero.Plugins.clearDefaultPrefs` when a plugin is disabled. The intended purpose of this function is to clear only preferences that have not been modified by the user.

Here is the relevant source code for the `clearDefaultPrefs` method:

https://github.com/zotero/zotero/blob/84764570f4af1df81fb7de3df4b03b5c9f5a9139/chrome/content/zotero/xpcom/plugins.js#L387-L407

The critical line is `branch.deleteBranch(pref)`. When `extensions.zotero.test-plugin.feature-1` is processed, and since it hasn't been modified by the user (`!branch.prefHasUserValue(pref)` is true), `deleteBranch(pref)` is called. This function, however, deletes the *entire branch* of preferences starting with `extensions.zotero.test-plugin.feature-1`, inadvertently removing `extensions.zotero.test-plugin.feature-1.option-1a` along with it, even though the latter was user-modified.

## Proposed Solution

I believe this behavior is unintended. The function should only clear preferences that have *not* been modified by the user, rather than deleting an entire preference branch that might contain user-modified sub-preferences.

Therefore, I propose that `branch.clearUserPref(pref)` should be used instead of `branch.deleteBranch(pref)`. This change would ensure that only the user's value for the *specific* preference `pref` is cleared (if it hasn't been modified), leaving any related sub-preferences (like `extensions.zotero.test-plugin.feature-1.option-1a`) untouched if they have user-modified values.

Thank you for your time and consideration.
