### PR TITLE
Add by Identifier: Stay open with input, don't clear unless submitted

### DIFF
--- a/chrome/content/zotero/lookup.js
+++ b/chrome/content/zotero/lookup.js
@@ -150,6 +150,10 @@ var Zotero_Lookup = new function () {
 			// The item tree's DOM id has a view-specific suffix, so use the current view's id
 			document.getElementById(ZoteroPane.itemsView.id).focus();
 		}
+		else {
+			// Hide on failure too
+			document.getElementById("zotero-lookup-panel").hidePopup();
+		}
 		return false;
 	};
 
@@ -164,6 +168,11 @@ var Zotero_Lookup = new function () {
 	};
 	
 	this.onFocusOut = function (event) {
+		// Ignore focus loss caused by the window being deactivated
+		if (Services.focus.activeWindow !== window) {
+			return;
+		}
+
 		// If the lookup popup was triggered by the lookup button,
 		// we want to return there on focus out. So we check
 		// (1) that we came from a button and (2) that
@@ -183,14 +192,51 @@ var Zotero_Lookup = new function () {
 	};
 	
 	
-	/**
-	 * Focuses the field
-	 */
 	this.onShown = function (event) {
 		// Ignore context menu
 		if (event.originalTarget.id != 'zotero-lookup-panel') return;
 		
+		// Focus the field
 		this.getActivePanel().querySelector('textarea').focus();
+
+		// Add handlers to dismiss the popup when contextually appropriate.
+		// We set noautohide="true" so the popup doesn't lose input when
+		// switching windows (e.g., so you can build a long list of identifiers
+		// copied from another app), but that means we need to manually handle
+		// closing on click outside (_onMouseDown) and closing on a window
+		// switch when there's no content (_onBlur)
+		window.addEventListener('mousedown', this._onMouseDown, { capture: true });
+		document.getElementById('zotero-lookup-panel').addEventListener('blur', this._onBlur, { capture: true });
+	};
+
+
+	/**
+	 * Hide on a click outside the panel
+	 */
+	this._onMouseDown = (event) => {
+		// Ignore clicks inside the panel or any popup (e.g. its context menu);
+		// only a click outside dismisses it
+		if (event.target.closest("panel, menupopup")) {
+			return;
+		}
+		document.getElementById("zotero-lookup-panel").hidePopup();
+		// Prevent the toolbar button's own handlers from triggering, so the
+		// popup doesn't immediately reopen
+		if (document.getElementById("zotero-tb-lookup").contains(event.target)) {
+			event.preventDefault();
+			event.stopPropagation();
+		}
+	};
+
+
+	this._onBlur = () => {
+		if (Services.focus.activeWindow === window) {
+			return;
+		}
+		let textBox = document.getElementById('zotero-lookup-textbox');
+		if (textBox.value.trim() === '') {
+			document.getElementById('zotero-lookup-panel').hidePopup();
+		}
 	};
 	
 	
@@ -201,6 +247,9 @@ var Zotero_Lookup = new function () {
 		// Ignore context menu
 		if (event.originalTarget.id != 'zotero-lookup-panel') return;
 		
+		window.removeEventListener('mousedown', this._onMouseDown, { capture: true });
+		document.getElementById('zotero-lookup-panel').removeEventListener('blur', this._onBlur, { capture: true });
+
 		document.getElementById("zotero-lookup-textbox").value = "";
 		Zotero_Lookup.setShowProgress(false);
 		

--- a/chrome/content/zotero/lookup.js
+++ b/chrome/content/zotero/lookup.js
@@ -28,6 +28,9 @@
  * @namespace
  */
 var Zotero_Lookup = new function () {
+	this._button = null;
+	this._accepted = false;
+
 	/**
 	 * Performs a lookup by DOI, PMID, or ISBN on the given textBox value
 	 * and adds any items it can.
@@ -41,7 +44,6 @@ var Zotero_Lookup = new function () {
 	 * @param toggleProgress {function} - Callback to toggle progress on/off
 	 * @returns {Promise<Zotero.Item[]>}
 	 */
-	this._button = null;
 	this.addItemsFromIdentifier = async function (textBox, childItem, toggleProgress) {
 		var identifiers = Zotero.Utilities.extractIdentifiers(textBox.value);
 		if (!identifiers.length) {
@@ -137,6 +139,8 @@ var Zotero_Lookup = new function () {
 	 * Try a lookup and hide popup if successful
 	 */
 	this.accept = async function (textBox) {
+		this._accepted = true;
+		
 		let newItems = await Zotero_Lookup.addItemsFromIdentifier(
 			textBox,
 			false,
@@ -195,6 +199,8 @@ var Zotero_Lookup = new function () {
 	this.onShown = function (event) {
 		// Ignore context menu
 		if (event.originalTarget.id != 'zotero-lookup-panel') return;
+
+		this._accepted = false;
 		
 		// Focus the field
 		this.getActivePanel().querySelector('textarea').focus();
@@ -250,7 +256,9 @@ var Zotero_Lookup = new function () {
 		window.removeEventListener('mousedown', this._onMouseDown, { capture: true });
 		document.getElementById('zotero-lookup-panel').removeEventListener('blur', this._onBlur, { capture: true });
 
-		document.getElementById("zotero-lookup-textbox").value = "";
+		if (this._accepted) {
+			document.getElementById("zotero-lookup-textbox").value = "";
+		}
 		Zotero_Lookup.setShowProgress(false);
 		
 		// Revert to single-line when closing

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -1278,6 +1278,7 @@
 												/>
 												
 												<panel id="zotero-lookup-panel" type="arrow" animate="false"
+														noautohide="true"
 														onpopupshown="Zotero_Lookup.onShown(event)"
 														onpopuphidden="Zotero_Lookup.onHidden(event)"
 														onfocusout="Zotero_Lookup.onFocusOut(event)"


### PR DESCRIPTION
- Always close on click outside or Escape
- When the window is deactivated, only close if there's no input in the box
- Don't clear input when closing unless the user submitted (pressed Enter)

I think this is less frustrating than the current behavior, which feels non-obvious to new users (and might cause them to lose work once or twice before they learn that Add by Identifier can't be relied on to stay open or remember input). And it makes it so lists of identifiers can be built within Zotero, instead of needing to build them in a text editor and paste them in.

https://forums.zotero.org/discussion/comment/513918/#Comment_513918