### PR TITLE
File renaming: Allow local time conversion for accessDate

### DIFF
--- a/test/tests/attachmentsTest.js
+++ b/test/tests/attachmentsTest.js
@@ -1441,6 +1441,7 @@ describe("Zotero.Attachments", function () {
 			item.setField('journalAbbreviation', 'BPP');
 			item.setField('issue', '42');
 			item.setField('pages', '321');
+			item.setField('accessDate', '2009-02-07T06:15:10Z');
 
 			itemBookSection = createUnsavedDataObject('item', { title: 'Book Section', itemType: 'bookSection', libraryID: 1 });
 			itemBookSection.setField('bookTitle', 'Book Title');
@@ -1939,6 +1940,26 @@ describe("Zotero.Attachments", function () {
 			assert.equal(
 				Zotero.Attachments.getFileBaseNameFromItem(item, { formatString: '{{ title replaceFrom="lorem" replaceTo="foobar" regexOpts="" }}' }),
 				'Lorem Ipsum'
+			);
+		});
+
+		it('should output the accessDate according to the declared timezone', async function () {
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, { formatString: '{{ accessDate timeZone="America/New_York" replaceFrom=":" replaceTo="-" regexOpts="g" }}' }),
+				'2009-02-07 01-15-10'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, { formatString: '{{ accessDate timeZone="Europe/Berlin" replaceFrom=":" replaceTo="-" regexOpts="g" }}' }),
+				'2009-02-07 07-15-10'
+			);
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, { formatString: '{{ accessDate timeZone="America/Los_Angeles" truncate="10" }}' }),
+				'2009-02-06'
+			);
+			// timeZone is optional; UTC date, as stored, is returned if not specified
+			assert.equal(
+				Zotero.Attachments.getFileBaseNameFromItem(item, { formatString: '{{ accessDate replaceFrom=":" replaceTo="-" regexOpts="g" }}' }),
+				'2009-02-07 06-15-10'
 			);
 		});
 


### PR DESCRIPTION
Example use of the new field: `{{ accessDate timeZone="America/New_York" }}`. Since ":" is not allowed in file names, I suspect users will want to either replace it or truncate time, I've included examples of both in tests. I’ll tweak the documentation once this PR is merged.

Depends on `Temporal`, so it cannot be back-ported to Zotero 7.

Resolve #5701.