### PR TITLE
Fix wrong focus on shift-tab from note-editor

### DIFF
--- a/chrome/content/zotero/xpcom/editorInstance.js
+++ b/chrome/content/zotero/xpcom/editorInstance.js
@@ -751,8 +751,20 @@ class EditorInstance {
 					return;
 				}
 				case 'focusBack': {
-					let win = Zotero.getMainWindow();
-					win.Zotero_Tabs.focusBack();
+					// If editor is in a tab, let Zotero_Tabs handle the focus
+					if (this._tabID) {
+						let win = Zotero.getMainWindow();
+						win.Zotero_Tabs.focusBack();
+					}
+					// If the editor is in a standalone window, itemPane, or contextPane,
+					// move focus back from the iframe
+					else {
+						let iframe = this._iframeWindow.browsingContext.embedderElement;
+						// Forget the previously focused element within the iframe to avoid
+						// it receiving focus for a moment if you later tab back into the editor
+						iframe.ownerDocument.activeElement.blur();
+						Services.focus.moveFocus(iframe.ownerGlobal, iframe, Services.focus.MOVEFOCUS_BACKWARD, Services.focus.FLAG_SHOWRING);
+					};
 					return;
 				}
 				case 'focusForward': {


### PR DESCRIPTION
Fixes: #5690

Before. In ZoteroPane, the sync button receives focus instead of the itemTree. In a standalone window, Shift-Tab from the toolbar does nothing.

https://github.com/user-attachments/assets/0e9ed65c-3038-47ed-9281-20ea49e77d5c

After. In ZoteroPane, itemTree receives focus on Shift-Tab. In a standalone window, Shift-Tab from the toolbar wraps focus around to focus the `collapsible-section`s at the bottom (no way to get to them otherwise).

https://github.com/user-attachments/assets/e5b439be-af60-49a9-bfea-3da9cfaab612

