### PR TITLE
Fix connector save-session garbage collection (sessions never freed)

### DIFF
--- a/chrome/content/zotero/xpcom/server/saveSession.js
+++ b/chrome/content/zotero/xpcom/server/saveSession.js
@@ -49,9 +49,9 @@ Zotero.Server.Connector.SessionManager = {
 		var ttl = this._sessions.size >= 10 ? 60 : 600;
 		var deleteBefore = new Date() - ttl * 1000;
 
-		for (let session of this._sessions) {
+		for (let [id, session] of this._sessions) {
 			if (session.created < deleteBefore) {
-				this._session.delete(session.id);
+				this._sessions.delete(id);
 			}
 		}
 	}
@@ -147,7 +147,7 @@ Zotero.Server.Connector.SaveSession = class {
 	}
 
 	remove() {
-		delete Zotero.Server.Connector.SessionManager._sessions[this.id];
+		Zotero.Server.Connector.SessionManager._sessions.delete(this.id);
 	}
 
 	/**

--- a/chrome/content/zotero/xpcom/server/server.js
+++ b/chrome/content/zotero/xpcom/server/server.js
@@ -502,7 +502,7 @@ Zotero.Server.RequestHandler.prototype._processEndpoint = async function (method
 		}
 	} catch(e) {
 		Zotero.debug(e);
-		this._requestFinished(this._generateResponse(500), "text/plain", "An error occurred\n");
+		this._requestFinished(this._generateResponse(500, "text/plain", "An error occurred\n"));
 		throw e;
 	}
 };

--- a/test/tests/server_connectorTest.js
+++ b/test/tests/server_connectorTest.js
@@ -93,6 +93,41 @@ describe("Connector Server", function () {
 		});
 	});
 
+	describe("SaveSession.SessionManager", function () {
+		var SessionManager = Zotero.Server.Connector.SessionManager;
+
+		it("should expire sessions older than the TTL when gc() runs", function () {
+			var id = "gcOld_" + Zotero.Utilities.randomString();
+			var session = SessionManager.create(id, 'saveItems', {});
+			// Backdate creation beyond the 10-minute TTL
+			session.created = new Date(Date.now() - 11 * 60 * 1000);
+
+			SessionManager.gc();
+
+			assert.isUndefined(SessionManager.get(id), "stale session should be removed by gc()");
+		});
+
+		it("should keep sessions newer than the TTL when gc() runs", function () {
+			var id = "gcNew_" + Zotero.Utilities.randomString();
+			var session = SessionManager.create(id, 'saveItems', {});
+
+			SessionManager.gc();
+
+			assert.strictEqual(SessionManager.get(id), session, "fresh session should survive gc()");
+			session.remove();
+		});
+
+		it("should remove a session via SaveSession#remove()", function () {
+			var id = "remove_" + Zotero.Utilities.randomString();
+			var session = SessionManager.create(id, 'saveItems', {});
+			assert.strictEqual(SessionManager.get(id), session);
+
+			session.remove();
+
+			assert.isUndefined(SessionManager.get(id), "remove() should delete the session from the manager");
+		});
+	});
+
 	describe('/connector/getTranslatorCode', function () {
 		it('should respond with translator code', async function () {
 			var code = 'function detectWeb() {}\nfunction doImport() {}';


### PR DESCRIPTION
We built a custom client that hooks into the connector HTTP API (not the official browser connector). When it reused session IDs, we got unexpected SESSION_EXISTS errors (409) from /connector/saveItems. Old sessions were supposed to be expired by SessionManager.gc() after their TTL, but they never were, so previously-used IDs lingered indefinitely and collided.

Root cause
SessionManager.gc() in chrome/content/zotero/xpcom/server/saveSession.js never frees anything, due to two compounding bugs:
- It iterates the _sessions Map with for (let session of this._sessions). Map iteration yields [id, session] entry pairs, so session.created and session.id are always undefined and the age comparison never matches.
- The delete in the body references this._session (singular) instead of this._sessions, so even if the condition matched it would throw rather than delete.

There's a related issue in SaveSession.remove(), which does delete Zotero.Server.Connector.SessionManager._sessions[this.id] — but _sessions is a Map, and the delete operator is a no-op on Maps, so explicit removal also fails silently.

Net effect: connector save-sessions accumulate for the lifetime of the Zotero process and their IDs are never released, surfacing as the spurious SESSION_EXISTS errors above.

Also fixed
While in the surrounding server code I noticed a likely-unrelated typo in server.js _processEndpoint's error handler — a misplaced parenthesis passes the content type and body to _requestFinished() instead of _generateResponse(), so the 500 error response is sent without its body. Happy to split this into its own PR if preferred.

Tests
Added a SaveSession.SessionManager block to test/tests/server_connectorTest.js covering the three previously-broken behaviors (gc expiring stale sessions, gc retaining fresh ones, and remove() deleting a session). There was previously no coverage of gc(), which is why this went unnoticed. Each case fails on the original code and passes with the fix.

Changes
- saveSession.js: correct Map iteration/deletion in gc(); fix remove() to use Map.delete().
- server.js: move the closing paren so _generateResponse(500, "text/plain", "An error occurred\n") is built correctly.
- test/tests/server_connectorTest.js: regression tests.