### PR TITLE
Fix US-formatted Last Read dates in en-* alias locales

### DIFF
--- a/chrome/content/zotero/dateOverrides.js
+++ b/chrome/content/zotero/dateOverrides.js
@@ -1,5 +1,9 @@
 /* eslint-disable no-extend-native */
 
+// Patches Date.prototype.toLocale*String in whichever global this script is
+// loaded into, so that date formatting follows the app locale when no
+// explicit locale is passed
+
 let originalToLocaleString = Date.prototype.toLocaleString;
 Date.prototype.toLocaleString = function (locales, options) {
 	if (locales === undefined || (Array.isArray(locales) && !locales.length)) {

--- a/chrome/content/zotero/zotero.mjs
+++ b/chrome/content/zotero/zotero.mjs
@@ -230,8 +230,25 @@ function makeZoteroContext() {
 		zContext = new ZoteroContext();
 		zContext.Zotero = function () {};
 
-		// Override Date prototype to follow Zotero configured locale #3880
-		subscriptLoader.loadSubScript("chrome://zotero/content/dateOverrides.js");
+		// Override Date prototype to follow Zotero configured locale (#3880).
+		// Patch this module scope, every open chrome window, and each chrome
+		// window opened in the future. Each require loader sandbox is patched
+		// separately in require.js.
+		let dateOverridesURL = "chrome://zotero/content/dateOverrides.js";
+		subscriptLoader.loadSubScript(dateOverridesURL);
+		for (let win of Services.wm.getEnumerator(null)) {
+			subscriptLoader.loadSubScript(dateOverridesURL, win);
+		}
+		Services.ww.registerNotification({
+			observe(subject, topic) {
+				if (topic !== 'domwindowopened') {
+					return;
+				}
+				subject.addEventListener('load', () => {
+					subscriptLoader.loadSubScript(dateOverridesURL, subject);
+				}, { once: true });
+			}
+		});
 	}
 	
 	// Load zotero.js first

--- a/resource/require.js
+++ b/resource/require.js
@@ -144,6 +144,15 @@ function ZoteroLoader({
 		}
 	})
 
+	// If we're using a new sandbox, patch Date#toLocale*String() there to
+	// follow the app locale
+	if (!sharedGlobal) {
+		Services.scriptloader.loadSubScript(
+			'chrome://zotero/content/dateOverrides.js',
+			this.loader.sharedGlobal
+		);
+	}
+
 	// Fetch custom pseudo modules and globals
 	const { modules, globals } = {
 		// TODO: TEMP: Stub this out


### PR DESCRIPTION
By applying `dateOverrides.js` to all windows and `require.js` globals.

This issue didn't affect Date Modified etc. because they use `Zotero.Date.sqlToDate()`, which returns a Date object from the global scope, where `toLocale[Date]String()`was already being patched. Now we patch it in all scopes.

Addresses #5933, but `navigator.language` is actually still incorrect - correcting that seems to require turning `en-CA`, `en-AU`, and `en-NZ` into real locales instead of aliases - so that issue isn't fully fixed.

I would love to find a cleaner, more comprehensive fix for this. Firefox uses `toLocaleString()` without passing a locale parameter and it apparently works fine for them, so I assume the issue is caused by something we're doing, but I just can't find it. This PR addresses the symptoms for now.