### PR TITLE
Fix removal logic for menu added by MenuManager

### DIFF
--- a/chrome/content/zotero/xpcom/pluginAPI/menuManager.js
+++ b/chrome/content/zotero/xpcom/pluginAPI/menuManager.js
@@ -238,6 +238,8 @@
 				}
 			}
 
+			let mainKey = this._getOptionMainKey(option);
+
 			// Validate nested menus recursively
 			for (let i = 0; i < option.menus.length; i++) {
 				let result = this._validateMenuData(option.menus[i], `menus[${i}]`);
@@ -245,6 +247,8 @@
 					return false;
 				}
 				option.menus[i] = result.obj;
+				// Record mainKey so DOM elements can be found by it during unregister
+				option.menus[i]._mainKey = mainKey;
 			}
 			return option;
 		}
@@ -299,7 +303,7 @@
 
 		async _unregisterByPluginID(pluginID) {
 			let removedKeys = await super._unregisterByPluginID(pluginID);
-			if (!removedKeys) {
+			if (!removedKeys || removedKeys.length === 0) {
 				return [];
 			}
 			// Remove all custom menu items from the main window and reader window
@@ -310,9 +314,9 @@
 			}
 			windows.push(...Zotero.getMainWindows());
 			for (let window of windows) {
-				// Remove all custom menu items that match the removed keys
 				// The query selector is like ".CUSTOM_MENU_CLASS:is(.key1, .key2, .key3)"
-				window.document.querySelectorAll(`.${CUSTOM_MENU_CLASS}:is(.${removedKeys.join(", .")})`)
+				let selector = removedKeys.map(k => `.${CSS.escape(k)}`).join(", ");
+				window.document.querySelectorAll(`.${CUSTOM_MENU_CLASS}:is(${selector})`)
 					.forEach(elem => elem.remove());
 			}
 			return removedKeys;
@@ -442,7 +446,7 @@
 						break;
 					}
 				}
-				menuElem.classList.add(CUSTOM_MENU_CLASS, menuData._key);
+				menuElem.classList.add(CUSTOM_MENU_CLASS, menuData._key, menuData._mainKey);
 
 				// Init label and icon for non-separator menu items
 				if (menuData.menuType !== "separator") {

--- a/test/tests/pluginAPITest.js
+++ b/test/tests/pluginAPITest.js
@@ -1109,6 +1109,33 @@ describe("Plugin API", function () {
 			reader.close();
 		});
 
+		it("should remove menu DOM elements on plugin shutdown", async function () {
+			let pluginID = "test-plugin@zotero.org";
+			let option = Object.assign({}, defaultOption, {
+				pluginID,
+				target: "main/menubar/file",
+			});
+
+			initCache("onShowing");
+			let menuID = Zotero.MenuManager.registerMenu(option);
+			assert.isString(menuID);
+
+			let popup = doc.querySelector("#menu_FilePopup");
+			await simulateMenuOpen(popup);
+			await getCache("onShowing");
+
+			let menuSelector = `.zotero-custom-menu-item.${CSS.escape(menuID)}`;
+			assert.exists(popup.querySelector(menuSelector),
+				"Menu element should exist after registration");
+
+			await simulateMenuClosed(popup);
+
+			await Zotero.MenuManager._menuManager._unregisterByPluginID(pluginID);
+
+			assert.notExists(popup.querySelector(menuSelector),
+				"Menu element should be removed after plugin shutdown");
+		});
+
 		it("should group custom menus", async function () {
 			let option = Object.assign({}, defaultOption, {
 				target: "main/library/item",


### PR DESCRIPTION
Add the registered main key to menu class list so that they can be found when plugin is removed. Add test for the fix.

Before the fix, the menus are only removed the next time the popup opens. But due to the manual triggering of FTL translation on some menus, this can cause issues if the plugin is removed with all the referenced FTL files gone, the menu popup may not open, as described in some posts.

Relevant post: https://forums.zotero.org/discussion/comment/510986#Comment_510986
