### PR TITLE
Add PMID/PMCID columns

### DIFF
--- a/chrome/content/zotero/itemTreeColumns.jsx
+++ b/chrome/content/zotero/itemTreeColumns.jsx
@@ -339,6 +339,15 @@ const COLUMNS = [
 		zoteroPersist: ["width", "hidden", "sortDirection"]
 	},
 	{
+		dataKey: "PMCID",
+		disabledIn: ["feeds", "feed"],
+		showInColumnPicker: true,
+		columnPickerSubMenu: true,
+		label: "PMCID",
+		flex: 1,
+		zoteroPersist: ["width", "hidden", "sortDirection"]
+	},
+	{
 		dataKey: "extra",
 		disabledIn: ["feeds", "feed"],
 		showInColumnPicker: true,

--- a/chrome/content/zotero/itemTreeColumns.jsx
+++ b/chrome/content/zotero/itemTreeColumns.jsx
@@ -330,6 +330,15 @@ const COLUMNS = [
 		zoteroPersist: ["width", "hidden", "sortDirection"]
 	},
 	{
+		dataKey: "PMID",
+		disabledIn: ["feeds", "feed"],
+		showInColumnPicker: true,
+		columnPickerSubMenu: true,
+		label: "itemFields.PMID",
+		flex: 1,
+		zoteroPersist: ["width", "hidden", "sortDirection"]
+	},
+	{
 		dataKey: "extra",
 		disabledIn: ["feeds", "feed"],
 		showInColumnPicker: true,

--- a/chrome/content/zotero/itemTreeColumns.jsx
+++ b/chrome/content/zotero/itemTreeColumns.jsx
@@ -334,7 +334,7 @@ const COLUMNS = [
 		disabledIn: ["feeds", "feed"],
 		showInColumnPicker: true,
 		columnPickerSubMenu: true,
-		label: "itemFields.PMID",
+		label: "PMID",
 		flex: 1,
 		zoteroPersist: ["width", "hidden", "sortDirection"]
 	},


### PR DESCRIPTION
I mimic from your previous commit to add citationKey column, in order to allow inclusion of PMID/PMCID columns too. I am only not sure if dataKey should be `PMID` or `pmid` or if some other coding must be done.

Thanks!

https://forums.zotero.org/discussion/comment/508934/#Comment_508934 
https://forums.zotero.org/discussion/130190/allow-to-include-new-item-fields-as-columns-in-main-middle-pane