### PR TITLE
Add GET /api/reader/openItems endpoint to local API

### DIFF
--- a/chrome/content/zotero/xpcom/server/server_localAPI.js
+++ b/chrome/content/zotero/xpcom/server/server_localAPI.js
@@ -883,6 +883,43 @@ Zotero.Server.Endpoints["/api/groups/:groupID/tags/:tag"] = Zotero.Server.LocalA
 
 
 /**
+ * Returns the top-level items whose attachments are currently open in the reader,
+ * deduplicated by parent item. Used by external tools (e.g. editor plugins) to
+ * cite papers the user is actively reading without requiring clipboard interaction.
+ */
+Zotero.Server.LocalAPI.OpenReaderItems = class extends LocalAPIEndpoint {
+	supportedMethods = ['GET'];
+
+	run(_) {
+		let seen = new Set();
+		let items = [];
+
+		for (let reader of Zotero.Reader._readers) {
+			let attachment = Zotero.Items.get(reader.itemID);
+			if (!attachment) continue;
+
+			let parentID = attachment.parentID;
+			if (!parentID || seen.has(parentID)) continue;
+			seen.add(parentID);
+
+			let parent = Zotero.Items.get(parentID);
+			if (!parent) continue;
+
+			items.push({
+				key: parent.key,
+				title: parent.getField('title') || '',
+				date: parent.getField('date') || '',
+				creators: parent.getCreatorsJSON(),
+			});
+		}
+
+		return [200, 'application/json', JSON.stringify(items, null, 4)];
+	}
+};
+Zotero.Server.Endpoints["/api/reader/openItems"] = Zotero.Server.LocalAPI.OpenReaderItems;
+
+
+/**
  * Convert a {@link Zotero.DataObject}, or an array of DataObjects, to response JSON
  * 		with appropriate included data based on the 'include' query parameter.
  *


### PR DESCRIPTION
Returns the top-level items currently open in the PDF reader, deduplicated by parent item. Each entry
includes key, title, date, and creators in the same format as other local API endpoints.

This enables external tools (e.g. editor plugins) to present a picker of papers the user is actively reading and insert a citation without any clipboard or GUI interaction.

Note: The implementation accesses Zotero.Reader._readers directly. Happy to add a public accessor to
reader.js if preferred.