### PR TITLE
Reduce the judgment threshold for checking duplicate items by year

### DIFF
--- a/chrome/content/zotero/xpcom/duplicates.js
+++ b/chrome/content/zotero/xpcom/duplicates.js
@@ -359,7 +359,7 @@ Zotero.Duplicates.prototype._findDuplicates = async function () {
 			// If both items have a year and they're off by more than one, it's not a dupe
 			if (typeof yearCache[a.itemID] != 'undefined'
 					&& typeof yearCache[b.itemID] != 'undefined'
-					&& Math.abs(yearCache[a.itemID] - yearCache[b.itemID]) > 1) {
+					&& Math.abs(yearCache[a.itemID] - yearCache[b.itemID]) >= 1) {
 				return 0;
 			}
 			


### PR DESCRIPTION
(I'm not sure how reasonable this is, and if you think this modification is not reasonable, please feel free to close it.)

Now, for the following two example items, Zotero marks them as duplicates, and this can be avoided only when `2021` is changed to `2022`. I think this threshold (one year) is a bit high and may lead to some false positives. Changing it to `>= 1` seems more reasonable.

```json
[
	{
		"id": "http://zotero.org/users/11729930/items/KIEL2LZB",
		"type": "article-journal",
		"language": "en",
		"title": "This is a example title",
		"issued": {
			"date-parts": [
				[
					"2020"
				]
			]
		}
	},
	{
		"id": "http://zotero.org/users/11729930/items/FSRZPSX5",
		"type": "article-journal",
		"language": "en",
		"title": "This is a example title",
		"issued": {
			"date-parts": [
				[
					"2021"
				]
			]
		}
	}
]
```
