### PR TITLE
fix: indentation for some settings items is not taking effect on Windows

### DIFF
--- a/chrome/content/zotero/preferences/preferences_general.xhtml
+++ b/chrome/content/zotero/preferences/preferences_general.xhtml
@@ -150,11 +150,13 @@
 						/>
 					</hbox>
 				</vbox>
-				<checkbox id="rename-linked-files" class="indented-pref"
-					label="&zotero.preferences.autoRenameFiles.renameLinked;"
-					preference="extensions.zotero.autoRenameFiles.linked"
-					oncommand="Zotero_Preferences.General.updateAutoRenameFilesUI()" native="true"
-				/>
+				<vbox class="indented-pref">
+					<checkbox id="rename-linked-files"
+						label="&zotero.preferences.autoRenameFiles.renameLinked;"
+						preference="extensions.zotero.autoRenameFiles.linked"
+						oncommand="Zotero_Preferences.General.updateAutoRenameFilesUI()" native="true"
+					/>
+				</vbox>
 				<hbox id="file-renaming-buttons">
 					<button id="file-renaming-customize-button"
 						data-l10n-id="preferences-file-renaming-customize-button"
@@ -226,12 +228,13 @@
 					</menupopup>
 				</menulist>
 			</vbox>
-			<checkbox id="open-reader-in-new-window"
-				data-l10n-id="preferences-reader-open-in-new-window"
-				class="indented-pref"
-				preference="extensions.zotero.openReaderInNewWindow"
-				native="true"
-			/>
+			<vbox class="indented-pref">
+				<checkbox id="open-reader-in-new-window"
+					data-l10n-id="preferences-reader-open-in-new-window"
+					preference="extensions.zotero.openReaderInNewWindow"
+					native="true"
+				/>
+			</vbox>
 			
 			<hbox align="center">
 				<label value="&zotero.preferences.reader.tabsTitle.label;" control="reader-tabs-title"/>
@@ -259,12 +262,13 @@
 				</menulist>
 			</hbox>
 
-			<checkbox
-				class="indented-pref"
-				preference="extensions.zotero.reader.ebookHyphenate"
-				data-l10n-id="preferences-reader-ebook-hyphenate"
-				native="true"
-			/>
+			<vbox class="indented-pref">
+				<checkbox
+					preference="extensions.zotero.reader.ebookHyphenate"
+					data-l10n-id="preferences-reader-ebook-hyphenate"
+					native="true"
+				/>
+			</vbox>
 		</groupbox>
 
 		<groupbox id="zotero-prefpane-note-groupbox" aria-labelledby="preferences-note-title">
@@ -321,7 +325,7 @@
 			<label><html:h2>&zotero.preferences.groups;</html:h2></label>
 
 			<label value="&zotero.preferences.groups.whenCopyingInclude;"/>
-			<vbox style="margin-left: 2em">
+			<vbox class="indented-pref">
 				<checkbox label="&zotero.preferences.groups.childNotes;" preference="extensions.zotero.groups.copyChildNotes" native="true"/>
 				<checkbox label="&zotero.preferences.groups.childFiles;" preference="extensions.zotero.groups.copyChildFileAttachments" native="true"/>
 				<checkbox label="&zotero.preferences.groups.annotations;" preference="extensions.zotero.groups.copyAnnotations" native="true"/>


### PR DESCRIPTION
1. Fix indentation for some settings items that are not taking effect on Windows due to the 2nd assumptions in preferences.scss from #4609

https://github.com/zotero/zotero/blob/30e8c74e5b6256313503170beaf456484cb13c13/scss/preferences.scss#L307-L312

2. Modify the style of items in `&zotero.preferences.groups` to be compatible with RTL

<body>
    <table>
        <tr>
            <td></td>
            <td>Before</td>
            <td>After</td>
        </tr>
        <tr>
            <td>1</td>
            <td>
<img height="500" alt="1-1" src="https://github.com/user-attachments/assets/73d11faf-203d-49f1-92c1-dfb2497041fd" />
</td>
            <td>
<img height="500" alt="1-2" src="https://github.com/user-attachments/assets/5b98499a-2d23-4635-9e2b-b085dc5dbcac" />
</td>
        </tr>
        <tr>
            <td>2</td>
            <td>
<img height="500" alt="2-1" src="https://github.com/user-attachments/assets/cdeeccb9-39d1-4155-afb0-e9df875f439c" />
</td>
            <td>
<img height="500" alt="2-2" src="https://github.com/user-attachments/assets/0f850639-cd98-4fe6-848b-279a4cc35b34" />
</td>
        </tr>
    </table>
</body>