### PR TITLE
Citation dialog: display first run guidance panel when the first item is added vs on initial open

### DIFF
--- a/chrome/content/zotero/integration/citationDialog.js
+++ b/chrome/content/zotero/integration/citationDialog.js
@@ -144,18 +144,6 @@ async function onLoad() {
 		}
 	});
 
-	//
-	// Show guidance panel on the first run. Noop on subsequent runs.
-	//
-	// Use localized locator string (e.g., "p10")
-	let locatorString = Zotero.Cite.getLocatorString("page", "short").toLowerCase()
-		// Strip trailing period ("p." → "p")
-		.replace(/\.$/, '')
-		+ "10";
-	doc.querySelector("guidance-panel").show({ l10nArgs: { locator: locatorString } });
-	// Hide guidance panel on any keypress
-	doc.addEventListener("keydown", () => doc.querySelector("guidance-panel").hide(), { capture: true, once: true });
-
 	DIALOG_STATE.loaded = true;
 	let initTime = timer.stop();
 	Zotero.debug(`Citation Dialog: initialized in ${initTime} s`);
@@ -1395,6 +1383,15 @@ const IOManager = {
 		}
 
 		this.updateBubbleInput();
+
+		// Show guidance panel on the first run
+		if (DIALOG_STATE.isCitingItems() && !Zotero.Prefs.get("firstRunGuidanceShown.citationDialog")) {
+			doc.querySelector(".bubble").id = "first-bubble";
+			// Center the panel on the first bubble
+			let width = doc.querySelector(".bubble").getBoundingClientRect().width;
+			doc.querySelector("guidance-panel").setAttribute("x", Math.round(width / 2));
+			IOManager.showFirstRunDialog();
+		}
 		// Always refresh items list to make sure the opened and selected items are up to date
 		await currentLayout.refreshItemsList();
 		if (!noInputRefocus) {
@@ -1580,6 +1577,17 @@ const IOManager = {
 			desiredMode = "library";
 		}
 		return desiredMode;
+	},
+
+	showFirstRunDialog() {
+		let locatorString = Zotero.Cite.getLocatorString("page", "short").toLowerCase()
+			// Strip trailing period ("p." → "p")
+			.replace(/\.$/, '')
+			+ "10";
+		// Use localized locator string (e.g., "p10")
+		doc.querySelector("guidance-panel").show({ l10nArgs: { locator: locatorString } });
+		// Hide guidance panel on any keypress
+		doc.addEventListener("keydown", () => doc.querySelector("guidance-panel").hide(), { capture: true, once: true });
 	},
 	
 	// handle drag start of item nodes into bubble-input

--- a/chrome/content/zotero/integration/citationDialog.xhtml
+++ b/chrome/content/zotero/integration/citationDialog.xhtml
@@ -183,7 +183,7 @@
 					</div>
 				</div>
 			</xul:panel>
-			<xul:guidance-panel about="citationDialog" for="z-icon-container" x="5"/>
+			<xul:guidance-panel about="citationDialog" for="first-bubble"/>
 		</div>
 	</body>
 </html>

--- a/chrome/locale/en-US/zotero/integration.ftl
+++ b/chrome/locale/en-US/zotero/integration.ftl
@@ -133,9 +133,7 @@ integration-warning-discard-changes = Discard Changes
 
 integration-warning-command-is-running = A word processor integration command is already running.
 
-first-run-guidance-citationDialog = Type a title, author, and/or year to search for a reference.
-    
-    After you’ve made your selection, click the bubble or select it via the keyboard and press ↓/Space to show citation options such as page number, prefix, and suffix.
+first-run-guidance-citationDialog = Click the bubble or select it via the ← key and press ↓/Space to customize citation options such as page number, prefix, and suffix.
     
     You can also add a page number or other locator by including it with your search terms (e.g., “history { $locator }”) or by typing it after the bubble and pressing { return-or-enter }.
 

--- a/chrome/locale/en-US/zotero/integration.ftl
+++ b/chrome/locale/en-US/zotero/integration.ftl
@@ -133,7 +133,7 @@ integration-warning-discard-changes = Discard Changes
 
 integration-warning-command-is-running = A word processor integration command is already running.
 
-first-run-guidance-citationDialog = Click the bubble or select it via the ← key and press ↓/Space to customize citation options such as page number, prefix, and suffix.
+first-run-guidance-citationDialog = Click the bubble or use the ← and ↓ keys to view the citation details and customize options such as page number, prefix, and suffix.
     
     You can also add a page number or other locator by including it with your search terms (e.g., “history { $locator }”) or by typing it after the bubble and pressing { return-or-enter }.
 


### PR DESCRIPTION
And update the message in the guidance panel to skip instructions on how to search for items, since this panel likely appears after the item was searched for. Besides, the placeholder in the `bubble-input` also conveys that it is the search field.

https://github.com/user-attachments/assets/5111c9aa-3f5e-4a02-a620-57681e0f774a

