### PR TITLE
Citation dialog: List mode tab always before Library

### DIFF
--- a/chrome/content/zotero/integration/citationDialog.js
+++ b/chrome/content/zotero/integration/citationDialog.js
@@ -1276,10 +1276,6 @@ const IOManager = {
 		if (!desiredMode) {
 			desiredMode = "list";
 		}
-		// If List is the initial mode, move the List type tab to the front
-		if (desiredMode == "list") {
-			_id("dialog-mode-setting").appendChild(_id("dialog-mode-library"));
-		}
 		this.toggleDialogMode(desiredMode);
 	},
 	

--- a/chrome/content/zotero/integration/citationDialog.xhtml
+++ b/chrome/content/zotero/integration/citationDialog.xhtml
@@ -101,11 +101,11 @@
 				<div class="hbox" style="flex:1"></div>
 				<div id="bottom-btn-group" class="hbox">
 					<div id="dialog-mode-setting" class="segmented-switch" role="radiogroup" data-arrow-nav="horizontal" data-tabindex="71" aria-orientation="horizontal">
-						<div id="dialog-mode-library" class="option keyboard-clickable" value="library" role="radio" aria-checked="false" tabindex="-1" data-arrow-nav-enabled="true">
-							<span data-l10n-id="integration-citationDialog-mode-library"></span>
-						</div>
 						<div id="dialog-mode-list" class="option keyboard-clickable" value="list" role="radio" aria-checked="false" tabindex="-1" data-arrow-nav-enabled="true">
 							<span data-l10n-id="integration-citationDialog-mode-list"></span>
+						</div>
+						<div id="dialog-mode-library" class="option keyboard-clickable" value="library" role="radio" aria-checked="false" tabindex="-1" data-arrow-nav-enabled="true">
+							<span data-l10n-id="integration-citationDialog-mode-library"></span>
 						</div>
 					</div>
 					<button id="settings-button" class="btn-icon icon-citation-dialog-settings" data-l10n-id="integration-citationDialog-btn-settings" tabindex="-1" data-tabindex="72"></button>


### PR DESCRIPTION
In the segmented control switch, List mode tab always appears before the Library. Tabs are no longer
reordered based on the default mode preference.


https://github.com/user-attachments/assets/27a32f69-2b41-43dc-a64b-04915fa1ea37

