### PR TITLE
fix: respect explicit open-in-tab/window prefs for note and attachments

### DIFF
--- a/chrome/content/zotero/locateMenu.js
+++ b/chrome/content/zotero/locateMenu.js
@@ -377,6 +377,11 @@ var Zotero_LocateMenu = new function () {
 	function ViewItem(alternateWindowBehavior) {
 		this._viewItemType = "mixed";
 		this._numItems = 0;
+		let _getOpenInNewWindow = function (viewItemType) {
+			return Zotero.Prefs.get(
+				viewItemType === "note" ? "openNoteInNewWindow" : "openReaderInNewWindow"
+			);
+		};
 		Object.defineProperty(this, "className", {
 			get() {
 				switch (this._viewItemType) {
@@ -407,7 +412,7 @@ var Zotero_LocateMenu = new function () {
 					openIn = "external";
 				}
 				else {
-					let openInNewWindow = Zotero.Prefs.get("openReaderInNewWindow");
+					let openInNewWindow = _getOpenInNewWindow(this._viewItemType);
 					if (alternateWindowBehavior) {
 						openInNewWindow = !openInNewWindow;
 					}
@@ -432,8 +437,12 @@ var Zotero_LocateMenu = new function () {
 				&& alternateWindowBehavior) {
 				return false;
 			}
-			if ((locateMode === "tab" && !alternateWindowBehavior)
-				|| (locateMode === "window" && alternateWindowBehavior)) {
+			let openInWindow = _getOpenInNewWindow(usableItem.isNote() ? "note" : usableItem.attachmentReaderType);
+			if (alternateWindowBehavior) {
+				openInWindow = !openInWindow;
+			}
+			if ((locateMode === "tab" && !openInWindow)
+				|| (locateMode === "window" && openInWindow)) {
 				// Don't show option if it would open in the same type of the current context
 				return false;
 			}
@@ -473,10 +482,15 @@ var Zotero_LocateMenu = new function () {
 				if (usableItem) usableItems.push(usableItem);
 			}
 			
+			let forceOpenInWindow;
+			let openIn = this.l10nArgs.openIn;
+			forceOpenInWindow = { window: true, tab: false }[openIn];
+
 			ZoteroPane.viewItems(usableItems, event,
 				{
 					noLocateOnMissing: false,
-					forceAlternateWindowBehavior: alternateWindowBehavior
+					forceAlternateWindowBehavior: alternateWindowBehavior,
+					forceOpenInWindow,
 				});
 		};
 		

--- a/chrome/content/zotero/locateMenu.js
+++ b/chrome/content/zotero/locateMenu.js
@@ -483,8 +483,16 @@ var Zotero_LocateMenu = new function () {
 			}
 			
 			let forceOpenInWindow;
-			let openIn = this.l10nArgs.openIn;
-			forceOpenInWindow = { window: true, tab: false }[openIn];
+			if (this._viewItemType !== "mixed" && Zotero.Prefs.get(`fileHandler.${this._viewItemType}`)) {
+				// Use external handler; keep forceOpenInWindow undefined
+			}
+			else {
+				let openInNewWindow = _getOpenInNewWindow(this._viewItemType);
+				if (alternateWindowBehavior) {
+					openInNewWindow = !openInNewWindow;
+				}
+				forceOpenInWindow = openInNewWindow;
+			}
 
 			ZoteroPane.viewItems(usableItems, event,
 				{

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -5018,7 +5018,17 @@ var ZoteroPane = new function () {
 				if (!this.collectionsView.editable) {
 					continue;
 				}
-				let openInWindow = event?.shiftKey || options.forceAlternateWindowBehavior;
+				let openInWindow;
+				if (typeof options.forceOpenInWindow === 'boolean') {
+					openInWindow = options.forceOpenInWindow;
+				}
+				else {
+					openInWindow = Zotero.Prefs.get('openNoteInNewWindow');
+					let useAlternateWindowBehavior = event?.shiftKey || options.forceAlternateWindowBehavior;
+					if (useAlternateWindowBehavior) {
+						openInWindow = !openInWindow;
+					}
+				}
 				ZoteroPane.openNote(item.id, { openInWindow });
 			}
 			else if (item.isAttachment()) {
@@ -5064,10 +5074,16 @@ var ZoteroPane = new function () {
 				await item.saveTx();
 			}
 
-			let openInWindow = Zotero.Prefs.get('openReaderInNewWindow');
-			let useAlternateWindowBehavior = event?.shiftKey || extraData?.forceAlternateWindowBehavior;
-			if (useAlternateWindowBehavior) {
-				openInWindow = !openInWindow;
+			let openInWindow;
+			if (typeof extraData?.forceOpenInWindow === 'boolean') {
+				openInWindow = extraData.forceOpenInWindow;
+			}
+			else {
+				openInWindow = Zotero.Prefs.get('openReaderInNewWindow');
+				let useAlternateWindowBehavior = event?.shiftKey || extraData?.forceAlternateWindowBehavior;
+				if (useAlternateWindowBehavior) {
+					openInWindow = !openInWindow;
+				}
 			}
 			await Zotero.FileHandlers.open(item, {
 				location: extraData?.location,


### PR DESCRIPTION
- Introduce `_getOpenInNewWindow` to distinguish between note and reader preferences
- Add `forceOpenInWindow` logic to locateMenu and zoteroPane
- Ensure explicit menu selections override default preferences and alternate behavior toggles
- Fix visibility logic for context menu options based on current locate mode

fixes:
1. https://forums.zotero.org/discussion/128815/shift-enter-is-not-opening-notes-in-tabs
2. The 'Open in new tab' option incorrectly appears in the tab locate menu when the `openReaderInNewWindow` and/or `openNoteInNewWindow` prefs are enabled. **This logic seems flawed. If the item is currently open in a tab, the menu should always display the Open in new window option.** While PR #5528 resolved the issue where the ['Open Note in New Tab' menu item was non-functional](https://github.com/zotero/zotero/pull/5528#issuecomment-3280611174), incorrect behavior persists when the `openReaderInNewWindow` or `openNoteInNewWindow` prefs are enabled.
3. With `openReaderInNewWindow` enabled and `openNoteInNewWindow` disabled, selecting both a note and a PDF and choosing 'Open in Tab' from the ZoteroPane locate menu incorrectly opens the note in a new window.

Maybe @windingwind  could take a look at this when you have time?