### PR TITLE
add copy to clipboard button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 .signatures.json
 tmp
 app/win/codesign
+.build-cache

--- a/chrome/content/zotero/exportOptions.js
+++ b/chrome/content/zotero/exportOptions.js
@@ -36,6 +36,21 @@ const OPTION_PREFIX = "export-option-";
 var Zotero_File_Interface_Export = new function() {
 	this.accept = accept;
 	this.cancel = cancel;
+
+	/*
+	 * Copy current export to clipboard: populate the io object, mark copy flag,
+	 * and close with accept so the caller can handle the request.
+	 */
+	this.copyToClipboard = function() {
+		try {
+			accept();
+			window.arguments[0].copyToClipboard = true;
+			document.querySelector('dialog').acceptDialog();
+		}
+		catch (e) {
+			Zotero.logError(e);
+		}
+	};
 	
 	var _charsets = false;
 	

--- a/chrome/content/zotero/exportOptions.xhtml
+++ b/chrome/content/zotero/exportOptions.xhtml
@@ -48,5 +48,8 @@
 			</vbox>
 		</groupbox>
 	</vbox>
+
+	<!-- Custom copy-to-clipboard button -->
+	<button id="export-copy-to-clipboard" label="&zotero.exportOptions.copyToClipboard.label;" oncommand="Zotero_File_Interface_Export.copyToClipboard()"/>
 </dialog>
 </window>

--- a/chrome/locale/af-ZA/zotero/zotero.dtd
+++ b/chrome/locale/af-ZA/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Formaat:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Vertalerskeuses">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "Karakterenkodering">
 <!ENTITY zotero.moreEncodings.label "Meer enkoderings">
 

--- a/chrome/locale/ar/zotero/zotero.dtd
+++ b/chrome/locale/ar/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "الصياغة:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "خيارات المترجم">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "نسخ للحافظة">
+
 <!ENTITY zotero.charset.label "ترميز الأحرف">
 <!ENTITY zotero.moreEncodings.label "المزيد من الترميزات">
 

--- a/chrome/locale/bg-BG/zotero/zotero.dtd
+++ b/chrome/locale/bg-BG/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Формат:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Параметри на извличащите данни програми">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "Кодиране на символите">
 <!ENTITY zotero.moreEncodings.label "Повече кодирания">
 

--- a/chrome/locale/br/zotero/zotero.dtd
+++ b/chrome/locale/br/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Stumm:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Dibarzhioù troer">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "Enkodiñ an arouezioù">
 <!ENTITY zotero.moreEncodings.label "Muioc'h a engodurioù">
 

--- a/chrome/locale/ca-AD/zotero/zotero.dtd
+++ b/chrome/locale/ca-AD/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Format:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Opcions del traductor">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "Codificació del caràcters">
 <!ENTITY zotero.moreEncodings.label "Més codificacions">
 

--- a/chrome/locale/cs-CZ/zotero/zotero.dtd
+++ b/chrome/locale/cs-CZ/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Formát:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Možnosti překladače">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "Kódování znaků">
 <!ENTITY zotero.moreEncodings.label "Další kódování">
 

--- a/chrome/locale/da-DK/zotero/zotero.dtd
+++ b/chrome/locale/da-DK/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Format:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Oversættelsesmuligheder">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "Tegnsæt">
 <!ENTITY zotero.moreEncodings.label "Flere tegnsæt">
 

--- a/chrome/locale/de/zotero/zotero.dtd
+++ b/chrome/locale/de/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Format:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Übersetzer-Einstellungen">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "Zeichenkodierung">
 <!ENTITY zotero.moreEncodings.label "Weitere Kodierungen">
 

--- a/chrome/locale/el-GR/zotero/zotero.dtd
+++ b/chrome/locale/el-GR/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Μορφή:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Επιλογές μεταφραστή">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "Κωδικοποίηση χαρακτήρων">
 <!ENTITY zotero.moreEncodings.label "Περισσότερες κωδικοποιησεις">
 

--- a/chrome/locale/en-GB/zotero/zotero.dtd
+++ b/chrome/locale/en-GB/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Format:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Translator Options">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "Character Encoding">
 <!ENTITY zotero.moreEncodings.label "More Encodings">
 

--- a/chrome/locale/en-US/zotero/zotero.dtd
+++ b/chrome/locale/en-US/zotero/zotero.dtd
@@ -188,6 +188,8 @@
 <!ENTITY zotero.exportOptions.format.label				"Format:">
 <!ENTITY zotero.exportOptions.translatorOptions.label	"Translator Options">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label		"Copy to Clipboard">
+
 <!ENTITY zotero.charset.label							"Character Encoding">
 <!ENTITY zotero.moreEncodings.label						"More Encodings">
 

--- a/chrome/locale/es-ES/zotero/zotero.dtd
+++ b/chrome/locale/es-ES/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Formato:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Opciones del traductor">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "Codificación de caracteres">
 <!ENTITY zotero.moreEncodings.label "Más codificaciones">
 

--- a/chrome/locale/et-EE/zotero/zotero.dtd
+++ b/chrome/locale/et-EE/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Formaat:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Tõlkija seaded">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "Märgikodeering">
 <!ENTITY zotero.moreEncodings.label "Rohkem kodeeringud">
 

--- a/chrome/locale/eu-ES/zotero/zotero.dtd
+++ b/chrome/locale/eu-ES/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Formatua:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Itzultzailearen aukerak">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "Karaktere-kodeketa">
 <!ENTITY zotero.moreEncodings.label "Kodeketa gehiago">
 

--- a/chrome/locale/fa/zotero/zotero.dtd
+++ b/chrome/locale/fa/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "قالب:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "گزینه‌های مترجم">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "کدبندی نویسه‌ها">
 <!ENTITY zotero.moreEncodings.label "کدبندی‌های بیشتر">
 

--- a/chrome/locale/fi-FI/zotero/zotero.dtd
+++ b/chrome/locale/fi-FI/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Muoto:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Kääntäjän asetukset">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "Merkistökoodaus">
 <!ENTITY zotero.moreEncodings.label "Lisää koodauksia">
 

--- a/chrome/locale/fr-FR/zotero/zotero.dtd
+++ b/chrome/locale/fr-FR/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Format :">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Options du convertisseur">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "Encodage des caractères">
 <!ENTITY zotero.moreEncodings.label "Plus d'encodages">
 

--- a/chrome/locale/gl-ES/zotero/zotero.dtd
+++ b/chrome/locale/gl-ES/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Formato:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Opcións do tradutor">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "Codificación de caracteres">
 <!ENTITY zotero.moreEncodings.label "Máis codificacións">
 

--- a/chrome/locale/he-IL/zotero/zotero.dtd
+++ b/chrome/locale/he-IL/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "עיצוב:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "אפשרויות תרגום">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "קידוד תווים">
 <!ENTITY zotero.moreEncodings.label "קידודים נוספים">
 

--- a/chrome/locale/hr-HR/zotero/zotero.dtd
+++ b/chrome/locale/hr-HR/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Format:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Translator Options">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "Character Encoding">
 <!ENTITY zotero.moreEncodings.label "More Encodings">
 

--- a/chrome/locale/hu-HU/zotero/zotero.dtd
+++ b/chrome/locale/hu-HU/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Formátum:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Adatkonverter beállításai">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "Karakterkódolás">
 <!ENTITY zotero.moreEncodings.label "További karakterkódolások">
 

--- a/chrome/locale/id-ID/zotero/zotero.dtd
+++ b/chrome/locale/id-ID/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Format:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Opsi Translator">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "Pengkodean Karakter">
 <!ENTITY zotero.moreEncodings.label "Pengkodean Lainnya">
 

--- a/chrome/locale/is-IS/zotero/zotero.dtd
+++ b/chrome/locale/is-IS/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Snið:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Þýðingarstillingar">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "Kóðun bókstafa">
 <!ENTITY zotero.moreEncodings.label "Viðbótar kóðun">
 

--- a/chrome/locale/it-IT/zotero/zotero.dtd
+++ b/chrome/locale/it-IT/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Formato:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Opzioni">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "Codifica dei caratteri">
 <!ENTITY zotero.moreEncodings.label "Altre codifiche">
 

--- a/chrome/locale/ja-JP/zotero/zotero.dtd
+++ b/chrome/locale/ja-JP/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "フォーマット:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "トランスレータのオプション">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "文字コード">
 <!ENTITY zotero.moreEncodings.label "その他の文字コード">
 

--- a/chrome/locale/km/zotero/zotero.dtd
+++ b/chrome/locale/km/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "ទ្រង់ទ្រាយ:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "ជម្រើសកូដចម្លង">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "បញ្ចូលកូដតួអក្សរ">
 <!ENTITY zotero.moreEncodings.label "បញ្ចូលកូដបន្ថែម">
 

--- a/chrome/locale/ko-KR/zotero/zotero.dtd
+++ b/chrome/locale/ko-KR/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "양식:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "중계기 옵션">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "문자 인코딩">
 <!ENTITY zotero.moreEncodings.label "추가 인코딩">
 

--- a/chrome/locale/lt-LT/zotero/zotero.dtd
+++ b/chrome/locale/lt-LT/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Formatas:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Vertimo parinktys">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Kopijuoti į iškaprinę">
+
 <!ENTITY zotero.charset.label "Rašmenų koduotė">
 <!ENTITY zotero.moreEncodings.label "Daugiau koduočių">
 

--- a/chrome/locale/mn-MN/zotero/zotero.dtd
+++ b/chrome/locale/mn-MN/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Format:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Translator Options">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "Character Encoding">
 <!ENTITY zotero.moreEncodings.label "More Encodings">
 

--- a/chrome/locale/nb-NO/zotero/zotero.dtd
+++ b/chrome/locale/nb-NO/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Format:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Valg for oversetter">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "Tegnkoding">
 <!ENTITY zotero.moreEncodings.label "Flere tegnkodinger">
 

--- a/chrome/locale/nl-NL/zotero/zotero.dtd
+++ b/chrome/locale/nl-NL/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Formaat:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Vertaler-opties">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Kopieer naar klembord">
+
 <!ENTITY zotero.charset.label "Tekensetcodering">
 <!ENTITY zotero.moreEncodings.label "Meer coderingen">
 

--- a/chrome/locale/nn-NO/zotero/zotero.dtd
+++ b/chrome/locale/nn-NO/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Format:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Omsetjarval">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "Teiknsett">
 <!ENTITY zotero.moreEncodings.label "Fleire teiknsett">
 

--- a/chrome/locale/pl-PL/zotero/zotero.dtd
+++ b/chrome/locale/pl-PL/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Format:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Opcje translacji">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "Kodowanie znaków">
 <!ENTITY zotero.moreEncodings.label "Więcej kodowań">
 

--- a/chrome/locale/pt-BR/zotero/zotero.dtd
+++ b/chrome/locale/pt-BR/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Formato:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Opções do tradutor">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "Codificação de caracteres">
 <!ENTITY zotero.moreEncodings.label "Mais codificações">
 

--- a/chrome/locale/pt-PT/zotero/zotero.dtd
+++ b/chrome/locale/pt-PT/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Formato:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Opções do Tradutor">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "Codificação de Caracteres">
 <!ENTITY zotero.moreEncodings.label "Mais Codificações">
 

--- a/chrome/locale/ro-RO/zotero/zotero.dtd
+++ b/chrome/locale/ro-RO/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Formatare:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Opțiuni translator">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "Codificare caractere">
 <!ENTITY zotero.moreEncodings.label "Mai multe codificări">
 

--- a/chrome/locale/ru-RU/zotero/zotero.dtd
+++ b/chrome/locale/ru-RU/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Формат:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Настройки транслятора:">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "Кодировка символов">
 <!ENTITY zotero.moreEncodings.label "Ещё кодировки">
 

--- a/chrome/locale/sk-SK/zotero/zotero.dtd
+++ b/chrome/locale/sk-SK/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Formát:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Možnosti konvertorov">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "Kódovanie">
 <!ENTITY zotero.moreEncodings.label "Viac">
 

--- a/chrome/locale/sl-SI/zotero/zotero.dtd
+++ b/chrome/locale/sl-SI/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Vrsta datoteke:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Možnosti prevajanja">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "Kodiranje znakov">
 <!ENTITY zotero.moreEncodings.label "Dodatna kodiranja">
 

--- a/chrome/locale/sr-RS/zotero/zotero.dtd
+++ b/chrome/locale/sr-RS/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Формат:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Опције преводиоца">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "Кодирање знакова">
 <!ENTITY zotero.moreEncodings.label "Додатна кодирања">
 

--- a/chrome/locale/sv-SE/zotero/zotero.dtd
+++ b/chrome/locale/sv-SE/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Format:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Inställningar för källfångare">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Kopiera till urklipp">
+
 <!ENTITY zotero.charset.label "Teckenkodning">
 <!ENTITY zotero.moreEncodings.label "Fler teckenkodningar">
 

--- a/chrome/locale/ta/zotero/zotero.dtd
+++ b/chrome/locale/ta/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "வடிவம்:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "மொழிபெயர்ப்பாளர் விருப்பங்கள்">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "எழுத்து குறியாக்கம்">
 <!ENTITY zotero.moreEncodings.label "மேலும் குறியாக்கங்கள்">
 

--- a/chrome/locale/th-TH/zotero/zotero.dtd
+++ b/chrome/locale/th-TH/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "รูปแบบ:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "ตัวเลือกของโปรแกรมแปลข้อมูลเมทา">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "การเข้ารหัสอักษร">
 <!ENTITY zotero.moreEncodings.label "การเข้ารหัสอื่นๆ">
 

--- a/chrome/locale/tr-TR/zotero/zotero.dtd
+++ b/chrome/locale/tr-TR/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Biçim">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Çevirmen Seçenekleri">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "Karakter Kodlaması">
 <!ENTITY zotero.moreEncodings.label "Diğer Kodlamalar">
 

--- a/chrome/locale/uk-UA/zotero/zotero.dtd
+++ b/chrome/locale/uk-UA/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Формат:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Налаштування транслятора">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "Кодування символів">
 <!ENTITY zotero.moreEncodings.label "Ще кодування">
 

--- a/chrome/locale/vi-VN/zotero/zotero.dtd
+++ b/chrome/locale/vi-VN/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "Định dạng:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "Các tùy chọn cho Bộ-biến-đổi">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Sao chép vào Clipboard">
+
 <!ENTITY zotero.charset.label "Mã hóa ký tự">
 <!ENTITY zotero.moreEncodings.label "More Encodings">
 

--- a/chrome/locale/zh-CN/zotero/zotero.dtd
+++ b/chrome/locale/zh-CN/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "格式:">
 <!ENTITY zotero.exportOptions.translatorOptions.label "转换器选项">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "Copy to Clipboard">
+
 <!ENTITY zotero.charset.label "字符编码">
 <!ENTITY zotero.moreEncodings.label "更多编码">
 

--- a/chrome/locale/zh-TW/zotero/zotero.dtd
+++ b/chrome/locale/zh-TW/zotero/zotero.dtd
@@ -187,6 +187,8 @@
 <!ENTITY zotero.exportOptions.format.label "格式：">
 <!ENTITY zotero.exportOptions.translatorOptions.label "翻譯器選項">
 
+<!ENTITY zotero.exportOptions.copyToClipboard.label "複製到剪貼簿">
+
 <!ENTITY zotero.charset.label "字元編碼">
 <!ENTITY zotero.moreEncodings.label "更多編碼">
 


### PR DESCRIPTION
hi!

to ease my own work, I added a "copy to clipboard option"

it works with bib/csv or any format your currently support

I did did beause I found it too awkward to select references, export to bib, open that file, and then copy and paste into my bib file for the article I'm working on

I hope it's useful, it can copy 1,2,..., N references to the clipboard
<img width="1212" height="715" alt="Screenshot_20251212_193459" src="https://github.com/user-attachments/assets/2b02081e-94ea-49f6-9e2d-53ac81763c1d" />
