### PR TITLE
Restore -default suffix on item tree column-prefs keys

### DIFF
--- a/chrome/content/zotero/collectionViewItemTree.jsx
+++ b/chrome/content/zotero/collectionViewItemTree.jsx
@@ -124,10 +124,7 @@ class CollectionViewItemTreeRowProvider extends ItemTreeRowProvider {
 
 		// Set ID based on visibilityGroup
 		const visibilityGroup = collectionTreeRow.visibilityGroup || 'default';
-		let treeID = "item-tree-" + this.itemTree.props.id;
-		if (visibilityGroup != 'default') {
-			treeID += "-" + visibilityGroup;
-		}
+		let treeID = "item-tree-" + this.itemTree.props.id + "-" + visibilityGroup;
 		// Needs to be called after this.collectionTreeRow is set so that this.itemTree.visibilityGroup is correct
 		let idChanged = await this.itemTree.setId(treeID);
 		

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -42,6 +42,49 @@ const { ZOTERO_CONFIG } = ChromeUtils.importESModule('resource://zotero/config.m
 const CHILD_INDENT = 16;
 const COLUMN_PREFS_FILEPATH = OS.Path.join(Zotero.Profile.dir, "treePrefs.json");
 
+// Migrate unsuffixed `<id>` keys back to `<id>-default`. Earlier 10.0 betas dropped the `-default`
+// suffix from main-library tree IDs, stranding 9.0.x prefs and breaking version switching.
+// Restoring the suffix lets both versions share state.
+let _treePrefsMigrationPromise = null;
+function _migrateTreePrefsFile() {
+	if (!_treePrefsMigrationPromise) {
+		_treePrefsMigrationPromise = (async () => {
+			let persistSettings;
+			try {
+				let contents = await Zotero.File.getContentsAsync(COLUMN_PREFS_FILEPATH);
+				persistSettings = JSON.parse(contents);
+			}
+			catch {
+				return;
+			}
+			if (!persistSettings || typeof persistSettings !== 'object') return;
+			let knownSuffixes = [
+				'-default',
+				...Object.values(Zotero.CollectionTreeRow.visibilityGroups).map(g => '-' + g),
+			];
+			let changed = false;
+			for (let key of Object.keys(persistSettings)) {
+				if (knownSuffixes.some(s => key.endsWith(s))) continue;
+				let newKey = key + '-default';
+				let value = persistSettings[key];
+				// Prefer the unsuffixed (beta-era) data when non-empty, since
+				// it's newer than anything left at `-default` from 9.0.x.
+				if (!(newKey in persistSettings) || (value && Object.keys(value).length)) {
+					persistSettings[newKey] = value;
+				}
+				delete persistSettings[key];
+				changed = true;
+			}
+			if (changed) {
+				await Zotero.File.putContentsAsync(
+					COLUMN_PREFS_FILEPATH, JSON.stringify(persistSettings)
+				);
+			}
+		})();
+	}
+	return _treePrefsMigrationPromise;
+}
+
 /**
  * Base row data provider for ItemTree.
  *
@@ -2394,18 +2437,11 @@ var ItemTree = class ItemTree extends LibraryTree {
 	
 	_loadColumnPrefsFromFile = async () => {
 		if (!this.props.columnPicker) return;
+		await _migrateTreePrefsFile();
 		try {
 			let columnPrefs = await Zotero.File.getContentsAsync(COLUMN_PREFS_FILEPATH);
 			let persistSettings = JSON.parse(columnPrefs);
-			// Fall back to the pre-item-tree-refactor "<id>-default" key,
-			// including when "<id>" is an empty object written out by an
-			// earlier post-refactor beta before this fallback was added.
-			// _writeColumnPrefsToFile() removes it on the next write.
-			let prefs = persistSettings[this.id];
-			if (!prefs || !Object.keys(prefs).length) {
-				prefs = persistSettings[this.id + '-default'];
-			}
-			this._columnPrefs = prefs || {};
+			this._columnPrefs = persistSettings[this.id] || {};
 		}
 		catch (e) {
 			this._columnPrefs = {};
@@ -2420,6 +2456,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 	 */
 	_writeColumnPrefsToFile = async (force=false) => {
 		if (!this.props.columnPicker) return;
+		await _migrateTreePrefsFile();
 		var writeToFile = async () => {
 			try {
 				let persistSettingsString = await Zotero.File.getContentsAsync(COLUMN_PREFS_FILEPATH);
@@ -2429,7 +2466,6 @@ var ItemTree = class ItemTree extends LibraryTree {
 				persistSettings = {};
 			}
 			persistSettings[this.id] = this._columnPrefs;
-			delete persistSettings[this.id + '-default'];
 
 			let prefString = JSON.stringify(persistSettings);
 			Zotero.debug(`Writing column prefs of length ${prefString.length} to file ${COLUMN_PREFS_FILEPATH}`);

--- a/chrome/content/zotero/lookup.js
+++ b/chrome/content/zotero/lookup.js
@@ -147,7 +147,7 @@ var Zotero_Lookup = new function () {
 			// Send the focus to the item tree after the popup closes
 			ZoteroPane.lastFocusedElement = null;
 			document.getElementById("zotero-lookup-panel").hidePopup();
-			document.getElementById("item-tree-main").focus();
+			document.getElementById("item-tree-main-default").focus();
 		}
 		return false;
 	};

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -438,7 +438,7 @@ var ZoteroPane = new function () {
 
 		itemTree.addEventListener("keydown", (event) => {
 			let actionsMap = {
-				'item-tree-main': {
+				'item-tree-main-default': {
 					ShiftTab: () => document.getElementById('zotero-tb-toggle-item-pane-stacked')
 				}
 			};
@@ -1066,7 +1066,7 @@ var ZoteroPane = new function () {
 			else {
 				enableHighlight = !event.shiftKey && !event.metaKey && event.key == "Control" && !event.altKey;
 			}
-			let isItemTreeFocused = document.activeElement.id == "item-tree-main";
+			let isItemTreeFocused = document.activeElement.id == "item-tree-main-default";
 			// Only highlight collections when itemTree is focused to try to avoid
 			// conflicts with other shortcuts
 			if (enableHighlight && isItemTreeFocused) {

--- a/test/tests/citationDialogTest.js
+++ b/test/tests/citationDialogTest.js
@@ -863,7 +863,7 @@ describe("Citation Dialog", function () {
 			await Zotero.Promise.delay();
 			// Expect that itemTree row is selected and itemTree is focused
 			assert.equal(dialog.libraryLayout.itemsView.getSelectedItems(true)[0], parentItem.id);
-			assert.equal(dialog.document.activeElement.id, "item-tree-citationDialog");
+			assert.equal(dialog.document.activeElement.id, "item-tree-citationDialog-default");
 		});
 
 		it("should display selected items and selected annotations in separate decks", async function () {

--- a/test/tests/zoteroPaneTest.js
+++ b/test/tests/zoteroPaneTest.js
@@ -23,9 +23,9 @@ describe("ZoteroPane", function () {
 			await selectLibrary(win);
 			await zp.itemsView.selectItem(item.id);
 			
-			var itemTree = doc.getElementById("item-tree-main");
+			var itemTree = doc.getElementById("item-tree-main-default");
 			itemTree.focus();
-			assert.equal(doc.activeElement.id, "item-tree-main");
+			assert.equal(doc.activeElement.id, "item-tree-main-default");
 			
 			var key = Zotero.isMac ? "Alt" : "Control";
 			itemTree.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));


### PR DESCRIPTION
The earlier fix (ef7896ab5f) migrated 9.0.x's `<id>-default` prefs forward to the refactor's new `<id>` key, but that left 9.0.x and 10 beta keying differently in treePrefs.json, so switching between versions always reset 9.0.x to defaults.

Put the `-default` suffix back so both versions read and write the same key, and migrate any unsuffixed `<id>` data written by an earlier beta back to `<id>-default` on first load. The migration runs once per process and can be removed in a future release once beta users have all updated.

https://forums.zotero.org/discussion/131653/zotero-10-beta-5-reinitializes-the-columns-in-main-pane