### PR TITLE
fix bg color for highlighted and selected rows in collection tree

### DIFF
--- a/scss/components/_collection-tree.scss
+++ b/scss/components/_collection-tree.scss
@@ -117,7 +117,7 @@ $universal-icons: (
 	
 	// Highlight takes priority over selection
 	.row.highlighted.selected {
-		background: #FFFF99;
+		background: var(--highlight-color, var(--accent-highlight));
 	}
 
 	.cell.primary {


### PR DESCRIPTION
regression from a365465

Fixes: Highlight color for selected collection in dark mode.
![20260323_225723_screenshots](https://github.com/user-attachments/assets/19de6b82-8cd1-4e02-b973-3efe1afcfa87)

For #3468, we can set `--highlight-color` with `#FFFF99` if needed.