### PR TITLE
Fix `contextPaneOpen` race condition causing duplicate button

### DIFF
--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -2062,7 +2062,6 @@ class Reader {
 	constructor() {
 		this._sidebarWidth = 240;
 		this._sidebarOpen = false;
-		this._contextPaneOpen = false;
 		this._bottomPlaceholderHeight = 0;
 		this._readers = [];
 		this._notifierID = Zotero.Notifier.registerObserver(this, ['item', 'setting', 'tab'], 'reader');
@@ -2367,7 +2366,7 @@ class Reader {
 				background: openInBackground,
 				sidebarWidth: this._sidebarWidth,
 				sidebarOpen: this._sidebarOpen,
-				contextPaneOpen: this._contextPaneOpen,
+				contextPaneOpen: !win.ZoteroContextPane.collapsed,
 				bottomPlaceholderHeight: this._bottomPlaceholderHeight,
 				preventJumpback: preventJumpback,
 				onToggleSidebar: (open) => {


### PR DESCRIPTION
I haven't done a bisect but I believe this was a note-in-tab regression; all the code that set `Zotero.Reader._contextPaneOpen` was removed, but we were still passing it to new reader instances. @windingwind, let me know if this looks OK or if there's a better approach we could use.

Fixes #5715