### PR TITLE
Add attachment storage type search filter

### DIFF
--- a/chrome/content/zotero/elements/zoteroSearch.js
+++ b/chrome/content/zotero/elements/zoteroSearch.js
@@ -1087,6 +1087,7 @@
 			switch (condition) {
 				case 'fulltextContent':
 				case 'fileTypeID':
+				case 'attachmentStorageType':
 				case 'lastRead':
 					return 'attachment';
 				case 'annotationText':
@@ -1275,6 +1276,16 @@
 					this._valueMenuPending = false;
 					break;
 				}
+				case 'attachmentStorageType':
+				{
+					let rows = ['stored', 'linked'].map(type => ({
+						name: Zotero.getString('attachment-storage-type-' + type),
+						value: type
+					}));
+					
+					this.createValueMenu(rows);
+					break;
+				}
 				default:
 				{
 					if (operatorsList.value == 'isInTheLast') {
@@ -1313,7 +1324,8 @@
 					|| this.selectedCondition == 'fileTypeID'
 					|| this.selectedCondition == 'annotationType'
 					|| this.selectedCondition == 'annotationColor'
-					|| this.selectedCondition == 'annotationAuthor') {
+					|| this.selectedCondition == 'annotationAuthor'
+					|| this.selectedCondition == 'attachmentStorageType') {
 				this.querySelector('#valuefield').hidden = true;
 				this.querySelector('#valuemenu').hidden = false;
 				this.querySelector('#value-date-age').hidden = true;

--- a/chrome/content/zotero/elements/zoteroSearch.js
+++ b/chrome/content/zotero/elements/zoteroSearch.js
@@ -1278,7 +1278,7 @@
 				}
 				case 'attachmentStorageType':
 				{
-					let rows = ['stored', 'linked'].map(type => ({
+					let rows = ['storedFile', 'linkedFile', 'webLink'].map(type => ({
 						name: Zotero.getString('attachment-storage-type-' + type),
 						value: type
 					}));

--- a/chrome/content/zotero/xpcom/data/search.js
+++ b/chrome/content/zotero/xpcom/data/search.js
@@ -1641,11 +1641,7 @@ Zotero.Search.prototype._buildQuery = async function () {
 								throw ("Invalid attachmentStorageType '" + condition.value
 									+ "' specified in search.js");
 						}
-						condSQL += 'linkMode ';
-						if (condition.operator == 'isNot') {
-							condSQL += 'NOT ';
-						}
-						condSQL += `IN (${linkModes.map(() => '?').join(', ')})`;
+						condSQL += `linkMode IN (${linkModes.map(() => '?').join(', ')})`;
 						condSQLParams.push(...linkModes);
 						skipOperators = true;
 						break;

--- a/chrome/content/zotero/xpcom/data/search.js
+++ b/chrome/content/zotero/xpcom/data/search.js
@@ -1619,6 +1619,37 @@ Zotero.Search.prototype._buildQuery = async function () {
 						}
 						skipOperators = true;
 						break;
+
+					case 'attachmentStorageType': {
+						let linkModes;
+						switch (condition.value) {
+							case 'stored':
+								linkModes = [
+									Zotero.Attachments.LINK_MODE_IMPORTED_FILE,
+									Zotero.Attachments.LINK_MODE_IMPORTED_URL
+								];
+								break;
+
+							case 'linked':
+								linkModes = [
+									Zotero.Attachments.LINK_MODE_LINKED_FILE,
+									Zotero.Attachments.LINK_MODE_LINKED_URL
+								];
+								break;
+
+							default:
+								throw ("Invalid attachmentStorageType '" + condition.value
+									+ "' specified in search.js");
+						}
+						condSQL += 'linkMode ';
+						if (condition.operator == 'isNot') {
+							condSQL += 'NOT ';
+						}
+						condSQL += `IN (${linkModes.map(() => '?').join(', ')})`;
+						condSQLParams.push(...linkModes);
+						skipOperators = true;
+						break;
+					}
 					
 					case 'tag':
 						condSQL += "tagID IN (SELECT tagID FROM tags WHERE ";

--- a/chrome/content/zotero/xpcom/data/search.js
+++ b/chrome/content/zotero/xpcom/data/search.js
@@ -1623,16 +1623,21 @@ Zotero.Search.prototype._buildQuery = async function () {
 					case 'attachmentStorageType': {
 						let linkModes;
 						switch (condition.value) {
-							case 'stored':
+							case 'storedFile':
 								linkModes = [
 									Zotero.Attachments.LINK_MODE_IMPORTED_FILE,
 									Zotero.Attachments.LINK_MODE_IMPORTED_URL
 								];
 								break;
 
-							case 'linked':
+							case 'linkedFile':
 								linkModes = [
-									Zotero.Attachments.LINK_MODE_LINKED_FILE,
+									Zotero.Attachments.LINK_MODE_LINKED_FILE
+								];
+								break;
+
+							case 'webLink':
+								linkModes = [
 									Zotero.Attachments.LINK_MODE_LINKED_URL
 								];
 								break;

--- a/chrome/content/zotero/xpcom/data/searchConditions.js
+++ b/chrome/content/zotero/xpcom/data/searchConditions.js
@@ -382,6 +382,16 @@ Zotero.SearchConditions = new function () {
 				// Matches attachment items; see 'level' handling in search.js
 				level: 'attachment'
 			},
+
+			{
+				name: 'attachmentStorageType',
+				operators: {
+					is: true,
+					isNot: true
+				},
+				table: 'itemAttachments',
+				field: 'linkMode'
+			},
 			
 			{
 				name: 'tagID',

--- a/chrome/content/zotero/xpcom/data/searchConditions.js
+++ b/chrome/content/zotero/xpcom/data/searchConditions.js
@@ -390,7 +390,8 @@ Zotero.SearchConditions = new function () {
 					isNot: true
 				},
 				table: 'itemAttachments',
-				field: 'linkMode'
+				field: 'linkMode',
+				level: 'attachment'
 			},
 			
 			{

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -1014,6 +1014,7 @@ search-conditions-submenu-annotation = Annotation
 # context. The full names above are still shown once a condition is selected.
 search-conditions-short-fulltextContent = Content
 search-conditions-short-fileTypeID = File Type
+search-conditions-short-attachmentStorageType = Storage Type
 search-conditions-short-lastRead = Last Read
 search-conditions-short-annotationText = Text
 search-conditions-short-annotationComment = Comment

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -995,6 +995,7 @@ search-conditions-dateModified = Date Modified
 search-conditions-fulltextContent = Attachment Content
 search-conditions-programmingLanguage = Programming Language
 search-conditions-fileTypeID = Attachment File Type
+search-conditions-attachmentStorageType = Attachment Storage Type
 search-conditions-lastRead = Attachment Last Read
 search-conditions-annotationText = Annotation Text
 search-conditions-annotationComment = Annotation Comment
@@ -1050,6 +1051,9 @@ file-type-video = Video
 file-type-presentation = Presentation
 file-type-document = Document
 file-type-ebook = Ebook
+
+attachment-storage-type-stored = Stored
+attachment-storage-type-linked = Linked
 
 post-upgrade-message = You’ve been upgraded to <span data-l10n-name="post-upgrade-appver">{ -app-name } { $version }</span>! Learn about <a data-l10n-name="new-features-link">what’s new</a>.
 post-upgrade-remind-me-later =

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -1053,8 +1053,9 @@ file-type-presentation = Presentation
 file-type-document = Document
 file-type-ebook = Ebook
 
-attachment-storage-type-stored = Stored
-attachment-storage-type-linked = Linked
+attachment-storage-type-storedFile = Stored File
+attachment-storage-type-linkedFile = Linked File
+attachment-storage-type-webLink = Web Link
 
 post-upgrade-message = You’ve been upgraded to <span data-l10n-name="post-upgrade-appver">{ -app-name } { $version }</span>! Learn about <a data-l10n-name="new-features-link">what’s new</a>.
 post-upgrade-remind-me-later =

--- a/chrome/locale/en-US/zotero/zotero.json
+++ b/chrome/locale/en-US/zotero/zotero.json
@@ -1247,6 +1247,9 @@
 	"search-conditions-fileTypeID": {
 		"string": "Attachment File Type"
 	},
+	"search-conditions-attachmentStorageType": {
+		"string": "Attachment Storage Type"
+	},
 	"search-conditions-lastRead": {
 		"string": "Attachment Last Read"
 	},
@@ -1342,6 +1345,12 @@
 	},
 	"file-type-ebook": {
 		"string": "Ebook"
+	},
+	"attachment-storage-type-stored": {
+		"string": "Stored"
+	},
+	"attachment-storage-type-linked": {
+		"string": "Linked"
 	},
 	"post-upgrade-message": {
 		"string": "You’ve been upgraded to <span data-l10n-name=\"post-upgrade-appver\">{ app-name } { version }</span>! Learn about <a data-l10n-name=\"new-features-link\">what’s new</a>."

--- a/chrome/locale/en-US/zotero/zotero.json
+++ b/chrome/locale/en-US/zotero/zotero.json
@@ -1346,11 +1346,14 @@
 	"file-type-ebook": {
 		"string": "Ebook"
 	},
-	"attachment-storage-type-stored": {
-		"string": "Stored"
+	"attachment-storage-type-storedFile": {
+		"string": "Stored File"
 	},
-	"attachment-storage-type-linked": {
-		"string": "Linked"
+	"attachment-storage-type-linkedFile": {
+		"string": "Linked File"
+	},
+	"attachment-storage-type-webLink": {
+		"string": "Web Link"
 	},
 	"post-upgrade-message": {
 		"string": "You’ve been upgraded to <span data-l10n-name=\"post-upgrade-appver\">{ app-name } { version }</span>! Learn about <a data-l10n-name=\"new-features-link\">what’s new</a>."

--- a/test/tests/searchTest.js
+++ b/test/tests/searchTest.js
@@ -257,9 +257,9 @@ describe("Zotero.Search", function () {
 				title: 'linked-file-pdf'
 			});
 			linkedURLItem = await Zotero.Attachments.linkFromURL({
-				url: 'http://example.com/linked-url',
+				url: 'http://example.com/linked-url.pdf',
 				title: 'linked-url',
-				contentType: 'text/html'
+				contentType: 'application/pdf'
 			});
 			
 			let group = await getGroup();
@@ -954,12 +954,14 @@ describe("Zotero.Search", function () {
 					s.libraryID = userLibraryID;
 					s.addCondition('attachmentStorageType', 'is', 'storedFile');
 					let matches = await s.search();
-					assert.sameMembers(matches, [
+					assert.includeMembers(matches, [
 						fooItem.id,
 						foobarItem.id,
 						bazItem.id,
 						importedURLItem.id
 					]);
+					assert.notInclude(matches, linkedFileItem.id);
+					assert.notInclude(matches, linkedURLItem.id);
 				});
 
 				it("should find linked files", async function () {
@@ -967,7 +969,9 @@ describe("Zotero.Search", function () {
 					s.libraryID = userLibraryID;
 					s.addCondition('attachmentStorageType', 'is', 'linkedFile');
 					let matches = await s.search();
-					assert.sameMembers(matches, [linkedFileItem.id]);
+					assert.include(matches, linkedFileItem.id);
+					assert.notInclude(matches, bazItem.id);
+					assert.notInclude(matches, linkedURLItem.id);
 				});
 
 				it("should find web links", async function () {
@@ -975,7 +979,9 @@ describe("Zotero.Search", function () {
 					s.libraryID = userLibraryID;
 					s.addCondition('attachmentStorageType', 'is', 'webLink');
 					let matches = await s.search();
-					assert.sameMembers(matches, [linkedURLItem.id]);
+					assert.include(matches, linkedURLItem.id);
+					assert.notInclude(matches, bazItem.id);
+					assert.notInclude(matches, linkedFileItem.id);
 				});
 			});
 			

--- a/test/tests/searchTest.js
+++ b/test/tests/searchTest.js
@@ -949,10 +949,10 @@ describe("Zotero.Search", function () {
 			});
 
 			describe("attachmentStorageType", function () {
-				it("should search by stored attachment storage type", async function () {
+				it("should find stored files", async function () {
 					let s = new Zotero.Search();
 					s.libraryID = userLibraryID;
-					s.addCondition('attachmentStorageType', 'is', 'stored');
+					s.addCondition('attachmentStorageType', 'is', 'storedFile');
 					let matches = await s.search();
 					assert.sameMembers(matches, [
 						fooItem.id,
@@ -962,12 +962,20 @@ describe("Zotero.Search", function () {
 					]);
 				});
 
-				it("should search by linked attachment storage type", async function () {
+				it("should find linked files", async function () {
 					let s = new Zotero.Search();
 					s.libraryID = userLibraryID;
-					s.addCondition('attachmentStorageType', 'is', 'linked');
+					s.addCondition('attachmentStorageType', 'is', 'linkedFile');
 					let matches = await s.search();
-					assert.sameMembers(matches, [linkedFileItem.id, linkedURLItem.id]);
+					assert.sameMembers(matches, [linkedFileItem.id]);
+				});
+
+				it("should find web links", async function () {
+					let s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('attachmentStorageType', 'is', 'webLink');
+					let matches = await s.search();
+					assert.sameMembers(matches, [linkedURLItem.id]);
 				});
 			});
 			

--- a/test/tests/searchTest.js
+++ b/test/tests/searchTest.js
@@ -983,8 +983,23 @@ describe("Zotero.Search", function () {
 					assert.notInclude(matches, bazItem.id);
 					assert.notInclude(matches, linkedFileItem.id);
 				});
+
+				it("should match a top-level item via a child attachment", async function () {
+					let item = await createDataObject('item');
+					let attachment = await importPDFAttachment(item);
+
+					let s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('resultLevel', 'item');
+					s.addCondition('attachmentStorageType', 'is', 'storedFile');
+					let matches = await s.search();
+					assert.include(matches, item.id);
+					assert.notInclude(matches, attachment.id);
+
+					await item.eraseTx();
+				});
 			});
-			
+
 			describe("lastRead", function () {
 				it("should roll a child attachment's last-read date up to its top-level item", async function () {
 					var item = await createDataObject('item', { title: 'zlastread' });

--- a/test/tests/searchTest.js
+++ b/test/tests/searchTest.js
@@ -225,6 +225,9 @@ describe("Zotero.Search", function () {
 		var fooItem;
 		var foobarItem;
 		var bazItem;
+		var importedURLItem;
+		var linkedFileItem;
+		var linkedURLItem;
 		var fooItemGroup;
 		var foobarItemGroup;
 		var bazItemGroup;
@@ -239,6 +242,25 @@ describe("Zotero.Search", function () {
 			foobarItem = await importFileAttachment("search/foobar.html");
 			bazItem = await importFileAttachment("search/baz.pdf");
 			userLibraryID = fooItem.libraryID;
+			let testPDF = getTestDataDirectory();
+			testPDF.append('test.pdf');
+			importedURLItem = await Zotero.Attachments.importSnapshotFromFile({
+				file: testPDF,
+				libraryID: userLibraryID,
+				title: 'imported-url-pdf',
+				url: 'http://example.com/imported-url.pdf',
+				contentType: 'application/pdf',
+				singleFile: true
+			});
+			linkedFileItem = await Zotero.Attachments.linkFromFile({
+				file: OS.Path.join(getTestDataDirectory().path, 'test.pdf'),
+				title: 'linked-file-pdf'
+			});
+			linkedURLItem = await Zotero.Attachments.linkFromURL({
+				url: 'http://example.com/linked-url',
+				title: 'linked-url',
+				contentType: 'text/html'
+			});
 			
 			let group = await getGroup();
 			fooItemGroup = await importFileAttachment("search/foo.html", { libraryID: group.libraryID });
@@ -250,6 +272,9 @@ describe("Zotero.Search", function () {
 			yield fooItem.eraseTx();
 			yield foobarItem.eraseTx();
 			yield bazItem.eraseTx();
+			yield importedURLItem.eraseTx();
+			yield linkedFileItem.eraseTx();
+			yield linkedURLItem.eraseTx();
 			yield fooItemGroup.eraseTx();
 			yield foobarItemGroup.eraseTx();
 			yield bazItemGroup.eraseTx();
@@ -920,6 +945,42 @@ describe("Zotero.Search", function () {
 					s.addCondition('fileTypeID', 'is', Zotero.FileTypes.getID('webpage'));
 					let matches = await s.search();
 					assert.sameMembers(matches, [fooItem.id, foobarItem.id]);
+				});
+			});
+
+			describe("attachmentStorageType", function () {
+				it("should search by stored attachment storage type", async function () {
+					let s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('attachmentStorageType', 'is', 'stored');
+					let matches = await s.search();
+					assert.sameMembers(matches, [
+						fooItem.id,
+						foobarItem.id,
+						bazItem.id,
+						importedURLItem.id
+					]);
+				});
+
+				it("should search by linked attachment storage type", async function () {
+					let s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('attachmentStorageType', 'is', 'linked');
+					let matches = await s.search();
+					assert.sameMembers(matches, [linkedFileItem.id, linkedURLItem.id]);
+				});
+
+				it("should support isNot", async function () {
+					let s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('attachmentStorageType', 'isNot', 'linked');
+					let matches = await s.search();
+					assert.sameMembers(matches, [
+						fooItem.id,
+						foobarItem.id,
+						bazItem.id,
+						importedURLItem.id
+					]);
 				});
 			});
 			

--- a/test/tests/searchTest.js
+++ b/test/tests/searchTest.js
@@ -969,19 +969,6 @@ describe("Zotero.Search", function () {
 					let matches = await s.search();
 					assert.sameMembers(matches, [linkedFileItem.id, linkedURLItem.id]);
 				});
-
-				it("should support isNot", async function () {
-					let s = new Zotero.Search();
-					s.libraryID = userLibraryID;
-					s.addCondition('attachmentStorageType', 'isNot', 'linked');
-					let matches = await s.search();
-					assert.sameMembers(matches, [
-						fooItem.id,
-						foobarItem.id,
-						bazItem.id,
-						importedURLItem.id
-					]);
-				});
 			});
 			
 			describe("lastRead", function () {


### PR DESCRIPTION
Small PR to improve the search, as mentioned in the issues: #1657 #3034.

With this PR you can filter in advanced search for stored files (link modes 0 and 1) and linked files (link modes 2 and 3) 