### PR TITLE
Improve UI responsiveness on macOS

### DIFF
--- a/chrome/content/zotero/components/windowed-list.js
+++ b/chrome/content/zotero/components/windowed-list.js
@@ -88,6 +88,10 @@ module.exports = class {
 	 * Call to remove the windowed-list from the container
 	 */
 	destroy() {
+		if (this._scrollRafId) {
+			cancelAnimationFrame(this._scrollRafId);
+			this._scrollRafId = null;
+		}
 		if (this.innerElem) {
 			this.targetElement.removeEventListener('scroll', this._handleScroll);
 			this.targetElement.removeChild(this.innerElem);
@@ -284,7 +288,7 @@ module.exports = class {
 	_handleScroll = (event) => {
 		const { scrollOffset: prevScrollOffset } = this;
 		const { clientHeight, scrollHeight, scrollTop } = event.currentTarget;
-		
+
 		if (prevScrollOffset === scrollTop) {
 			// Scroll position may have been updated by cDM/cDU,
 			// In which case we don't need to trigger another render,
@@ -301,7 +305,13 @@ module.exports = class {
 		this.scrollDirection = prevScrollOffset < scrollOffset ? 1 : -1;
 		this.scrollOffset = scrollOffset;
 		this._resetScrollDirection();
-		this.render();
+		// Coalesce multiple scroll events into a single render per animation frame
+		if (!this._scrollRafId) {
+			this._scrollRafId = requestAnimationFrame(() => {
+				this._scrollRafId = null;
+				this.render();
+			});
+		}
 	};
 	
 	_binarySearchOffsets(array, searchValue, lookupByOffset=false) {

--- a/chrome/content/zotero/contextPane.js
+++ b/chrome/content/zotero/contextPane.js
@@ -90,11 +90,12 @@ var ZoteroContextPane = new function () {
 
 		this.context = _contextPaneInner;
 
-		window.addEventListener('resize', this.update);
+		this._onResize = Zotero.Utilities.throttle(this.update, 100);
+		window.addEventListener('resize', this._onResize);
 	};
 
 	this.destroy = function () {
-		window.removeEventListener('resize', this.update);
+		window.removeEventListener('resize', this._onResize);
 	};
 
 	this.updateAddToNote = () => {

--- a/chrome/content/zotero/elements/bubbleInput.js
+++ b/chrome/content/zotero/elements/bubbleInput.js
@@ -41,6 +41,10 @@
 			DragDropHandler.init(this);
 		}
 
+		destroy() {
+			DragDropHandler.destroy();
+		}
+
 		focus() {
 			this.refocusInput();
 		}
@@ -382,11 +386,29 @@
 			this.dragOver = null;
 			this.doc = bubbleInput.ownerDocument;
 
-			bubbleInput.addEventListener("dragstart", this.handleDragStart.bind(this));
-			bubbleInput.addEventListener("dragenter", this.handleDragEnter.bind(this));
-			bubbleInput.addEventListener("dragover", this.handleDragOver.bind(this));
-			bubbleInput.addEventListener("drop", this.handleDrop.bind(this));
-			this.doc.addEventListener("dragend", this.handleDragEnd.bind(this));
+			this._boundHandlers = {
+				dragstart: this.handleDragStart.bind(this),
+				dragenter: this.handleDragEnter.bind(this),
+				dragover: this.handleDragOver.bind(this),
+				drop: this.handleDrop.bind(this),
+				dragend: this.handleDragEnd.bind(this),
+			};
+			bubbleInput.addEventListener("dragstart", this._boundHandlers.dragstart);
+			bubbleInput.addEventListener("dragenter", this._boundHandlers.dragenter);
+			bubbleInput.addEventListener("dragover", this._boundHandlers.dragover);
+			bubbleInput.addEventListener("drop", this._boundHandlers.drop);
+			this.doc.addEventListener("dragend", this._boundHandlers.dragend);
+		},
+
+		destroy() {
+			if (this._boundHandlers) {
+				this.bubbleInput?.removeEventListener("dragstart", this._boundHandlers.dragstart);
+				this.bubbleInput?.removeEventListener("dragenter", this._boundHandlers.dragenter);
+				this.bubbleInput?.removeEventListener("dragover", this._boundHandlers.dragover);
+				this.bubbleInput?.removeEventListener("drop", this._boundHandlers.drop);
+				this.doc?.removeEventListener("dragend", this._boundHandlers.dragend);
+				this._boundHandlers = null;
+			}
 		},
 
 		handleDragStart(event) {

--- a/chrome/content/zotero/elements/editableText.js
+++ b/chrome/content/zotero/elements/editableText.js
@@ -211,6 +211,11 @@
 			this.render();
 		}
 
+		destroy() {
+			this._resizeObserver?.disconnect();
+			this.removeEventListener('keydown', this._captureAutocompleteKeydown, true);
+		}
+
 		render() {
 			let autocompleteParams = this.autocomplete;
 			let autocompleteEnabled = !this.multiline && !!autocompleteParams;

--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -169,6 +169,7 @@
 
 			Zotero.Prefs.unregisterObserver(this._prefsObserverID);
 
+			this._creatorTypeMenu?.removeEventListener('command', this._handleCreatorTypeChange);
 			this._id('zotero-creator-transform-menu')?.removeEventListener('popupshowing', this._handleCreatorTransformMenuShowing);
 			this._id('zotero-creator-transform-menu')?.removeEventListener('command', this._handleCreatorTransformMenuCommand);
 			this._id('creator-transform-swap-names')?.removeEventListener('command', this._handleCreatorTransformSwapNames);

--- a/chrome/content/zotero/xpcom/notifier.js
+++ b/chrome/content/zotero/xpcom/notifier.js
@@ -400,9 +400,10 @@ Zotero.Notifier = new function () {
 				};
 				
 				// Remove redundant ids
+				let seen = new Set();
 				for (let i = 0; i < queue[type][event].ids.length; i++) {
 					let id = queue[type][event].ids[i];
-					
+
 					// Don't send modify on nonexistent items or tags
 					if (event == 'modify') {
 						if (type == 'item' && !((await Zotero.Items.getAsync(id)))) {
@@ -412,8 +413,9 @@ Zotero.Notifier = new function () {
 							continue;
 						}
 					}
-					
-					if (runQueue[type][event].ids.indexOf(id) == -1) {
+
+					if (!seen.has(id)) {
+						seen.add(id);
 						runQueue[type][event].ids.push(id);
 					}
 				}

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -117,13 +117,14 @@ var ZoteroPane = new function () {
 		this.itemPane = document.querySelector("#zotero-item-pane");
 		ZoteroPane_Local.updateLayout();
 		this.updateWindow();
-		window.addEventListener("resize", () => {
+		this._onResize = Zotero.Utilities.debounce(() => {
 			this.updateWindow();
-			let tabsDeck = document.querySelector('#tabs-deck')
+			let tabsDeck = document.querySelector('#tabs-deck');
 			if (!tabsDeck || tabsDeck.getAttribute('selectedIndex') == 0) {
 				this.updateLayoutConstraints();
 			}
-		});
+		}, 100);
+		window.addEventListener("resize", this._onResize);
 		window.setTimeout(this.updateLayoutConstraints.bind(this), 0);
 		
 		Zotero.updateQuickSearchBox(document);
@@ -741,7 +742,11 @@ var ZoteroPane = new function () {
 		if (!Zotero || !Zotero.initialized || !_loaded) {
 			return;
 		}
-		
+
+		if (this._onResize) {
+			window.removeEventListener("resize", this._onResize);
+		}
+
 		this.serializePersist();
 
 		if(this.collectionsView) this.collectionsView.unregister();
@@ -749,7 +754,7 @@ var ZoteroPane = new function () {
 		if (_syncRemindersObserverID) {
 			Zotero.Notifier.unregisterObserver(_syncRemindersObserverID);
 		}
-		
+
 		this.uninitContainers();
 		
 		observerService.removeObserver(_reloadObserver, "zotero-reloaded");


### PR DESCRIPTION
- Debounce/throttle window resize handlers in zoteroPane and contextPane to avoid excessive layout recalculations during drag-resize
- Replace O(n²) indexOf-based dedup in Notifier.commit() with Set for faster batch notification processing in large libraries
- Coalesce windowed-list scroll renders via requestAnimationFrame to ensure at most one render per frame during fast scrolling
- Fix event listener leaks: add destroy() to editableText (ResizeObserver, keydown capture) and bubbleInput (DragDropHandler document-level listeners), add missing creatorTypeMenu cleanup in itemBox