### PR TITLE
Fix plugin prefs.js change not taking effect after update

### DIFF
--- a/chrome/content/zotero/xpcom/plugins.js
+++ b/chrome/content/zotero/xpcom/plugins.js
@@ -371,9 +371,12 @@ Zotero.Plugins = new function () {
 			}
 		};
 		try {
-			Services.scriptloader.loadSubScript(
+			Services.scriptloader.loadSubScriptWithOptions(
 				addon.getResourceURI("prefs.js").spec,
-				obj
+				{
+					target: obj,
+					ignoreCache: true
+				}
 			);
 		}
 		catch (e) {
@@ -394,9 +397,12 @@ Zotero.Plugins = new function () {
 			}
 		};
 		try {
-			Services.scriptloader.loadSubScript(
+			Services.scriptloader.loadSubScriptWithOptions(
 				addon.getResourceURI("prefs.js").spec,
-				obj
+				{
+					target: obj,
+					ignoreCache: true
+				}
 			);
 		}
 		catch (e) {


### PR DESCRIPTION
Do not use cache for loading the prefs.js

Relevant: https://groups.google.com/g/zotero-dev/c/ZXVyidbJcE8