### PR TITLE
Fix keyboard navigation through advanced search buttons and deck

### DIFF
--- a/chrome/content/zotero/elements/quickSearchTextbox.js
+++ b/chrome/content/zotero/elements/quickSearchTextbox.js
@@ -124,7 +124,12 @@
 			});
 			this.querySelector('.advanced-close-button').addEventListener('command', (event) => {
 				event.stopPropagation();
+				// if activated via the keyboard, move focus to the Advanced Search button
+				let triggeredByKeyboard = [MouseEvent.MOZ_SOURCE_KEYBOARD, MouseEvent.MOZ_SOURCE_UNKNOWN].includes(event.inputSource);
 				ZoteroPane.toggleAdvancedSearchState('closed');
+				if (triggeredByKeyboard) {
+					this.querySelector('#zotero-tb-search-advanced-button').focus();
+				}
 			});
 			
 			// If Alt-Up/Down, show popup

--- a/chrome/content/zotero/elements/quickSearchTextbox.js
+++ b/chrome/content/zotero/elements/quickSearchTextbox.js
@@ -39,7 +39,7 @@
 					<hbox id="advanced-search-indicator">
 						<label id="advanced-search-label"/>
 						<toolbarbutton class="zotero-clicky advanced-collapse-button" tabindex="0"/>
