### PR TITLE
Space on an option of menulist dropdown will select it

### DIFF
--- a/chrome/content/zotero/customElements.js
+++ b/chrome/content/zotero/customElements.js
@@ -360,11 +360,11 @@ Services.scriptloader.loadSubScript('chrome://zotero/content/elements/itemTreeMe
 				}, { once: true });
 				target.open = false;
 			}
-			// No blinking happens on linux or windows
+			// No blinking happens on Linux or Windows
 			else {
 				target.activeChild.doCommand();
 				// Timeout to avoid empty context menu behind an alert or dialog if one
-				// appears on 'command' event on windows (https://github.com/zotero/zotero/issues/5633)
+				// appears on 'command' event on Windows (https://github.com/zotero/zotero/issues/5633)
 				setTimeout(() => {
 					target.open = false;
 				});


### PR DESCRIPTION
Fixes: #5779


For reference, this is what I mean by "empty context menu behind an alert" that the timeout is needed for (https://github.com/zotero/zotero/issues/5633):



<img width="656" height="596" alt="Screenshot 2026-02-04 at 4 55 01 PM" src="https://github.com/user-attachments/assets/4a771215-9722-4c87-80f1-2306d5a64f0f" />
