### PR TITLE
Delete duplicate renamed styles on init and map vancouver to nlm-citation-sequence

### DIFF
--- a/chrome/content/zotero/xpcom/style.js
+++ b/chrome/content/zotero/xpcom/style.js
@@ -29,13 +29,7 @@ Zotero.Styles = new function () {
 	var _styles, _visibleStyles;
 	
 	var _renamedStyles = null;
-
-	// Overrides for styles that we have renamed unilaterally besides CSL repo
-	// https://github.com/citation-style-language/styles/pull/7928
-	const RENAMED_STYLES = {
-		vancouver: "nlm-citation-sequence",
-	};
-
+	
 	this.xsltProcessor = null;
 	this.ns = {
 		"csl":"http://purl.org/net/xbiblio/csl"
@@ -114,7 +108,6 @@ Zotero.Styles = new function () {
 		_renamedStyles = JSON.parse(
 			await Zotero.File.getResourceAsync("resource://zotero/schema/renamed-styles.json")
 		);
-		Object.assign(_renamedStyles, RENAMED_STYLES);
 
 		// Delete installed styles that have been renamed if the new style is also installed
 		var prefix = "http://www.zotero.org/styles/";

--- a/chrome/content/zotero/xpcom/style.js
+++ b/chrome/content/zotero/xpcom/style.js
@@ -116,8 +116,13 @@ Zotero.Styles = new function () {
 			let newID = prefix + _renamedStyles[oldName];
 			if (_styles[oldID] && _styles[newID]) {
 				Zotero.debug("Deleting renamed style '" + oldID + "'");
-				await OS.File.remove(_styles[oldID].path);
-				delete _styles[oldID];
+				try {
+					await OS.File.remove(_styles[oldID].path);
+					delete _styles[oldID];
+				}
+				catch (e) {
+					Zotero.logError(e);
+				}
 			}
 		}
 		_visibleStyles = _visibleStyles.filter(s => _styles[s.styleID]);

--- a/resource/schema/renamed-styles.json
+++ b/resource/schema/renamed-styles.json
@@ -586,6 +586,7 @@
     "university-of-york-oscola": "oscola",
     "uqam-universite-du-quebec-a-montreal": "universite-du-quebec-a-montreal",
     "user-modeling-and-useradapted-interaction": "user-modeling-and-user-adapted-interaction",
+    "vancouver": "nlm-citation-sequence",
     "vancouver-alphabetical": "nlm-citation-name",
     "vancouver-author-date": "nlm-name-year",
     "vancouver-brackets": "nlm-citation-sequence-brackets",

--- a/test/tests/styleTest.js
+++ b/test/tests/styleTest.js
@@ -165,13 +165,12 @@ describe("Zotero.Styles", function () {
 		});
 	});
 
-	// Tests for our own RENAMED_STYLES overrides in style.js (beyond CSL repo's renamed-styles.json)
 	describe("renamed styles", function () {
 		var oldName = "vancouver";
 		var newName = "nlm-citation-sequence";
 		var prefix = "http://www.zotero.org/styles/";
 
-		it("should map a RENAMED_STYLES entry to its new ID via get()", function () {
+		it("should map a renamed style to its new ID via get()", function () {
 			var style = Zotero.Styles.get(prefix + oldName);
 			assert.isOk(style);
 			assert.equal(style.styleID, prefix + newName);


### PR DESCRIPTION
After citation-style-language/styles#7928 renamed Vancouver styles to NLM terminology, Zotero installations end up with both vancouver.csl and nlm-citation-sequence.csl.

CSL repo decided to make vancouver.csl a dependant style, on nlm-citation-sequence.csl for now, but it could technically be something else in the future. We add a custom remap of vancouver to nlm-citation-senquence in this PR.

Also on init, delete any installed style whose ID appears in the renamed mapping if the target style also exists.