### PR TITLE
Citation dialog: skip irrelevant child rows in itemTree

### DIFF
--- a/chrome/content/zotero/integration/citationDialog.js
+++ b/chrome/content/zotero/integration/citationDialog.js
@@ -697,6 +697,16 @@ class LibraryLayout extends Layout {
 			},
 			emptyMessage: Zotero.getString('pane.items.loading'),
 			columns: itemColumns,
+			// Skip irrelevant child rows (e.g. no notes in annotations mode)
+			filterChildItems: (item) => {
+				if (DIALOG_STATE.isAddingAnnotations()) {
+					return SearchHandler.isItemWithAnnotations(item);
+				}
+				else if (DIALOG_STATE.isAddingNote()) {
+					return SearchHandler.isItemWithNotes(item);
+				}
+				return true;
+			},
 			// getExtraField helps itemTree fetch the data for a column that's
 			// not a part of actual item properties
 			getExtraField: (item, key) => {
@@ -803,7 +813,7 @@ class LibraryLayout extends Layout {
 				let items = await collectionTreeRow.getItems();
 				// when citing notes, only keep notes or note parents
 				if (DIALOG_STATE.isAddingNote()) {
-					items = items.filter(item => item.isNote() || item.getNotes().length);
+					items = items.filter(item => SearchHandler.isItemWithNotes(item));
 				}
 				// when adding annotations, only keep annotations, their attachments, and their top-level items
 				if (DIALOG_STATE.isAddingAnnotations()) {

--- a/chrome/content/zotero/integration/citationDialog/searchHandler.mjs
+++ b/chrome/content/zotero/integration/citationDialog/searchHandler.mjs
@@ -234,15 +234,26 @@ export class CitationDialogSearchHandler {
 
 	// Return items that are either annotations or are ancestors of annotations
 	keepItemsWithAnnotations(items) {
-		return items.filter((item) => {
-			if (item.isAnnotation()) return true;
-			if (item.isFileAttachment() && item.getAnnotations().length) return true;
-			if (item.isRegularItem()) {
-				let attachments = Zotero.Items.get(item.getAttachments());
-				return attachments.some(att => att.isFileAttachment() && att.getAnnotations().length);
-			}
-			return false;
-		});
+		return items.filter(item => this.isItemWithAnnotations(item));
+	}
+	
+	isItemWithAnnotations(item) {
+		if (item.isAnnotation()) return true;
+		if (item.isFileAttachment() && item.getAnnotations().length) return true;
+		if (item.isRegularItem()) {
+			let attachments = Zotero.Items.get(item.getAttachments());
+			return attachments.some(att => att.isFileAttachment() && att.getAnnotations().length);
+		}
+		return false;
+	}
+
+	isItemWithNotes(item) {
+		if (item.isNote() && item.getNote().length > 0) return true;
+		if (item.isRegularItem()) {
+			let notes = Zotero.Items.get(item.getNotes());
+			return notes.some(note => note.getNote().length > 0);
+		}
+		return false;
 	}
 
 	getAllAnnotations(item) {

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -109,7 +109,8 @@ var ItemTree = class ItemTree extends LibraryTree {
 		onContextMenu: noop,
 		onActivate: noop,
 		emptyMessage: '',
-		getExtraField: noop
+		getExtraField: noop,
+		filterChildItems: null
 	};
 
 	static propTypes = {
@@ -1819,6 +1820,10 @@ var ItemTree = class ItemTree extends LibraryTree {
 		if (newRows) {
 			if (!item.isFileAttachment()) {
 				newRows = Zotero.Items.get(newRows);
+			}
+			// Skip unwanted child items (e.g. in citation dialog)
+			if (this.props.filterChildItems) {
+				newRows = newRows.filter(this.props.filterChildItems);
 			}
 			for (let i = 0; i < newRows.length; i++) {
 				count++;

--- a/test/tests/citationDialogTest.js
+++ b/test/tests/citationDialogTest.js
@@ -675,6 +675,41 @@ describe("Citation Dialog", function () {
 			let itemNode = dialog.document.querySelector(`.item[id="${item.id}"]`);
 			assert.isOk(itemNode);
 		});
+
+		it("should not display empty note child rows", async function () {
+			await dialog.setDialogType("add-note");
+			await IOManager.toggleDialogMode("library");
+			while (SearchHandler.searching) {
+				await Zotero.Promise.delay(10);
+			}
+
+			let parentItem = await createDataObject('item', { title: "parent_with_notes" });
+			let noteWithContent = await createDataObject('item', {
+				itemType: 'note',
+				parentID: parentItem.id
+			});
+			noteWithContent.setNote('<p>Some note content</p>');
+			await noteWithContent.saveTx();
+
+			let emptyNote = await createDataObject('item', {
+				itemType: 'note',
+				parentID: parentItem.id
+			});
+			await emptyNote.saveTx();
+
+			// Refresh itemTree
+			await dialog.libraryLayout.search("", { skipDebounce: true });
+
+			// The empty note should not be among the itemTree rows
+			let emptyNoteRowIndex = dialog.libraryLayout.itemsView.getRowIndexByID(emptyNote.id);
+			assert.isFalse(emptyNoteRowIndex);
+
+			// The note with content should be present
+			let noteRowIndex = dialog.libraryLayout.itemsView.getRowIndexByID(noteWithContent.id);
+			assert.isOk(noteRowIndex !== false);
+
+			await parentItem.eraseTx();
+		});
 	});
 
 
@@ -843,6 +878,24 @@ describe("Citation Dialog", function () {
 			let annotationPreview = popup.querySelector("annotation-row");
 			assert.isOk(annotationPreview);
 			assert.notOk(annotationPreview.closest("[hidden]"));
+		});
+
+		it("should not display note child rows", async function () {
+			let note = await createDataObject('item', {
+				itemType: 'note',
+				parentID: parentItem.id
+			});
+			note.setNote('<p>Test note content</p>');
+			await note.saveTx();
+
+			// Refresh itemTree
+			await dialog.libraryLayout.search("", { skipDebounce: true });
+
+			// Check that the note is not among the itemTree rows
+			let noteRowIndex = dialog.libraryLayout.itemsView.getRowIndexByID(note.id);
+			assert.isFalse(noteRowIndex);
+
+			await note.eraseTx();
 		});
 	});
 


### PR DESCRIPTION
Pass `filterChildItems` to `itemTree` from `citationDialog` to filter out unwanted child rows before adding them in `toggleOpenState`.

In annotations mode, do not add child notes and attachments without annotations
In add-note mode, only keep child notes that have content

https://github.com/user-attachments/assets/52b93366-9225-4c69-968c-8bba7622e3b8

---

Initially, I tried to overload the `toggleOpenState` in citationDialog to keep all logic there and avoid conflicts with the big `itemTree` refactor. But that lead to issues during column sorting, since `toggleOpenState` is used in very many places. So this is safer and much easier.

@adomasven, is adding this going to cause issues for the itemTree refactor? 

