### PR TITLE
Make icons directory during build

### DIFF
--- a/app/build.sh
+++ b/app/build.sh
@@ -1055,6 +1055,8 @@ if [ $BUILD_LINUX == 1 ]; then
 		mkdir "$APPDIR/integration"
 		cp -RH "$CALLDIR/modules/zotero-libreoffice-integration/install" "$APPDIR/integration/libreoffice"
 		
+		# Make icons dir for firefox builds without an updater (i.e. Linux distributions)
+		mkdir -p "$APPDIR/icons"
 		# Copy icons
 		cp "$CALLDIR/linux/icons/icon32.png" "$APPDIR/icons/"
 		cp "$CALLDIR/linux/icons/icon64.png" "$APPDIR/icons/"

--- a/app/build.sh
+++ b/app/build.sh
@@ -1055,7 +1055,7 @@ if [ $BUILD_LINUX == 1 ]; then
 		mkdir "$APPDIR/integration"
 		cp -RH "$CALLDIR/modules/zotero-libreoffice-integration/install" "$APPDIR/integration/libreoffice"
 		
-		# Make icons dir for firefox builds without an updater (i.e. Linux distributions)
+		# Firefox includes an 'icons' folder with updater.png, but some Linux distro builds omit it
 		mkdir -p "$APPDIR/icons"
 		# Copy icons
 		cp "$CALLDIR/linux/icons/icon32.png" "$APPDIR/icons/"


### PR DESCRIPTION
I'm not quite sure why your build scripts don't need that, but the builds for [Alpine Linux](https://gitlab.alpinelinux.org/alpine/aports/-/blob/19e1f927f8491b433b9c2de8395daf3f28d8658a/community/zotero/zotero_build-modifications.patch#L41) and [NixOS](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/zo/zotero/build-fixes.patch#L33) require this patch. It shouldn't hurt anyone, and reduce our patches a bit.