### PR TITLE
About window: Always pass centerscreen, and pass dialog=yes on macOS

### DIFF
--- a/chrome/content/zotero/standalone/hiddenWindow.xhtml
+++ b/chrome/content/zotero/standalone/hiddenWindow.xhtml
@@ -46,10 +46,12 @@
 		Services.scriptloader.loadSubScript("chrome://zotero/content/platformKeys.js", this);
 	</script>
 	<script>
+		// Equivalent to ZoteroPane.openAboutDialog(), but hiddenWindow.xhtml
+		// is only used on macOS
 		function openAbout() {
 			var ww = Components.classes['@mozilla.org/embedcomp/window-watcher;1']
 				.getService(Components.interfaces.nsIWindowWatcher);
-			ww.openWindow(null, 'chrome://zotero/content/about.xhtml', 'about', 'chrome,dialog=yes', null);
+			ww.openWindow(null, 'chrome://zotero/content/about.xhtml', 'about', 'chrome,centerscreen,dialog=yes', null);
 		}
 		
 		// Equivalent to Zotero.Utilities.Internal.openPreferences()

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -6962,7 +6962,11 @@ var ZoteroPane = new function () {
 	 * Opens the about dialog
 	 */
 	this.openAboutDialog = function () {
-		window.openDialog('chrome://zotero/content/about.xhtml', 'about', 'chrome,centerscreen');
+		let flags = 'chrome,centerscreen';
+		if (Zotero.isMac) {
+			flags += ',dialog=yes';
+		}
+		window.openDialog('chrome://zotero/content/about.xhtml', 'about', flags);
 	}
 	
 	/**


### PR DESCRIPTION
Fixes window appearing off center on macOS.

The ZP implementation is never actually called on macOS as far as I can tell, but it was weird to have two separate implementations with different behavior with no explanation.