-						<toolbarbutton class="zotero-clicky advanced-close-button" tabindex="0"/>
+						<toolbarbutton class="zotero-clicky advanced-close-button" data-l10n-id="advanced-search-close" tabindex="0"/>
 					</hbox>
 				</deck>
 			`, ['chrome://zotero/locale/zotero.dtd']);
@@ -200,6 +200,10 @@
 				this.deck.selectedIndex = state === 'closed' ? 0 : 1;
 				this.querySelector('#advanced-search-indicator').dataset.collapsed = state === 'collapsed';
 				this.querySelector('.advanced-collapse-button').hidden = selectedSearchType === 'saved';
+				document.l10n.setAttributes(
+					this.querySelector('.advanced-collapse-button'),
+					state === 'collapsed' ? 'advanced-search-expand' : 'advanced-search-collapse'
+				);
 			}
 		}
 		

--- a/chrome/content/zotero/elements/quickSearchTextbox.js
+++ b/chrome/content/zotero/elements/quickSearchTextbox.js
@@ -106,7 +106,7 @@
 			if (document.documentElement.getAttribute('windowtype') === 'navigator:browser') {
 				let advancedButton = document.createXULElement('toolbarbutton');
 				advancedButton.id = 'zotero-tb-search-advanced-button';
-				advancedButton.tabIndex = 0;
+				advancedButton.tabIndex = -1;
 				document.l10n.setAttributes(advancedButton, 'quicksearch-advanced-search-button');
 				advancedButton.addEventListener('command', (event) => {
 					// Don't trigger a quick search via the oncommand handler

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -446,9 +446,9 @@ var ZoteroPane = new function () {
 				// The item tree's DOM id has a view-specific suffix, so key on the current view's id
 				[ZoteroPane.itemsView?.id]: {
 					ShiftTab: () => {
-						// Focus last element in Advanced Search deck
 						let advancedSearchDeck = document.getElementById('zotero-advanced-search-pane-deck');
-						if (advancedSearchDeck && !advancedSearchDeck.hidden) {
+						// Advanced Search open - focus the last focusable element of the deck
+						if (advancedSearchDeck?.state === 'open') {
 							Services.focus.moveFocus(
 								window,
 								document.getElementById('zotero-items-pane'),
@@ -456,6 +456,10 @@ var ZoteroPane = new function () {
 								0
 							);
 							return null;
+						}
+						// Advanced Search collapsed - focus the close button
+						if (advancedSearchDeck?.state === 'collapsed') {
+							return document.querySelector('#zotero-tb-search .advanced-close-button');
 						}
 						return document.getElementById('zotero-tb-toggle-item-pane-stacked');
 					}

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -401,13 +401,20 @@ var ZoteroPane = new function () {
 					Tab: () => document.getElementById("zotero-tb-search-textbox"),
 					ShiftTab: () => document.getElementById('zotero-tb-add')
 				},
+				'advanced-collapse-button': {
+					ShiftTab: () => document.getElementById('zotero-tb-add')
+				},
 				'zotero-tb-search-textbox': {
-					Tab: () => document.getElementById("zotero-tb-toggle-item-pane-stacked"),
+					Tab: () => document.getElementById("zotero-tb-search-advanced-button"),
 					ShiftTab: () => document.getElementById("zotero-tb-search").focus()
+				},
+				'zotero-tb-search-advanced-button': {
+					Tab: () => document.getElementById("zotero-tb-toggle-item-pane-stacked"),
+					ShiftTab: () => document.getElementById("zotero-tb-search-textbox")
 				},
 				'zotero-tb-toggle-item-pane-stacked': {
 					Tab: () => itemTree.querySelector(".virtualized-table"),
-					ShiftTab: () => document.getElementById("zotero-tb-search-textbox")
+					ShiftTab: () => document.getElementById("zotero-tb-search-advanced-button")
 				},
 			};
 			moveFocus(actionsMap, event, true);
@@ -438,7 +445,20 @@ var ZoteroPane = new function () {
 			let actionsMap = {
 				// The item tree's DOM id has a view-specific suffix, so key on the current view's id
 				[ZoteroPane.itemsView?.id]: {
-					ShiftTab: () => document.getElementById('zotero-tb-toggle-item-pane-stacked')
+					ShiftTab: () => {
+						// Focus last element in Advanced Search deck
+						let advancedSearchDeck = document.getElementById('zotero-advanced-search-pane-deck');
+						if (advancedSearchDeck && !advancedSearchDeck.hidden) {
+							Services.focus.moveFocus(
+								window,
+								document.getElementById('zotero-items-pane'),
+								Services.focus.MOVEFOCUS_BACKWARD,
+								0
+							);
+							return null;
+						}
+						return document.getElementById('zotero-tb-toggle-item-pane-stacked');
+					}
 				}
 			};
 			moveFocus(actionsMap, event);

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -736,6 +736,12 @@ menuitem-advanced-search =
 quicksearch-advanced-search-button =
     .tooltiptext = { advanced-search }
     .aria-label = { advanced-search }
+advanced-search-close =
+    .tooltiptext = Close Advanced Search
+advanced-search-expand =
+    .tooltiptext = Expand Advanced Search
+advanced-search-collapse =
+    .tooltiptext = Collapse Advanced Search
 
 item-pane-header-view-as =
     .label = View As

--- a/scss/elements/_quickSearchTextbox.scss
+++ b/scss/elements/_quickSearchTextbox.scss
@@ -88,7 +88,7 @@ quick-search-textbox {
 	height: 28px;
 	min-width: 0;
 	margin: 0;
-	margin-inline-start: -26px;
+	margin-inline-start: -28px;
 	margin-inline-end: 2px;
 	padding: 0;
 	z-index: 2;
@@ -110,6 +110,9 @@ quick-search-textbox {
 		// a pixel left to optically center it (physical sides -- doesn't flip in RTL)
 		padding: 5px 6px 5px 4px;
 		border-radius: 4px;
+		// The button is 4px wider than the chip and left-aligns it, which puts the
+		// focus ring off-center; shift the chip 2px to center it within the button
+		margin-inline-start: 2px;
 	}
 
 	&:hover .toolbarbutton-icon {
@@ -174,10 +177,10 @@ quick-search-textbox {
 	
 	.advanced-close-button {
 		@include svgicon-menu("x", "universal", "20");
-		// Inset to match the filter button's right edge in the closed state (its
-		// chip sits 4px in from the field edge), so the edge doesn't shift when
-		// toggling between the search field and this header
-		margin-inline-end: 4px;
+		// Inset to match the filter button's chip in the closed state (it sits 2px
+		// in from the field edge), so the edge doesn't shift when toggling between
+		// the search field and this header
+		margin-inline-end: 2px;
 	}
 
 	&[data-collapsed="true"] {

--- a/test/tests/zoteroPaneTest.js
+++ b/test/tests/zoteroPaneTest.js
@@ -1464,6 +1464,7 @@ describe("ZoteroPane", function () {
 
 		// Focus sequence for Zotero Pane
 		let sequence = [
+			"zotero-tb-search-textbox",
 			"zotero-tb-search-dropmarker",
 			"zotero-tb-add",
 			"tag-selector-actions",
@@ -1488,8 +1489,10 @@ describe("ZoteroPane", function () {
 		});
 
 		it("should shift-tab across the zotero pane", async function () {
-			let searchBox = doc.getElementById('zotero-tb-search-textbox');
-			searchBox.focus();
+			// Start from the Advanced Search button (the last focusable element in the
+			// search field) so the first shift-tab exercises advanced button -> search field
+			let advancedButton = doc.getElementById('zotero-tb-search-advanced-button');
+			advancedButton.focus();
 
 			for (let id of sequence) {
 				// Set up focus listener before dispatching the event
@@ -1560,6 +1563,9 @@ describe("ZoteroPane", function () {
 					assert.include(clases, id);
 				}
 			}
+			// Tab from the search field to the Advanced Search button at the end of the field
+			doc.activeElement.dispatchEvent(tab);
+			assert.equal(doc.activeElement.id, "zotero-tb-search-advanced-button");
 		});
 
 		it("should navigate toolbarbuttons with arrows", async function () {


### PR DESCRIPTION
- Make Advanced Search button focusable, include it into the tab sequence
- Tab: quick-search textbox -> Advanced Search button -> item tree
- Shift-Tab: Advanced Search button -> quick-search textbox
- Shift-Tab: item tree -> Advanced Search button (when the deck is closed)
- Shift-Tab: Advanced Search collapse button -> New Item button
- Fix Shift-Tab from the item tree doing nothing when the Advanced Search deck is open; now moves focus to the deck's last focusable element