### PR TITLE
Web-based login flow

### DIFF
--- a/chrome/content/zotero/preferences/preferences_sync.xhtml
+++ b/chrome/content/zotero/preferences/preferences_sync.xhtml
@@ -29,35 +29,24 @@
 				<label><html:h2>&zotero.preferences.sync.syncServer;</html:h2></label>
 
 				<hbox>
-					<html:div class="form-grid">
-						<label id="username-label" value="&zotero.preferences.sync.username;"/>
-						<html:input id="sync-username-textbox" aria-labelledby="username-label"
-							onblur="Zotero_Preferences.Sync.trimUsername()"
-							oninput="Zotero_Preferences.Sync.credentialsChange(event)"
-							onchange="Zotero_Preferences.Sync.credentialsChange(event)"
-							onkeypress="Zotero_Preferences.Sync.credentialsKeyPress(event)"/>
-
-						<label id="password-label" value="&zotero.preferences.sync.password;"/>
-						<html:input id="sync-password" type="password" aria-labelledby="password-label"
-							oninput="Zotero_Preferences.Sync.credentialsChange(event)"
-							onchange="Zotero_Preferences.Sync.credentialsChange(event)"
-							onkeypress="Zotero_Preferences.Sync.credentialsKeyPress(event)"/>
-
-						<box/>
-						<hbox>
-							<button id="sync-auth-button"
-								label="&zotero.preferences.sync.setUpSync;"
-								oncommand="Zotero_Preferences.Sync.linkAccount(event)"
-								disabled="true"/>
-							<label id="sync-status-indicator"/>
+					<vbox>
+						<hbox id="sync-login-default">
+							<button id="sync-login-button"
+								data-l10n-id="preferences-sync-login-button"
+								oncommand="Zotero_Preferences.Sync.linkAccount(event)"/>
 						</hbox>
-					</html:div>
+						<hbox id="sync-login-pending" hidden="true" align="center">
+							<label id="sync-status-indicator"/>
+							<label id="sync-login-status"
+								data-l10n-id="preferences-sync-waiting-for-login"/>
+							<button data-l10n-id="preferences-sync-cancel-button"
+								oncommand="Zotero_Preferences.Sync.cancelLogin()"/>
+						</hbox>
+					</vbox>
 
 					<vbox style="width:2em"/>
 					<vbox>
 						<label is="zotero-text-link" value="&zotero.preferences.sync.createAccount;" href="http://zotero.org/user/register"/>
-						<separator class="thin"/>
-						<label is="zotero-text-link" value="&zotero.preferences.sync.lostPassword;" href="http://zotero.org/user/lostpassword"/>
 						<separator class="thin"/>
 						<label is="zotero-text-link" value="&zotero.preferences.sync.about;" href="http://www.zotero.org/support/sync"/>
 					</vbox>

--- a/chrome/content/zotero/xpcom/sync/syncRunner.js
+++ b/chrome/content/zotero/xpcom/sync/syncRunner.js
@@ -1657,6 +1657,39 @@ Zotero.Sync.Runner_Module = function (options = {}) {
 	}
 
 
+	this.startLoginSession = async function () {
+		let client = this.getAPIClient();
+		let userID = Zotero.Users.getCurrentUserID();
+		return client.createLoginSession(userID || undefined);
+	}
+
+
+	this.checkLoginSession = async function (sessionToken, result) {
+		if (!result) {
+			let client = this.getAPIClient();
+			result = await client.checkLoginSession(sessionToken);
+		}
+		if (result.status == "completed") {
+			if (!result.apiKey) throw new Error("apiKey not found in session response");
+			if (!result.userID) throw new Error("userID not found in session response");
+			if (!result.username) throw new Error("username not found in session response");
+			await Zotero.Sync.Data.Local.setAPIKey(result.apiKey);
+		}
+		return result;
+	}
+
+
+	this.cancelLoginSession = async function (sessionToken) {
+		try {
+			let client = this.getAPIClient();
+			await client.cancelLoginSession(sessionToken);
+		}
+		catch (e) {
+			Zotero.debug("Failed to cancel login session: " + e, 2);
+		}
+	}
+
+
 	this.deleteAPIKey = async function () {
 		this.resetStorageController('zfs');
 		var apiKey = await Zotero.Sync.Data.Local.getAPIKey();

--- a/chrome/locale/en-US/zotero/preferences.ftl
+++ b/chrome/locale/en-US/zotero/preferences.ftl
@@ -129,3 +129,10 @@ preferences-sync-reset-restore-to-server-checkbox-label = { $remoteItemsDeletedC
     }
 preferences-sync-reset-restore-to-server-confirmation-text = delete online library
 preferences-sync-reset-restore-to-server-yes = Replace Data in Online Library
+
+preferences-sync-login-button =
+    .label = Log In
+preferences-sync-waiting-for-login =
+    .value = Waiting for login…
+preferences-sync-cancel-button =
+    .label = { general-cancel }

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -860,5 +860,7 @@ normalize-attachment-titles-text = { -app-name } automatically renames files on 
     
     Would you like to update the selected attachments to use simpler titles? Only primary attachments with titles that match the filename will be changed.
 
-banner-close-button = 
+banner-close-button =
     .aria-label = Dismiss notification
+
+sync-error-login-session-expired = Your login session has expired. Please try again.

--- a/scss/preferences/_sync.scss
+++ b/scss/preferences/_sync.scss
@@ -29,8 +29,20 @@
 	margin-inline-end: 10px;
 }
 
-#zotero-prefpane-sync #sync-auth-button {
+#zotero-prefpane-sync #sync-login-button {
 	margin-inline-start: 0;
+}
+
+#zotero-prefpane-sync #sync-login-pending {
+	gap: 6px;
+
+	button {
+		margin-block: 0;
+	}
+}
+
+#zotero-prefpane-sync #sync-login-status {
+	font-style: italic;
 }
 
 #zotero-prefpane-sync #sync-status-indicator


### PR DESCRIPTION
Replaces the login form with a "Log In" button that creates a dataserver login session and opens the website for logging in. The client polls for session completion every few seconds and also watches for a notification from the streaming server.

TODO:

- Better UI
- Clearer text (i.e., about opening in browser)