### PR TITLE
add Find option to Edit menu in note tab and window

### DIFF
--- a/chrome/content/zotero/note.js
+++ b/chrome/content/zotero/note.js
@@ -32,6 +32,10 @@ function showInLibrary() {
 	noteEditor._editorInstance._showInLibrary([noteEditor._editorInstance._item.id]);
 }
 
+function handleFind() {
+	noteEditor._editorInstance.openFindBar();
+}
+
 async function onLoad() {
 	if (window.arguments) {
 		var io = window.arguments[0];

--- a/chrome/content/zotero/note.xhtml
+++ b/chrome/content/zotero/note.xhtml
@@ -48,6 +48,8 @@
 	<commandset id="mainCommandSet">
 		<!--FILE-->
 		<command id="cmd_close" oncommand="window.close();"/>
+		<!--EDIT-->
+		<command id="cmd_find" oncommand="handleFind();"/>
 	</commandset>
 
 	<keyset id="mainKeyset">
@@ -108,6 +110,10 @@
 				<menuitem id="menu_selectAll"
 						  key="key_selectAll"
 						  command="cmd_selectAll" data-l10n-id="text-action-select-all"/>
+				<menuseparator/>
+				<menuitem id="menu_find"
+						  key="key_find"
+						  command="cmd_find" label="&findCmd.label;"/>
 			</menupopup>
 		</menu>
 

--- a/chrome/content/zotero/xpcom/editorInstance.js
+++ b/chrome/content/zotero/xpcom/editorInstance.js
@@ -425,6 +425,11 @@ class EditorInstance {
 		this._postMessage({ action: 'focusToolbar' });
 	}
 
+	openFindBar() {
+		this._iframeWindow.focus();
+		this._postMessage({ action: 'openFindBar' });
+	}
+
 	async importImages(annotations) {
 		for (let annotation of annotations) {
 			if (annotation.image && !this._filesReadOnly) {

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -1636,6 +1636,25 @@ var ZoteroPane = new function () {
 		return this.collectionsView.toggleVirtualCollection(libraryID, type, show, select);
 	};
 	
+	this.handleFind = function () {
+		switch (Zotero_Tabs.selectedType) {
+			case 'reader': {
+				ZoteroStandalone.currentReader.toggleFindPopup({ open: true });
+				return;
+			}
+			case 'note': {
+				let noteEditor = Zotero.Notes.getByTabID(Zotero_Tabs.selectedID)
+				if (noteEditor) {
+					return noteEditor.openFindBar();
+				}
+				return;
+			}
+			default:
+				document.getElementById('zotero-tb-search-textbox').select();
+				return;
+		}
+	};
+
 	this.openAdvancedSearchWindow = function () {
 		var wm = Components.classes["@mozilla.org/appshell/window-mediator;1"]
 					.getService(Components.interfaces.nsIWindowMediator);

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -95,9 +95,7 @@
 		<command id="cmd_close" oncommand="ZoteroPane.handleClose(event)"/>
 		
 		<!--EDIT-->
-		<command id="cmd_find"
-			oncommand="document.getElementById('zotero-tb-search-textbox').select()"/>
-			
+		<command id="cmd_find" oncommand="ZoteroPane.handleFind();"/>
 		<command id="cmd_zotero_reportErrors" oncommand="ZoteroPane_Local.reportErrors();"/>
 		<command id="cmd_zotero_import" oncommand="Zotero_File_Interface.showImportWizard();"/>
 		<command id="cmd_zotero_importFromClipboard" oncommand="Zotero_File_Interface.importFromClipboard();"/>
@@ -421,12 +419,9 @@
 									oncommand="ZoteroStandalone.currentReader.rotatePageRight()"
 							/>
 							<menuseparator/>
-							<menuitem id="menu_find" class="menu-type-library" label="&findCmd.label;"
+							<menuitem id="menu_find" label="&findCmd.label;"
 									key="key_find" accesskey="&findCmd.accesskey;"
 									command="cmd_find"/>
-							<menuitem id="menu_find_reader" class="menu-type-reader" label="&findCmd.label;"
-									key="key_find" accesskey="&findCmd.accesskey;"
-									oncommand="ZoteroStandalone.currentReader.toggleFindPopup({ open: true });"/>
 							<menuitem id="menu_advancedSearch"
 									label="&zotero.toolbar.advancedSearch;"
 									key="key_advancedSearch"


### PR DESCRIPTION
unify Find option as a ZoteroPane.js function that runs the appropriate find based on the tab type

requires Zotero/note-editor#75