### PR TITLE
fix(attachments): add PMCID fallback for PubMed resolver lookup

### DIFF
--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -1239,9 +1239,10 @@ Zotero.Attachments = new function () {
 	
 	
 	this.canFindFileForItem = function (item) {
+		let pmcid = item.getField('PMCID') || item.getExtraField('PMCID');
 		return item.isRegularItem()
 			&& !item.isFeedItem
-			&& (!!item.getField('DOI') || !!item.getField('url') || !!item.getExtraField('DOI'))
+			&& (!!item.getField('DOI') || !!item.getField('url') || !!item.getExtraField('DOI') || !!pmcid)
 			&& this.FIND_AVAILABLE_FILE_TYPES.every(type => item.numFileAttachmentsWithContentType(type) == 0);
 	};
 
@@ -1275,7 +1276,12 @@ Zotero.Attachments = new function () {
 		
 		var resolvers = [];
 		var doi = item.getField('DOI') || item.getExtraField('DOI');
+		var pmcid = item.getField('PMCID') || item.getExtraField('PMCID');
 		doi = Zotero.Utilities.cleanDOI(doi);
+		if (pmcid) {
+			let matches = pmcid.match(/\bPMC\d+\b/i);
+			pmcid = matches && matches[0].toUpperCase();
+		}
 		
 		if (useDOI && doi) {
 			doi = Zotero.Utilities.cleanDOI(doi);
@@ -1298,6 +1304,13 @@ Zotero.Attachments = new function () {
 					});
 				}
 			}
