### PR TITLE
Fix tab focus control

### DIFF
--- a/chrome/content/zotero/elements/contextPane.js
+++ b/chrome/content/zotero/elements/contextPane.js
@@ -218,7 +218,6 @@
 					// updated by another select tab event.
 					&& (action === 'select'
 						|| (action === 'load' && Zotero_Tabs.selectedID == tabID))) {
-				this._handleTabReady(tabID);
 				if (Zotero_Tabs.hasNoteContext(tabType)) {
 					this._setupNotesContext(tabID);
 				}
@@ -258,27 +257,6 @@
 
 		_disableNotesContext() {
 			this.sidenav.contextNotesPaneEnabled = false;
-		}
-
-		async _handleTabReady(tabID) {
-			let tabContent = Zotero_Tabs.getTabContent(tabID);
-			if (!tabContent) {
-				return;
-			}
-			// Focus tab content (e.g. reader pages view) if context pane note editor is not selected
-			if (Zotero_Tabs.selectedID == tabID
-				&& !Zotero_Tabs.tabsMenuPanel.visible
-				&& (!document.activeElement
-					|| !document.activeElement.closest('.context-node iframe[id="editor-view"]'))) {
-				if (!Zotero_Tabs.focusOptions?.keepTabFocused) {
-					// Do not move focus to the reader during keyboard navigation
-					setTimeout(() => {
-						// Timeout to make sure focus does not stick to the tab
-						// after click on windows
-						tabContent.setFocus();
-					});
-				}
-			}
 		}
 
 		_getCurrentNotesContext() {

--- a/chrome/content/zotero/elements/tabContent.js
+++ b/chrome/content/zotero/elements/tabContent.js
@@ -97,18 +97,6 @@
 				}
 			}));
 		}
-
-		/**
-		 * Notify the tab content that it has received focus.
-		 * Used by the context pane to move focus.
-		 */
-		setFocus() {
-			this.dispatchEvent(new CustomEvent("tab-focus", {
-				detail: {
-					tabID: this.tabID
-				}
-			}));
-		}
 	}
 
 	customElements.define("tab-content", TabContent);

--- a/chrome/content/zotero/xpcom/data/notes.js
+++ b/chrome/content/zotero/xpcom/data/notes.js
@@ -148,10 +148,6 @@ Zotero.Notes = new function () {
 					this.setContextPaneOpen(noteEditor, event.detail.open);
 				});
 
-				container.addEventListener('tab-focus', () => {
-					noteEditor.focus();
-				});
-
 				container.addEventListener('tab-selection-change', (event) => {
 					if (event.detail.selected) {
 						this._updateLayout();
@@ -161,6 +157,7 @@ Zotero.Notes = new function () {
 
 			if (select) {
 				this._updateLayout();
+				noteEditor.focus();
 			}
 		}
 		return noteEditor;

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -1494,10 +1494,6 @@ class ReaderTab extends ReaderInstance {
 				this.setContextPaneOpen(event.detail.open);
 			});
 
-			this._tabContainer.addEventListener('tab-focus', () => {
-				this.focus();
-			});
-
 			this._tabContainer.addEventListener('tab-selection-change', (event) => {
 				if (event.detail.selected) {
 					this._updateLayout();

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -268,7 +268,7 @@ var ZoteroPane = new function () {
 					ArrowNext: () => null,
 					ArrowPrevious: () => null,
 					Tab: () => {
-						Zotero_Tabs.focusContent();
+						Zotero_Tabs.focusFirst();
 						return null;
 					},
 					ShiftTab: () => document.getElementById('zotero-tb-sync-error')


### PR DESCRIPTION
fix: #5683
fix: #5684
fix: #5688

Rename tab hook focus -> focusFirst
Replace tab-focus custom event with tab hook refocus
Move context pane _handleTabReady to Zotero_Tabs
Focus note editor after opening tab
Use setTimeout to ensure the focus does not stay in tab element