### PR TITLE
fix tag colors order for focused row

### DIFF
--- a/scss/components/_item-tree.scss
+++ b/scss/components/_item-tree.scss
@@ -104,6 +104,16 @@
 					transform: scaleX(-1);
 					flex-direction: row-reverse;
 				}
+				
+				// Fix the stacking order reversing issue when selected
+				.tag-swatch {
+					position: relative;
+					@for $i from 1 through 9 {
+						&:nth-child(#{$i}) {
+							z-index: 10 - $i;
+						}
+					}
+				}
 			}
 
 			.icon-item-type + .tag-swatch,


### PR DESCRIPTION
fixes https://forums.zotero.org/discussion/comment/510193/#Comment_510193

Before: <img width="91" height="81" alt="image" src="https://github.com/user-attachments/assets/7071af13-9e04-4391-a084-600e9912d540" />
After: <img width="93" height="81" alt="image" src="https://github.com/user-attachments/assets/cfc89796-d958-422f-a5d9-f3c587d8ea64" />
