### PR TITLE
Fix related item sometimes not selected on click

### DIFF
--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -1304,7 +1304,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 					// Clear the quick search and tag selection and try again (once)
 					if (!noRecurse && window.ZoteroPane) {
 						let hasQuickSearch = !!this.collectionTreeRow.searchText;
-						let hasTagFilters = this.collectionTreeRow.tags.size > 0;
+						let hasTagFilters = this.collectionTreeRow.tags?.size > 0;
 						if (hasQuickSearch || hasTagFilters) {
 							// Clear all searches set on the collection tree row directly on
 							// collectionTreeRow (vs using ZoteroPane functions) to avoid


### PR DESCRIPTION
https://forums.zotero.org/discussion/130887/clicking-related-fails-zotero-report-id-1418809492

Though I have never been able to actually reproduce this myself. `collectionTreeRow.tags` is never `undefined` for me. But I could reproduce it by manually clearing tags before clicking on the related item that is not in the current collection.