### PR TITLE
Fix Libraries and Collections box editable field is undefined in note editor

### DIFF
--- a/chrome/content/zotero/elements/noteEditor.js
+++ b/chrome/content/zotero/elements/noteEditor.js
@@ -444,6 +444,7 @@
 			this._mode = val;
 			this._id('related').editable = val == "edit";
 			this._id('tags').editable = val == "edit";
+			this._id('libraries-collections').editable = val == "edit";
 			this.refresh();
 		}
 


### PR DESCRIPTION
fix: #5698