### PR TITLE
Add open note in tab context menu

### DIFF
--- a/chrome/content/zotero/elements/notesContext.js
+++ b/chrome/content/zotero/elements/notesContext.js
@@ -77,7 +77,8 @@
 				
 				<menupopup class="context-pane-list-popup">
 					<menuitem class="context-pane-list-show-in-library" label="&zotero.items.menu.showInLibrary;"/>
-					<menuitem class="context-pane-list-edit-in-window" label="&zotero.context.editInWindow;"/>
+					<menuitem class="context-pane-list-edit-in-tab" data-l10n-id="context-notes-edit-in-tab"/>
+					<menuitem class="context-pane-list-edit-in-window" data-l10n-id="context-notes-edit-in-window"/>
 					<menuseparator/>
 					<menuitem class="context-pane-list-move-to-trash" label="&zotero.general.moveToTrash;"/>
 				</menupopup>
@@ -514,6 +515,10 @@
 				case 'context-pane-list-show-in-library':
 					ZoteroPane_Local.selectItem(id);
 					Zotero_Tabs.select('zotero-pane');
+					break;
+
+				case 'context-pane-list-edit-in-tab':
+					ZoteroPane.openNote(id, { openInWindow: false });
 					break;
 
 				case 'context-pane-list-edit-in-window':

--- a/chrome/content/zotero/xpcom/editorInstance.js
+++ b/chrome/content/zotero/xpcom/editorInstance.js
@@ -658,11 +658,17 @@ class EditorInstance {
 					this._showInLibrary(this._item.id);
 					return;
 				}
+				case 'openTab': {
+					await this._ensureNoteCreated();
+					let zp = Zotero.getActiveZoteroPane();
+					zp.openNote(this._item.id, { openInWindow: false });
+					return;
+				}
 				case 'openWindow': {
 					// TODO: Can we can avoid creating empty note just to open it in a new window?
 					await this._ensureNoteCreated();
 					let zp = Zotero.getActiveZoteroPane();
-					zp.openNoteWindow(this._item.id);
+					zp.openNote(this._item.id, { openInWindow: true });
 					return;
 				}
 				case 'update': {

--- a/chrome/locale/en-US/zotero/note-editor.ftl
+++ b/chrome/locale/en-US/zotero/note-editor.ftl
@@ -43,6 +43,7 @@ note-editor-show-on-page = Show on Page
 note-editor-add-citation = Add Citation
 note-editor-remove-citation = Hide Citation
 note-editor-find-and-replace = Find and Replace
+note-editor-edit-in-tab = Edit in a New Tab
 note-editor-edit-in-window = Edit in a Separate Window
 note-editor-apply-annotation-colors = Show Annotation Colors
 note-editor-remove-annotation-colors = Hide Annotation Colors

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -639,6 +639,10 @@ context-notes-search =
     .placeholder = Search Notes
 context-notes-return-button =
     .aria-label = { general-go-back }
+context-notes-edit-in-tab =
+    .label = Edit in a New Tab
+context-notes-edit-in-window =
+    .label = Edit in a Separate Window
 
 new-collection = New Collection…
 menu-new-collection =


### PR DESCRIPTION
Since we have added Open Note as tab, this PR
- Introduce `Open Note in New Tab` context menu in both noteEditor toolbar (...) and rightpane context menu.
- Rename *Edit in a Separate Window* to *Open Note in New Window*, unified with the item menu strings.