### PR TITLE
Citation dialog: fix CI test breakage

### DIFF
--- a/chrome/content/zotero/integration/citationDialog.js
+++ b/chrome/content/zotero/integration/citationDialog.js
@@ -2095,6 +2095,7 @@ window.addEventListener("focus", async () => {
 	// which replaces accept button with the spinner and interrupts the click event.
 	await Zotero.Promise.delay(100);
 	if (accepted) return;
+	if (SearchHandler.searching) return;
 	SearchHandler.clearNonLibraryItemsCache();
 	if (!currentLayout) return;
 	if (currentLayout.type == "list") {

--- a/test/tests/citationDialogTest.js
+++ b/test/tests/citationDialogTest.js
@@ -510,6 +510,11 @@ describe("Citation Dialog", function () {
 			while (SearchHandler.searching) {
 				await Zotero.Promise.delay(10);
 			}
+			// Re-set cached items right before search to guard against
+			// the window focus handler clearing them
+			SearchHandler.selectedItems = [selectedOne, selectedTwo, selectedAndOpenOne];
+			SearchHandler.openItems = [openOne, openTwo, selectedAndOpenOne, citedAndOpenOne];
+			SearchHandler.citedItems = [citedOne, citedAndOpenOne];
 			// Search for "one"
 			await dialog.currentLayout.search("one", { skipDebounce: true });
 			// Selected items should have both "one_selected" and "one_selected_open"
@@ -541,6 +546,11 @@ describe("Citation Dialog", function () {
 			while (SearchHandler.searching) {
 				await Zotero.Promise.delay(10);
 			}
+			// Re-set cached items right before search to guard against
+			// the window focus handler clearing them
+			SearchHandler.selectedItems = [selectedOne, selectedTwo, selectedAndOpenOne];
+			SearchHandler.openItems = [openOne, openTwo, selectedAndOpenOne, citedAndOpenOne];
+			SearchHandler.citedItems = [citedOne, citedAndOpenOne];
 			// Search for "one"
 			await dialog.currentLayout.search("one", { skipDebounce: true });
 			// Selected items should have both "one_selected" and "one_selected_open"
@@ -678,6 +688,9 @@ describe("Citation Dialog", function () {
 
 		it("should not display empty note child rows", async function () {
 			await dialog.setDialogType("add-note");
+			while (SearchHandler.searching) {
+				await Zotero.Promise.delay(10);
+			}
 			await IOManager.toggleDialogMode("library");
 			while (SearchHandler.searching) {
 				await Zotero.Promise.delay(10);


### PR DESCRIPTION
- prevent the focus handler from resetting the cached items in search handler
- wait for search to finish after changing dialog type in "should not display empty note child rows" test