### PR TITLE
Add resetData() as lightweight alternative to resetDB() for sync tests

### DIFF
--- a/chrome/content/zotero/xpcom/data/creators.js
+++ b/chrome/content/zotero/xpcom/data/creators.js
@@ -31,6 +31,7 @@ Zotero.Creators = new function () {
 	var _cache = {};
 	
 	this.init = async function () {
+		_cache = {};
 		var repaired = false;
 		var sql = "SELECT * FROM creators";
 		var rows = await Zotero.DB.queryAsync(sql);

--- a/chrome/content/zotero/xpcom/data/tags.js
+++ b/chrome/content/zotero/xpcom/data/tags.js
@@ -40,6 +40,8 @@ Zotero.Tags = new function () {
 	
 	
 	this.init = async function () {
+		_tagsByID.clear();
+		_idsByTag.clear();
 		await Zotero.DB.queryAsync(
 			"SELECT tagID, name FROM tags",
 			false,

--- a/chrome/content/zotero/xpcom/syncedSettings.js
+++ b/chrome/content/zotero/xpcom/syncedSettings.js
@@ -73,9 +73,7 @@ Zotero.SyncedSettings = (function () {
 		loadAll: async function (libraryID) {
 			Zotero.debug("Loading synced settings for library " + libraryID);
 			
-			if (!_cache[libraryID]) {
-				_cache[libraryID] = {};
-			}
+			_cache[libraryID] = {};
 			
 			var invalid = [];
 			

--- a/chrome/content/zotero/xpcom/users.js
+++ b/chrome/content/zotero/xpcom/users.js
@@ -61,7 +61,8 @@ Zotero.Users = new function () {
 			
 			_localUserKey = key;
 		}
-		
+
+		_users = {};
 		rows = await Zotero.DB.queryAsync("SELECT userID, name FROM users");
 		for (let row of rows) {
 			_users[row.userID] = row.name;

--- a/test/content/support.js
+++ b/test/content/support.js
@@ -497,10 +497,14 @@ var getGroup = function () {
 
 
 var createGroup = async function (props = {}) {
-	// Create a group item requires the current user to be set
-	if (!Zotero.Users.getCurrentUserID()) {
+	// Creating a group item requires the current user to be set and in the users table
+	let currentUserID = Zotero.Users.getCurrentUserID();
+	if (!currentUserID) {
 		await Zotero.Users.setCurrentUserID(1);
-		await Zotero.Users.setName(1, 'Name');
+		currentUserID = 1;
+	}
+	if (!Zotero.Users.getName(currentUserID)) {
+		await Zotero.Users.setName(currentUserID, 'Name');
 	}
 	
 	var group = new Zotero.Group;
@@ -745,6 +749,92 @@ async function resetDB(options = {}) {
 		options
 	);
 	await Zotero.Schema.schemaUpdatePromise;
+}
+
+/**
+ * Lightweight alternative to resetDB() that clears user data and sync state without doing a full
+ * Zotero shutdown/reinit cycle. Uses application APIs where possible to keep in-memory caches
+ * consistent.
+ *
+ * This is much faster than resetDB() because it avoids reloading all JS files and reinitializing
+ * the entire Zotero context. It's suitable for tests that need a clean data state (no items,
+ * collections, searches, or sync state) but don't need a completely fresh Zotero instance.
+ */
+async function resetData() {
+	resetPrefs();
+
+	// Erase group and feed libraries (cascades to their items, collections, etc.)
+	for (let group of Zotero.Groups.getAll()) {
+		await group.eraseTx({ skipDeleteLog: true });
+	}
+	for (let feed of Zotero.Feeds.getAll()) {
+		await feed.eraseTx({ skipDeleteLog: true });
+	}
+	_defaultGroup = null;
+
+	let userLibraryID = Zotero.Libraries.userLibraryID;
+
+	// Erase all objects in user library using application APIs so caches stay consistent.
+	// Top-level items first (children are erased automatically), then collections, then searches.
+	await Zotero.DB.executeTransaction(async function () {
+		let eraseOptions = { skipDeleteLog: true };
+		for (let item of (await Zotero.Items.getAll(userLibraryID, true, true))) {
+			await item.erase(eraseOptions);
+		}
+		for (let collection of Zotero.Collections.getByLibrary(userLibraryID, false, true)) {
+			if (!collection.parentID) {
+				await collection.erase(eraseOptions);
+			}
+		}
+		for (let search of (await Zotero.Searches.getAll(userLibraryID))) {
+			await search.erase(eraseOptions);
+		}
+
+		// Clear synced settings
+		let sql = "SELECT setting FROM syncedSettings WHERE libraryID=?";
+		let settings = await Zotero.DB.columnQueryAsync(sql, userLibraryID);
+		for (let setting of settings) {
+			await Zotero.SyncedSettings.clear(userLibraryID, setting, { skipDeleteLog: true });
+		}
+
+		// Clear sync-specific tables
+		await Zotero.Sync.Data.Local.clearCacheForLibrary(userLibraryID);
+		await Zotero.Sync.Data.Local.clearQueueForLibrary(userLibraryID);
+
+		// Clear fulltext and last-sync version entries
+		await Zotero.DB.queryAsync(
+			"DELETE FROM version WHERE schema IN (?, 'lastsync')",
+			"fulltext_" + userLibraryID
+		);
+
+		// Clear orphaned shared tables (items are gone but value rows remain)
+		await Zotero.DB.queryAsync("DELETE FROM tags");
+		await Zotero.DB.queryAsync("DELETE FROM creators");
+
+		// Clear account settings so Users.init() resets its private state
+		await Zotero.DB.queryAsync(
+			"DELETE FROM settings WHERE setting='account' AND key IN ('userID', 'libraryID', 'username')"
+		);
+		await Zotero.DB.queryAsync("DELETE FROM users");
+
+		// Reset library version
+		await Zotero.DB.queryAsync(
+			"UPDATE libraries SET version=0, storageVersion=0, lastSync=0 WHERE libraryID=?",
+			userLibraryID
+		);
+	});
+
+	// Clear delete logs
+	await Zotero.Sync.Data.Local.clearDeleteLogForLibrary(userLibraryID);
+	await Zotero.DB.queryAsync("DELETE FROM storageDeleteLog WHERE libraryID=?", userLibraryID);
+
+	// Reload caches from DB
+	await Zotero.Libraries.init();
+	await Zotero.Users.init();
+	await Zotero.Tags.init();
+	await Zotero.Creators.init();
+	await Zotero.SyncedSettings.loadAll(userLibraryID);
+	await Zotero.Sync.Data.Local.init();
 }
 
 /**

--- a/test/tests/syncEngineTest.js
+++ b/test/tests/syncEngineTest.js
@@ -163,17 +163,14 @@ describe("Zotero.Sync.Data.Engine", function () {
 	//
 	// Tests
 	//
-	beforeEach(function* () {
-		yield resetDB({
-			thisArg: this,
-			skipBundledFiles: true
-		});
-		
+	beforeEach(async function () {
+		await resetData();
+
 		Zotero.HTTP.mock = sinon.FakeXMLHttpRequest;
-		
-		yield Zotero.Users.setCurrentUserID(userID);
-		yield Zotero.Users.setCurrentUsername("testuser");
-		yield Zotero.Users.setCurrentName("Test User");
+
+		await Zotero.Users.setCurrentUserID(userID);
+		await Zotero.Users.setCurrentUsername("testuser");
+		await Zotero.Users.setCurrentName("Test User");
 	})
 	
 	after(function () {

--- a/test/tests/syncFullTextEngineTest.js
+++ b/test/tests/syncFullTextEngineTest.js
@@ -45,10 +45,7 @@ describe("Zotero.Sync.Data.FullTextEngine", function () {
 	// Tests
 	//
 	beforeEach(function* () {
-		yield resetDB({
-			thisArg: this,
-			skipBundledFiles: true
-		});
+		yield resetData();
 		
 		Zotero.HTTP.mock = sinon.FakeXMLHttpRequest;
 		

--- a/test/tests/syncLocalTest.js
+++ b/test/tests/syncLocalTest.js
@@ -540,10 +540,7 @@ describe("Zotero.Sync.Data.Local", function () {
 		var types = Zotero.DataObjectUtilities.getTypes();
 		
 		beforeEach(function* () {
-			yield resetDB({
-				thisArg: this,
-				skipBundledFiles: true
-			});
+			yield resetData();
 		})
 		
 		it("shouldn't trigger an auto-sync", async function () {

--- a/test/tests/syncRunnerTest.js
+++ b/test/tests/syncRunnerTest.js
@@ -169,10 +169,7 @@ describe("Zotero.Sync.Runner", function () {
 	// Tests
 	//
 	beforeEach(function* () {
-		yield resetDB({
-			thisArg: this,
-			skipBundledFiles: true
-		});
+		yield resetData();
 		
 		userLibraryID = Zotero.Libraries.userLibraryID;
 		

--- a/test/tests/webdavTest.js
+++ b/test/tests/webdavTest.js
@@ -171,10 +171,7 @@ describe("Zotero.Sync.Storage.Mode.WebDAV", function () {
 	}
 	
 	beforeEach(async function () {
-		await resetDB({
-			thisArg: this,
-			skipBundledFiles: true
-		});
+		await resetData();
 		
 		var port;
 		({ httpd, port } = await startHTTPServer());

--- a/test/tests/zfsTest.js
+++ b/test/tests/zfsTest.js
@@ -42,10 +42,7 @@ describe("Zotero.Sync.Storage.Mode.ZFS", function () {
 	// Tests
 	//
 	beforeEach(async function () {
-		await resetDB({
-			thisArg: this,
-			skipBundledFiles: true
-		});
+		await resetData();
 		win = await loadZoteroPane();
 		
 		Zotero.HTTP.mock = sinon.FakeXMLHttpRequest;


### PR DESCRIPTION
resetData() clears user data and sync state using application APIs instead of doing a full Zotero shutdown/reinit cycle, making it much faster for tests that just need clean state between runs.

Also make Tags.init(), Creators.init(), Users.init(), and SyncedSettings.loadAll() properly clear their caches before reloading, so they are safe to call more than once.