### PR TITLE
Allow custom delimiters for tag splitting detection

### DIFF
--- a/chrome/content/zotero/elements/tagsBox.js
+++ b/chrome/content/zotero/elements/tagsBox.js
@@ -372,13 +372,25 @@
 				});
 				event.preventDefault();
 			}
+			
 			let delimiters = [',', ';'];
-			let interceptRegex = new RegExp(`\\w+\\s*(${delimiters.join('|')})\\s*\\w+`, 'i');
-			let match = str.match(interceptRegex);
-			if (match) {
-				event.preventDefault();
-				textbox.value = str.trim();
-				this.openTagSplitterWindow(str, match[1], textbox);
+			if (Zotero.Prefs.prefHasUserValue('tags.splitting.detection.delimiters')) {
+				try {
+					delimiters = Zotero.Prefs.get('tags.splitting.detection.delimiters').split('');
+				}
+				catch {
+					// Do nothing, we fall back to the default value
+				}
+			}
+
+			if (delimiters.length) {
+				let interceptRegex = new RegExp(`\\w+\\s*(${delimiters.join('|')})\\s*\\w+`, 'i');
+				let match = str.match(interceptRegex);
+				if (match) {
+					event.preventDefault();
+					textbox.value = str.trim();
+					this.openTagSplitterWindow(str, match[1], textbox);
+				}
 			}
 		};
 


### PR DESCRIPTION
We currently hard-code delimiters for detecting whether a pasted tag should open split tag window to `,` and `'`. This PR introduces a "hidden" preference to override or disable (with an empty string value) this behavior.

https://forums.zotero.org/discussion/129683/how-to-configure-split-tags-default-character