### PR TITLE
Remove `1px solid transparent` border on links

### DIFF
--- a/chrome/skin/default/zotero/zotero.css
+++ b/chrome/skin/default/zotero/zotero.css
@@ -4,19 +4,9 @@ groupbox > label > h2, groupbox > * > label > h2 {
 	margin-bottom: .3em;
 }
 
-label.zotero-text-link {
-	-moz-user-focus: normal;
-	color: LinkText;
-	text-decoration: underline;
-	border: 1px solid transparent;
-	cursor: pointer;
-}
-
 .text-link {
-	-moz-user-focus: normal;
 	color: LinkText;
 	text-decoration: underline;
-	border: 1px solid transparent;
 	cursor: pointer;
 }
 

--- a/scss/components/_textLink.scss
+++ b/scss/components/_textLink.scss
@@ -2,7 +2,6 @@
 	-moz-user-focus: normal;
 	color: LinkText;
 	text-decoration: underline;
-	border: var(--material-border-transparent);
 	cursor: pointer;
 	@include focus-ring;
 }


### PR DESCRIPTION
We seem to have had this for years (since at least 2011), but I'm not sure why, since it means that a link at the end of a sentence pushes the period away from the link.

<img width="588" height="64" alt="Screenshot 2025-12-16 at 3 32 00 PM" src="https://github.com/user-attachments/assets/33efec1d-7760-4193-a931-7e4b1cbeea27" />

<img width="610" height="64" alt="Screenshot 2025-12-16 at 3 32 10 PM" src="https://github.com/user-attachments/assets/295a96db-e105-4c37-9fa3-fc424ffd9d4e" />
