### PR TITLE
"Export Note" context menu option on annotation rows

### DIFF
--- a/chrome/content/zotero/fileInterface.js
+++ b/chrome/content/zotero/fileInterface.js
@@ -181,6 +181,7 @@ var Zotero_File_Interface = new function () {
 	this.exportCollection = exportCollection;
 	this.exportItemsToClipboard = exportItemsToClipboard;
 	this.exportItems = exportItems;
+	this.exportAnnotations = exportAnnotations;
 	this.bibliographyFromItems = bibliographyFromItems;
 	
 	/**
@@ -236,7 +237,23 @@ var Zotero_File_Interface = new function () {
 		
 		exporter.save();
 	}
-	
+
+	/*
+	 * Exports annotations from selected items
+	 */
+	async function exportAnnotations() {
+		let annotations = ZoteroPane.getSelectedAnnotations();
+		if (!annotations.length) return;
+
+		let note = await Zotero.EditorInstance.createNoteFromAnnotations(
+			annotations, { noSave: true }
+		);
+
+		var exporter = new Zotero_File_Exporter();
+		exporter.items = [note];
+		exporter.save();
+	}
+
 	
 	/*
 	 * exports items to clipboard

--- a/chrome/content/zotero/xpcom/editorInstance.js
+++ b/chrome/content/zotero/xpcom/editorInstance.js
@@ -1448,9 +1448,11 @@ class EditorInstance {
 	 * @param {Object} options
 	 * @param {Integer} options.parentID - Creates standalone note if not provided
 	 * @param {Integer} options.collectionID - Only valid if parentID not provided
+	 * @param {Boolean} options.noSave - Create and return the note without saving it
+	 * @returns {Promise<Zotero.Item>}
 	 * @returns {Promise<Zotero.Item>}
 	 */
-	static async createNoteFromAnnotations(annotations, { parentID, collectionID } = {}) {
+	static async createNoteFromAnnotations(annotations, { parentID, collectionID, noSave } = {}) {
 		if (!annotations.length) {
 			throw new Error("No annotations provided");
 		}
@@ -1470,14 +1472,16 @@ class EditorInstance {
 		}
 
 		let note = new Zotero.Item('note');
-		note.libraryID = annotations[0].libraryID;
-		if (parentID) {
-			note.parentID = parentID;
+		if (!noSave) {
+			note.libraryID = annotations[0].libraryID;
+			if (parentID) {
+				note.parentID = parentID;
+			}
+			else if (collectionID) {
+				note.addToCollection(collectionID);
+			}
+			await note.saveTx();
 		}
-		else if (collectionID) {
-			note.addToCollection(collectionID);
-		}
-		await note.saveTx();
 		let editorInstance = new EditorInstance();
 		editorInstance._item = note;
 		let jsonAnnotations = [];
@@ -1497,7 +1501,11 @@ class EditorInstance {
 		// New line is needed for note title parser
 		html += '\n';
 
-		await editorInstance.importImages(jsonAnnotations);
+		// If there is no real note item saved, do not import images as annotations.
+		// Instead, serializeAnnotations below will embed images as "data:image/..." strings
+		if (!noSave) {
+			await editorInstance.importImages(jsonAnnotations);
+		}
 
 		let multipleParentParent = false;
 		let lastParentParentID;
@@ -1559,7 +1567,9 @@ class EditorInstance {
 		}
 		html = `<div data-citation-items="${citationItems}" data-schema-version="${schemaVersion}">${html}</div>`;
 		note.setNote(html);
-		await note.saveTx();
+		if (!noSave) {
+			await note.saveTx();
+		}
 		return note;
 	}
 }
@@ -1584,7 +1594,7 @@ class EditorInstanceUtilities {
 			if (!annotation.text
 				&& !annotation.comment
 				&& !annotation.imageAttachmentKey
-				|| annotation.type === 'ink') {
+				&& !annotation.image) {
 				continue;
 			}
 
@@ -1636,12 +1646,32 @@ class EditorInstanceUtilities {
 			}
 
 			// Image
-			if (annotation.imageAttachmentKey) {
-				// // let imageAttachmentKey = await this._importImage(annotation.image);
-				// delete annotation.image;
+			if (annotation.imageAttachmentKey || annotation.image) {
+				// Find the bounding rectangle of the annotation
+				let rect;
+				if (annotation.type == "ink") {
+					let x = annotation.position.paths[0][0];
+					let y = annotation.position.paths[0][1];
+					rect = [x, y, x, y];
+					for (let path of annotation.position.paths) {
+						for (let i = 0; i < path.length - 1; i += 2) {
+							let x = path[i];
+							let y = path[i + 1];
+							rect[0] = Math.min(rect[0], x);
+							rect[1] = Math.min(rect[1], y);
+							rect[2] = Math.max(rect[2], x);
+							rect[3] = Math.max(rect[3], y);
+						}
+					}
+				}
+				else if (annotation.type == "image") {
+					rect = annotation.position.rects[0];
+				}
+				else {
+					throw new Error("Unexpected annotation type for image embedding: " + annotation.type);
+				}
 
 				// Normalize image dimensions to 1.25 of the print size
-				let rect = annotation.position.rects[0];
 				let rectWidth = rect[2] - rect[0];
 				let rectHeight = rect[3] - rect[1];
 				// Constants from pdf.js
@@ -1649,7 +1679,13 @@ class EditorInstanceUtilities {
 				const PDFJS_DEFAULT_SCALE = 1.25;
 				let width = Math.round(rectWidth * CSS_UNITS * PDFJS_DEFAULT_SCALE);
 				let height = Math.round(rectHeight * width / rectWidth);
-				imageHTML = `<img data-attachment-key="${annotation.imageAttachmentKey}" width="${width}" height="${height}" data-annotation="${encodeURIComponent(JSON.stringify(storedAnnotation))}"/>`;
+				// if imageAttachmentKey is provided, use it in the HTML, otherwise use data:image/... string as src
+				if (annotation.imageAttachmentKey) {
+					imageHTML = `<img data-attachment-key="${annotation.imageAttachmentKey}" width="${width}" height="${height}" data-annotation="${encodeURIComponent(JSON.stringify(storedAnnotation))}"/>`;
+				}
+				else {
+					imageHTML = `<img class="${annotation.type}" src="${annotation.image}" width="${width}" height="${height}" data-annotation="${encodeURIComponent(JSON.stringify(storedAnnotation))}"/>`;
+				}
 			}
 
 			// Text
@@ -1671,7 +1707,7 @@ class EditorInstanceUtilities {
 			else if (['note', 'text'].includes(annotation.type)) {
 				template = Zotero.Prefs.get('annotations.noteTemplates.note');
 			}
-			else if (annotation.type === 'image') {
+			else {
 				template = '<p>{{image}}<br/>{{citation}} {{comment}}</p>';
 			}
 

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -3221,7 +3221,41 @@ var ZoteroPane = new function () {
 				return this.getSelectedItems(asIDs);
 		}
 	};
-	
+
+
+	/**
+	 * Return annotations from the currently selected items
+	 *
+	 * Returns child annotations of selected regular items or attachments,
+	 * as well as selected annotations
+	 *
+	 * @return {Zotero.Item[]}
+	 */
+	this.getSelectedAnnotations = function () {
+		let selectedItemIDs = this.getSelectedItems(true);
+		let itemIDs = this.getSortedItems(true).filter(id => selectedItemIDs.includes(id));
+		let annotationsByID = new Map();
+		for (let item of Zotero.Items.get(itemIDs)) {
+			if (item.isAnnotation()) {
+				annotationsByID.set(item.id, item);
+				continue;
+			}
+			let attachments = [];
+			if (item.isRegularItem()) {
+				attachments = Zotero.Items.get(item.getAttachments())
+					.filter(att => att.isFileAttachment() && att.getAnnotations().length);
+			}
+			else if (item.isFileAttachment() && item.getAnnotations().length) {
+				attachments = [item];
+			}
+			for (let attachment of attachments) {
+				for (let annotation of attachment.getAnnotations()) {
+					annotationsByID.set(annotation.id, annotation);
+				}
+			}
+		}
+		return [...annotationsByID.values()];
+	};
 	
 	function getSortField() {
 		if (!this.itemsView) {
@@ -3721,6 +3755,7 @@ var ZoteroPane = new function () {
 			'sep4',
 			'exportItems',
 			'exportPDF',
+			'exportAnnotations',
 			'createBib',
 			'loadReport',
 			'sep5',
@@ -4175,6 +4210,13 @@ var ZoteroPane = new function () {
 		if (numFiles) {
 			show.add(m.exportPDF);
 			menu.childNodes[m.exportPDF].setAttribute('label', Zotero.getString(`pane.items.menu.exportPDF${numFiles == 1 ? '' : '.multiple'}`));
+		}
+
+		// Export Annotations... on items with annotations
+		let numAnnotations = this.getSelectedAnnotations().length;
+		if (numAnnotations) {
+			show.add(m.exportAnnotations);
+			document.l10n.setAttributes(menu.childNodes[m.exportAnnotations], "item-menu-export-annotations", { count: numAnnotations });
 		}
 
 		// Set labels, plural if necessary

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -3720,6 +3720,7 @@ var ZoteroPane = new function () {
 			'relateItems',
 			'sep4',
 			'exportItems',
+			'exportPDF',
 			'createBib',
 			'loadReport',
 			'sep5',
@@ -4167,6 +4168,13 @@ var ZoteroPane = new function () {
 				if (menuItemsForAnnotations.includes(i)) continue;
 				show.delete(m[i]);
 			}
+		}
+
+		// Export PDF(s)... on PDF attachment(s) or their parent
+		let numFiles = Zotero.Items.numDistinctFileAttachmentsForLabel(items, item => item.isPDFAttachment());
+		if (numFiles) {
+			show.add(m.exportPDF);
+			menu.childNodes[m.exportPDF].setAttribute('label', Zotero.getString(`pane.items.menu.exportPDF${numFiles == 1 ? '' : '.multiple'}`));
 		}
 
 		// Set labels, plural if necessary

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -1018,6 +1018,7 @@
 			<menuseparator/>
 			<menuitem class="menuitem-iconic zotero-menuitem-export" oncommand="Zotero_File_Interface.exportItems();"/>
 			<menuitem class="menuitem-iconic zotero-menuitem-exportPDF" oncommand="ZoteroPane.exportSelectedFiles();"/>
+			<menuitem class="menuitem-iconic zotero-menuitem-exportAnnotations" data-l10n-id="item-menu-export-annotations" oncommand="Zotero_File_Interface.exportAnnotations();"/>
 			<menuitem class="menuitem-iconic zotero-menuitem-create-bibliography" oncommand="Zotero_File_Interface.bibliographyFromItems();"/>
 			<menuitem class="menuitem-iconic zotero-menuitem-create-report" oncommand="Zotero_Report_Interface.loadItemReport()"/>
 			<menuseparator/>

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -1017,6 +1017,7 @@
 			<menuitem class="menuitem-iconic zotero-menuitem-relate-items" data-l10n-id="item-menu-relate-items" oncommand="ZoteroPane_Local.relateSelectedItems();"/>
 			<menuseparator/>
 			<menuitem class="menuitem-iconic zotero-menuitem-export" oncommand="Zotero_File_Interface.exportItems();"/>
+			<menuitem class="menuitem-iconic zotero-menuitem-exportPDF" oncommand="ZoteroPane.exportSelectedFiles();"/>
 			<menuitem class="menuitem-iconic zotero-menuitem-create-bibliography" oncommand="Zotero_File_Interface.bibliographyFromItems();"/>
 			<menuitem class="menuitem-iconic zotero-menuitem-create-report" oncommand="Zotero_Report_Interface.loadItemReport()"/>
 			<menuseparator/>

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -227,6 +227,11 @@ item-menu-change-parent-item =
      .label = Change Parent Item…
 item-menu-relate-items =
     .label = Relate Items
+item-menu-export-annotations =
+    .label = { $count ->
+                [one] Export Annotation as a Note…
+                *[other] Export Annotations as a Note…
+            } 
 
 view-online = View Online
 item-menu-option-view-online =

--- a/test/tests/annotationsTest.js
+++ b/test/tests/annotationsTest.js
@@ -478,4 +478,18 @@ describe("Create a note from annotations from multiple items and attachments", f
 		// Check item URIs count
 		assert.equal(note.note.split('zotero.org').length - 1, 16);
 	});
+
+	it("should create a note from annotations without saving it as an item", async function () {
+		let annotations = [];
+		let attachment = await importPDFAttachment();
+		let annotation1 = await createAnnotation('highlight', attachment);
+		annotations.push(annotation1);
+		let annotation2 = await createAnnotation('highlight', attachment);
+		annotations.push(annotation2);
+		let note = await Zotero.EditorInstance.createNoteFromAnnotations(annotations, { noSave: true });
+		assert.notOk(note.id);
+		assert.equal(note.note.split('test').length - 1, 1);
+		assert.equal(note.note.split(annotation1.annotationText).length - 1, 1);
+		assert.equal(note.note.split(annotation2.annotationText).length - 1, 1);
+	});
 });


### PR DESCRIPTION
Display "Export Note" menu option when annotations are selected to allow one to export selected annotations without having to create a note first.

Modifier Zotero.EditorInstance.createNoteFromAnnotations to be able to convert annotations into a note without saving the note item to DB.

Fixes: #5722