### PR TITLE
Citation dialog: search by citationKey in list mode

### DIFF
--- a/chrome/content/zotero/integration/citationDialog/searchHandler.mjs
+++ b/chrome/content/zotero/integration/citationDialog/searchHandler.mjs
@@ -335,7 +335,16 @@ export class CitationDialogSearchHandler {
 			// Generate a string to search for each item
 			let itemStr = item.getCreators()
 				.map(creator => creator.firstName + " " + creator.lastName)
-				.concat([item.getField("title"), item.getField("date", true, true).substr(0, 4)])
+				.concat([
+					// conditions from quicksearch-titleCreatorYear
+					item.getField("title"),
+					item.getField("date", true, true).substr(0, 4),
+					item.getField("publicationTitle"),
+					item.getField("shortTitle"),
+					item.getField("court"),
+					item.getField("year"),
+					item.getField("citationKey")
+				])
 				.join(" ")
 				.toLowerCase();
 			

--- a/chrome/content/zotero/xpcom/data/search.js
+++ b/chrome/content/zotero/xpcom/data/search.js
@@ -326,6 +326,7 @@ Zotero.Search.prototype.addCondition = function (condition, operator, value, req
 				this.addCondition('shortTitle', operator, part.text, false);
 				this.addCondition('court', operator, part.text, false);
 				this.addCondition('year', operator, part.text, false);
+				this.addCondition('citationKey', operator, part.text, false);
 			}
 			else {
 				this.addCondition('field', operator, part.text, false);


### PR DESCRIPTION
https://forums.zotero.org/discussion/130090/zotero-picker-i-cant-search-item-by-citation-key

In citation dialog list mode, search by `citaitonKey` in addition to `quicksearch-titleCreatorYear` condition. In library mode, search already uses all data fields.


https://github.com/user-attachments/assets/f90781d4-2b15-4d00-bebc-43e2f5291608

