### PR TITLE
Citation dialog: scroll to 1st cited row in library mode on open

### DIFF
--- a/chrome/content/zotero/integration/citationDialog.js
+++ b/chrome/content/zotero/integration/citationDialog.js
@@ -788,7 +788,7 @@ class LibraryLayout extends Layout {
 		// Scroll to the first cited item
 		let firstCitedRow = this.itemsView._rows.findIndex(row => CitationDataManager.itemAddedCache.has(row.ref.id));
 		if (firstCitedRow == -1) return;
-		this.itemsView.ensureRowIsVisible(firstCitedRow);
+		this.itemsView.ensureRowsAreVisible([firstCitedRow]);
 	}
 
 	// after an item is added, bubble-input's height may increase and push the itemTree down


### PR DESCRIPTION
If the dialog opens in library mode, after loading, scroll to the first cited item in this citation in current collection.

Fixes: #5780

Also, fix sorting by `+` column not working due to typo.

https://github.com/user-attachments/assets/83038349-8943-479c-aa8c-c9d4cb4ab119

---

I am not sure I remember what was the scrolling behavior of the classic citation dialog. I thought it makes sense to do it on the initial open but we shouldn't scroll anywhere after, since it may be disorienting as you just try to browse collections. If you want to always see all cited items, you can sort by the column with the `+` sign.