### PR TITLE
fix: use URL fragment PDF page number for Chrome/Edge/Firefox on Win OS

### DIFF
--- a/chrome/content/zotero/xpcom/fileHandlers.js
+++ b/chrome/content/zotero/xpcom/fileHandlers.js
@@ -283,7 +283,18 @@ Zotero.FileHandlers = {
 	_handlersWin: {
 		pdf: [
 			{
-				name: new RegExp(''), // Match any handler
+				name: /chrome\.exe|msedge\.exe|firefox\.exe/i,
+				async open(appPath, { filePath, page }) {
+					let args = [Zotero.File.pathToFileURI(filePath)];
+					if (page !== undefined) {
+						// Chrome/Edge/Firefox uses URL fragment for page number
+						args[0] += '#page=' + page;
+					}
+					await Zotero.FileHandlers._checkAndExecWithoutBlocking(appPath, args);
+				}
+			},
+			{
+				name: new RegExp(''), // Fallback for other handlers
 				async open(appPath, { filePath, page }) {
 					let args = [filePath];
 					if (page !== undefined) {


### PR DESCRIPTION
fixes: https://forums.zotero.org/discussion/130135/bug-zotero-8-0-3-custom-pdf-handler-chrome-fails-to-open-file-from-attachment-info-pane

Supports Chrome/Edge/Firefox opening PDFs to specified page numbers; now only supports Adobe Acrobat and PDF-XChange.