### PR TITLE
Hide "Recently Read" pseudo-collection during filtering

### DIFF
--- a/chrome/content/zotero/collectionTree.jsx
+++ b/chrome/content/zotero/collectionTree.jsx
@@ -3021,7 +3021,7 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 		var newRows = 0;
 		
 		// Recently Read
-		if (showRecentlyRead) {
+		if (showRecentlyRead && this._isFilterEmpty()) {
 			let s = new Zotero.Search();
 			s.libraryID = libraryID;
 			s.name = Zotero.getString('pane.collections.recentlyRead');


### PR DESCRIPTION
Same way as unfiled, duplicates and trash pseudo-collections are hidden. Unless we want to keep "Recently Read" always visible for some specific reason, this is just more consistent?

Before:

https://github.com/user-attachments/assets/3edf84cd-9214-45b2-83f3-b7ec183c7ce7

After:

https://github.com/user-attachments/assets/3e261c1f-8e80-430b-8ece-14a57f736649

