### PR TITLE
fix(notes): prevent unloaded note tabs from opening as windows on shu…

### DIFF
--- a/chrome/content/zotero/tabs.js
+++ b/chrome/content/zotero/tabs.js
@@ -781,6 +781,12 @@ var Zotero_Tabs = new function () {
 	 * Close all tabs except the first one
 	 */
 	this.closeAll = function () {
+		// Ensure a non-loadable tab is selected before bulk-close. Otherwise,
+		// closing the currently selected tab can auto-select an unloaded tab,
+		// which triggers lazy-load hooks during shutdown.
+		if (this._selectedID !== 'zotero-pane') {
+			this.select('zotero-pane');
+		}
 		this.close(this._tabs.slice(1).map(x => x.id));
 	};
 	


### PR DESCRIPTION
…tdown

Fix an issue where closing Zotero incorrectly opens notes as window if [`note-unloaded`](https://github.com/zotero/zotero/blob/9c1af8e61ca9db604d2a3781e64c567ba8a8a0de/chrome/content/zotero/tabs.js#L265-L282) tabs exist after the currently selected tab.

Previously, if Note A was opened as a tab and focus switched to a preceding tab, restarting Zotero would load Note A as `note-unloaded`. Upon closing Zotero again, Note A would [incorrectly spawn as a separate window](https://github.com/zotero/zotero/blob/391e8497a6b4772592ac01bc39fa10f4c36bc554/chrome/content/zotero/xpcom/data/notes.js#L51-L53) instead of closing with the main pane.

This fix ensures that `note-unloaded` type note tabs are not incorrectly opened in new window during the shutdown process.


https://github.com/user-attachments/assets/ff3a9f45-0eb3-44be-9205-9f7d0650c6a7
