### PR TITLE
Skip plugin strict_max_version check on non-stable releases

### DIFF
--- a/app/scripts/fetch_xulrunner
+++ b/app/scripts/fetch_xulrunner
@@ -244,17 +244,11 @@ function modify_omni {
 	
 	# When installing addon, use app version instead of toolkit version for targetApplication
 	replace_line "id: TOOLKIT_ID," "id: '$APP_ID'," modules/addons/XPIInstall.sys.mjs
-
+	
 	# Set strictCompatibility to false on beta/dev/source builds to skip strict_max_version check
 	replace_line 'addon.strictCompatibility = true;' \
 		'let version = Services.appinfo.version;
 		addon.strictCompatibility = !version.includes("-beta") && !version.includes("-dev") && !version.includes("SOURCE");' modules/addons/XPIInstall.sys.mjs
-	replace_line 'return gStrictCompatibility;' \
-		'let version = Services.appinfo.version;
-		if (version.includes("-beta") || version.includes("-dev") || version.includes("SOURCE")) {
-			return false;
-		}
-		return gStrictCompatibility;' modules/AddonManager.sys.mjs
 	
 	# Accept zotero@chnm.gmu.edu for target application to allow Zotero 6 plugins to remain
 	# installed in Zotero 7


### PR DESCRIPTION
resolve: #5775

When the strictCompatibility of addon instance and the `extensions.strictCompatibility` are both set to false, the plugin version check only compares the min version.

See https://searchfox.org/firefox-esr140/source/toolkit/mozapps/extensions/internal/XPIDatabase.sys.mjs#592-597