### PR TITLE
Use grep -E instead of egrep

### DIFF
--- a/app/build.sh
+++ b/app/build.sh
@@ -392,7 +392,7 @@ prefs_file=defaults/preferences/zotero.js
 # - network.captive-portal-service.enabled
 #       Disable the captive portal check against Mozilla servers
 # - extensions.systemAddon.update.url
-egrep -v '(network.captive-portal-service.enabled|extensions.systemAddon.update.url)' defaults/preferences/firefox.js > $prefs_file
+grep -E -v '(network.captive-portal-service.enabled|extensions.systemAddon.update.url)' defaults/preferences/firefox.js > $prefs_file
 rm defaults/preferences/firefox.js
 
 # Combine app and "extension" Zotero prefs

--- a/app/scripts/utils.sh
+++ b/app/scripts/utils.sh
@@ -41,7 +41,7 @@ get_canonical_arch() {
 
 function check_line {
 	pattern=$1
-	if ! egrep -q "$pattern" "$file"; then
+	if ! grep -E -q "$pattern" "$file"; then
 		echo "$pattern" not found in "$file" -- aborting 2>&1
 		exit 1
 	fi
@@ -52,7 +52,7 @@ function replace_line {
 	replacement=$2
 	file=$3
 	
-	if egrep -q "$pattern" "$file"; then
+	if grep -E -q "$pattern" "$file"; then
 		perl -pi -e "s/$pattern/$replacement/" "$file"
 	else
 		echo "$pattern" not found in "$file" -- aborting 2>&1
@@ -64,8 +64,8 @@ function remove_line {
 	pattern=$1
 	file=$2
 	
-	if egrep -q "$pattern" "$file"; then
-		egrep -v "$pattern" "$file" > "$file.tmp"
+	if grep -E -q "$pattern" "$file"; then
+		grep -E -v "$pattern" "$file" > "$file.tmp"
 		mv "$file.tmp" "$file"
 	else
 		echo "$pattern" not found in "$file" -- aborting 2>&1
@@ -78,7 +78,7 @@ function remove_between {
 	end_pattern=$2
 	file=$3
 	
-	if egrep -q "$start_pattern" "$file" && egrep -q "$end_pattern" "$file"; then
+	if grep -E -q "$start_pattern" "$file" && grep -E -q "$end_pattern" "$file"; then
 		perl -ni -e '
 		if (/'"$start_pattern"'/) { $skip = 1; next; }
 		elsif ($skip && /'"$end_pattern"'/) { $skip = 0; next; }


### PR DESCRIPTION
While updating my Zotero installation on Arch, I saw in the build output a bunch of warnings from `egrep` saying that it’s outdated:

> warning: egrep is obsolescent; using grep -E

It seems like it might be a good idea to change those calls to directly use `grep -E`, but there might be some scenarios where this could cause errors (I’m not familiar enough with it to ensure that making the change is perfectly safe).

I’ve updated the bash scripts to call `grep -E` instead of `egrep`.