### PR TITLE
`showAttachmentFilenames`: Fall back on invalid attachment path

### DIFF
--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -3422,7 +3422,14 @@ var ItemTree = class ItemTree extends LibraryTree {
 				// TODO: Adjust this if we localize "Snapshot"
 				&& !(treeRow.ref.isSnapshotAttachment() && /snapshot/i.test(treeRow.ref.getField('title')))
 				&& Zotero.Prefs.get('showAttachmentFilenames')) {
-			row.title = treeRow.ref.attachmentFilename;
+			try {
+				row.title = treeRow.ref.attachmentFilename;
+			}
+			catch {
+				// Path wasn't parseable - it could be truly invalid, or just
+				// invalid for this platform (e.g., Windows path on macOS/Linux)
+				row.title = treeRow.ref.attachmentPath;
+			}
 		}
 		else {
 			row.title = treeRow.ref.getDisplayTitle();


### PR DESCRIPTION
Fixes error when attempting to render a Windows path on macOS/Linux, and in other cases where attachment paths are invalid for the current platform.