### PR TITLE
Fix missing ellipsis for styles in the style selector

### DIFF
--- a/chrome/content/zotero/elements/styleConfigurator.js
+++ b/chrome/content/zotero/elements/styleConfigurator.js
@@ -86,8 +86,11 @@
 					.replace(/^American Sociological Association/, "American Sociological Association (ASA)");
 				
 				let richlistitem = document.createXULElement('richlistitem');
+				let labelEL = document.createXULElement("label");
+				labelEL.setAttribute("value", label);
+				labelEL.setAttribute("tooltiptext", label);
+				richlistitem.appendChild(labelEL);
 				richlistitem.value = value;
-				richlistitem.textContent = label;
 				styleListEl.append(richlistitem);
 			});
 			this.value = this.getAttribute('value');

--- a/scss/elements/_styleConfigurator.scss
+++ b/scss/elements/_styleConfigurator.scss
@@ -39,10 +39,16 @@ style-configurator {
 		
 		richlistitem {
 			line-height: var(--style-configurator-richlistitem-line-height, 1.66666666em);
-			overflow: hidden;
-			text-overflow: ellipsis;
 			padding: var(--style-configurator-richlistitem-padding, 0px 8px 0px 4px);
 			border-radius: var(--style-configurator-richlistitem-border-radius, 5px);
+
+			> label {
+				// XUL renders the label text as generated content in ::before, so we need to apply text-overflow styles there
+				&::before {
+					overflow: hidden;
+					text-overflow: ellipsis;
+				}
+			}
 		}
 		
 		@media (-moz-platform: macos) {


### PR DESCRIPTION
It might be a regression, but the style selector doesn’t use ellipsis when long style names are truncated. This PR fixes that and also introduces a tooltip attribute so that it’s possible to check the entire style name by hovering over a style label.

Before:

<img width="687" height="756" alt="Screenshot 2026-01-26 at 14 24 47" src="https://github.com/user-attachments/assets/0951811e-62f3-45b4-9f61-504af76b7814" />

After:

<img width="687" height="756" alt="Screenshot 2026-01-26 at 14 20 19" src="https://github.com/user-attachments/assets/1b0b31a1-8b01-4c3b-81c0-8106b91433ca" />

