### PR TITLE
feat(notes): add content width prefs for note and note tab

### DIFF
--- a/chrome/content/zotero/preferences/preferences_general.xhtml
+++ b/chrome/content/zotero/preferences/preferences_general.xhtml
@@ -224,6 +224,22 @@
 				preference="extensions.zotero.openNoteInNewWindow"
 				native="true"
 			/>
+			<vbox class="fileHandler-menus">
+				<label data-l10n-id="preferences-note-content-view" control="note-content-view-mode"/>
+				<menulist id="note-content-view-mode" preference="extensions.zotero.note.contentViewMode" native="true">
+					<menupopup>
+						<menuitem data-l10n-id="preferences-note-content-view-wide" value="wide"/>
+						<menuitem data-l10n-id="preferences-note-content-view-comfortable" value="comfortable"/>
+					</menupopup>
+				</menulist>
+				<label data-l10n-id="preferences-note-tab-content-view" control="note-tab-content-view-mode"/>
+				<menulist id="note-tab-content-view-mode" preference="extensions.zotero.note.tabContentViewMode" native="true">
+					<menupopup>
+						<menuitem data-l10n-id="preferences-note-content-view-wide" value="wide"/>
+						<menuitem data-l10n-id="preferences-note-content-view-comfortable" value="comfortable"/>
+					</menupopup>
+				</menulist>
+			</vbox>
 		</groupbox>
 		
 		<groupbox id="zotero-prefpane-locate-groupbox" aria-label="&zotero.preferences.prefpane.locate;" aria-describedby="preferences-locate-library-lookup-intro">

--- a/chrome/content/zotero/xpcom/editorInstance.js
+++ b/chrome/content/zotero/xpcom/editorInstance.js
@@ -92,6 +92,8 @@ class EditorInstance {
 			Zotero.Prefs.registerObserver('note.fontSize', this._handleFontChange),
 			Zotero.Prefs.registerObserver('note.tabFontSize', this._handleFontChange),
 			Zotero.Prefs.registerObserver('note.fontFamily', this._handleFontChange),
+			Zotero.Prefs.registerObserver('note.contentViewMode', this._handleContentViewModeChange),
+			Zotero.Prefs.registerObserver('note.tabContentViewMode', this._handleContentViewModeChange),
 			Zotero.Prefs.registerObserver('note.css', this._handleStyleChange),
 			Zotero.Prefs.registerObserver('layout.spellcheckDefault', this._handleSpellCheckChange, true)
 		];
@@ -375,8 +377,8 @@ class EditorInstance {
 	}
 
 	_getContentViewMode() {
-		// TODO: Use prefs
-		return this._tabID ? 'comfortable' : 'wide';
+		let contentViewModePrefKey = this._tabID ? 'note.tabContentViewMode' : 'note.contentViewMode';
+		return Zotero.Prefs.get(contentViewModePrefKey) || 'wide';
 	}
 	
 	_handleFontChange = () => {

--- a/chrome/locale/en-US/zotero/preferences.ftl
+++ b/chrome/locale/en-US/zotero/preferences.ftl
@@ -31,6 +31,12 @@ preferences-reader-ebook-hyphenate =
 preferences-note-title = Notes
 preferences-note-open-in-new-window =
     .label = Open notes in new windows instead of tabs
+preferences-note-content-view = Note content width
+preferences-note-tab-content-view = Note tab content width
+preferences-note-content-view-wide =
+    .label = Full width
+preferences-note-content-view-comfortable =
+    .label = Readable width
 
 preferences-color-scheme = Color Scheme:
 preferences-color-scheme-auto =

--- a/defaults/preferences/zotero.js
+++ b/defaults/preferences/zotero.js
@@ -207,6 +207,8 @@ pref("extensions.zotero.fileHandler.snapshot", "");
 pref("extensions.zotero.openReaderInNewWindow", false);
 
 pref("extensions.zotero.openNoteInNewWindow", false);
+pref("extensions.zotero.note.contentViewMode", "wide");
+pref("extensions.zotero.note.tabContentViewMode", "comfortable");
 
 // File/URL opening executable if launch() fails
 pref("extensions.zotero.fallbackLauncher.unix", "/usr/bin/xdg-open");


### PR DESCRIPTION
There are some FRs about this todo, and I think we should leave the choice to the user.

https://github.com/windingwind/zotero-better-notes/issues/1520
https://github.com/windingwind/zotero-better-notes/issues/1523#issuecomment-4018975829
https://github.com/windingwind/zotero-better-notes/discussions/1517
https://github.com/windingwind/zotero-better-notes/issues/1549