### PR TITLE
Fix release build on x86 mac

### DIFF
--- a/app/mac/set-channel-prefs-channel
+++ b/app/mac/set-channel-prefs-channel
@@ -19,7 +19,8 @@ binary=$1
 from_channel=$2
 to_channel=$3
 # `strings` has a 4-character minimum by default, but we need 3 for 'dev'
-strings_cmd="strings -n 3"
+# `-arch all` is needed so builds on x86 mac also find the two positions of `source`
+strings_cmd="strings -n 3 -arch all"
 
 if [ ${#to_channel} -gt 7 ]; then
 	echo "Channel length cannot exceed 7 characters -- aborting" >&2

--- a/app/mac/set-channel-prefs-channel
+++ b/app/mac/set-channel-prefs-channel
@@ -19,7 +19,7 @@ binary=$1
 from_channel=$2
 to_channel=$3
 # `strings` has a 4-character minimum by default, but we need 3 for 'dev'
-# `-arch all` is needed so builds on x86 mac also find the two positions of `source`
+# `-arch all` scans all slices of the universal binary rather than just the host architecture
 strings_cmd="strings -n 3 -arch all"
 
 if [ ${#to_channel} -gt 7 ]; then


### PR DESCRIPTION
While trying to [fix](https://github.com/NixOS/nixpkgs/pull/519431) another issue in the Zotero package for nixpkgs, I discovered a new bug. When setting a non-`source` update channel, the build fails on MacOS with x86 architectures.

The build fails with:
```
source not found twice in ChannelPrefs

source

stringWithCString:encoding:
```
Which definitely means it is caused by the `strings` command [here](https://github.com/zotero/zotero/blob/main/app/mac/set-channel-prefs-channel#L29).

When manually executing the strings command on the file, I can repeat getting only one `source` result on x86 mac, while getting two on arm64 or linux. After digging around, I tried with the flag `-arch all`, and both `source` values are found on x86 mac. Full command: `strings -n 3 -arch all $binary`.

Not sure if you can safely add this flag to the strings command, but it definitely fixes it for me on MacOS 26.4.1.