### PR TITLE
Add hidden preference for default spread mode in reader

### DIFF
--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -1043,6 +1043,7 @@ class ReaderInstance {
 			}
 		}
 
+		let defaultSpreadMode = Zotero.Prefs.get('reader.defaultSpreadMode');
 		if (this._type === 'pdf') {
 			let pageIndex = item.getAttachmentLastPageIndex();
 			if (state) {
@@ -1054,7 +1055,10 @@ class ReaderInstance {
 				return state;
 			}
 			else if (Number.isInteger(pageIndex)) {
-				return { pageIndex };
+				return { pageIndex, spreadMode: defaultSpreadMode };
+			}
+			else {
+				return { spreadMode: defaultSpreadMode };
 			}
 		}
 		else if (this._type === 'epub') {
@@ -1064,7 +1068,7 @@ class ReaderInstance {
 				return state;
 			}
 			else {
-				return { cfi };
+				return { cfi, spreadMode: defaultSpreadMode };
 			}
 		}
 		else if (this._type === 'snapshot') {
@@ -2318,14 +2322,15 @@ class ReaderPreview extends ReaderInstance {
 	}
 
 	async _getState() {
+		let defaultSpreadMode = Zotero.Prefs.get('reader.defaultSpreadMode');
 		if (this._type === "pdf") {
-			return { pageIndex: 0, scale: "page-height", scrollMode: 0, spreadMode: 0 };
+			return { pageIndex: 0, scale: "page-height", scrollMode: 0, spreadMode: defaultSpreadMode };
 		}
 		else if (this._type === "epub") {
 			return Object.assign(await super._getState(), {
 				scale: 1,
 				flowMode: "paginated",
-				spreadMode: 0
+				spreadMode: defaultSpreadMode
 			});
 		}
 		else if (this._type === "snapshot") {

--- a/defaults/preferences/zotero.js
+++ b/defaults/preferences/zotero.js
@@ -242,6 +242,7 @@ pref("extensions.zotero.reader.autoDisableTool.note", true);
 pref("extensions.zotero.reader.autoDisableTool.text", true);
 pref("extensions.zotero.reader.autoDisableTool.image", true);
 pref("extensions.zotero.reader.lastSidebarTab", "annotations");
+pref("extensions.zotero.reader.defaultSpreadMode", 0);
 
 // Set color scheme to auto by default
 pref("browser.theme.toolbar-theme", 2);


### PR DESCRIPTION
## Summary
- Adds `extensions.zotero.reader.defaultSpreadMode` hidden preference (0=no spreads, 1=odd, 2=even)
- Applies the preference when opening PDFs and EPUBs for the first time (no saved per-document state)
- Per-document saved state still takes precedence over the preference

## Test plan
- [ ] Set `extensions.zotero.reader.defaultSpreadMode` to `1` (odd spreads) in Config Editor
- [ ] Open a PDF that hasn't been opened before — verify it opens in odd spreads mode
- [ ] Close and reopen the same PDF — verify saved state is preserved
- [ ] Repeat with EPUB files
- [ ] Verify default value of `0` preserves existing behavior (no spreads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)