### PR TITLE
Citation dialog: fix popup buttons overflow for some locales

### DIFF
--- a/scss/components/_citationDialog.scss
+++ b/scss/components/_citationDialog.scss
@@ -621,7 +621,8 @@
 		}
 		#itemDetails {
 			.popup {
-				width: 364px; // with padding and border, the panel is 400px
+				width: min-content;
+				min-width: 364px; // with padding and border, the panel is 400px
 				.details-header {
 					.icon {
 						margin-inline-end: 5px;
@@ -671,8 +672,20 @@
 						}
 					}
 				}
+				.buttons {
+					display: flex;
+					flex-wrap: nowrap;
+					white-space: nowrap;
+					gap: 4px;
+				}
 				button.done {
-					float: right;
+					// align html buttons with 'done' xul:button
+					@media not (-moz-platform: macos) {
+						margin-top: 0;
+						margin-bottom: 0;
+						margin-inline-end: 0;
+					}
+					margin-inline-start: auto;
 				}
 				button.remove {
 					color: var(--accent-red);


### PR DESCRIPTION
With some locales (e.g. German), on Linux, the buttons do not fit into the fixed width of the item details popup. To avoid buttons overflowing, stretch the popup if buttons require more width than the popup currently has.

Reported in: https://forums.zotero.org/discussion/130208/spacing-is-off-in-citation-detail-pop-up

Before:
<img width="563" height="356" alt="Screenshot 2026-03-11 at 3 54 46 PM" src="https://github.com/user-attachments/assets/0a97df0e-4f68-46db-96de-d7d3c5bdb97e" />

After:
<img width="534" height="342" alt="Screenshot 2026-03-11 at 3 52 11 PM" src="https://github.com/user-attachments/assets/ec359a6b-a69a-473b-8989-a336802c72d6" />