+		}
+		
+		if (useOA && pmcid) {
+			resolvers.push({
+				pageURL: `https://pmc.ncbi.nlm.nih.gov/articles/${pmcid}/`,
+				accessMethod: 'oa'
+			});
 		}
 		
 		if (useOA && doi) {

--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -1276,8 +1276,8 @@ Zotero.Attachments = new function () {
 		
 		var resolvers = [];
 		var doi = item.getField('DOI') || item.getExtraField('DOI');
-		var pmcid = item.getField('PMCID');
 		doi = Zotero.Utilities.cleanDOI(doi);
+		var pmcid = item.getField('PMCID');
 		if (pmcid) {
 			let matches = pmcid.match(/\bPMC\d+\b/i);
 			pmcid = matches && matches[0].toUpperCase();

--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -1239,7 +1239,7 @@ Zotero.Attachments = new function () {
 	
 	
 	this.canFindFileForItem = function (item) {
-		let pmcid = item.getField('PMCID') || item.getExtraField('PMCID');
+		let pmcid = item.getField('PMCID');
 		return item.isRegularItem()
 			&& !item.isFeedItem
 			&& (!!item.getField('DOI') || !!item.getField('url') || !!item.getExtraField('DOI') || !!pmcid)
@@ -1276,7 +1276,7 @@ Zotero.Attachments = new function () {
 		
 		var resolvers = [];
 		var doi = item.getField('DOI') || item.getExtraField('DOI');
-		var pmcid = item.getField('PMCID') || item.getExtraField('PMCID');
+		var pmcid = item.getField('PMCID');
 		doi = Zotero.Utilities.cleanDOI(doi);
 		if (pmcid) {
 			let matches = pmcid.match(/\bPMC\d+\b/i);

--- a/chrome/content/zotero/xpcom/attachments.js
+++ b/chrome/content/zotero/xpcom/attachments.js
@@ -1239,10 +1239,9 @@ Zotero.Attachments = new function () {
 	
 	
 	this.canFindFileForItem = function (item) {
-		let pmcid = item.getField('PMCID');
 		return item.isRegularItem()
 			&& !item.isFeedItem
-			&& (!!item.getField('DOI') || !!item.getField('url') || !!item.getExtraField('DOI') || !!pmcid)
+			&& (!!item.getField('DOI') || !!item.getField('url') || !!item.getExtraField('DOI') || !!item.getField('PMCID'))
 			&& this.FIND_AVAILABLE_FILE_TYPES.every(type => item.numFileAttachmentsWithContentType(type) == 0);
 	};
 

--- a/test/tests/attachmentsTest.js
+++ b/test/tests/attachmentsTest.js
@@ -1031,6 +1031,48 @@ describe("Zotero.Attachments", function () {
 			assert.equal(await OS.File.stat(attachment.getFilePath()).size, pdfSize);
 		});
 
+		it("should include a PubMed Central resolver from a PMCID in Extra", async function () {
+			var item = createUnsavedDataObject('item', { itemType: 'journalArticle' });
+			item.setField('title', 'Test');
+			item.setField('extra', 'PMCID: PMC9262588');
+			await item.saveTx();
+
+			var resolvers = Zotero.Attachments.getFileResolvers(item, ['oa']);
+
+			assert.deepEqual(resolvers, [
+				{
+					pageURL: 'https://pmc.ncbi.nlm.nih.gov/articles/PMC9262588/',
+					accessMethod: 'oa'
+				}
+			]);
+		});
+
+		it("should include a PubMed Central resolver alongside DOI OA resolvers", async function () {
+			var item = createUnsavedDataObject('item', { itemType: 'journalArticle' });
+			item.setField('title', 'Test');
+			item.setField('DOI', '10.1093/nar/gkac173');
+			item.setField('extra', 'PMCID: PMC9262588');
+			await item.saveTx();
+
+			var resolvers = Zotero.Attachments.getFileResolvers(item, ['oa']);
+
+			assert.lengthOf(resolvers, 2);
+			assert.deepEqual(resolvers[0], {
+				pageURL: 'https://pmc.ncbi.nlm.nih.gov/articles/PMC9262588/',
+				accessMethod: 'oa'
+			});
+			assert.isFunction(resolvers[1]);
+		});
+
+		it("should allow finding files for an item with a PMCID in Extra", async function () {
+			var item = createUnsavedDataObject('item', { itemType: 'journalArticle' });
+			item.setField('title', 'Test');
+			item.setField('extra', 'PMCID: PMC9262588');
+			await item.saveTx();
+
+			assert.isTrue(Zotero.Attachments.canFindFileForItem(item));
+		});
+
 		it("should add a PDF from a URL", async function () {
 			var url = pageURL1;
 			var item = createUnsavedDataObject('item', { itemType: 'journalArticle' });

--- a/test/tests/attachmentsTest.js
+++ b/test/tests/attachmentsTest.js
@@ -1047,7 +1047,7 @@ describe("Zotero.Attachments", function () {
 			]);
 		});
 
-		it("should include a PubMed Central resolver alongside DOI OA resolvers", async function () {
+		it("should include a PubMed Central resolver before DOI OA resolvers", async function () {
 			var item = createUnsavedDataObject('item', { itemType: 'journalArticle' });
 			item.setField('title', 'Test');
 			item.setField('DOI', '10.1093/nar/gkac173');

--- a/test/tests/attachmentsTest.js
+++ b/test/tests/attachmentsTest.js
@@ -1031,10 +1031,10 @@ describe("Zotero.Attachments", function () {
 			assert.equal(await OS.File.stat(attachment.getFilePath()).size, pdfSize);
 		});
 
-		it("should include a PubMed Central resolver from a PMCID in Extra", async function () {
+		it("should include a PubMed Central resolver from a PMCID", async function () {
 			var item = createUnsavedDataObject('item', { itemType: 'journalArticle' });
 			item.setField('title', 'Test');
-			item.setField('extra', 'PMCID: PMC9262588');
+			item.setField('PMCID', 'PMC9262588');
 			await item.saveTx();
 
 			var resolvers = Zotero.Attachments.getFileResolvers(item, ['oa']);
@@ -1051,7 +1051,7 @@ describe("Zotero.Attachments", function () {
 			var item = createUnsavedDataObject('item', { itemType: 'journalArticle' });
 			item.setField('title', 'Test');
 			item.setField('DOI', '10.1093/nar/gkac173');
-			item.setField('extra', 'PMCID: PMC9262588');
+			item.setField('PMCID', 'PMC9262588');
 			await item.saveTx();
 
 			var resolvers = Zotero.Attachments.getFileResolvers(item, ['oa']);
@@ -1064,10 +1064,10 @@ describe("Zotero.Attachments", function () {
 			assert.isFunction(resolvers[1]);
 		});
 
-		it("should allow finding files for an item with a PMCID in Extra", async function () {
+		it("should allow finding files for an item with a PMCID", async function () {
 			var item = createUnsavedDataObject('item', { itemType: 'journalArticle' });
 			item.setField('title', 'Test');
-			item.setField('extra', 'PMCID: PMC9262588');
+			item.setField('PMCID', 'PMC9262588');
 			await item.saveTx();
 
 			assert.isTrue(Zotero.Attachments.canFindFileForItem(item));

--- a/test/tests/server_connectorTest.js
+++ b/test/tests/server_connectorTest.js
@@ -701,7 +701,7 @@ describe("Connector Server", function () {
 			assert.isTrue(JSON.parse(response.responseText));
 		});
 
-		it("should respond with 'true' if the item has a PMCID fallback", async function () {
+		it("should respond with 'true' if the item has a PMCID", async function () {
 			const sessionID = Zotero.Utilities.randomString();
 			const itemID = Zotero.Utilities.randomString();
 			const body = {
@@ -711,7 +711,7 @@ describe("Connector Server", function () {
 						id: itemID,
 						itemType: "journalArticle",
 						title: "Test Article with PMCID",
-						extra: "PMCID: PMC9262588",
+						PMCID: "PMC9262588",
 					}
 				]
 			};

--- a/test/tests/server_connectorTest.js
+++ b/test/tests/server_connectorTest.js
@@ -701,6 +701,52 @@ describe("Connector Server", function () {
 			assert.isTrue(JSON.parse(response.responseText));
 		});
 
+		it("should respond with 'true' if the item has a PMCID fallback", async function () {
+			const sessionID = Zotero.Utilities.randomString();
+			const itemID = Zotero.Utilities.randomString();
+			const body = {
+				sessionID,
+				items: [
+					{
+						id: itemID,
+						itemType: "journalArticle",
+						title: "Test Article with PMCID",
+						extra: "PMCID: PMC9262588",
+					}
+				]
+			};
+			
+			let response = await httpRequest(
+				"POST",
+				connectorServerPath + "/connector/saveItems", 
+				{
+					headers: {
+						"Content-Type": "application/json"
+					},
+					body: JSON.stringify(body)
+				}
+			);
+			
+			assert.equal(response.status, 201);
+			
+			response = await httpRequest(
+				"POST",
+				connectorServerPath + "/connector/hasAttachmentResolvers",
+				{
+					headers: {
+						"Content-Type": "application/json"
+					},
+					body: JSON.stringify({
+						sessionID,
+						itemID
+					}),
+				}
+			);
+			
+			assert.equal(response.status, 200);
+			assert.isTrue(JSON.parse(response.responseText));
+		});
+
 		it("should respond with 'false' if the item has no OA attachments", async function () {
 			const sessionID = Zotero.Utilities.randomString();
 			const itemID = Zotero.Utilities.randomString();


### PR DESCRIPTION
## Summary
- treat PMCID as a valid full-text lookup signal when deciding whether an item has attachment resolvers
- add a PubMed Central resolver based on the saved PMCID before DOI-based OA lookup
- cover the PMCID fallback path in attachment resolver tests and the connector resolver endpoint test

## Problem
PubMed-saved items can include a `PMCID` in `Extra` and show a `Free full text at PubMed Central` path even when DOI-based full-text lookup does not produce a PDF. The connector already passes the saved item through to the desktop resolver flow, but the resolver logic only considered DOI and URL data, so this PMC fallback was never attempted.

## Implementation Notes
The change keeps the logic in the existing desktop attachment resolver path rather than adding a PubMed-specific branch in the connector. `getFileResolvers()` now normalizes `PMCID` values and adds a PMC article resolver at `https://pmc.ncbi.nlm.nih.gov/articles/<PMCID>/`. `canFindFileForItem()` also treats `PMCID` as a valid signal so the connector fallback endpoints can surface the resolver.

## Test Plan
- `test/runtests.sh -b -f -g "should include a PubMed Central resolver from a PMCID in Extra|should include a PubMed Central resolver alongside DOI OA resolvers|should allow finding files for an item with a PMCID in Extra|should respond with .true. if the item has a PMCID fallback" attachments server_connector`

Refs #2269
