### PR TITLE
Fix windowIcon logged error in titlebar.js on win

### DIFF
--- a/chrome/content/zotero/integration/progressBar.xhtml
+++ b/chrome/content/zotero/integration/progressBar.xhtml
@@ -30,7 +30,6 @@
 	class="citation-dialog progress-bar"
 	orient="vertical"
 	title="&zotero.progress.title;"
-	no-titlebar-icon="true"
 	xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:xul="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
 	persist="screenX screenY">

--- a/chrome/content/zotero/progressWindow.xhtml
+++ b/chrome/content/zotero/progressWindow.xhtml
@@ -34,7 +34,6 @@
         xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
 		xmlns:html="http://www.w3.org/1999/xhtml"
 		title="&zotero.progress.title;"
-        no-titlebar-icon="true"
         drawintitlebar-platforms="win,linux"
         style="min-width: 300px"
         windowtype="alert:alert">

--- a/chrome/content/zotero/titlebar.js
+++ b/chrome/content/zotero/titlebar.js
@@ -46,8 +46,9 @@ window.addEventListener("load", function () {
 		window.document.documentElement.setAttribute('sizemode', 'normal');
 	}
 
-	if (Zotero.isWin && !document.querySelector("window")?.hasAttribute("no-titlebar-icon")) {
+	if (Zotero.isWin) {
 		let windowIcon = document.querySelector(".titlebar-icon");
+		if (!windowIcon) return;
 		// Simulate Windows window control
 		windowIcon.addEventListener("dblclick", (ev) => {
 			if (ev.button !== 0) {


### PR DESCRIPTION
Instead of adding listeners to the window icon unless `[no-titlebar-icon]` is set on the window, add listeners to the icon whenever it exists. That way, one doesn't have to remember to add the `[no-titlebar-icon]` attribute to every window that doesn't have an icon. Some windows had `[no-titlebar-icon]` set (e.g. progress bar) but many others did not (e.g. select item dialog, citation dialog).

Fixes: #5733