### PR TITLE
Fix Zotero.log() script error initialization

### DIFF
--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -1311,8 +1311,16 @@ const { CommandLineOptions } = ChromeUtils.importESModule("chrome://zotero/conte
 	/*
 	 * Log a message to the Mozilla JS error console
 	 *
-	 * |type| is a string with one of the flag types in nsIScriptError:
-	 *    'error', 'warning', 'exception', 'strict'
+	 * |type| is a string matching one of the flag constants on nsIScriptError.
+	 * As of Firefox 140 ESR only three are defined:
+	 *    'error'   -> errorFlag   (0x0, default)
+	 *    'warning' -> warningFlag (0x1)
+	 *    'info'    -> infoFlag    (0x8)
+	 * The legacy 'exception' and 'strict' values have been removed upstream;
+	 * passing them yields an undefined flag and silently falls back to errorFlag.
+	 *
+	 * |sourceLine| is no longer accepted by nsIScriptError.init(), but is kept
+	 * in the signature for compatibility with older Zotero.log() callers.
 	 */
 	this.log = function (message, type, sourceName, sourceLine, lineNumber, columnNumber) {
 		var scriptError = Components.classes["@mozilla.org/scripterror;1"]
@@ -1326,7 +1334,6 @@ const { CommandLineOptions } = ChromeUtils.importESModule("chrome://zotero/conte
 		scriptError.init(
 			message,
 			sourceName ? sourceName : null,
-			sourceLine != undefined ? sourceLine : null,
 			lineNumber != undefined ? lineNumber : null, 
 			columnNumber != undefined ? columnNumber : null,
 			flags,


### PR DESCRIPTION
## Summary
- Fix `Zotero.log()` to initialize `nsIScriptError` with the Firefox 140 ESR argument order.
- Stop passing the removed `sourceLine` argument into `nsIScriptError.init()`, while keeping `sourceLine` in `Zotero.log()`'s public signature for older callers.
- Update the nearby comment to document the currently supported `nsIScriptError` severity flags.

## Issues fixed
`Zotero.log()` was still using the older `nsIScriptError.init()` call shape that included `sourceLine`. In Firefox 140 ESR, `sourceLine` has been removed from `init()`, so every argument after `sourceName` was shifted by one slot.

That caused several runtime problems:

- `flags` was initialized from `columnNumber`, so calls without a column number passed `null` as the severity flag. Since `errorFlag` is `0x0`, `info` and `warning` message are initialized as default error-level script messages.
- `category` received the numeric severity flag instead of `"system javascript"`.
- `fromPrivateWindow` and `fromChromeContext` were also shifted, so the message metadata did not match the intended chrome-system context.

The comment also still listed historical `exception` and `strict` log types, but Firefox 140 ESR exposes only `errorFlag`, `warningFlag`, and `infoFlag` on `nsIScriptError`.

## Validation
Validated against Firefox ESR 140 `dom/bindings/nsIScriptError.idl`, where the available flags are:

```idl
const unsigned long errorFlag = 0x0;
const unsigned long warningFlag = 0x1;
const unsigned long infoFlag = 0x8;
```

and the current `init()` signature is:

```idl
void init(in AString message,
          in ACString sourceName,
          in uint32_t lineNumber,
          in uint32_t columnNumber,
          in uint32_t flags,
          in ACString category,
          [optional] in boolean fromPrivateWindow,
          [optional] in boolean fromChromeContext);
```

Source: https://raw.githubusercontent.com/mozilla-firefox/firefox/esr140/dom/bindings/nsIScriptError.idl

## Testing
- Local build on macOS confirming that the Zotero.log output in browser console with expected category including: 

```
Zotero.log("Hello from zotero log info", "info")
Zotero.log("Hello from zotero log error", "error")
Zotero.log("Hello from zotero log warning", "warning")
```