### PR TITLE
Journal Abbreviation for Atmospheric as Atmos.

### DIFF
--- a/resource/schema/abbreviations.json
+++ b/resource/schema/abbreviations.json
@@ -4879,6 +4879,7 @@
 			"atmosferostojkost-": "atmosferostojk.",
 			"atmosfær-": "atmos.",
 			"atmosphaer-": "Atmos.",
+			"atmospher-": "atmos.",
 			"atmosphér-": "atmos.",
 			"atmung": "Atm.",
 			"atom": "At.",


### PR DESCRIPTION
example: 
"Atmospheric Chemistry and Physics" is currently incorrectly abbreviated as "Atmospheric Chem. Phys." should be abbreviated "Atmos. Chem. Phys."