### PR TITLE
Update menulists keyboard nav on windows

### DIFF
--- a/chrome/content/zotero/elements/zoteroSearch.js
+++ b/chrome/content/zotero/elements/zoteroSearch.js
@@ -379,6 +379,9 @@
 			
 			// Skip if no condition or correct condition already selected
 			if (!conditionName || (conditionName == this.selectedCondition && !reload)) {
+				// When "More" option is selected, the condition value remains unchanged,
+				// so make sure that it still has the checkbox.
+				this.updateMenuCheckboxesRecursive(conditionsMenu, this.selectedCondition);
 				return;
 			}
 			
@@ -416,8 +419,6 @@
 				}
 			}
 			operatorsList.selectedIndex = selectThis;
-			// Setting `selected` does not change `checked`. Should explicitly set it.
-			operatorsList.selectedItem.setAttribute('checked', true);
 			this.updateMenuCheckboxesRecursive(operatorsList, operatorsList.selectedItem.getAttribute('value'));
 			
 			// Generate drop-down menu instead of textbox for certain conditions
@@ -686,9 +687,11 @@
 				if (item.localName == 'menuitem') {
 					if (item.getAttribute('value') == value) {
 						item.setAttribute('checked', true);
+						item.setAttribute('selected', true);
 					}
 					else {
 						item.removeAttribute('checked');
+						item.removeAttribute('selected');
 					}
 				}
 				else {

--- a/scss/linux/_menu.scss
+++ b/scss/linux/_menu.scss
@@ -5,6 +5,10 @@ menuitem {
 	}
 }
 
+menulist {
+	@include focus-ring;
+}
+
 @each $cls, $icon in $menu-icons {
 	.zotero-menuitem-#{$cls} {
 		// If icon starts with "light-dark:", use light and dark icon

--- a/scss/preferences.scss
+++ b/scss/preferences.scss
@@ -381,3 +381,9 @@ button {
 		margin-block: 4px;
 	}
 }
+
+@media (-moz-platform: linux) {
+	menulist {
+		@include focus-ring;
+	}
+}


### PR DESCRIPTION
- Space/Enter on menulist will open its menupopup
- manual handling of arrowUp/Down to navigate options in a menulist without emitting the 'command' event. Otherwise, as you just try to get to a desired option, you may get alerts meant to be shown only when a selection is made (e.g. after changing the language in preferences).
- fix odd appearance of checked menulist options in advanced search condition dropdowns when "More" option is selected.

Fixes #5772

---

For reference, this was trying to navigate the items menu type that immediately shows the alert on arrowUp:

https://github.com/user-attachments/assets/ec5309b7-7204-4854-91b9-2f59f5d74400

And this is navigating the item type menu now:

https://github.com/user-attachments/assets/8158587e-c608-4d37-9dd3-0093e11cf58b

Same would happen with Languages menulist in preferences.

And this is the oddly appearing selected options in menulist of advanced search before:

<img width="251" height="610" alt="before_2" src="https://github.com/user-attachments/assets/139c2c46-243c-430c-968b-709cee5d3c6d" />
<img width="468" height="678" alt="before_1" src="https://github.com/user-attachments/assets/295aeb9f-9d18-4e7c-83c9-e83b10383365" />

And this is after:

<img width="427" height="641" alt="Screenshot 2026-02-02 at 3 40 32 PM" src="https://github.com/user-attachments/assets/6421cbd3-a948-4530-8153-6714e2ed487d" />
<img width="322" height="580" alt="Screenshot 2026-02-02 at 3 40 21 PM" src="https://github.com/user-attachments/assets/f17a5d8f-d4c9-43e5-9ed0-3cc43aba2585" />
