### PR TITLE
Fix field and abstract changes not refreshing in the library pane if performed from the context pane

### DIFF
--- a/chrome/content/zotero/elements/abstractBox.js
+++ b/chrome/content/zotero/elements/abstractBox.js
@@ -67,7 +67,7 @@
 		}
 
 		init() {
-			this._notifierID = Zotero.Notifier.registerObserver(this, ['item'], 'abstractBox');
+			this._notifierID = Zotero.Notifier.registerObserver(this, ['item', 'tab'], 'abstractBox');
 
 			this.initCollapsibleSection();
 
@@ -85,6 +85,9 @@
 		notify(action, type, ids) {
 			if (action == 'modify' && this.item && ids.includes(this.item.id)) {
 				this._forceRenderAll();
+			}
+			if (action === 'select' && type === 'tab' && ids.length > 0) {
+				this._handleTabSelect(ids[0]);
 			}
 		}
 		
@@ -202,6 +205,20 @@
 
 		_handleFieldBlur = () => {
 			this.save();
+		};
+
+		_handleTabSelect = (tabID) => {
+			if (!this.tabID || typeof Zotero_Tabs === 'undefined') {
+				return;
+			}
+			if (tabID !== this.tabID) {
+				return;
+			}
+
+			if (this._syncRenderPending) {
+				this._syncRenderPending = false;
+				this.render();
+			}
 		};
 	}
 	customElements.define("abstract-box", AbstractBox);

--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -153,7 +153,7 @@
 			// Ensure no button is forced to stay visible once the menu is closed
 			this.addEventListener('popuphidden', this._handlePopupHidden);
 
-			this._notifierID = Zotero.Notifier.registerObserver(this, ['item', 'infobox'], 'itemBox');
+			this._notifierID = Zotero.Notifier.registerObserver(this, ['item', 'infobox', 'tab'], 'itemBox');
 			this._prefsObserverID = Zotero.Prefs.registerObserver('fontSize', () => {
 				this._forceRenderAll();
 			});
@@ -402,6 +402,9 @@
 			}
 			if (event == 'modify' && this.item?.id && ids.includes(this.item.id)) {
 				this._forceRenderAll();
+			}
+			if (event === 'select' && type === 'tab' && ids.length > 0) {
+				this._handleTabSelect(ids[0]);
 			}
 		}
 		
@@ -2965,6 +2968,20 @@
 			let focusLeftUnsavedCreatorRow = !unsavedCreatorRow.contains(focused);
 			if (focusLeftUnsavedCreatorRow) {
 				this.removeUnsavedCreatorRow(true);
+			}
+		};
+
+		_handleTabSelect = (tabID) => {
+			if (!this.tabID || typeof Zotero_Tabs === 'undefined') {
+				return;
+			}
+			if (tabID !== this.tabID) {
+				return;
+			}
+			
+			if (this._syncRenderPending) {
+				this._syncRenderPending = false;
+				this.render();
 			}
 		};
 	}

--- a/chrome/content/zotero/elements/itemPaneSection.js
+++ b/chrome/content/zotero/elements/itemPaneSection.js
@@ -167,12 +167,12 @@ class ItemPaneSectionElementBase extends XULElementBase {
 	}
 
 	async _forceRenderAll() {
+		this._resetRenderedFlags();
 		if (this.hidden || this.skipRender) {
 			this._syncRenderPending = true;
 			this._asyncRenderPending = true;
 			return;
 		}
-		this._resetRenderedFlags();
 		if (this.render) this.render();
 		if (this.asyncRender) await this.asyncRender();
 	}


### PR DESCRIPTION
`InfoBox` registers an observer for when an item is updated, but if the tab is not visible, this won’t trigger a render. And since it’s not listening for a tab change, it won’t ever refresh the rendered fields. `AbstractBox` has the same problem. There is a separate listener for a tab change already in the `ItemDetails`, but that, as far as I can tell, is unaware of the item change.

In this PR, I’ve introduced an observer for tab changes in the `InfoBox` and `AbstractBox` so that these components can “catch up” after any renders missed due to item changes on other tabs.

Fix #5694