### PR TITLE
Fix plugin FTL registration

### DIFF
--- a/chrome/content/zotero/xpcom/file.js
+++ b/chrome/content/zotero/xpcom/file.js
@@ -352,13 +352,20 @@ Zotero.File = new function () {
 	}
 
 	/**
-	 * Return a promise for the contents of resource.
+	 * Return a promise for the contents of a local resource URL as a UTF-8
+	 * string. Goes through an nsIChannel to handle jar: URLs containing '@'.
 	 *
-	 * @param {String} url - the resource url
+	 * @param {String} url - the resource url (file://, jar:, resource://, chrome://)
 	 * @return {Promise<String>} the resource contents as a string
 	 */
 	this.getResourceAsync = function (url) {
-		return getContentsFromURLAsync(url);
+		let channel = NetUtil.newChannel({
+			uri: url,
+			loadUsingSystemPrincipal: true,
+			securityFlags: Ci.nsILoadInfo.SEC_ALLOW_CROSS_ORIGIN_SEC_CONTEXT_IS_NULL,
+			contentPolicyType: Ci.nsIContentPolicy.TYPE_OTHER,
+		});
+		return this.getContentsAsync(channel, 'UTF-8');
 	}
 	
 	

--- a/chrome/content/zotero/xpcom/plugins.js
+++ b/chrome/content/zotero/xpcom/plugins.js
@@ -40,7 +40,15 @@ Zotero.Plugins = new function () {
 	var scopes = new Map();
 	var observers = new Set();
 	var addonVersions = new Map();
-	var addonL10nSources = new Map();
+
+	// All plugins' FTL content is consolidated into one L10nFileSource, so the
+	// solver never has to choose between competing per-plugin sources.
+	// Miscompiles can happen when a plugin uses `{optional: true}` because the tester
+	// can't distinguish "source has content" from "source is an optional-miss".
+	const PLUGIN_L10N_SOURCE_NAME = "zotero-plugins";
+	const PLUGIN_L10N_PRE_PATH = "zotero-plugins:{locale}/";
+	// addon.id -> Map<full_path, ftl_content>
+	var addonL10nContents = new Map();
 	
 	const REASONS = {
 		APP_STARTUP: 1,
@@ -421,16 +429,9 @@ Zotero.Plugins = new function () {
 	 * could be included in an XHTML file as
 	 *   <link rel="localization" href="make-it-red.ftl"/>
 	 *
-	 * Locale subdirectories that match Zotero locales (Services.locale.availableLocales)
-	 * are registered as is. Other locales are aliased to a best-fit Zotero locale.
-	 * For example, Zotero has an 'eu-ES' locale but no 'eu-FR' locale. If a plugin
-	 * included an 'eu-FR' locale instead, 'eu-FR' would be aliased to 'eu-ES',
-	 * and 'eu-FR' strings would show if the user's Zotero locale is 'eu-ES'.
-	 *
-	 * If a plugin doesn't have a locale matching the current Zotero locale, 'en-US'
-	 * is used as a fallback. If it doesn't have an 'en-*' locale, Fluent chooses a
-	 * fallback arbitrarily. For instance, a plugin with only a 'de' locale would
-	 * show German strings even if the user's Zotero locale is 'en-US'.
+	 * For each Zotero locale the plugin doesn't ship translations for, the
+	 * plugin's closest-locale content (exact -> same-language -> en-US ->
+	 * first available) is used, so every Zotero locale has a valid bundle.
 	 *
 	 * @param addon
 	 * @returns {Promise<void>}
@@ -449,58 +450,102 @@ Zotero.Plugins = new function () {
 			Zotero.logError(e);
 			return;
 		}
-		
-		let matchedLocales = [];
-		let unmatchedLocales = [];
+
+		// Read every .ftl in every plugin locale directory into memory.
+		let pluginFilesByLocale = new Map();
 		for (let pluginLocale of pluginLocales) {
-			(zoteroLocales.includes(pluginLocale) ? matchedLocales : unmatchedLocales)
-				.push(pluginLocale);
-		}
-		
-		let sources = [];
-		// All locales that exactly match a Zotero locale can be registered at once
-		if (matchedLocales.length) {
-			sources.push(new L10nFileSource(
-				addon.id,
-				'app',
-				matchedLocales,
-				// {locale} is replaced with the locale code
-				rootURI.spec + 'locale/{locale}/',
-			));
-		}
-		// Other locales need to be registered individually to create aliases
-		for (let unmatchedLocale of unmatchedLocales) {
-			let resolvedLocale = Zotero.Utilities.Internal.resolveLocale(unmatchedLocale, zoteroLocales);
-			// resolveLocale() returns en-US as a fallback; don't use it unless
-			// the unmatched plugin locale is en-*
-			if (resolvedLocale === 'en-US' && !unmatchedLocale.startsWith('en')) {
-				Zotero.debug(`${addon.id}: No matching locale for ${unmatchedLocale}`);
+			let files;
+			try {
+				files = await readDirectory(rootURI, `locale/${pluginLocale}`);
+			}
+			catch (e) {
+				Zotero.logError(e);
 				continue;
 			}
-			Zotero.debug(`${addon.id}: Aliasing ${unmatchedLocale} to ${resolvedLocale}`);
-			if (sources.some(source => source.locales.includes(resolvedLocale))) {
-				Zotero.debug(`${addon.id}: ${resolvedLocale} already registered`);
-				continue;
+			let contents = new Map();
+			for (let file of files) {
+				if (!file.endsWith('.ftl')) continue;
+				let url = rootURI.spec + `locale/${pluginLocale}/${file}`;
+				try {
+					contents.set(file, await Zotero.File.getResourceAsync(url));
+				}
+				catch (e) {
+					Zotero.logError(new Error(`${addon.id}: failed to read ${url}: ${e}`));
+				}
 			}
-			sources.push(new L10nFileSource(
-				addon.id + '-' + unmatchedLocale,
-				'app',
-				[resolvedLocale],
-				// Don't use the {locale} placeholder here - manually specify the aliased locale code
-				rootURI.spec + `locale/${unmatchedLocale}/`,
-			));
+			pluginFilesByLocale.set(pluginLocale, contents);
 		}
-		L10nRegistry.getInstance().registerSources(sources);
-		addonL10nSources.set(addon.id, sources.map(source => source.name));
+
+		// Plugin locales can have partial coverage, pick the fallback per file.
+		let localesPerFile = new Map();
+		for (let [pluginLocale, files] of pluginFilesByLocale) {
+			for (let filename of files.keys()) {
+				if (!localesPerFile.has(filename)) {
+					localesPerFile.set(filename, []);
+				}
+				localesPerFile.get(filename).push(pluginLocale);
+			}
+		}
+
+		let contributions = new Map();
+		for (let zoteroLocale of zoteroLocales) {
+			let prefix = PLUGIN_L10N_PRE_PATH.replace('{locale}', zoteroLocale);
+			for (let [filename, available] of localesPerFile) {
+				let pick = Zotero.Utilities.Internal.resolveLocale(
+					zoteroLocale, available, { silent: true }
+				);
+				if (!pick) {
+					pick = available.find(l => l.startsWith('en')) || available[0];
+				}
+				contributions.set(
+					prefix + filename,
+					pluginFilesByLocale.get(pick).get(filename)
+				);
+			}
+		}
+		addonL10nContents.set(addon.id, contributions);
+		rebuildUnifiedPluginSource(zoteroLocales);
 	}
-	
-	
-	function unregisterLocales(addon) {
-		let sources = addonL10nSources.get(addon.id);
-		if (sources) {
-			L10nRegistry.getInstance().removeSources(sources);
-			addonL10nSources.delete(addon.id);
+
+
+	/**
+	 * Rebuild the unified plugin L10nFileSource from all active plugins'
+	 * contributions and register (or update) it in L10nRegistry.
+	 */
+	function rebuildUnifiedPluginSource(zoteroLocales) {
+		let fs = [];
+		for (let contributions of addonL10nContents.values()) {
+			for (let [path, source] of contributions) {
+				fs.push({ path, source });
+			}
 		}
+		let registry = L10nRegistry.getInstance();
+		if (!fs.length) {
+			if (registry.hasSource(PLUGIN_L10N_SOURCE_NAME)) {
+				registry.removeSources([PLUGIN_L10N_SOURCE_NAME]);
+			}
+			return;
+		}
+		let source = L10nFileSource.createMock(
+			PLUGIN_L10N_SOURCE_NAME,
+			'app',
+			zoteroLocales,
+			PLUGIN_L10N_PRE_PATH,
+			fs
+		);
+		if (registry.hasSource(PLUGIN_L10N_SOURCE_NAME)) {
+			registry.updateSources([source]);
+		}
+		else {
+			registry.registerSources([source]);
+		}
+	}
+
+
+	function unregisterLocales(addon) {
+		if (!addonL10nContents.has(addon.id)) return;
+		addonL10nContents.delete(addon.id);
+		rebuildUnifiedPluginSource(Services.locale.availableLocales);
 	}
 
 	/**

--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -1469,7 +1469,18 @@ Zotero.Utilities.Internal = {
 	},
 	
 	
-	resolveLocale: function (locale, locales) {
+	/**
+	 * Resolve `locale` to the best-fit entry in `locales`.
+	 *
+	 * @param {String} locale
+	 * @param {String[]} locales
+	 * @param {Object} [options]
+	 * @param {Boolean} [options.silent=false] - Suppress the not-found logError
+	 *     and return null instead of throwing when no match exists.
+	 * @return {String|null}
+	 */
+	resolveLocale: function (locale, locales, options = {}) {
+		let { silent = false } = options;
 		// If the locale exists as-is, use it
 		if (locales.includes(locale)) {
 			return locale;
@@ -1487,9 +1498,10 @@ Zotero.Utilities.Internal = {
 		// If none, use en-US
 		if (!possibleLocales.length) {
 			if (!locales.includes('en-US')) {
+				if (silent) return null;
 				throw new Error("Locales not available");
 			}
-			Zotero.logError(`Locale ${locale} not found`);
+			if (!silent) Zotero.logError(`Locale ${locale} not found`);
 			return 'en-US';
 		}
 		


### PR DESCRIPTION
Use one registry to avoid competing of language detect between plugins, as resources declared as optional is identical to resource missing and thus fails the check and returns null for the string (https://searchfox.org/mozilla-esr140/source/intl/l10n/rust/l10nregistry-rs/src/registry/asynchronous.rs#140) Register the plugin FTL for all languages Zotero supports with proper fallback logic so that even resources are declared as required, the check doesn't fail when plugin doesn't provide the resource. FIx Zotero.File.getResourceAsync to use NetUtil channel to handle jar: url with `@`.

We have two different long-existing issues with the FTL registration:

1. Plugin X FTL provides LANG_A, registered in window as optional, later initialized plugin Y doesn't provide LANG_A => plugin X's optional FTL get ignored (https://forums.zotero.org/discussion/comment/510987/#Comment_510987)

2. Zotero in LANG_B, plugin doesn't provide LANG_B, plugin FTL registered in window as required => DOM localized together with the missing plugin l10n will all fallback to en-US (https://github.com/jlegewie/beaver-zotero/issues/162)

So to fix 1. we now register all plugin FTL in one registry instead of multiple, so that no matter if they are optional or required the resource check always works (detailed reason see below)

To fix 2., we simply register all resources for all supported languages in Zotero.

| Before fix for 2 | After |
| ---- | ---- |
| <img width="318" height="132" alt="2026-04-28_15-47-21" src="https://github.com/user-attachments/assets/893a3e53-7f7d-44e8-9b27-805a2fd99281" /> | <img width="317" height="131" alt="2026-04-28_15-47-00" src="https://github.com/user-attachments/assets/fbecdd40-9f76-4045-af73-26079d07468c" /> |
| The plugin causes Zotero UI to partially fallback to en-US in fr | the Zotero UI uses fr correctly |



Below is context summarized by CC:

----


Root cause: two interacting Gecko L10nRegistry solver behaviors, exposed by Zotero's per-plugin L10nFileSource registration

Load-order-dependent null for optional: true resources. When a plugin registers its FTL via document.l10n.addResourceIds([{ path, optional: true }]), Zotero adds a per-plugin L10nFileSource. During bundle generation, the async solver's tester maps ResourceOption::MissingOptional to true via !is_required_and_missing() ([asynchronous.rs:140-147](https://searchfox.org/mozilla-esr140/source/intl/l10n/rust/l10nregistry-rs/src/registry/asynchronous.rs#140)) — i.e., a source that doesn't have an optional resource looks identical to one that does. The solver locks in the first "available" source, which is the latest-registered source ([registry/mod.rs:140](https://searchfox.org/mozilla-esr140/source/intl/l10n/rust/l10nregistry-rs/src/registry/mod.rs#140) — sources are accessed in reverse-push order). Then bundle_from_order calls fetch_file_sync, sees MissingOptional, and silently skips the resource. Net effect: plugin A's resource gets routed through plugin B's source, plugin B doesn't actually have the file, bundle ends up empty for that resource → formatMessages returns null. Whether plugin A or plugin B "wins" depends entirely on load order.

MozXULElement.insertFTLIfNeeded registers as REQUIRED, killing entire bundles. That path appends a <link rel="localization"> and Gecko's Document::LocalizationLinkAdded calls mDocumentL10n->AddResourceId(href) with ResourceType::Required — there is no optional variant for the link path. If the plugin only ships en-US, then for any other Zotero locale (e.g. de), no source provides the required resource → solver fails the entire de bundle with MissingResource → Gecko falls back to the en-US bundle for all ids in that batch, including unrelated core Zotero strings. This is what issue [jlegewie/beaver-zotero#162](https://github.com/jlegewie/beaver-zotero/issues/162) was about; switching to optional: true worked around it, which exposed bug 1.


