### PR TITLE
RTF Scan rework

### DIFF
--- a/chrome/content/zotero/modules/rtf.mjs
+++ b/chrome/content/zotero/modules/rtf.mjs
@@ -1,0 +1,647 @@
+export const UNMAPPED = 0;
+export const AMBIGUOUS = 1;
+export const MAPPED = 2;
+
+const BIBLIOGRAPHY_PLACEHOLDER = "\\{Bibliography\\}";
+
+// https://en.wikipedia.org/wiki/Rich_Text_Format#Character_encoding
+// https://encoding.spec.whatwg.org/
+const CHARSET_CODEPAGE_LOOKUP = new Map([
+	[0, 'windows-1252'],			// 	Latin alphabet, Western Europe / Americas
+	[128, 'Shift_JIS'],				// 	Japanese, Shift JIS - TextEncoder has no support for "windows-932" but this should be close enough (https://en.wikipedia.org/wiki/Code_page_932_(Microsoft_Windows)) 
+	[129, 'windows-949'], 			// 	Korean, Unified Hangul Code (extended Wansung)
+	// [130, 'windows-1361'], 		// 	Korean, Johab (ASCII-based version) - TextEncoder has no support for anything close
+	[134, 'GBK'], 					// 	Chinese, GBK (extended GB 2312) - windows-936
+	[136, 'Big5'], 					// 	Chinese, Big5 - windows-950
+	[161, 'windows-1253'], 			// 	Greek
+	[162, 'windows-1254'], 			// 	Latin alphabet, Turkish
+	[163, 'windows-1258'], 			// 	Latin alphabet, Vietnamese
+	[177, 'windows-1255'], 			// 	Hebrew
+	[178, 'windows-1256'], 			// 	Arabic
+	[186, 'windows-1257'], 			// 	Baltic
+	[204, 'windows-1251'], 			// 	Cyrillic
+	[238, 'windows-1250'], 			// 	Latin alphabet, Eastern Europe
+]);
+
+// Regular expressions for citation parsing; see `parseCitations` for capture groups
+const nameRe = String.raw`(?:\p{L}\p{M}*(?:[\p{L}\p{M}'’\-·]*\p{L}\p{M}*)?|\p{Lu}\.(?:\p{Lu}\.)*)(?:\p{Zs}+(?!(?:et\.?\p{Zs}+al\.?\b))(?:\p{L}\p{M}*(?:[\p{L}\p{M}'’\-·]*\p{L}\p{M}*)?|\p{Lu}\.(?:\p{Lu}\.)*))*`;
+const creatorRe = String.raw`((?:(?:${nameRe}, )*${nameRe}(?:,? and|,? &|,) )?${nameRe})(,? et al\.?)?`;
+const creatorSplitRe = /(?:,| *(?:and|&)) +/g;// TODO: localize "and" term
+const titleRe = String.raw`(?:"(?:([^"]*?),")|"(?:([^"]*)",)|“(?:([^”]*?),”|([^”]*)”,)|„(?:([^“]*?),“|([^“]*)“,)|„(?:([^”]*?),”|([^”]*)”,)|‟(?:([^”]*?),”|([^”]*)”,))`;
+const citationRe = new RegExp(String.raw`(\\\{|; )((?:${creatorRe},? )?(?:${titleRe} )?([0-9]{4})(?:\p{Ll})?)(?:,(?: pp?.?)? ([^ )]+))?(?=;|\\\})`, "gmu");
+const suppressedCitationPartRe = new RegExp(String.raw`^\\\{([0-9]{4})(?:\p{Ll})?\\\}$`, "u");
+const suppressedCitationRe = new RegExp(String.raw`((\p{L}[^ .,;]+)(,? et al\.?)? (?:\\\{([0-9]{4})(?:\p{Ll})?\\\}))`, "mu");
+
+class Stack {
+	constructor() {
+		this._items = [];
+	}
+
+	push(value) {
+		this._items.push(value);
+	}
+
+	pop() {
+		return this._items.pop();
+	}
+
+	swap(value) {
+		if (this._items.length === 0) {
+			throw new Error("Cannot swap on an empty stack");
+		}
+		this._items[this._items.length - 1] = value;
+	}
+
+	peek() {
+		return this._items[this._items.length - 1];
+	}
+}
+
+export function decodeHex(charCode, codepage) {
+	try {
+		let decoder = new TextDecoder(codepage);
+		let binary = Uint8Array.fromHex(charCode); // `fromHex` requires FF 133
+		return decoder.decode(binary);
+	}
+	catch {
+		Zotero.warn("Invalid ANSI codepage: " + codepage);
+		return "?";
+	}
+}
+
+const escapedHexByteRe = /\\'[0-9a-fA-F]{2}/y;
+
+function readHexRun(str, start = 0) {
+	escapedHexByteRe.lastIndex = start;
+	let end = start;
+
+	while (escapedHexByteRe.test(str)) {
+		end = escapedHexByteRe.lastIndex;
+	}
+
+	return str.slice(start, end);
+}
+
+function extractFontCharset(rtfString) {
+	const starts = rtfString.matchAll(/\{\s*\\fonttbl\b/g); // regex finds candidate starts
+	const fontToCharset = new Map();
+
+	for (const m of starts) {
+		const start = m.index;
+		let depth = 0;
+		
+
+		// Walk forward until the matching closing brace for this group.
+		for (let i = start; i < rtfString.length - start; i++) {
+			const ch = rtfString.charAt(i);
+
+			if (ch === '{' && (i === 0 || rtfString.charAt(i - 1) !== "\\")) {
+				depth++;
+			}
+			else if (ch === "}" && (i === 0 || rtfString.charAt(i - 1) !== "\\")) {
+				depth--;
+				if (depth === 0) {
+					const fontTable = rtfString.slice(start, i + 1);
+					const fontEntries = fontTable.matchAll(/\\f(\d+)[^}]*?\\fcharset(\d+)/g);
+					for (const entry of fontEntries) {
+						const fontNum = entry[1];
+						const charset = entry[2] ? parseInt(entry[2]) : null;
+						if (charset !== null) {
+							fontToCharset.set(parseInt(fontNum), charset);
+						}
+					}
+
+					break;
+				}
+			}
+		}
+	}
+	return fontToCharset;
+}
+
+function stripRtfControlSequences(rtf) {
+	return rtf
+		// Remove RTF groups' braces
+		.replace(/(?<!\\)[{}]/g, "")
+		// Remove control words with optional numeric parameter.
+		// If a space follows the control word, it’s a delimiter and should be removed too.
+		.replace(/(?<!\\(?:\\\\)*)\\[a-zA-Z]+-?\d*\b ?/g, "")
+		// Remove control symbols (single-character controls)
+		.replace(/(?<!\\(?:\\\\)*)\\[~_\-|:*]/g, "")
+		.replace(/\n/g, "");
+}
+
+export function decodeRTF(rtfString, codepage = 'windows-1252') {
+	if (!rtfString) {
+		return "";
+	}
+	
+	let fontToCharset = extractFontCharset(rtfString);
+	let ucTracker = new Stack();
+	let codepageTracker = new Stack();
+	let decodedString = "";
+	
+	const deffMatch = rtfString.match(/(?<!\\)\\deff(\d+)/);
+	if (deffMatch) {
+		const defaultFontID = parseInt(deffMatch[1]);
+		if (fontToCharset.has(defaultFontID)) {
+			codepage = CHARSET_CODEPAGE_LOOKUP.get(fontToCharset.get(defaultFontID));
+		}
+	}
+	
+	// removed unescaped space delimiters after \ucN and \uN sequences
+	rtfString = rtfString.replaceAll(/(?<!\\)(\\(?:uc|u)\d+)\x20/g, '$1');
+	
+	ucTracker.push(1); // RTF's default value for "uc", i.e. how many characters to substitute for a Unicode character
+	codepageTracker.push(codepage);
+
+	for (let i = 0; i < rtfString.length; i++) {
+		let char = rtfString.charAt(i);
+		// CHUNK is an arbitrary number: how many characters after the beginning of the sequence to check, 7 would be bare minimum (\u is 2 and then 5 decimal digits required to represent a 16-bit integer (shifted to positive range so no minus sign)
+		let CHUNK = 10;
+
+		// Handle \uc sequences
+		if (char === "\\" && (i === 0 || rtfString.charAt(i - 1) !== "\\") && rtfString.charAt(i + 1) === "u" && rtfString.charAt(i + 2) === "c") {
+			const match = rtfString.slice(i, i + CHUNK).match(/^\\uc([0-9]+)/);
+			if (match) {
+				ucTracker.swap(parseInt(match[1]));
+				i += 2 + match[1].length; // skip the \ucN sequence
+				continue;
+			}
+		}
+
+		// Handle \ansicpg sequences
+		if (char === "\\" && (i === 0 || rtfString.charAt(i - 1) !== "\\") && rtfString.slice(i, i + 8) === "\\ansicpg") {
+			const match = rtfString.slice(i, i + 8 + CHUNK).match(/^\\ansicpg([0-9]+)/);
+			if (match) {
+				let codepage = `windows-${match[1]}`;
+				codepageTracker.swap(codepage);
+				decodedString += "\\ansicpg" + match[1];
+				i += 7 + match[1].length;
+				continue;
+			}
+		}
+		
+		// Handle \f sequences
+		if (char === "\\" && (i === 0 || rtfString.charAt(i - 1) !== "\\") && rtfString.charAt(i + 1) === 'f') {
+			const match = rtfString.slice(i, i + 9 + CHUNK).match(/^\\f([0-9]+)/);
+			if (match) {
+				let fontID = parseInt(match[1]);
+				if (fontToCharset.has(fontID)) {
+					const fcharset = fontToCharset.get(fontID);
+					if (CHARSET_CODEPAGE_LOOKUP.has(fcharset)) {
+						codepageTracker.swap(CHARSET_CODEPAGE_LOOKUP.get(fcharset));
+					}
+				}
+			}
+		}
+
+		// Handle scope opening
+		if (char === '{' && (i === 0 || rtfString.charAt(i - 1) !== "\\")) {
+			// inherit properties from the parent scope
+			ucTracker.push(ucTracker.peek());
+			codepageTracker.push(codepageTracker.peek());
+			decodedString += char;
+			continue;
+		}
+
+		// Handle scope closing
+		if (char === '}' && (i === 0 || rtfString.charAt(i - 1) !== "\\")) {
+			ucTracker.pop();
+			codepageTracker.pop();
+			decodedString += char;
+			continue;
+		}
+
+		// Handle \u sequences
+		if (char === "\\" && (i === 0 || rtfString.charAt(i - 1) !== "\\") && rtfString.charAt(i + 1) === "u") {
+			const match = rtfString.slice(i, i + CHUNK).match(/^\\u([0-9]+)/);
+			if (match) {
+				let charCode = parseInt(match[1]);
+				decodedString += String.fromCharCode(charCode);
+				// Skip the \uN sequence and the substitution characters
+				i += 1 + match[1].length + ucTracker.peek(); // skip the \uN sequence and the substitution characters
+				continue;
+			}
+		}
+		
+		// Handle \' sequences, according to the current codepage
+		if (char === "\\" && (i === 0 || rtfString.charAt(i - 1) !== "\\") && rtfString.charAt(i + 1) === "'") {
+			const escapedBytes = readHexRun(rtfString, i);
+			if (escapedBytes.length) {
+				const hexBytes = [...escapedBytes.matchAll(/\\'([0-9a-fA-F]{2})/g)].map(m => m[1]).join("");
+				decodedString += decodeHex(hexBytes, codepageTracker.peek());
+				i += escapedBytes.length - 1;
+				continue;
+			}
+		}
+			
+		decodedString += char;
+	}
+	
+	return decodedString;
+}
+
+export function encodeRTF(unicodeString) {
+	if (!unicodeString) {
+		return "";
+	}
+
+	// ensure no \uc sequences are present
+	unicodeString = unicodeString.replaceAll(/(?<!\\)(\\uc\d+)/g, '');
+	// inject \uc0 at the beginning of the document
+	unicodeString = unicodeString.replace('\\rtf1', '\\rtf1\\uc0');
+
+	let rtfString = "";
+	for (let i = 0; i < unicodeString.length; i++) {
+		let charCode = unicodeString.charCodeAt(i);
+		if (charCode > 127) {
+			rtfString += "\\u" + charCode;
+		}
+		else {
+			rtfString += unicodeString.charAt(i);
+		}
+	}
+
+	return rtfString;
+}
+
+
+/**
+ * Compares in-text creator string with an item creator object to determine if they match.
+ *
+ * @param {string} creator - The full name or initial string representation of the creator.
+ * @param {Object} itemCreator - An object representing the item's creator, containing `firstName` and `lastName` properties.
+ * @param {string} itemCreator.firstName - The first name of the item creator.
+ * @param {string} itemCreator.lastName - The last name of the item creator.
+ * @return {boolean} Returns `true` if the provided creator string matches the item creator object; otherwise, `false`.
+ */
+function matchesItemCreator(creator, itemCreator) {
+	// make sure the last name matches
+	const lowerLast = itemCreator.lastName.toLowerCase();
+	if (lowerLast !== creator.slice(-lowerLast.length).toLowerCase()) {
+		return false;
+	}
+
+	// make sure that the first name matches (if it exists)
+	if (creator.length > lowerLast.length) {
+		const firstName = Zotero.Utilities.trim(creator.substr(0, creator.length - lowerLast.length));
+		if (firstName.length) {
+			// check to see whether the first name is all initials
+			const initialRe = /^(?:\p{L}\.? ?)+$/u;
+			let match = initialRe.exec(firstName);
+			if (match) {
+				const initials = firstName.replace(/[^\p{L}]/gu, "");
+				const itemInitials = itemCreator.firstName.split(/ +/g)
+					.map(name => name[0].toUpperCase())
+					.join("");
+				if (initials !== itemInitials) {
+					return false;
+				}
+			}
+			else {
+				// not all initials; verify that the first name matches
+				const firstWord = firstName.slice(0, itemCreator.firstName)
+					.toLowerCase();
+				const itemFirstWord = itemCreator.firstName.substr(0, itemCreator.firstName.indexOf(" "))
+					.toLowerCase();
+				if (firstWord !== itemFirstWord) {
+					return false;
+				}
+			}
+		}
+	}
+
+	return true;
+}
+
+/**
+ * Determines if the creators of a given in-text citation match the creators of an item
+ *
+ * @param {Array} creators - The list of creators from the citation to match against the item.
+ * @param {Object} item - The item whose creators are being checked for a match.
+ * @param {boolean} etAl - Indicates whether the "et al." condition is being used for matching.
+ * @return {boolean} Returns true if the creators of the citation match the creators of the item,
+ *                   considering the specified conditions; otherwise, false.
+ */
+function matchesItemCreators(creators, item, etAl) {
+	let itemCreators = item.getCreators();
+	let primaryCreators = [];
+	let primaryCreatorTypeID = Zotero.CreatorTypes.getPrimaryIDForType(item.itemTypeID);
+
+	// use only primary creators if primary creators exist
+	for (let i = 0; i < itemCreators.length; i++) {
+		if (itemCreators[i].creatorTypeID == primaryCreatorTypeID) {
+			primaryCreators.push(itemCreators[i]);
+		}
+	}
+	// if primaryCreators matches the creator list length, or if et al. is being used, use only
+	// primary creators
+	if (primaryCreators.length === creators.length || etAl) {
+		itemCreators = primaryCreators;
+	}
+
+	// for us to have an exact match, either the citation creator list length has to match the
+	// item creator list length, or et al. has to be used
+	if (itemCreators.length === creators.length || (etAl && itemCreators.length > creators.length)) {
+		var matched = true;
+		for (let i = 0; i < creators.length; i++) {
+			// check each item creator to see if it matches
+			matched = matched && matchesItemCreator(creators[i], itemCreators[i]);
+			if (!matched) break;
+		}
+		return matched;
+	}
+
+	return false;
+}
+
+/**
+ * Parses RTF content to extract citation details
+ *
+ * @param {string} content - The RTF content with Unicode characters already decoded as a string.
+ * @return {Array<Object>} An array of citation objects, where each object contains information such as citation strings, pages, data (e.g., creators, title, date), start and end positions, and whether the author is suppressed.
+ */
+export function parseCitations(content) {
+	let citations = [];
+	let lastEnd = 0; // track where the previous citation ended when dealing with suppressed citations
+	const starts = content.matchAll(/\\\{/g);
+	
+	for (const m of starts) {
+		const start = m.index;
+		let end = content.indexOf("\\}", start);
+		if (end === -1) {
+			continue;
+		}
+		
+		end += 2; // account for "\}"
+		const slice = stripRtfControlSequences(content.slice(start, end));
+		
+		// try suppressed citation first
+		let potentialSuppressedMatch = slice.match(suppressedCitationPartRe);
+		if (potentialSuppressedMatch) {
+			// look behind for a suppressed citation. We consider everything since the previous citation up to a 100-character limit.
+			let searchStart = Math.max(start - 100, lastEnd);
+			let candidate = content.slice(searchStart, end);
+			let match = candidate.match(suppressedCitationRe);
+			if (match) {
+				const citationString = match[1].replaceAll("\\{", "{").replaceAll("\\}", "}");
+				const creators = match[2];
+				// const etAl = !!match[3];
+				const date = match[4];
+				let citation = { citationStrings: [citationString], pages: [], data: [{ creators, date, title: undefined }], suppressAuthor: true, start, end };
+				citations.push(citation);
+				lastEnd = end;
+				continue;
+			}
+		}
+		
+		// try to match standard citations
+		let match;
+		let citation = { citationStrings: [], pages: [], data: [], suppressAuthor: false, start, end };
+		while ((match = citationRe.exec(slice))) {
+			const citationString = match[2].replaceAll("\\{", "{").replaceAll("\\}", "}");
+			const creators = match[3];
+			// const etAl = !!match[4];
+			const title = match[5] ?? match[6] ?? match[7] ?? match[8] ?? match[9] ?? match[10] ?? match[11] ?? match[12] ?? match[13] ?? match[14];
+			const date = match[15];
+			const pages = match[16];
+			citation.citationStrings.push(citationString);
+			citation.pages.push(pages);
+			citation.data.push({ creators, title, date });
+		}
+		citations.push(citation);
+		lastEnd = end;
+	}
+	
+	return citations;
+}
+
+/**
+ * Processes a list of citation objects (from `parseCitations`) and attempts to match them to the existing items
+ *
+ * @param {Array<Object>} citationObjects - An array of citation objects, where each object contains citation strings and associated metadata as data.
+ * @return {Promise<Array<Object>>} A promise that resolves to an array of mappings. Each mapping consists of the citation string, associated items (if any), and its mapping type (unmapped, mapped, or ambiguous).
+ */
+export async function processCitations(citationObjects) {
+	let mappings = [];
+	const citationsSeen = new Set();
+
+	for (let citationObject of citationObjects) {
+		for (let i = 0; i < citationObject.citationStrings.length; i++) {
+			let citationString = citationObject.citationStrings[i];
+			let {
+				creators,
+				title,
+				date
+			} = citationObject.data[i];
+			// only add each citation once
+			if (citationsSeen.has(citationString)) {
+				continue;
+			}
+			citationsSeen.add(citationString);
+			Zotero.debug("Found citation " + citationString);
+
+			// for each individual match, look for an item in the database
+			let search = new Zotero.Search;
+			
+			if (creators) {
+				creators = creators.replace(".", "");
+				// TODO: localize "et al." term
+				creators = creators.split(creatorSplitRe);
+
+				for (let i = 0; i < creators.length; i++) {
+					if (!creators[i]) {
+						if (i === creators.length - 1) {
+							break;
+						}
+						else {
+							creators.splice(i, 1);
+						}
+					}
+
+					const spaceIndex = creators[i].lastIndexOf(" ");
+					const lastName = spaceIndex === -1 ? creators[i] : creators[i].slice(spaceIndex + 1);
+					search.addCondition("lastName", "contains", lastName);
+				}
+				if (title) {
+					search.addCondition("title", "contains", title);
+				}
+			}
+
+			search.addCondition("date", "is", date);
+			let ids = await search.search();
+			Zotero.debug("Mapped to " + ids);
+
+			// no mapping found
+			if (!ids.length) {
+				mappings.push({
+					rtf: citationString,
+					items: [],
+					type: UNMAPPED
+				});
+			}
+			// some mapping found
+			else {
+				let items = await Zotero.Items.getAsync(ids);
+				if (items.length > 1) {
+					// check to see how well the author list matches the citation
+					let matchedItems = [];
+					for (let item of items) {
+						await item.loadAllData();
+						if (creators && matchesItemCreators(creators, item)) {
+							matchedItems.push(item);
+						}
+					}
+
+					if (matchedItems.length !== 0) {
+						items = matchedItems;
+					}
+				}
+
+				// only one mapping
+				if (items.length === 1) {
+					await items[0].loadAllData();
+					mappings.push({
+						rtf: citationString,
+						items: [items[0]],
+						type: MAPPED
+					});
+				}
+				// ambiguous mapping
+				else {
+					mappings.push({
+						rtf: citationString,
+						items,
+						type: AMBIGUOUS
+					});
+				}
+			}
+		}
+	}
+
+	return mappings;
+}
+
+/**
+ * Regenerates the RTF document with citations replaced
+ *
+ * @param {string} content - The RTF content with Unicode characters already decoded as a string.
+ * @param {Array<Object>} citations - An array of citations, extracted with `parseCitations`.
+ * @param {Object} citationItemIDs - A mapping of citation strings to corresponding item IDs.
+ * @param {string} style - The citation style to apply.
+ * @param {string} locale - The locale for the citation style.
+ * @param {string} displayAs - Specifies how the citations should be displayed, such as "endnotes" or "footnotes".
+ * @return {Promise<string>} The re-formatted raw RTF document as a string.
+ */
+export async function replaceCitations(content, citations, citationItemIDs, style, locale, displayAs) {
+	// load style and create ItemSet with all items
+	let zStyle = Zotero.Styles.get(style);
+	let cslEngine = zStyle.getCiteProc(locale, 'rtf');
+	let isNote = zStyle.class === "note";
+
+	// create citations
+	// var k = 0;
+	let cslCitations = [];
+	let itemIDs = {};
+	// var shouldBeSubsequent = {};
+	for (let i = 0; i < citations.length; i++) {
+		let citation = citations[i];
+		let cslCitation = {
+			citationItems: [],
+			properties: {}
+		};
+		if (isNote) {
+			cslCitation.properties.noteIndex = i;
+		}
+
+		// create citation items
+		for (var j = 0; j < citation.citationStrings.length; j++) {
+			var citationItem = {};
+			citationItem.id = citationItemIDs[citation.citationStrings[j]][0];
+			itemIDs[citationItem.id] = true;
+			citationItem.locator = citation.pages[j];
+			citationItem.label = "page";
+			citationItem["suppress-author"] = citation.suppressAuthor && !isNote;
+			cslCitation.citationItems.push(citationItem);
+		}
+
+		cslCitations.push(cslCitation);
+	}
+
+	Zotero.debug(cslCitations);
+	itemIDs = Object.keys(itemIDs);
+	Zotero.debug(itemIDs);
+
+	// prepare the list of rendered citations
+	let citationResults = cslEngine.rebuildProcessorState(cslCitations, "rtf");
+
+	// format citations
+	let contentArray = [];
+	let lastEnd = 0;
+	for (let i = 0; i < citations.length; i++) {
+		let citation = citationResults[i][2];
+
+		// if using notes, we might have to move the note after the punctuation
+		if (isNote && citations[i].start !== 0 && content[citations[i].start - 1] === " ") {
+			contentArray.push(content.substring(lastEnd, citations[i].start - 1));
+		}
+		else {
+			contentArray.push(content.substring(lastEnd, citations[i].start));
+		}
+
+		lastEnd = citations[i].end;
+		if (isNote && citations[i].end < content.length && ".,!?".indexOf(content[citations[i].end]) !== -1) {
+			contentArray.push(content[citations[i].end]);
+			lastEnd++;
+		}
+
+		if (isNote) {
+			if (displayAs === 'endnotes') {
+				contentArray.push("{\\super\\chftn}\\ftnbj {\\footnote\\ftnalt {\\super\\chftn } " + citation + "}");
+			}
+			else {	// footnotes
+				contentArray.push("{\\super\\chftn}\\ftnbj {\\footnote {\\super\\chftn } " + citation + "}");
+			}
+		}
+		else {
+			contentArray.push(citation);
+		}
+	}
+	contentArray.push(content.substring(lastEnd));
+	content = contentArray.join("");
+
+	// add bibliography
+	if (zStyle.hasBibliography) {
+		let bibliography = Zotero.Cite.makeFormattedBibliography(cslEngine, "rtf");
+		bibliography = bibliography.substring(5, bibliography.length - 1);
+		// fix line breaks
+		let linebreak = "\r\n";
+		if (content.indexOf("\r\n") === -1) {
+			bibliography = bibliography.replaceAll("\r\n", "\n");
+			linebreak = "\n";
+		}
+
+		if (content.indexOf(BIBLIOGRAPHY_PLACEHOLDER) !== -1) {
+			content = content.replace(BIBLIOGRAPHY_PLACEHOLDER, bibliography);
+		}
+		else {
+			// add two newlines before bibliography
+			bibliography = linebreak + "\\" + linebreak + "\\" + linebreak + bibliography;
+
+			// add bibliography automatically inside the last set of brackets closed
+			const bracketRe = /^\{+/;
+			var m = bracketRe.exec(content);
+			if (m) {
+				var closeBracketRe = new RegExp("(\\}{" + m[0].length + "}\\s*)$");
+				content = content.replace(closeBracketRe, bibliography + "$1");
+			}
+			else {
+				content += bibliography;
+			}
+		}
+	}
+
+	cslEngine.free();
+	return content;
+}

--- a/test/tests/data/testRTFScanAdvanced.rtf
+++ b/test/tests/data/testRTFScanAdvanced.rtf
@@ -1,0 +1,32 @@
+{\rtf1\ansi\ansicpg1252\cocoartf2822
+\cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fswiss\fcharset0 Helvetica;\f1\fnil\fcharset134 PingFangSC-Regular;\f2\fswiss\fcharset0 Helvetica-Bold;
+}
+{\colortbl;\red255\green255\blue255;}
+{\*\expandedcolortbl;;}
+\paperw11900\paperh16840\margl1440\margr1440\vieww11520\viewh8400\viewkind0
+\pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
+
+\f0\fs24 \cf0 More advanced citations that RTF Scan should detect.\
+Unicode names \{M\'fcller, 2012; 
+\f1 \'c9\'bd\'b1\'be
+\f0 , 2019\}.\
+Compound names \{O\'92Connor, "Drink Before the War", 1987\}\
+Unicode titles \{Smith, "\uc0\u37329 \u27611 \u23547 \u22238 \u29356 ," 2010\}.\
+ASCII quotes with comma outside \{Smith, "Title", 2008\}.\
+Unicode quotes \{Smith, \'93Title,\'94 2009\}\
+Unicode quotes with comma outside \{Smith, \'93Title\'94, 2009\}\
+Low/High quotes \{Smith, \'84Title\'94, 2009\}\
+Just the title \{"Title," 2009\}\
+Just the title, comma outside \{"Title", 2009\}\
+Just the title, Unicode quotes \{\'93Title,\'94 2009\}\
+Initials \{J.R.R. Tolkien, 1954\}\
+More compound names \{van Buuren, 2008\}\
+Formatting inside a citations \{
+\f2\b Smith
+\f0\b0 , 2009\}\
+Legacy multi-byte titles \{Smith, "
+\f1 \'bd\'f0\'c3\'ab\'d1\'b0\'bb\'d8\'c8\'ae
+\f0 ," 2010\}.\
+Suppressed citations by \uc0\u23665 \u26412  et al. \{2019\}\
+Unicode titles with replacement character \{Smith, "\uc1\u37329?\u27611?\u23547?\u22238?\u29356?," 2010\}.\
+}

--- a/test/tests/data/testRTFScanBasic.rtf
+++ b/test/tests/data/testRTFScanBasic.rtf
@@ -1,0 +1,14 @@
+{\rtf1\ansi\ansicpg1252\cocoartf2822 \cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fmodern\fcharset0 Courier;}
+{\colortbl;\red255\green255\blue255;\red0\green0\blue0;}
+{\*\expandedcolortbl;;\cssrgb\c0\c0\c0;}
+\paperw11900\paperh16840\margl1440\margr1440\vieww20020\viewh12720\viewkind0
+\deftab720
+\pard\pardeftab720\partightenfactor0
+
+\f0\fs24 \cf2 \expnd0\expndtw0\kerning0
+Citations from the RTFScan intro page, with some text intertwined.\
+Lorem ipsum dolot \{Smith, 2009\}.\
+Minima laboriosam nemo tenetur ducimus Smith \{2009\},  aperiam aut impedit nisi \{Smith et al., 2009\}.\
+Placeat quas dolore \{John Smith, 2009\}; deleniti ut repudiandae \{Smith, 2009, 10-14\} commodi quidem dignissimos\
+Lorem \{Smith, "Title," 2009\}.\
+Two Sources \{Jones, 2005; Smith, 2009\}.}

--- a/test/tests/rtfScanTest.js
+++ b/test/tests/rtfScanTest.js
@@ -1,0 +1,467 @@
+/* global assert, describe, it, before, beforeEach, afterEach, getTestDataDirectory, createDataObject, resetDB */
+
+let { decodeHex, decodeRTF, encodeRTF, parseCitations, processCitations, replaceCitations, UNMAPPED, AMBIGUOUS, MAPPED } = ChromeUtils.importESModule("chrome://zotero/content/modules/rtf.mjs");
+
+async function makeItems() {
+	let testItem1 = await createDataObject('item');
+	testItem1.setField('title', 'Title');
+	testItem1.setField('date', '2009');
+	testItem1.setCreators([{
+		lastName: 'Smith',
+		firstName: 'John',
+		creatorType: 'author'
+	}, {
+		lastName: 'Jones',
+		firstName: 'Jane',
+		creatorType: 'author',
+	}]);
+	await testItem1.saveTx();
+	let testItem2 = await createDataObject('item');
+	testItem2.setField('title', 'Lorem Ipsum');
+	testItem2.setField('date', '2005');
+	testItem2.setCreators([{
+		lastName: 'Jones',
+		firstName: 'Jane',
+		creatorType: 'author'
+	}]);
+	await testItem2.saveTx();
+	
+	let testItem3 = await createDataObject('item');
+	testItem3.setField('title', 'Foobar');
+	testItem3.setField('date', '2012');
+	testItem3.setCreators([{
+		lastName: 'Müller',
+		firstName: 'Johann',
+		creatorType: 'author'
+	}]);
+	await testItem3.saveTx();
+
+	let testItem4 = await createDataObject('item');
+	testItem3.setField('title', 'どの犬が一番いい子？');
+	testItem3.setField('date', '2019');
+	testItem3.setCreators([{
+		lastName: '山本',
+		firstName: '春樹',
+		creatorType: 'author'
+	}]);
+	await testItem4.saveTx();
+	
+	let testItem5 = await createDataObject('item');
+	testItem5.setField('title', '金毛寻回犬');
+	testItem5.setField('date', '2010');
+	testItem5.setCreators([{
+		lastName: 'Smith',
+		firstName: 'John',
+		creatorType: 'author'
+	}]);
+	await testItem5.saveTx();
+	
+
+	return [
+		testItem1,
+		testItem2,
+		testItem3,
+		testItem4,
+		testItem5
+	];
+}
+
+async function clearItems(items){
+	for (let item of items) {
+		await item.eraseTx();
+	}
+}
+
+describe('RTF processing', () => {
+	describe('decodeHex', () => {
+		it('should convert ANSI symbols to Unicode', () => {
+			assert.equal(decodeHex("a5", 'windows-1250'), "Ą");
+			assert.equal(decodeHex("A5", 'windows-1250'), "Ą");
+			assert.equal(decodeHex("a5", 'windows-1252'), "¥");
+			assert.equal(decodeHex("a5", 'INVALID'), "?"); // falls back to "?"
+		});
+	});
+	describe('decodeRTF', () => {
+		it('should convert RTF-escaped string to Unicode', () => {
+			assert.equal(decodeRTF(String.raw`M\'fcller`, 'windows-1252'), "Müller");
+			assert.equal(decodeRTF(String.raw`za\'bf\'f3\'b3\'e6`, "windows-1250"), "zażółć");
+			assert.equal(decodeRTF(String.raw`\u913?\u952?\u942?\u957?\u945?`), "Αθήνα");
+			assert.equal(decodeRTF(String.raw`\u55357?\u56832?\u55357?\u56960?`), "😀🚀");
+			assert.equal(decodeRTF(String.raw`\uc0\u55357\u56832\u55357\u56960`), "😀🚀");
+		});
+
+		it('should not affect literal backslash', () => {
+			assert.equal(decodeRTF(String.raw`\\'ab`), String.raw`\\'ab`);
+			assert.equal(decodeRTF(String.raw`\\u913`), String.raw`\\u913`);
+			assert.equal(decodeRTF(String.raw`\\uc9`), String.raw`\\uc9`);
+		});
+
+		it('should track current value of fallback characters', () => {
+			assert.equal(decodeRTF(String.raw`\u913?{\uc0\u952\u942\uc2{\u957??}\u945??}`), "Α{θή{ν}α}");
+		});
+		
+		it('should keep track of the current codepage', () => {
+			// F1 is ń in windows-1250 and ñ in windows-1252
+			assert.equal(decodeRTF(String.raw`\ansicpg1250ko\'f1\ansicpg1252ni\'f1o{\ansicpg1250\'F1}\'F1`), String.raw`\ansicpg1250koń\ansicpg1252niño{\ansicpg1250ń}ñ`);
+		});
+		it('should keep track of the font id and handle multi-byte encoded characters', () => {
+			// fcharset128 is a windows-932 codepage legacy multibyte encoding.
+			const fontTableJapanese = String.raw`{\fonttbl{\f0\fnil\fcharset0 Times New Roman;}{\f1\fnil\fcharset128 HiraMinProN-W3;}}`;
+			assert.equal(
+				decodeRTF(String.raw`${fontTableJapanese}\'93\'fa\'96\'7b\'8c\'ea\f1\'93\'fa\'96\'7b\'8c\'ea`),
+				String.raw`${fontTableJapanese}“ú–{Œê\f1日本語`
+			);
+			
+			// fcharset129 is a windows-949 codepage legacy multibyte encoding.
+			const fontTableKorean = String.raw`{\fonttbl\f0\fnil\fcharset129 AppleSDGothicNeo-Regular;\f1\fswiss\fcharset0 Helvetica;}`;
+			assert.equal(
+				decodeRTF(String.raw`${fontTableKorean}\f0\'b0\'f1\'b5\'e7\'b8\'ae\'c6\'ae\'b8\'ae\'b9\'f6 ASCII works too`),
+				String.raw`${fontTableKorean}\f0골든리트리버 ASCII works too`
+			);
+			
+			// GBK/windows-936 codepage legacy multibyte encoding.
+			const fontTableChinese = String.raw`{\fonttbl\f0\fnil\fcharset134 SimSun;}`;
+			assert.equal(
+				decodeRTF(String.raw`${fontTableChinese}\f0\'bc\'f2\'cc\'e5\'d6\'d0\'ce\'c4`),
+				String.raw`${fontTableChinese}\f0简体中文`
+			);
+			
+			// Big5
+			const fontTableBig5 = String.raw`{\fonttbl\f0\fnil\fcharset136 MingLiU;}`;
+			assert.equal(
+				decodeRTF(String.raw`${fontTableBig5}\f0\'C1\'63\'C5\'E9\'A4\'A4\'A4\'E5`),
+				String.raw`${fontTableBig5}\f0繁體中文`
+			);
+			
+			// Greek
+			const fontTableGreek = String.raw`{\fonttbl\f0\fnil\fcharset161 Arial;}`;
+			assert.equal(
+				decodeRTF(String.raw`${fontTableGreek}\f0\'c5\'eb\'eb\'e7\'ed\'e9\'ea\'dc`),
+				String.raw`${fontTableGreek}\f0Ελληνικά`
+			);
+		});
+		
+		it('should respect the default font id', () => {
+			const fontTableJapanese = String.raw`{\fonttbl{\f0\fnil\fcharset0 Times New Roman;}{\f1\fnil\fcharset128 HiraMinProN-W3;}}`;
+			assert.equal(
+				decodeRTF(String.raw`\deff1${fontTableJapanese}\'93\'fa\'96\'7b\'8c\'ea`),
+				String.raw`\deff1${fontTableJapanese}日本語`
+			);
+		});
+	});
+
+	describe('encodeRTF', () => {
+		it('should convert Unicode string to RTF-escaped', () => {
+			const golden = String.raw`\rtf1金毛寻回犬`;
+			assert.equal(decodeRTF(encodeRTF(golden)), golden);
+
+			const mullerRTF = String.raw`M\'fcller`; // "\'xx" is codepage-based encoding, we convert it to Unicode
+			assert.equal(decodeRTF(mullerRTF), 'Müller');
+			assert.equal(encodeRTF(String.raw`{\rtf1Müller}`), String.raw`{\rtf1\uc0M\u252ller}`);
+		});
+	});
+});
+
+describe("RTF Scan", function () {
+	let basicRTF, advancedRTF, items;
+
+	before(async () => {
+		await resetDB({
+			thisArg: this,
+			skipBundledFiles: true
+		});
+		basicRTF = decodeRTF(await Zotero.File.getContentsAsync(
+			OS.Path.join(getTestDataDirectory().path, 'testRTFScanBasic.rtf')
+		));
+
+		advancedRTF = decodeRTF(await Zotero.File.getContentsAsync(
+			OS.Path.join(getTestDataDirectory().path, 'testRTFScanAdvanced.rtf')
+		));
+	});
+	
+	beforeEach(async () => {
+		items = await makeItems();
+	});
+	
+	afterEach(async () => {
+		await clearItems(items);
+	});
+
+	it('should recognize citations in the RTF file', async () => {
+		let citations = parseCitations(basicRTF);
+		assert.lengthOf(citations, 7);
+		
+		assert.lengthOf(citations[0].citationStrings, 1);
+		assert.equal(citations[0].citationStrings[0], 'Smith, 2009');
+		assert.equal(citations[0].data[0].creators, 'Smith');
+		assert.isUndefined(citations[0].data[0].title);
+		assert.equal(citations[0].data[0].date, '2009');
+		assert.isFalse(citations[0].suppressAuthor);
+		
+		assert.lengthOf(citations[1].citationStrings, 1);
+		assert.equal(citations[1].citationStrings[0], 'Smith {2009}');
+		assert.equal(citations[1].data[0].creators, 'Smith');
+		assert.isUndefined(citations[1].data[0].title);
+		assert.equal(citations[1].data[0].date, '2009');
+		assert.isTrue(citations[1].suppressAuthor);
+		
+		assert.lengthOf(citations[2].citationStrings, 1);
+		assert.equal(citations[2].citationStrings[0], 'Smith et al., 2009');
+		assert.equal(citations[2].data[0].creators, 'Smith');
+		assert.isUndefined(citations[2].data[0].title);
+		assert.equal(citations[2].data[0].date, '2009');
+		assert.isFalse(citations[2].suppressAuthor);
+		
+		assert.lengthOf(citations[3].citationStrings, 1);
+		assert.equal(citations[3].citationStrings[0], 'John Smith, 2009');
+		assert.equal(citations[3].data[0].creators, 'John Smith');
+		assert.isUndefined(citations[3].data[0].title);
+		assert.equal(citations[3].data[0].date, '2009');
+		assert.isFalse(citations[3].suppressAuthor);
+
+		assert.lengthOf(citations[4].citationStrings, 1);
+		assert.equal(citations[4].citationStrings[0], 'Smith, 2009');
+		assert.equal(citations[4].pages[0], '10-14');
+		assert.equal(citations[4].data[0].creators, 'Smith');
+		assert.isUndefined(citations[4].data[0].title);
+		assert.equal(citations[4].data[0].date, '2009');
+		assert.isFalse(citations[4].suppressAuthor);
+
+		assert.lengthOf(citations[5].citationStrings, 1);
+		assert.equal(citations[5].citationStrings[0], 'Smith, "Title," 2009');
+		assert.equal(citations[5].data[0].creators, 'Smith');
+		assert.equal(citations[5].data[0].title, 'Title');
+		assert.equal(citations[5].data[0].date, '2009');
+		assert.isFalse(citations[5].suppressAuthor);
+
+		assert.lengthOf(citations[6].citationStrings, 2);
+		assert.equal(citations[6].citationStrings[0], 'Jones, 2005');
+		assert.equal(citations[6].citationStrings[1], 'Smith, 2009');
+		assert.equal(citations[6].data[0].creators, 'Jones');
+		assert.equal(citations[6].data[1].creators, 'Smith');
+		assert.isUndefined(citations[6].data[0].title);
+		assert.isUndefined(citations[6].data[1].title);
+		assert.equal(citations[6].data[0].date, '2005');
+		assert.equal(citations[6].data[1].date, '2009');
+		assert.isFalse(citations[6].suppressAuthor);
+	});
+	
+	it('should map citations to existing items, when matching items exist', async () => {
+		// create items that match citations perfectly
+		let [testItem1, testItem2, ..._] = items;
+
+		let citations = parseCitations(basicRTF);
+		let mappings = await processCitations(citations);
+		assert.lengthOf(citations, 7);
+		// 7 citations out of which one quotes two items give a total of 8 items,
+		// but "Smith, 2009" appears multiple times, which makes it 6 after deduplication.
+		assert.lengthOf(mappings, 6);
+		assert.equal(mappings[0].rtf, 'Smith, 2009');
+		assert.lengthOf(mappings[0].items, 1);
+		assert.equal(mappings[0].items[0].id, testItem1.id);
+		assert.equal(mappings[0].type, MAPPED);
+		assert.equal(mappings[1].rtf, 'Smith {2009}');
+		assert.lengthOf(mappings[1].items, 1);
+		assert.equal(mappings[1].items[0].id, testItem1.id);
+		assert.equal(mappings[1].type, MAPPED);
+		assert.equal(mappings[2].rtf, 'Smith et al., 2009');
+		assert.lengthOf(mappings[2].items, 1);
+		assert.equal(mappings[2].items[0].id, testItem1.id);
+		assert.equal(mappings[2].type, MAPPED);
+		assert.equal(mappings[3].rtf, 'John Smith, 2009');
+		assert.lengthOf(mappings[3].items, 1);
+		assert.equal(mappings[3].items[0].id, testItem1.id);
+		assert.equal(mappings[3].type, MAPPED);
+		assert.equal(mappings[4].rtf, 'Smith, "Title," 2009');
+		assert.lengthOf(mappings[4].items, 1);
+		assert.equal(mappings[4].items[0].id, testItem1.id);
+		assert.equal(mappings[4].type, MAPPED);
+		assert.equal(mappings[5].rtf, 'Jones, 2005');
+		assert.lengthOf(mappings[5].items, 1);
+		assert.equal(mappings[5].items[0].id, testItem2.id);
+		assert.equal(mappings[5].type, MAPPED);
+	});
+
+	it('should map mark mappings as AMBIGUOUS when more than one matching item is found', async () => {
+		// clear matching items, then create two items that both match "Smith, 2009"
+		await clearItems(items);
+		let testItem1 = await createDataObject('item');
+		testItem1.setField('title', 'First Title');
+		testItem1.setField('date', '2009');
+		testItem1.setCreators([{
+			lastName: 'Smith',
+			firstName: 'John',
+			creatorType: 'author'
+		}]);
+		await testItem1.saveTx();
+
+		let testItem2 = await createDataObject('item');
+		testItem2.setField('title', 'Second Title');
+		testItem2.setField('date', '2009');
+		testItem2.setCreators([{
+			lastName: 'Smith',
+			firstName: 'Jane',
+			creatorType: 'author'
+		}]);
+		await testItem2.saveTx();
+
+		let citations = parseCitations(basicRTF);
+		let mappings = await processCitations(citations);
+
+		assert.equal(mappings[0].rtf, 'Smith, 2009');
+		assert.lengthOf(mappings[0].items, 2);
+		assert.include([mappings[0].items[0].id, mappings[0].items[1].id], testItem1.id);
+		assert.include([mappings[0].items[0].id, mappings[0].items[1].id], testItem2.id);
+		assert.equal(mappings[0].type, AMBIGUOUS);
+
+		// clean up items created for this test
+		await testItem1.eraseTx();
+		await testItem2.eraseTx();
+	});
+	
+	it('should map unmapped citations to UNMAPPED', async () => {
+		// ensure no matching items exist beforehand
+		await clearItems(items);
+		let citations = parseCitations(basicRTF);
+		let mappings = await processCitations(citations);
+		assert.equal(mappings[0].rtf, 'Smith, 2009');
+		assert.lengthOf(mappings[0].items, 0);
+		assert.equal(mappings[0].type, UNMAPPED);
+	});
+	
+	it('should recognize citations with Unicode in the RTF file', async () => {
+		let citations = parseCitations(advancedRTF);
+		// total number of citations
+		assert.lengthOf(citations, 16);
+
+		// 0 - Unicode Names: Müller, 2012 / 山本, 2019
+		assert.lengthOf(citations[0].citationStrings, 2);
+		assert.equal(citations[0].citationStrings[0], "Müller, 2012");
+		assert.equal(citations[0].citationStrings[1], "山本, 2019");
+		assert.equal(citations[0].data[0].creators, "Müller");
+		assert.equal(citations[0].data[1].creators, "山本");
+		assert.equal(citations[0].data[0].date, "2012");
+		assert.equal(citations[0].data[1].date, "2019");
+		assert.isFalse(citations[0].suppressAuthor);
+
+		// 1 - Compound names: O’Connor, "Drink Before the War", 1987
+		assert.lengthOf(citations[1].citationStrings, 1);
+		assert.equal(
+			citations[1].citationStrings[0],
+			"O’Connor, \"Drink Before the War\", 1987"
+		);
+		assert.equal(citations[1].data[0].creators, "O’Connor");
+		assert.equal(citations[1].data[0].date, "1987");
+		assert.isFalse(citations[1].suppressAuthor);
+
+		// 2 - Unicode titles: Smith, "金毛寻回犬," 2010
+		assert.lengthOf(citations[2].citationStrings, 1);
+		assert.equal(
+			citations[2].citationStrings[0],
+			"Smith, \"金毛寻回犬,\" 2010"
+		);
+		assert.equal(citations[2].data[0].creators, "Smith");
+		assert.equal(citations[2].data[0].date, "2010");
+
+		// 3 - ASCII quotes with comma outside: Smith, "Title", 2008
+		assert.lengthOf(citations[3].citationStrings, 1);
+		assert.equal(
+			citations[3].citationStrings[0],
+			"Smith, \"Title\", 2008"
+		);
+		assert.equal(citations[3].data[0].creators, "Smith");
+		assert.equal(citations[3].data[0].date, "2008");
+
+		// 4 - Unicode quotes: Smith, “Title,” 2009
+		assert.lengthOf(citations[4].citationStrings, 1);
+		assert.equal(
+			citations[4].citationStrings[0],
+			"Smith, “Title,” 2009"
+		);
+		assert.equal(citations[4].data[0].creators, "Smith");
+		assert.equal(citations[4].data[0].date, "2009");
+
+		// 5 - Unicode quotes with comma outside: Smith, “Title”, 2009
+		assert.lengthOf(citations[5].citationStrings, 1);
+		assert.equal(
+			citations[5].citationStrings[0],
+			"Smith, “Title”, 2009"
+		);
+		assert.equal(citations[5].data[0].creators, "Smith");
+		assert.equal(citations[5].data[0].date, "2009");
+
+		// 6 - Low/High quotes: Smith, „Title”, 2009
+		assert.lengthOf(citations[6].citationStrings, 1);
+		assert.equal(
+			citations[6].citationStrings[0],
+			"Smith, „Title”, 2009"
+		);
+		assert.equal(citations[6].data[0].creators, "Smith");
+		assert.equal(citations[6].data[0].date, "2009");
+
+		// 7 - Just the title: "Title," 2009 (no creators)
+		assert.lengthOf(citations[7].citationStrings, 1);
+		assert.equal(
+			citations[7].citationStrings[0],
+			"\"Title,\" 2009"
+		);
+		assert.isUndefined(citations[7].data[0].creators);
+		assert.equal(citations[7].data[0].date, "2009");
+
+		// 8 - Just the title, comma outside: "Title", 2009 (no creators)
+		assert.lengthOf(citations[8].citationStrings, 1);
+		assert.equal(
+			citations[8].citationStrings[0],
+			"\"Title\", 2009"
+		);
+		assert.isUndefined(citations[8].data[0].creators);
+		assert.equal(citations[8].data[0].date, "2009");
+
+		// 9 - Just the title, Unicode quotes: “Title,” 2009 (no creators)
+		assert.lengthOf(citations[9].citationStrings, 1);
+		assert.equal(
+			citations[9].citationStrings[0],
+			"“Title,” 2009"
+		);
+		assert.isUndefined(citations[9].data[0].creators);
+		assert.equal(citations[9].data[0].date, "2009");
+		
+		// 10 - Initials: J.R.R Tolkien, 1954
+		assert.lengthOf(citations[10].citationStrings, 1);
+		assert.equal(citations[10].citationStrings[0], "J.R.R. Tolkien, 1954");
+		assert.equal(citations[10].data[0].creators, "J.R.R. Tolkien");
+		assert.equal(citations[10].data[0].date, "1954");
+		
+		// 11 - More compound names: van Buuren, 2008
+		assert.lengthOf(citations[11].citationStrings, 1);
+		assert.equal(citations[11].citationStrings[0], "van Buuren, 2008");
+		assert.equal(citations[11].data[0].creators, "van Buuren");
+		assert.equal(citations[11].data[0].date, "2008");
+		
+		// 12 - Formatting inside a citation: Smith, 2009
+		assert.lengthOf(citations[12].citationStrings, 1);
+		assert.equal(citations[12].citationStrings[0], "Smith, 2009");
+		assert.equal(citations[12].data[0].creators, "Smith");
+		assert.equal(citations[12].data[0].date, "2009");
+		
+		// 13 - legacy multibyte encodings: Smith and Jones, 2010
+		assert.lengthOf(citations[13].citationStrings, 1);
+		assert.equal(citations[13].citationStrings[0], "Smith, \"金毛寻回犬,\" 2010");
+		assert.equal(citations[13].data[0].creators, "Smith");
+		assert.equal(citations[13].data[0].date, "2010");
+		
+		// 14 - suppressed citations with Unicode characters: 山本, 2019
+		assert.lengthOf(citations[14].citationStrings, 1);
+		assert.equal(citations[14].citationStrings[0], "山本 et al. {2019}");
+		assert.equal(citations[14].data[0].creators, "山本");
+		assert.equal(citations[14].data[0].date, "2019");
+		assert.isTrue(citations[14].suppressAuthor);
+		
+		// 15 - Unicode characters with a fallback character: Smith, 2010
+		assert.lengthOf(citations[15].citationStrings, 1);
+		assert.equal(citations[15].citationStrings[0], "Smith, \"金毛寻回犬,\" 2010");
+		assert.equal(citations[15].data[0].creators, "Smith");
+		assert.equal(citations[15].data[0].date, "2010");
+		assert.isFalse(citations[15].suppressAuthor);
+	});
+});


### PR DESCRIPTION
Current RTF Scan functionality is severely limited and will only correctly extract pure ASCII citations with no formatting from an RTF document. Citations with non-ASCII characters will either be ignored or presented incorrectly; in the latter case, searching for a matching document will also use incorrect search criteria and result in no matches.

This PR re-implements the RTF Scan feature with support for the various ways RTF can represent non-ASCII characters. It also improves citation discovery and adds a test suite. Close #5662.

Here is a screenshot from running RTF Scan for a [sample RTF document](https://github.com/user-attachments/files/24532696/demo.rtf) in current Zotero:

<img width="812" height="690" alt="Screenshot 2026-01-09 at 18 37 15" src="https://github.com/user-attachments/assets/7a7b3a35-9e65-425e-a41a-90e9f5c78ef9" />

And with this PR:

<img width="768" height="646" alt="Screenshot 2026-01-09 at 18 38 09" src="https://github.com/user-attachments/assets/6f9aea7e-1da1-4277-b86c-f1655b5587f0" />

Summary of changes:

- Separate RTF processing logic from the UI-related code
- Add test coverage
- Add support for citations with Unicode characters in authors and in the title (#5662)
- Add support for citations with non-ASCII quotation marks (Unicode left/right and high/low)
- Add support for citations with a title but no author (https://forums.zotero.org/discussion/128551/rtf-scan-problems-diacritics-and-missing-authors)
- Add support for documents encoded with multiple codepages
- Add support for legacy multi-byte encodings
- Add support for font lookup (which may affect encoding!)
- Ignore control sequences and control symbols when looking for citations
