### PR TITLE
Add condition groups, cross-level result levels, and quick-search prefill to Advanced Search

### DIFF
--- a/chrome/content/zotero/elements/advancedSearchPane.js
+++ b/chrome/content/zotero/elements/advancedSearchPane.js
@@ -127,6 +127,9 @@
 			}
 			else {
 				this._search = new Zotero.Search();
+				// Default a fresh search to top-level items, so a condition on a child
+				// (e.g. attachment content) maps up to its item without any grouping
+				this._search.addCondition('resultLevel', 'item');
 				this._search.addCondition('title', 'contains', '');
 			}
 			this._searchElem.search = this._search;

--- a/chrome/content/zotero/elements/advancedSearchPane.js
+++ b/chrome/content/zotero/elements/advancedSearchPane.js
@@ -187,15 +187,20 @@
 			await ZoteroPane.setSavedSearchEditorState('closed');
 		}
 
-		async submit() {
+		async submit({ focusResults = true } = {}) {
 			if (this.type === 'saved') {
 				throw new Error('submit() is unsupported for saved search');
 			}
-			
+
 			this._searchElem.updateSearch();
 			this._active = true;
 			await ZoteroPane.itemsView.setFilter('advanced-search', this._search);
-			ZoteroPane.itemsView.focus();
+			// Running the search normally moves focus to the results, but a caller that
+			// wants to keep focus in the search builder (e.g. quick search prefill) can
+			// opt out
+			if (focusResults) {
+				ZoteroPane.itemsView.focus();
+			}
 		}
 		
 		async clear() {

--- a/chrome/content/zotero/elements/quickSearchTextbox.js
+++ b/chrome/content/zotero/elements/quickSearchTextbox.js
@@ -111,7 +111,15 @@
 				advancedButton.addEventListener('command', (event) => {
 					// Don't trigger a quick search via the oncommand handler
 					event.stopPropagation();
-					ZoteroPane.toggleAdvancedSearchState('open');
+					// If there's text in the field, seed the Advanced Search with it,
+					// reproducing the current quick search mode as editable conditions.
+					let mode = Zotero.Prefs.get('search.quicksearch-mode');
+					if (this.value) {
+						ZoteroPane.openAdvancedSearchFromQuickSearch(this.value, mode);
+					}
+					else {
+						ZoteroPane.toggleAdvancedSearchState('open');
+					}
 				});
 				wrapper.appendChild(advancedButton);
 			}

--- a/chrome/content/zotero/elements/zoteroSearch.js
+++ b/chrome/content/zotero/elements/zoteroSearch.js
@@ -308,8 +308,11 @@
 					</menulist>
 					<label class="join-mode-suffix" value="&zotero.search.joinMode.suffix;"/>
 					<spacer flex="1"/>
-					<toolbarbutton class="remove-group zotero-clicky zotero-clicky-minus" tabindex="0" hidden="true" data-l10n-id="advanced-search-remove-group-btn" onclick="this.closest('search-condition-group').onRemoveGroupClicked()"/>
-					<toolbarbutton class="add-condition zotero-clicky zotero-clicky-plus" tabindex="0" data-l10n-id="advanced-search-add-btn" onclick="this.closest('search-condition-group').onAddSiblingClicked()"/>
+					<hbox class="group-actions">
+						<toolbarbutton class="remove-group zotero-clicky zotero-clicky-minus" tabindex="0" hidden="true" data-l10n-id="advanced-search-remove-group-btn" onclick="this.closest('search-condition-group').onRemoveGroupClicked()"/>
+						<toolbarbutton class="add-condition zotero-clicky zotero-clicky-plus" tabindex="0" data-l10n-id="advanced-search-add-btn" onclick="this.closest('search-condition-group').onAddSiblingClicked()"/>
+						<html:div class="group-action-placeholder"/>
+					</hbox>
 				</caption>
 				<vbox class="conditions"/>
 			</groupbox>

--- a/chrome/content/zotero/elements/zoteroSearch.js
+++ b/chrome/content/zotero/elements/zoteroSearch.js
@@ -297,7 +297,7 @@
 				search.removeCondition(0);
 			}
 			for (let condition of flat) {
-				search.addCondition(condition.condition, condition.operator, condition.value, condition.required);
+				search.addCondition(condition.condition, condition.operator, condition.value);
 			}
 		}
 
@@ -725,7 +725,7 @@
 				let ref;
 				if (data) {
 					let [condition, mode] = Zotero.SearchConditions.parseCondition(data.condition);
-					ref = { id: undefined, condition, mode, operator: data.operator, value: data.value, required: false };
+					ref = { id: undefined, condition, mode, operator: data.operator, value: data.value };
 				}
 				newGroup.addCondition(ref);
 				row.remove();
@@ -756,7 +756,7 @@
 
 			// Default to an empty 'title' condition
 			if (!ref) {
-				ref = { id: undefined, condition: 'title', operator: 'contains', value: '', mode: undefined, required: false };
+				ref = { id: undefined, condition: 'title', operator: 'contains', value: '', mode: undefined };
 			}
 
 			condition.initWithParentAndCondition(this.searchElement, ref);
@@ -1432,8 +1432,7 @@
 				condition: this.querySelector('#conditionsmenu').getAttribute('data-value'),
 				operator: this.querySelector('#operatorsmenu').value,
 				value: '',
-				mode: undefined,
-				required: false
+				mode: undefined
 			}, this.nextElementSibling);
 			this.parent.updateSearch();
 			this.parent.updateRemoveButtons();
@@ -1458,7 +1457,7 @@
 			var data = this.getConditionData();
 			if (data) {
 				let [condition, mode] = Zotero.SearchConditions.parseCondition(data.condition);
-				ref = { id: undefined, condition, mode, operator: data.operator, value: data.value, required: false };
+				ref = { id: undefined, condition, mode, operator: data.operator, value: data.value };
 			}
 			var newGroup = document.createXULElement('search-condition-group');
 			group.conditionsContainer.insertBefore(newGroup, this);

--- a/chrome/content/zotero/elements/zoteroSearch.js
+++ b/chrome/content/zotero/elements/zoteroSearch.js
@@ -38,9 +38,11 @@
 	class ZoteroSearch extends SearchElementBase {
 		content = MozXULElement.parseXULToFragment(`
 			<search-condition-group root="true"/>
+			<vbox id="search-binding-hint" hidden="true"/>
 			<hbox id="search-option-checkboxes">
 				<checkbox id="recursiveCheckbox" label="&zotero.search.recursive.label;" native="true"/>
-				<checkbox id="noChildrenCheckbox" label="&zotero.search.noChildren;" native="true"/>
+			</hbox>
+			<hbox id="search-legacy-options" align="center" hidden="true">
 				<checkbox id="includeParentsAndChildrenCheckbox" label="&zotero.search.includeParentsAndChildren;" native="true"/>
 			</hbox>
 		`, ['chrome://zotero/locale/zotero.dtd', 'chrome://zotero/locale/searchbox.dtd']);
@@ -65,9 +67,20 @@
 		init() {
 			this.rootGroup = this.querySelector('search-condition-group[root]');
 			this.addEventListener('keypress', event => this.handleKeyPress(event));
-			// Re-evaluate which remove buttons are enabled as the conditions change
-			this.addEventListener('input', () => this.updateRemoveButtons());
-			this.addEventListener('command', () => this.updateRemoveButtons());
+			// Re-evaluate which remove buttons are enabled and which groups can bind to the
+			// same descendant as the conditions change
+			this.addEventListener('input', () => {
+				this.updateRemoveButtons();
+				this.updateBindingMenus();
+				this.updateBindingHint();
+				this.updateLevelWarning();
+			});
+			this.addEventListener('command', () => {
+				this.updateRemoveButtons();
+				this.updateBindingMenus();
+				this.updateBindingHint();
+				this.updateLevelWarning();
+			});
 		}
 
 		// Build the condition tree (root group, nested groups, and search-global
@@ -75,9 +88,11 @@
 		renderConditions() {
 			var root = this.rootGroup;
 
-			for (let name of ['recursive', 'noChildren', 'includeParentsAndChildren']) {
-				this.querySelector('#' + name + 'Checkbox').checked = false;
-			}
+			this.querySelector('#recursiveCheckbox').checked = false;
+			// 'Include parent and child items' is a legacy hack subsumed by result levels;
+			// its checkbox is shown only for an existing search that still carries the flag
+			this.querySelector('#includeParentsAndChildrenCheckbox').checked = false;
+			this.querySelector('#search-legacy-options').hidden = true;
 
 			root.clear();
 
@@ -90,14 +105,33 @@
 				let condition = conditions[id];
 				switch (condition.condition) {
 					case 'recursive':
+						this.querySelector('#recursiveCheckbox').checked = condition.operator == 'true';
+						continue;
+
+					// Legacy "show only top-level items" is exactly result level = item, so
+					// fold it into the root result level rather than a checkbox
 					case 'noChildren':
+						if (condition.operator == 'true') {
+							root.resultLevel = 'item';
+						}
+						continue;
+
+					// Legacy include-parents-and-children: keep it editable for searches that
+					// have it, but don't offer it on new ones
 					case 'includeParentsAndChildren':
-						this.querySelector('#' + condition.condition + 'Checkbox').checked
+						this.querySelector('#includeParentsAndChildrenCheckbox').checked
 							= condition.operator == 'true';
+						if (condition.operator == 'true') {
+							this.querySelector('#search-legacy-options').hidden = false;
+						}
 						continue;
 
 					case 'joinMode':
 						stack[stack.length - 1].joinMode = condition.operator;
+						continue;
+
+					case 'resultLevel':
+						stack[stack.length - 1].resultLevel = condition.operator;
 						continue;
 
 					case 'groupStart': {
@@ -124,6 +158,73 @@
 			}
 
 			this.updateRemoveButtons();
+			this.updateBindingMenus();
+			this.updateBindingHint();
+			this.updateLevelWarning();
+		}
+
+		// Refresh each nested group's same-entity binding menu (visibility and options)
+		updateBindingMenus() {
+			for (let group of this.querySelectorAll('search-condition-group')) {
+				group.updateBindingMenu();
+			}
+		}
+
+		// Refresh every group's level warning. Each group flags only its own conditions, so the
+		// message sits on the group whose conditions actually conflict and speaks to that group's
+		// controls (see SearchConditionGroup.updateLevelWarning).
+		updateLevelWarning() {
+			for (let group of this.querySelectorAll('search-condition-group')) {
+				group.updateLevelWarning();
+			}
+		}
+
+		// Offer to bind ungrouped sibling conditions at the root. The root can't bind itself
+		// (it returns the result level), so 2+ of its conditions sharing a level below the
+		// result level are wrappable into a "same attachment" group -- surfaced as a hint
+		// with a button per such level. Nested groups use their own binding menu instead.
+		updateBindingHint() {
+			var hint = this.querySelector('#search-binding-hint');
+			var resultLevel = this.rootGroup.resultLevel;
+			var counts = {};
+			for (let row of this.rootGroup.conditionsContainer.children) {
+				// Skip rows the user hasn't filled in yet, so a freshly added (or just-retyped)
+				// condition doesn't trigger the hint until it actually has a value
+				if (row.localName != 'zoterosearchcondition' || !row.isPopulated()) {
+					continue;
+				}
+				let level = row.conditionLevel;
+				if (Zotero.Search._isAncestorLevel(resultLevel, level)) {
+					counts[level] = (counts[level] || 0) + 1;
+				}
+			}
+			var levels = ['attachment', 'note', 'annotation'].filter(l => counts[l] >= 2);
+			// Only rebuild when the set of bindable levels changes, so re-running this on every
+			// keystroke doesn't recreate the rows and make the hint flicker.
+			let key = levels.join(',');
+			if (key === this._bindingHintKey) {
+				return;
+			}
+			this._bindingHintKey = key;
+			hint.replaceChildren();
+			if (!levels.length) {
+				hint.hidden = true;
+				return;
+			}
+			// One self-contained line per level: a statement naming that level and a button to
+			// group its conditions into one entity. Separate lines when 2+ levels each qualify.
+			for (let level of levels) {
+				let row = document.createXULElement('hbox');
+				row.setAttribute('align', 'center');
+				let label = document.createXULElement('label');
+				label.setAttribute('data-l10n-id', 'advanced-search-binding-hint-' + level);
+				let button = document.createXULElement('button');
+				button.setAttribute('data-l10n-id', 'advanced-search-bind-same-' + level);
+				button.addEventListener('command', () => this.rootGroup.bindSameEntity(level));
+				row.append(label, button);
+				hint.append(row);
+			}
+			hint.hidden = false;
 		}
 
 		// Regenerate the search's flat condition list from the current tree. The DOM is
@@ -137,14 +238,23 @@
 			var flat = [];
 			this.collectGroup(this.rootGroup, flat, true);
 
-			// Search-global options
-			for (let name of ['recursive', 'noChildren', 'includeParentsAndChildren']) {
-				if (this.querySelector('#' + name + 'Checkbox').checked) {
-					flat.push({ condition: name, operator: 'true', value: null });
-				}
+			// Search-global options. noChildren is no longer emitted here -- it's carried by
+			// the result level (resultLevel = item). includeParentsAndChildren is emitted only when
+			// its legacy checkbox is present and still checked, so unchecking it drops it.
+			if (this.querySelector('#recursiveCheckbox').checked) {
+				flat.push({ condition: 'recursive', operator: 'true', value: null });
+			}
+			if (this.querySelector('#includeParentsAndChildrenCheckbox').checked) {
+				flat.push({ condition: 'includeParentsAndChildren', operator: 'true', value: null });
 			}
 
 			this.rebuildConditions(flat);
+
+			// Any mutation runs through here (including paths whose menus stopPropagation, like
+			// changing or removing a condition), so refresh the derived UI from one place
+			this.updateBindingMenus();
+			this.updateBindingHint();
+			this.updateLevelWarning();
 		}
 
 		// Append a group's serialized form to `flat`. The root contributes its
@@ -156,6 +266,11 @@
 			}
 			if (group.joinMode == 'any') {
 				flat.push({ condition: 'joinMode', operator: 'any', value: null });
+			}
+			// A concrete result level is emitted as a marker inside the group, like joinMode; 'any'
+			// (the default) is omitted
+			if (group.resultLevel && group.resultLevel != 'any') {
+				flat.push({ condition: 'resultLevel', operator: group.resultLevel, value: null });
 			}
 			for (let child of group.conditionsContainer.children) {
 				if (child.localName == 'zoterosearchcondition') {
@@ -299,12 +414,26 @@
 		content = MozXULElement.parseXULToFragment(`
 			<groupbox class="search-condition-group">
 				<caption align="center">
+					<label class="result-level-prefix"/>
+					<menulist class="result-level-menu" native="true" data-l10n-id="advanced-search-result-level-menu">
+						<menupopup>
+							<menuitem value="any" data-l10n-id="advanced-search-result-level-any" selected="true"/>
+							<menuitem value="item" data-l10n-id="advanced-search-result-level-item"/>
+							<menuitem value="attachment" data-l10n-id="advanced-search-result-level-attachment"/>
+							<menuitem value="note" data-l10n-id="advanced-search-result-level-note"/>
+							<menuitem value="annotation" data-l10n-id="advanced-search-result-level-annotation"/>
+						</menupopup>
+					</menulist>
 					<label class="join-mode-prefix" value="&zotero.search.joinMode.prefix;"/>
 					<menulist class="join-mode-menu" native="true" aria-label="&zotero.search.joinMode.prefix;">
 						<menupopup>
 							<menuitem label="&zotero.search.joinMode.any;" value="any"/>
 							<menuitem label="&zotero.search.joinMode.all;" value="all" selected="true"/>
 						</menupopup>
+					</menulist>
+					<label class="join-mode-following" data-l10n-id="advanced-search-of-the-following" hidden="true"/>
+					<menulist class="binding-menu" native="true" hidden="true" data-l10n-id="advanced-search-binding-menu">
+						<menupopup/>
 					</menulist>
 					<label class="join-mode-suffix" value="&zotero.search.joinMode.suffix;"/>
 					<spacer flex="1"/>
@@ -315,12 +444,53 @@
 					</hbox>
 				</caption>
 				<vbox class="conditions"/>
+				<hbox class="level-warning" hidden="true">
+					<description/>
+				</hbox>
 			</groupbox>
 		`, ['chrome://zotero/locale/zotero.dtd', 'chrome://zotero/locale/searchbox.dtd']);
 
 		init() {
 			this.joinMenu = this.querySelector('.join-mode-menu');
+			this.resultLevelMenu = this.querySelector('.result-level-menu');
+			this.bindingMenu = this.querySelector('.binding-menu');
 			this.conditionsContainer = this.querySelector('.conditions');
+			// The group's own warning element, stashed at init to avoid re-querying.
+			this.levelWarning = this.querySelector('.level-warning');
+
+			// The result level is tracked here and reflected to whichever control is active: the root's
+			// result-level menu ("Find ..."), or a nested group's binding menu ("... in the
+			// same attachment"). collectGroup/renderConditions read and write `resultLevel`.
+			this._resultLevel = 'any';
+
+			// The root surfaces the result-level menu; a nested group hides it and instead
+			// shows a binding menu (built on demand by updateBindingMenu) when it holds
+			// conditions that can be bound to the same descendant.
+			this.resultLevelMenu.value = 'any';
+			var scopePrefix = this.querySelector('.result-level-prefix');
+			if (this.isRoot) {
+				// Read as one sentence: "Find [Top-level items] matching [all] of the following:"
+				scopePrefix.setAttribute('data-l10n-id', 'advanced-search-result-level-prefix-root');
+				this.querySelector('.join-mode-prefix').setAttribute('data-l10n-id', 'advanced-search-join-prefix-root');
+				this.resultLevelControl = this.resultLevelMenu;
+			}
+			else {
+				// Nested: "Match [all] of the following:" -- the result level lives on the
+				// root. The binding menu (and its hiding of the suffix) is set up in
+				// updateBindingMenu().
+				this.resultLevelMenu.hidden = true;
+				scopePrefix.hidden = true;
+				this.resultLevelControl = this.bindingMenu;
+			}
+
+			// Keep the stored result level in sync when the user changes the control (the
+			// command target may be the menulist or a menuitem inside it), so a nested
+			// binding that later hides still round-trips its last value
+			this.addEventListener('command', (event) => {
+				if (this.resultLevelControl && this.resultLevelControl.contains(event.target)) {
+					this._resultLevel = this.resultLevelControl.value || 'any';
+				}
+			});
 			// At init the group has no nested groups yet, so these resolve to its own
 			// caption buttons
 			this.addConditionButton = this.querySelector('.add-condition');
@@ -357,8 +527,221 @@
 			this.joinMenu.value = val;
 		}
 
+		// The group's result level: 'any' (no level constraint -- mixed result for the root,
+		// plain grouping for a nested group) or a concrete 'item'/'attachment'/'note'/
+		// 'annotation' level for cross-level mapping. The active control's current
+		// selection is the source of truth; fall back to the stored value for a nested
+		// binding menu that's hidden (it has no options to read).
+		get resultLevel() {
+			if (this.resultLevelControl && !this.resultLevelControl.hidden) {
+				return this.resultLevelControl.value || 'any';
+			}
+			return this._resultLevel;
+		}
+
+		set resultLevel(val) {
+			this._resultLevel = val || 'any';
+			// Reflect to the active control if it currently offers a matching option; the
+			// binding menu's options are (re)built by updateBindingMenu()
+			let popup = this.resultLevelControl && this.resultLevelControl.querySelector('menupopup');
+			if (popup && [...popup.children].some(item => item.value == this._resultLevel)) {
+				this.resultLevelControl.value = this._resultLevel;
+			}
+		}
+
+		// Build the nested-group binding menu ("... in the same attachment"), shown only
+		// when binding is meaningful: 2+ conditions sharing a level below the result level.
+		updateBindingMenu() {
+			if (this.isRoot) {
+				return;
+			}
+			let resultLevel = 'any';
+			if (this.searchElement && this.searchElement.rootGroup) {
+				resultLevel = this.searchElement.rootGroup.resultLevel;
+			}
+			// Count this group's direct condition rows by level, keeping only levels below the
+			// result level -- those are what a group can bind to the same entity
+			let counts = {};
+			for (let row of this.conditionsContainer.children) {
+				// Skip rows the user hasn't filled in yet, so a freshly added (or just-retyped)
+				// condition doesn't trigger the hint until it actually has a value
+				if (row.localName != 'zoterosearchcondition' || !row.isPopulated()) {
+					continue;
+				}
+				let level = row.conditionLevel;
+				if (Zotero.Search._isAncestorLevel(resultLevel, level)) {
+					counts[level] = (counts[level] || 0) + 1;
+				}
+			}
+			let levels = Object.keys(counts);
+			// Binding is only meaningful when some level has 2+ conditions. When it isn't,
+			// hide the menu but preserve any stored level (a single descendant condition
+			// maps the same way bound or not, so it round-trips losslessly).
+			if (!levels.some(l => counts[l] >= 2)) {
+				this.bindingMenu.hidden = true;
+				// Plain group: "Match [all] of the following:" (the suffix carries the colon)
+				this.querySelector('.join-mode-suffix').hidden = false;
+				this.querySelector('.join-mode-following').hidden = true;
+				this._bindingMenuKey = null;
+				return;
+			}
+			// Drop a stored binding whose level is no longer offered
+			if (this._resultLevel != 'any' && !levels.includes(this._resultLevel)) {
+				this._resultLevel = 'any';
+			}
+
+			// Rebuild the popup only when its option set changes. Rebuilding it on every refresh
+			// would replace the menuitems mid-selection -- when the change came from this menu
+			// itself -- and wedge the drop-down.
+			let optionLevels = ['attachment', 'note', 'annotation'].filter(l => levels.includes(l));
+			let key = optionLevels.join(',');
+			if (key !== this._bindingMenuKey) {
+				this._bindingMenuKey = key;
+				let popup = this.bindingMenu.querySelector('menupopup');
+				popup.replaceChildren();
+				let separate = document.createXULElement('menuitem');
+				separate.setAttribute('value', 'any');
+				separate.setAttribute('data-l10n-id', 'advanced-search-binding-separate');
+				popup.append(separate);
+				for (let level of optionLevels) {
+					let item = document.createXULElement('menuitem');
+					item.setAttribute('value', level);
+					item.setAttribute('data-l10n-id', 'advanced-search-binding-same-' + level);
+					popup.append(item);
+				}
+			}
+			this.bindingMenu.hidden = false;
+			// Bound group: "Match [all] of the following in the same attachment". The binding
+			// phrase ends the caption, so swap the legacy "of the following:" (with its colon)
+			// for the colon-less "of the following" that precedes the binding menu.
+			this.querySelector('.join-mode-suffix').hidden = true;
+			this.querySelector('.join-mode-following').hidden = false;
+			this.bindingMenu.value = this._resultLevel;
+		}
+
+		// The level this group's conditions are actually matched at: its own result level (the
+		// result type for the root, the binding for a nested group) if set, otherwise the level
+		// it inherits from its enclosing group. Mirrors the engine, where an unbound
+		// ("separately") group maps its conditions to the parent's level rather than
+		// combining them at no level.
+		effectiveLevel() {
+			if (this.resultLevel != 'any') {
+				return this.resultLevel;
+			}
+			let parent = this.parentElement && this.parentElement.closest('search-condition-group');
+			return parent ? parent.effectiveLevel() : this.resultLevel;
+		}
+
+		// Warn when this group's own conditions can never combine: a child whose level can't
+		// reach the group's effective level, or -- with no level anywhere up the chain (a mixed
+		// result type) -- an "all" of children on different item-hierarchy branches. Each group
+		// flags only its own conditions, so the message sits where the problem is.
+		updateLevelWarning() {
+			let ownLevel = this.resultLevel;
+			let level = this.effectiveLevel();
+			// This group's direct children's levels: a populated condition row's own level (an
+			// empty row doesn't warn until it's filled in) or a nested group's binding. 'any'
+			// combines with anything, so drop it.
+			let childLevels = [...this.conditionsContainer.children].map((child) => {
+				if (child.localName == 'zoterosearchcondition') {
+					return child.isPopulated() ? child.conditionLevel : null;
+				}
+				if (child.localName == 'search-condition-group') {
+					return child.resultLevel;
+				}
+				return null;
+			}).filter(l => l && l != 'any');
+
+			let messageID = null;
+			let args = null;
+			let resultTypeArgs = () => {
+				let item = this.resultLevelMenu.querySelector('menuitem[value="item"]');
+				return { topLevelItems: item ? item.getAttribute('label') : 'top-level items' };
+			};
+			if (level != 'any') {
+				// A child that can't reach the effective level can never match here
+				if (childLevels.some(l => !this.levelsCombine(l, level))) {
+					if (!this.isRoot && ownLevel != 'any') {
+						// This group's own binding is the constraint, so "match separately" fixes it
+						messageID = 'advanced-search-group-warning-unreachable';
+						args = { entity: ownLevel };
+					}
+					else {
+						// The result type (this group's, or one it inherits) is the constraint
+						messageID = 'advanced-search-level-warning-unreachable';
+						args = resultTypeArgs();
+					}
+				}
+			}
+			else if (this.joinMode == 'all' && new Set(childLevels).size >= 2) {
+				// No level anywhere up the chain (mixed result type): ANDing conditions on
+				// different branches can never all match
+				let anyItem = this.joinMenu.querySelector('menuitem[value="any"]');
+				let matchAny = anyItem ? anyItem.getAttribute('label') : 'any';
+				if (this.isRoot) {
+					messageID = 'advanced-search-level-warning-mixed';
+					args = { matchAny, ...resultTypeArgs() };
+				}
+				else {
+					// Reachable only when the result type is "any", so setting one fixes it too
+					messageID = 'advanced-search-group-warning-mixed';
+					args = { matchAny, ...resultTypeArgs() };
+				}
+			}
+
+			// Only touch the DOM when the message changes, so re-running on every keystroke
+			// doesn't re-translate the string and make the warning flicker.
+			let key = messageID ? messageID + '\n' + JSON.stringify(args) : '';
+			if (key === this._levelWarningKey) {
+				return;
+			}
+			this._levelWarningKey = key;
+			if (messageID) {
+				document.l10n.setAttributes(this.levelWarning.querySelector('description'), messageID, args);
+			}
+			this.levelWarning.hidden = !messageID;
+		}
+
+		// Two levels combine if one is an ancestor of the other (or equal); 'any' matches any.
+		levelsCombine(a, b) {
+			return a == 'any' || b == 'any' || a == b
+				|| Zotero.Search._isAncestorLevel(a, b) || Zotero.Search._isAncestorLevel(b, a);
+		}
+
+		// Wrap this group's direct condition rows that match `level` into a new child group
+		// bound to that level ("the same attachment"). Used by the discoverability hint.
+		// Rows are rebuilt from their data rather than moved, since detaching a custom element
+		// wipes its contents.
+		bindSameEntity(level) {
+			let rows = [...this.conditionsContainer.children].filter(
+				row => row.localName == 'zoterosearchcondition' && row.conditionLevel == level);
+			if (rows.length < 2) {
+				return;
+			}
+			let newGroup = document.createXULElement('search-condition-group');
+			this.conditionsContainer.insertBefore(newGroup, rows[0]);
+			for (let row of rows) {
+				let data = row.getConditionData();
+				let ref;
+				if (data) {
+					let [condition, mode] = Zotero.SearchConditions.parseCondition(data.condition);
+					ref = { id: undefined, condition, mode, operator: data.operator, value: data.value, required: false };
+				}
+				newGroup.addCondition(ref);
+				row.remove();
+			}
+			newGroup.resultLevel = level;
+
+			let search = this.searchElement;
+			search.updateSearch();
+			search.updateRemoveButtons();
+			search.updateBindingMenus();
+			search.updateBindingHint();
+		}
+
 		clear() {
 			this.joinMode = 'all';
+			this.resultLevel = 'any';
 			while (this.conditionsContainer.firstChild) {
 				this.conditionsContainer.removeChild(this.conditionsContainer.firstChild);
 			}
@@ -757,6 +1140,14 @@
 				document.l10n.setAttributes(valueMenu, 'advanced-search-condition-input', { label: valueMenu.label });
 			}
 			this.updateMenuCheckboxesRecursive(operatorsList, operatorsList.selectedItem.getAttribute('value'));
+
+			// Changing the condition or operator is a mutation like add/remove, so rebuild the
+			// search and refresh the derived UI (binding hint, level warning) right away. The
+			// condition/operator menus stopPropagation, so this won't happen via event bubbling.
+			// (updateSearch no-ops during the initial render via its own guard.)
+			if (this.parent) {
+				this.parent.updateSearch();
+			}
 		}
 
 		createValueMenu(rows) {
@@ -1077,6 +1468,13 @@
 			this.parent.updateSearch();
 			this.parent.updateRemoveButtons();
 			newGroup.conditionsContainer.firstElementChild.querySelector('#conditionsmenu').focus();
+		}
+
+		// The item level this condition matches at ('item' by default), used to decide
+		// cross-level binding in a group
+		get conditionLevel() {
+			let data = this.selectedCondition && Zotero.SearchConditions.get(this.selectedCondition);
+			return (data && data.level) || 'item';
 		}
 
 		// Whether a value has been entered, used to decide whether the last

--- a/chrome/content/zotero/elements/zoteroSearch.js
+++ b/chrome/content/zotero/elements/zoteroSearch.js
@@ -37,23 +37,11 @@
 
 	class ZoteroSearch extends SearchElementBase {
 		content = MozXULElement.parseXULToFragment(`
-			<groupbox>
-				<caption align="center">
-					<label id="joinModeMenu-label" value="&zotero.search.joinMode.prefix;"/>
-					<menulist id="joinModeMenu" aria-labelledby="joinModeMenu-label" oncommand="this.closest('zoterosearch').updateJoinMode();" native="true">
-						<menupopup>
-							<menuitem label="&zotero.search.joinMode.any;" value="any"/>
-							<menuitem label="&zotero.search.joinMode.all;" value="all" selected="true"/>
-						</menupopup>
-					</menulist>
-					<label value="&zotero.search.joinMode.suffix;"/>
-				</caption>
-				<vbox id="conditions"/>
-			</groupbox>
+			<search-condition-group root="true"/>
 			<hbox id="search-option-checkboxes">
-				<checkbox id="recursiveCheckbox" label="&zotero.search.recursive.label;" oncommand="this.closest('zoterosearch').updateCheckbox('recursive');" native="true"/>
-				<checkbox id="noChildrenCheckbox" label="&zotero.search.noChildren;" oncommand="this.closest('zoterosearch').updateCheckbox('noChildren');" native="true"/>
-				<checkbox id="includeParentsAndChildrenCheckbox" label="&zotero.search.includeParentsAndChildren;" oncommand="this.closest('zoterosearch').updateCheckbox('includeParentsAndChildren');" native="true"/>
+				<checkbox id="recursiveCheckbox" label="&zotero.search.recursive.label;" native="true"/>
+				<checkbox id="noChildrenCheckbox" label="&zotero.search.noChildren;" native="true"/>
+				<checkbox id="includeParentsAndChildrenCheckbox" label="&zotero.search.includeParentsAndChildren;" native="true"/>
 			</hbox>
 		`, ['chrome://zotero/locale/zotero.dtd', 'chrome://zotero/locale/searchbox.dtd']);
 
@@ -63,162 +51,211 @@
 
 		set search(val) {
 			this.searchRef = val;
-
-			this.querySelector('#joinModeMenu').removeAttribute('condition');
-			this.querySelector('#joinModeMenu').value = 'all';
-			
-			this.querySelector('#recursiveCheckbox').checked = false;
-			this.querySelector('#noChildrenCheckbox').checked = false;
-			this.querySelector('#includeParentsAndChildrenCheckbox').checked = false;
-
-			var conditionsBox = this.querySelector('#conditions');
-			while (conditionsBox.hasChildNodes()) {
-				conditionsBox.removeChild(conditionsBox.firstChild);
+			// Setting condition controls' values during a render shouldn't trigger a
+			// rebuild of the search from the half-built tree
+			this._rendering = true;
+			try {
+				this.renderConditions();
 			}
-
-			var conditions = this.search.getConditions();
-			for (let id in conditions) {
-				let condition = conditions[id];
-				// Checkboxes
-				switch (condition.condition) {
-					case 'recursive':
-					case 'noChildren':
-					case 'includeParentsAndChildren':
-					{
-						let checkbox = condition.condition + 'Checkbox';
-						this.querySelector(`#${checkbox}`).setAttribute('condition', id);
-						this.querySelector(`#${checkbox}`).checked = condition.operator == 'true';
-						continue;
-					}
-				}
-
-				if (condition.condition == 'joinMode') {
-					this.querySelector('#joinModeMenu').setAttribute('condition', id);
-					this.querySelector('#joinModeMenu').value = condition.operator;
-				}
-				else {
-					this.addCondition(condition);
-				}
+			finally {
+				this._rendering = false;
 			}
 		}
-		
+
 		init() {
+			this.rootGroup = this.querySelector('search-condition-group[root]');
 			this.addEventListener('keypress', event => this.handleKeyPress(event));
 			// Re-evaluate which remove buttons are enabled as the conditions change
 			this.addEventListener('input', () => this.updateRemoveButtons());
 			this.addEventListener('command', () => this.updateRemoveButtons());
 		}
 
-		addCondition(ref) {
-			var conditionsBox = this.querySelector('#conditions');
-			var condition = document.createXULElement('zoterosearchcondition');
-			condition.setAttribute('flex', '1');
-			
-			conditionsBox.appendChild(condition);
-			
-			// Default to an empty 'title' condition
-			if (!ref) {
-				ref = this.search.getCondition(this.search.addCondition("title", "contains", ""));
+		// Build the condition tree (root group, nested groups, and search-global
+		// checkboxes) from the search's flat condition list
+		renderConditions() {
+			var root = this.rootGroup;
+
+			for (let name of ['recursive', 'noChildren', 'includeParentsAndChildren']) {
+				this.querySelector('#' + name + 'Checkbox').checked = false;
 			}
-			
-			condition.initWithParentAndCondition(this, ref);
+
+			root.clear();
+
+			// Walk the flat conditions, pushing/popping a group stack on the group
+			// markers. A 'joinMode' applies to the group on top of the stack; anything
+			// else becomes a condition row or a nested group within it.
+			var stack = [root];
+			var conditions = this.search.getConditions();
+			for (let id in conditions) {
+				let condition = conditions[id];
+				switch (condition.condition) {
+					case 'recursive':
+					case 'noChildren':
+					case 'includeParentsAndChildren':
+						this.querySelector('#' + condition.condition + 'Checkbox').checked
+							= condition.operator == 'true';
+						continue;
+
+					case 'joinMode':
+						stack[stack.length - 1].joinMode = condition.operator;
+						continue;
+
+					case 'groupStart': {
+						let group = document.createXULElement('search-condition-group');
+						stack[stack.length - 1].conditionsContainer.appendChild(group);
+						stack.push(group);
+						continue;
+					}
+
+					case 'groupEnd':
+						if (stack.length > 1) {
+							stack.pop();
+						}
+						continue;
+
+					default:
+						stack[stack.length - 1].addCondition(condition);
+				}
+			}
+
+			// The root always shows at least one condition, even for an empty search
+			if (!root.conditionsContainer.childElementCount) {
+				root.addCondition();
+			}
 
 			this.updateRemoveButtons();
 		}
 
-		removeCondition(id, focusRemoveButton) {
-			var conditionsBox = this.querySelector('#conditions');
-			// Removing the only remaining condition resets it to the default empty
-			// condition -- the same one shown when the pane is first opened -- rather
-			// than leaving the search with no conditions
-			var resetToDefault = conditionsBox.childNodes.length == 1;
+		// Regenerate the search's flat condition list from the current tree. The DOM is
+		// the source of truth: on any edit we walk the groups in order and rebuild
+		// search._conditions from scratch.
+		updateSearch() {
+			if (this._rendering || !this.search) {
+				return;
+			}
 
-			this.search.removeCondition(id);
-			let found = false;
-			for (var i = 0, len = conditionsBox.childNodes.length; i < len; i++) {
-				if (conditionsBox.childNodes[i].conditionID == id) {
-					conditionsBox.removeChild(conditionsBox.childNodes[i]);
-					found = true;
-					i--;
-					len--;
-					continue;
-				}
-				// When a condition is removed, ids of remaining conditions
-				// are shifted to remain in arithmetic sequence. The conditionID
-				// of the nodes need to be updated accordingly
-				if (found) {
-					conditionsBox.childNodes[i].conditionID--;
+			var flat = [];
+			this.collectGroup(this.rootGroup, flat, true);
+
+			// Search-global options
+			for (let name of ['recursive', 'noChildren', 'includeParentsAndChildren']) {
+				if (this.querySelector('#' + name + 'Checkbox').checked) {
+					flat.push({ condition: name, operator: 'true', value: null });
 				}
 			}
 
-			if (resetToDefault) {
-				this.addCondition();
+			this.rebuildConditions(flat);
+		}
+
+		// Append a group's serialized form to `flat`. The root contributes its
+		// conditions directly; a nested group is wrapped in groupStart/groupEnd markers.
+		// A 'joinMode' marker is emitted only for 'any'; 'all' is the default and is omitted.
+		collectGroup(group, flat, isRoot) {
+			if (!isRoot) {
+				flat.push({ condition: 'groupStart', operator: 'true', value: '' });
+			}
+			if (group.joinMode == 'any') {
+				flat.push({ condition: 'joinMode', operator: 'any', value: null });
+			}
+			for (let child of group.conditionsContainer.children) {
+				if (child.localName == 'zoterosearchcondition') {
+					let data = child.getConditionData();
+					if (data) {
+						flat.push(data);
+					}
+				}
+				else if (child.localName == 'search-condition-group') {
+					this.collectGroup(child, flat, false);
+				}
+			}
+			if (!isRoot) {
+				flat.push({ condition: 'groupEnd', operator: 'true', value: '' });
+			}
+		}
+
+		rebuildConditions(flat) {
+			var search = this.search;
+			var count = Object.keys(search.getConditions()).length;
+			// removeCondition() renumbers the remaining conditions, so 0 is always the
+			// next one to remove
+			for (let i = 0; i < count; i++) {
+				search.removeCondition(0);
+			}
+			for (let condition of flat) {
+				search.addCondition(condition.condition, condition.operator, condition.value, condition.required);
+			}
+		}
+
+		// Enable the remove (-) button on each condition. The root's last remaining
+		// condition can be removed only once it's populated, which resets it to the
+		// default empty condition.
+		updateRemoveButtons() {
+			var rootContainer = this.rootGroup.conditionsContainer;
+			var loneRootCondition = rootContainer.childElementCount == 1
+					&& rootContainer.firstElementChild.localName == 'zoterosearchcondition'
+				? rootContainer.firstElementChild
+				: null;
+			for (let row of this.querySelectorAll('zoterosearchcondition')) {
+				if (row == loneRootCondition && !row.isPopulated()) {
+					row.disableRemoveButton();
+				}
+				else {
+					row.enableRemoveButton();
+				}
+			}
+		}
+
+		// Remove a condition row, pruning any groups it empties. The root always keeps
+		// at least one condition, so emptying it resets it to a single empty default.
+		removeRow(row, focusRemoveButton) {
+			var group = row.closest('search-condition-group');
+			// Remember the row's place so focus can move there after a keyboard removal
+			var index = [...group.conditionsContainer.children].indexOf(row);
+			row.remove();
+			// A group left with no conditions is removed, bubbling up toward the root
+			while (!group.isRoot && !group.conditionsContainer.childElementCount) {
+				let parent = group.parentElement.closest('search-condition-group');
+				group.remove();
+				group = parent;
+			}
+
+			var reset = this.ensureNotEmpty();
+			this.updateSearch();
+			this.updateRemoveButtons();
+			if (reset) {
 				// The removed button is gone, so move focus to the new condition's drop-down
-				conditionsBox.firstChild.querySelector('#conditionsmenu').focus();
+				this.rootGroup.conditionsContainer.firstElementChild
+					.querySelector('#conditionsmenu').focus();
 			}
-			else {
-				this.updateRemoveButtons();
-				// After a keyboard removal, move focus to the remove button of the
-				// row that took the removed row's place, or the previous (now last)
-				// row if the last row was removed, so multiple conditions can be
-				// deleted in succession from the keyboard
-				if (focusRemoveButton) {
-					let rows = conditionsBox.childNodes;
-					let row = rows[id] || rows[rows.length - 1];
-					let button = row.querySelector('#remove');
-					// A disabled remove button can't take focus, so fall back to the
-					// row's condition drop-down
+			else if (focusRemoveButton && group.isConnected) {
+				// After a keyboard removal, move focus to the remove button of the row
+				// that took the removed row's place, or the last row if the removed row
+				// was last, so conditions can be deleted in succession from the keyboard
+				let rows = group.conditionsContainer.children;
+				let next = rows[index] || rows[rows.length - 1];
+				// A nested group may now hold that slot; focus its first condition
+				if (next && next.localName == 'search-condition-group') {
+					next = next.querySelector('zoterosearchcondition');
+				}
+				if (next) {
+					let button = next.querySelector('#remove');
+					// A disabled remove button can't take focus, so fall back to the drop-down
 					let target = button.getAttribute('disabled') == 'true'
-						? row.querySelector('#conditionsmenu')
+						? next.querySelector('#conditionsmenu')
 						: button;
 					setTimeout(() => target.focus({ focusVisible: true }));
 				}
 			}
 		}
 
-		// Enable the remove (-) button on each condition. The last remaining
-		// condition can be removed only when it's populated, which resets it to the
-		// default empty condition.
-		updateRemoveButtons() {
-			var conditionsBox = this.querySelector('#conditions');
-			var rows = conditionsBox.childNodes;
-			for (let row of rows) {
-				if (rows.length > 1 || row.isPopulated()) {
-					row.enableRemoveButton();
-				}
-				else {
-					row.disableRemoveButton();
-				}
+		// The root always shows at least one condition. Returns true if a default
+		// condition had to be added back.
+		ensureNotEmpty() {
+			if (!this.rootGroup.conditionsContainer.childElementCount) {
+				this.rootGroup.addCondition();
+				return true;
 			}
-		}
-
-		updateJoinMode() {
-			var menu = this.querySelector('#joinModeMenu');
-			if (menu.hasAttribute('condition')) this.search.updateCondition(menu.getAttribute('condition'), 'joinMode', menu.value, null);
-			else menu.setAttribute('condition', this.search.addCondition('joinMode', menu.value, null));
-		}
-
-		updateCheckbox(condition) {
-			var checkbox = this.querySelector('#' + condition + 'Checkbox');
-			var value = checkbox.checked ? 'true' : 'false';
-			if (checkbox.hasAttribute('condition')) {
-				this.search.updateCondition(checkbox.getAttribute('condition'),
-					condition, value, null);
-			}
-			else {
-				checkbox.setAttribute('condition',
-					this.search.addCondition(condition, value, null));
-			}
-		}
-
-		// Calls updateSearch() on all search conditions
-		updateSearch() {
-			var conditionsBox = this.querySelector('#conditions');
-			if (conditionsBox.hasChildNodes()) {
-				for (var i = 0, len = conditionsBox.childNodes.length; i < len; i++) {
-					conditionsBox.childNodes[i].updateSearch();
-				}
-			}
+			return false;
 		}
 
 		handleKeyPress(event) {
@@ -232,10 +269,14 @@
 					this.active = true;
 
 					if (event.shiftKey) {
-						this.addCondition();
-						// Move focus to the new row's drop-down so it can be set
-						// from the keyboard
-						this.focusNewCondition();
+						// Add to the group holding the focused control, falling back to the root
+						let group = event.target.closest
+							&& event.target.closest('search-condition-group');
+						let row = (group || this.rootGroup).addCondition();
+						this.updateSearch();
+						this.updateRemoveButtons();
+						// Move focus to the new row's drop-down so it can be set from the keyboard
+						this.focusNewCondition(row);
 					}
 					else {
 						this.doCommand();
@@ -244,16 +285,130 @@
 			}
 		}
 
-		// Move focus to the most recently added condition's drop-down. Deferred so
-		// it isn't immediately undone by the platform's own handling of the key
-		// event that triggered the addition (which otherwise keeps focus on the
-		// source element).
-		focusNewCondition() {
-			let menu = this.querySelector('#conditions').lastChild.querySelector('#conditionsmenu');
+		// Move focus to a newly added condition's drop-down. Deferred so it isn't
+		// immediately undone by the platform's own handling of the key event that
+		// triggered the addition (which otherwise keeps focus on the source element).
+		focusNewCondition(row) {
+			let menu = row.querySelector('#conditionsmenu');
 			setTimeout(() => menu.focus({ focusVisible: true }));
 		}
 	}
 	customElements.define("zoterosearch", ZoteroSearch);
+
+	class SearchConditionGroup extends SearchElementBase {
+		content = MozXULElement.parseXULToFragment(`
+			<groupbox class="search-condition-group">
+				<caption align="center">
+					<label class="join-mode-prefix" value="&zotero.search.joinMode.prefix;"/>
+					<menulist class="join-mode-menu" native="true" aria-label="&zotero.search.joinMode.prefix;">
+						<menupopup>
+							<menuitem label="&zotero.search.joinMode.any;" value="any"/>
+							<menuitem label="&zotero.search.joinMode.all;" value="all" selected="true"/>
+						</menupopup>
+					</menulist>
+					<label class="join-mode-suffix" value="&zotero.search.joinMode.suffix;"/>
+					<spacer flex="1"/>
+					<toolbarbutton class="remove-group zotero-clicky zotero-clicky-minus" tabindex="0" hidden="true" data-l10n-id="advanced-search-remove-group-btn" onclick="this.closest('search-condition-group').onRemoveGroupClicked()"/>
+					<toolbarbutton class="add-condition zotero-clicky zotero-clicky-plus" tabindex="0" data-l10n-id="advanced-search-add-btn" onclick="this.closest('search-condition-group').onAddSiblingClicked()"/>
+				</caption>
+				<vbox class="conditions"/>
+			</groupbox>
+		`, ['chrome://zotero/locale/zotero.dtd', 'chrome://zotero/locale/searchbox.dtd']);
+
+		init() {
+			this.joinMenu = this.querySelector('.join-mode-menu');
+			this.conditionsContainer = this.querySelector('.conditions');
+			// At init the group has no nested groups yet, so these resolve to its own
+			// caption buttons
+			this.addConditionButton = this.querySelector('.add-condition');
+			this.removeGroupButton = this.querySelector('.remove-group');
+
+			// The root group can't be removed and has no parent to add a sibling into, so
+			// its caption's remove ("-") and add ("+") buttons stay hidden; a nested group
+			// shows both
+			if (this.isRoot) {
+				this.addConditionButton.hidden = true;
+			}
+			else {
+				this.removeGroupButton.hidden = false;
+			}
+		}
+
+		get isRoot() {
+			return this.hasAttribute('root');
+		}
+
+		get searchElement() {
+			return this.closest('zoterosearch');
+		}
+
+		get search() {
+			return this.searchElement && this.searchElement.search;
+		}
+
+		get joinMode() {
+			return this.joinMenu.value;
+		}
+
+		set joinMode(val) {
+			this.joinMenu.value = val;
+		}
+
+		clear() {
+			this.joinMode = 'all';
+			while (this.conditionsContainer.firstChild) {
+				this.conditionsContainer.removeChild(this.conditionsContainer.firstChild);
+			}
+		}
+
+		// Add a condition row to this group. Inserts before `beforeNode` if given (e.g.
+		// right after the row whose "+" was clicked), otherwise appends.
+		addCondition(ref, beforeNode) {
+			var condition = document.createXULElement('zoterosearchcondition');
+			condition.setAttribute('flex', '1');
+			this.conditionsContainer.insertBefore(condition, beforeNode || null);
+
+			// Default to an empty 'title' condition
+			if (!ref) {
+				ref = { id: undefined, condition: 'title', operator: 'contains', value: '', mode: undefined, required: false };
+			}
+
+			condition.initWithParentAndCondition(this.searchElement, ref);
+			return condition;
+		}
+
+		// "+" in the group caption: add a sibling condition in the parent group, after
+		// this group -- the group's caption row acts as the group's single line item in
+		// its parent, so its "+" mirrors a condition row's "+". The root has no parent,
+		// so its "+" stays hidden.
+		onAddSiblingClicked() {
+			var parent = this.parentElement.closest('search-condition-group');
+			if (!parent) {
+				return;
+			}
+			var row = parent.addCondition(null, this.nextElementSibling);
+			var search = this.searchElement;
+			search.updateSearch();
+			search.updateRemoveButtons();
+			row.querySelector('#conditionsmenu').focus();
+		}
+
+		onRemoveGroupClicked() {
+			var search = this.searchElement;
+			var parent = this.parentElement.closest('search-condition-group');
+			this.remove();
+			// Removing a group can leave its parent empty; prune up toward the root
+			while (parent && !parent.isRoot && !parent.conditionsContainer.childElementCount) {
+				let grandparent = parent.parentElement.closest('search-condition-group');
+				parent.remove();
+				parent = grandparent;
+			}
+			search.ensureNotEmpty();
+			search.updateSearch();
+			search.updateRemoveButtons();
+		}
+	}
+	customElements.define("search-condition-group", SearchConditionGroup);
 
 	class ZoteroSearchCondition extends XULElementBase {
 		content = MozXULElement.parseXULToFragment(`
@@ -277,6 +432,7 @@
 				<zoterosearchagefield id="value-date-age" class="value-date-age" hidden="true"/>
 				<toolbarbutton id="remove" tabindex="0" data-l10n-id="advanced-search-remove-btn" class="zotero-clicky zotero-clicky-minus" value="-" onclick="this.closest('zoterosearchcondition').onRemoveClicked(event)"/>
 				<toolbarbutton id="add" tabindex="0" data-l10n-id="advanced-search-add-btn" class="zotero-clicky zotero-clicky-plus" value="+" onclick="this.closest('zoterosearchcondition').onAddClicked(event)"/>
+				<toolbarbutton id="group" tabindex="0" data-l10n-id="advanced-search-group-btn" class="zotero-clicky search-group-button" onclick="this.closest('zoterosearchcondition').onGroupClicked(event)"/>
 			</html:div>
 		`, ['chrome://zotero/locale/zotero.dtd', 'chrome://zotero/locale/searchbox.dtd']);
 
@@ -686,56 +842,62 @@
 			this.onConditionSelected(menu.value);
 		}
 
-		updateSearch() {
-			if (this.parent && this.parent.search && !this.dontupdate) {
-				var condition = this.selectedCondition;
-				var operator = this.querySelector('#operatorsmenu').value;
-				let value;
-				
-				// Regular text field
-				if (!this.querySelector('#valuefield').hidden) {
-					value = this.querySelector('#valuefield').value;
-					
-					// Convert datetimes to UTC before saving
-					switch (condition) {
-						case 'accessDate':
-						case 'dateAdded':
-						case 'dateModified':
-							if (Zotero.Date.isSQLDateTime(value)) {
-								value = Zotero.Date.dateToSQL(Zotero.Date.sqlToDate(value), true);
-							}
-					}
-					
-					// Append mode to condition
-					if (this.querySelector('#valuefield').mode) {
-						condition += '/' + this.querySelector('#valuefield').mode;
-					}
-				}
-				
-				// isInTheLast operator
-				else if (!this.querySelector('#value-date-age').hidden) {
-					value = this.querySelector('#value-date-age').value;
-				}
-				
-				// Handle special C1234 and S5678 form for
-				// collections and searches
-				else if (condition == 'collection') {
-					var letter = this.querySelector('#valuemenu').value.substr(0, 1);
-					if (letter == 'C') {
-						condition = 'collection';
-					}
-					else if (letter == 'S') {
-						condition = 'savedSearch';
-					}
-					value = this.querySelector('#valuemenu').value.substr(1);
-				}
-				
-				// Regular drop-down menu
-				else {
-					value = this.querySelector('#valuemenu').value;
-				}
-				this.parent.search.updateCondition(this.conditionID, condition, operator, value);
+		// Return this row's current {condition, operator, value} for serialization.
+		// The owning <zoterosearch> collects these across the tree and rebuilds the
+		// search from scratch. Returns null while the row is still being set up.
+		getConditionData() {
+			if (!(this.parent && this.parent.search) || this.dontupdate) {
+				return null;
 			}
+
+			var condition = this.selectedCondition;
+			var operator = this.querySelector('#operatorsmenu').value;
+			let value;
+
+			// Regular text field
+			if (!this.querySelector('#valuefield').hidden) {
+				value = this.querySelector('#valuefield').value;
+
+				// Convert datetimes to UTC before saving
+				switch (condition) {
+					case 'accessDate':
+					case 'dateAdded':
+					case 'dateModified':
+						if (Zotero.Date.isSQLDateTime(value)) {
+							value = Zotero.Date.dateToSQL(Zotero.Date.sqlToDate(value), true);
+						}
+				}
+
+				// Append mode to condition
+				if (this.querySelector('#valuefield').mode) {
+					condition += '/' + this.querySelector('#valuefield').mode;
+				}
+			}
+
+			// isInTheLast operator
+			else if (!this.querySelector('#value-date-age').hidden) {
+				value = this.querySelector('#value-date-age').value;
+			}
+
+			// Handle special C1234 and S5678 form for
+			// collections and searches
+			else if (condition == 'collection') {
+				var letter = this.querySelector('#valuemenu').value.substr(0, 1);
+				if (letter == 'C') {
+					condition = 'collection';
+				}
+				else if (letter == 'S') {
+					condition = 'savedSearch';
+				}
+				value = this.querySelector('#valuemenu').value.substr(1);
+			}
+
+			// Regular drop-down menu
+			else {
+				value = this.querySelector('#valuemenu').value;
+			}
+
+			return { condition, operator, value };
 		}
 
 		updateMenuCheckboxesRecursive(menu, value) {
@@ -859,27 +1021,59 @@
 		onRemoveClicked(event) {
 			if (this.parent) {
 				// A keyboard-synthesized click has detail 0, unlike a mouse click
-				this.parent.removeCondition(this.conditionID, event?.detail === 0);
+				this.parent.removeRow(this, event?.detail === 0);
 			}
 		}
 
 		onAddClicked(event) {
 			event.preventDefault();
-			if (this.parent) {
-				let ref = this.parent.search.getCondition(
-					this.parent.search.addCondition(
-						this.querySelector('#conditionsmenu').getAttribute('data-value'),
-						this.querySelector('#operatorsmenu').value,
-						""
-					)
-				);
-				this.parent.addCondition(ref);
-				// When activated from the keyboard (a synthesized click has detail
-				// 0, unlike a mouse click), move focus to the new row's drop-down
-				if (event.detail === 0) {
-					this.parent.focusNewCondition();
-				}
+			if (!this.parent) {
+				return;
 			}
+			// Add a sibling condition right after this one, seeded with this row's
+			// condition and operator
+			let group = this.closest('search-condition-group');
+			let row = group.addCondition({
+				id: undefined,
+				condition: this.querySelector('#conditionsmenu').getAttribute('data-value'),
+				operator: this.querySelector('#operatorsmenu').value,
+				value: '',
+				mode: undefined,
+				required: false
+			}, this.nextElementSibling);
+			this.parent.updateSearch();
+			this.parent.updateRemoveButtons();
+			// When activated from the keyboard (a synthesized click has detail 0,
+			// unlike a mouse click), move focus to the new row's drop-down
+			if (event.detail === 0) {
+				this.parent.focusNewCondition(row);
+			}
+		}
+
+		// Wrap this condition in a new group in its place, so further conditions can be
+		// added to the group to combine with it under a separate join mode
+		onGroupClicked(event) {
+			event.preventDefault();
+			if (!this.parent) {
+				return;
+			}
+			var group = this.closest('search-condition-group');
+			// Rebuild the condition inside the new group rather than moving the row, since
+			// detaching a custom element wipes its contents
+			var ref;
+			var data = this.getConditionData();
+			if (data) {
+				let [condition, mode] = Zotero.SearchConditions.parseCondition(data.condition);
+				ref = { id: undefined, condition, mode, operator: data.operator, value: data.value, required: false };
+			}
+			var newGroup = document.createXULElement('search-condition-group');
+			group.conditionsContainer.insertBefore(newGroup, this);
+			newGroup.addCondition(ref);
+			this.remove();
+
+			this.parent.updateSearch();
+			this.parent.updateRemoveButtons();
+			newGroup.conditionsContainer.firstElementChild.querySelector('#conditionsmenu').focus();
 		}
 
 		// Whether a value has been entered, used to decide whether the last

--- a/chrome/content/zotero/xpcom/data/dataObjectUtilities.js
+++ b/chrome/content/zotero/xpcom/data/dataObjectUtilities.js
@@ -440,35 +440,31 @@ Zotero.DataObjectUtilities = {
 		return changeset;
 	},
 	
-	_conditionsDiff: function (data1, data2 = {}) {
-		var changeset = [];
-		outer:
-		for (let i = 0; i < data1.length; i++) {
-			for (let j = 0; j < data2.length; j++) {
-				if (Zotero.SearchConditions.equals(data1[i], data2[j])) {
-					continue outer;
-				}
+	/**
+	 * Conditions are an ordered list -- with condition groups, the position of conditions and
+	 * the pairing of group markers (groupStart/groupEnd) are load-bearing -- so diff them as a
+	 * single unit, like creators, rather than as an unordered member set. A member-style diff
+	 * during a sync merge could reorder conditions or add/drop indistinguishable group markers,
+	 * corrupting the structure.
+	 */
+	_conditionsDiff: function (data1, data2 = []) {
+		if (!data2 || !data2.length) {
+			if (!data1 || !data1.length) {
+				return [];
 			}
-			changeset.push({
+			return [{
 				field: "conditions",
-				op: "member-remove",
-				value: data1[i]
-			});
+				op: "delete"
+			}];
 		}
-		outer:
-		for (let i = 0; i < data2.length; i++) {
-			for (let j = 0; j < data1.length; j++) {
-				if (Zotero.SearchConditions.equals(data2[i], data1[j])) {
-					continue outer;
-				}
-			}
-			changeset.push({
+		if (this._conditionsChanged(data1, data2)) {
+			return [{
 				field: "conditions",
-				op: "member-add",
-				value: data2[i]
-			});
+				op: "modify",
+				value: data2
+			}];
 		}
-		return changeset;
+		return [];
 	},
 	
 	_htmlDiff: function (field, html1, html2 = "") {
@@ -624,12 +620,10 @@ Zotero.DataObjectUtilities = {
 						throw new Error("Unimplemented");
 						break;
 					
-					case 'conditions':
 					case 'tags':
 						let found = false;
-						let f = c.field == 'conditions' ? Zotero.SearchConditions : Zotero.Tags;
 						for (let i = 0; i < json[c.field].length; i++) {
-							if (f.equals(json[c.field][i], c.value)) {
+							if (Zotero.Tags.equals(json[c.field][i], c.value)) {
 								found = true;
 								break;
 							}
@@ -657,11 +651,9 @@ Zotero.DataObjectUtilities = {
 						throw new Error("Unimplemented");
 						break;
 					
-					case 'conditions':
 					case 'tags':
-						let f = c.field == 'conditions' ? Zotero.SearchConditions : Zotero.Tags;
 						for (let i = 0; i < json[c.field].length; i++) {
-							if (f.equals(json[c.field][i], c.value)) {
+							if (Zotero.Tags.equals(json[c.field][i], c.value)) {
 								json[c.field].splice(i, 1);
 								break;
 							}

--- a/chrome/content/zotero/xpcom/data/search.js
+++ b/chrome/content/zotero/xpcom/data/search.js
@@ -206,8 +206,8 @@ Zotero.Search.prototype._saveData = async function (env) {
 		
 		var i = 0;
 		var sql = "INSERT INTO savedSearchConditions "
-			+ "(savedSearchID, searchConditionID, condition, operator, value, required) "
-			+ "VALUES (?,?,?,?,?,?)";
+			+ "(savedSearchID, searchConditionID, condition, operator, value) "
+			+ "VALUES (?,?,?,?,?)";
 		for (let id in this._conditions) {
 			let condition = this._conditions[id];
 			
@@ -221,8 +221,7 @@ Zotero.Search.prototype._saveData = async function (env) {
 				i,
 				conditionString,
 				condition.operator ? condition.operator : null,
-				condition.value ? condition.value : null,
-				condition.required ? 1 : null
+				condition.value ? condition.value : null
 			];
 			await Zotero.DB.queryAsync(sql, sqlParams);
 			i++;
@@ -296,6 +295,10 @@ Zotero.Search.prototype._finalizeErase = async function (env) {
 
 Zotero.Search.prototype.addCondition = function (condition, operator, value, required) {
 	this._requireData('conditions');
+	
+	if (required) {
+		throw new Error("The 'required' parameter is no longer supported; use a condition group");
+	}
 	
 	if (!Zotero.SearchConditions.hasOperator(condition, operator)){
 		let e = new Error("Invalid operator '" + operator + "' for condition " + condition);
@@ -414,8 +417,7 @@ Zotero.Search.prototype.addCondition = function (condition, operator, value, req
 		condition: condition,
 		mode: mode,
 		operator: operator,
-		value: value,
-		required: !!required
+		value: value
 	};
 	
 	this._sql = null;
@@ -441,11 +443,14 @@ Zotero.Search.prototype.setScope = function (searchObj, includeChildren) {
  * @param {String} condition
  * @param {String} operator
  * @param {String} value
- * @param {Boolean} [required]
  * @return {Promise}
  */
 Zotero.Search.prototype.updateCondition = function (searchConditionID, condition, operator, value, required) {
 	this._requireData('conditions');
+	
+	if (required) {
+		throw new Error("The 'required' parameter is no longer supported; use a condition group");
+	}
 	
 	if (typeof this._conditions[searchConditionID] == 'undefined'){
 		throw new Error('Invalid searchConditionID ' + searchConditionID);
@@ -466,8 +471,7 @@ Zotero.Search.prototype.updateCondition = function (searchConditionID, condition
 		condition: condition,
 		mode: mode,
 		operator: operator,
-		value: value,
-		required: !!required
+		value: value
 	};
 	
 	this._sql = null;
@@ -505,7 +509,7 @@ Zotero.Search.prototype.removeCondition = function (searchConditionID) {
 
 
 /*
- * Returns an array with 'condition', 'operator', 'value', 'required'
+ * Returns an array with 'condition', 'operator', 'value'
  * for the given searchConditionID
  */
 Zotero.Search.prototype.getCondition = function (searchConditionID){
@@ -528,8 +532,7 @@ Zotero.Search.prototype.getConditions = function (){
 			condition: condition.condition,
 			mode: condition.mode,
 			operator: condition.operator,
-			value: condition.value,
-			required: condition.required
+			value: condition.value
 		};
 	}
 	return conditions;
@@ -1106,7 +1109,6 @@ Zotero.Search.prototype._buildQuery = async function () {
 				operator: condition.operator,
 				value: condition.value,
 				flags: conditionData.flags,
-				required: condition.required,
 				inlineFilter: conditionData.inlineFilter,
 				// Item level(s) this condition matches at, for cross-level mapping
 				level: Zotero.Search._conditionLevel(name, conditionData)
@@ -1180,7 +1182,6 @@ Zotero.Search.prototype._buildQuery = async function () {
 							name: '_fulltextContentPredicate',
 							operator: condition.operator,
 							matchIDs,
-							required: condition.required,
 							// Full-text content is indexed per attachment, so matches are at
 							// the attachment level for cross-level mapping
 							level: 'attachment'
@@ -1388,7 +1389,7 @@ Zotero.Search.prototype._buildQuery = async function () {
 						let op = condition.operator == 'doesNotContain' ? 'NOT IN' : 'IN';
 						sql = 'itemID ' + op + ' (' + condition.matchIDs.join(',') + ')';
 					}
-					builtConditions.push({ sql, params: [], required: condition.required, level: condition.level });
+					builtConditions.push({ sql, params: [], level: condition.level });
 					continue;
 				}
 
@@ -1957,7 +1958,6 @@ Zotero.Search.prototype._buildQuery = async function () {
 				builtConditions.push({
 					sql: condSQL,
 					params: condSQLParams,
-					required: condition.required,
 					level: condition.level || 'item',
 					negate: condition.operator == 'isNot' || condition.operator == 'doesNotContain'
 				});
@@ -1981,7 +1981,7 @@ Zotero.Search.prototype._buildQuery = async function () {
  * Combine an ordered list of built condition predicates and group markers into a single SQL
  * predicate.
  *
- * Each item in `builtConditions` is either a predicate { sql, params, required } or a group
+ * Each item in `builtConditions` is either a predicate { sql, params } or a group
  * marker { marker: 'groupStart' | 'groupEnd' | 'joinMode', operator }. groupStart/groupEnd
  * delimit nested groups and a 'joinMode' marker sets its enclosing group's mode.
  *
@@ -1999,8 +1999,7 @@ Zotero.Search.prototype._buildQuery = async function () {
  * group markers is an unused placeholder -- they carry no value, but a condition's operator
  * can't be empty.
  *
- * In 'all' mode a group's children are ANDed; in 'any' mode they're ORed, except 'required'
- * conditions, which are always ANDed (legacy behavior, ultimately subsumable by grouping).
+ * In 'all' mode a group's children are ANDed; in 'any' mode they're ORed.
  *
  * A group may also carry a 'resultLevel' marker (a level: 'item'/'attachment'/'note'/'annotation'),
  * placed inside the group like 'joinMode'. When the result level is a descendant level of the
@@ -2066,7 +2065,7 @@ Zotero.Search.combineConditions = function (builtConditions, rootLevel = 'any') 
 			// When mapping reduces a predicate to a constant ('0'/'1' -- e.g., a condition
 			// whose level can't reach the result level), its placeholders are gone, so drop its params
 			let childParams = (childSQL === '0' || childSQL === '1') ? [] : result.params;
-			if (node.joinMode == 'all' || result.required) {
+			if (node.joinMode == 'all') {
 				requiredParts.push(childSQL);
 				requiredParams = requiredParams.concat(childParams);
 			}
@@ -2088,7 +2087,7 @@ Zotero.Search.combineConditions = function (builtConditions, rootLevel = 'any') 
 			params = params.concat(optionalParams);
 		}
 		if (!parts.length) {
-			return { sql: '', params: [], required: false };
+			return { sql: '', params: [] };
 		}
 		let sql = parts.length > 1 ? '(' + parts.join(' AND ') + ')' : parts[0];
 		// Map this group to the enclosing row's level. A 'any' enclosing level (the
@@ -2101,8 +2100,7 @@ Zotero.Search.combineConditions = function (builtConditions, rootLevel = 'any') 
 		return {
 			sql,
 			// Mapping to a constant drops the placeholders, so drop the params too
-			params: (sql === '0' || sql === '1') ? [] : params,
-			required: false
+			params: (sql === '0' || sql === '1') ? [] : params
 		};
 	};
 

--- a/chrome/content/zotero/xpcom/data/search.js
+++ b/chrome/content/zotero/xpcom/data/search.js
@@ -305,15 +305,23 @@ Zotero.Search.prototype.addCondition = function (condition, operator, value, req
 	
 	// Shortcut to add a condition on every table -- does not return an id
 	if (condition.match(/^quicksearch/)) {
+		// The full-text content post-filter in search() isn't group-aware, so it can't
+		// tell that a quicksearch's full-text matches sit inside per-word 'any' groups.
+		// This flag tells it to merge them as a union even though the top-level join mode
+		// is 'all'. Once full-text conditions participate in the group tree, this flag and
+		// the post-filter special case both go away, leaving quicksearch as plain groups.
+		this._hasQuicksearch = true;
 		var parts = Zotero.SearchConditions.parseSearchString(value);
-		
+
 		for (let part of parts) {
 			if (condition == 'quicksearch-titleCreatorYearNote') {
 				this.addCondition('note', operator, part.text, false);
 				continue;
 			}
-			
-			this.addCondition('blockStart');
+
+			// Each word is an OR-group over the fields below
+			this.addCondition('groupStart', 'true', '');
+			this.addCondition('joinMode', 'any');
 
 			// Allow searching for exact object key
 			if (operator == 'contains' && Zotero.Utilities.isValidObjectKey(part.text)) {
@@ -336,7 +344,7 @@ Zotero.Search.prototype.addCondition = function (condition, operator, value, req
 				this.addCondition('annotationComment', operator, part.text, false);
 			}
 			this.addCondition('creator', operator, part.text, false);
-			
+
 			if (condition == 'quicksearch-everything') {
 				if (part.inQuotes) {
 					this.addCondition('fulltextContent', operator, part.text, false);
@@ -348,8 +356,8 @@ Zotero.Search.prototype.addCondition = function (condition, operator, value, req
 					}
 				}
 			}
-			
-			this.addCondition('blockEnd');
+
+			this.addCondition('groupEnd', 'true', '');
 		}
 		
 		if (condition == 'quicksearch-titleCreatorYear') {
@@ -564,33 +572,31 @@ Zotero.Search.prototype.search = async function (asTempTable) {
 			await this._buildQuery();
 		}
 		
+		// Set true by the quicksearch expansion in addCondition()
+		var hasQuicksearch = !!this._hasQuicksearch;
 		// Set some variables for conditions to avoid further lookups
 		for (let condition of Object.values(this._conditions)) {
 			switch (condition.condition) {
 				case 'fulltextContent':
 					var fulltextContent = true;
 					break;
-				
+
 				case 'includeParentsAndChildren':
 					if (condition.operator == 'true') {
 						var includeParentsAndChildren = true;
 					}
 					break;
-				
+
 				case 'includeParents':
 					if (condition.operator == 'true') {
 						var includeParents = true;
 					}
 					break;
-				
+
 				case 'includeChildren':
 					if (condition.operator == 'true') {
 						var includeChildren = true;
 					}
-					break;
-				
-				case 'blockStart':
-					var hasQuicksearch = true;
 					break;
 			}
 		}
@@ -979,20 +985,30 @@ Zotero.Search.prototype._buildQuery = async function () {
 	var sql = 'SELECT itemID FROM items';
 	
 	var sqlParams = [];
-	// Separate ANY conditions for 'required' condition support
-	var anySQL = '';
-	var anySQLParams = [];
-	
+
 	var conditions = [];
-	
+
 	let lastCondition;
 	let conditionsToProcess = Object.values(this._conditions);
-	
-	// Process joinMode first, since other conditions may depend on it
+
+	// The search's top-level join mode, used by the full-text result merging in
+	// search(). Per-group join modes (including nested groups) are resolved from the
+	// 'joinMode' markers when the condition tree is assembled below, so the joinMode
+	// conditions are left in the stream rather than spliced out here. Only the
+	// top-level joinMode counts here, so skip any nested inside a group.
 	this._joinMode = 'all';
-	var joinModeIndex = conditionsToProcess.findIndex(cond => cond.condition == "joinMode");
-	if (joinModeIndex > -1) {
-		this._joinMode = conditionsToProcess.splice(joinModeIndex, 1)[0].operator;
+	let groupDepth = 0;
+	for (let cond of conditionsToProcess) {
+		if (cond.condition == 'groupStart') {
+			groupDepth++;
+		}
+		else if (cond.condition == 'groupEnd') {
+			groupDepth--;
+		}
+		else if (cond.condition == 'joinMode' && groupDepth == 0) {
+			this._joinMode = cond.operator;
+			break;
+		}
 	}
 	
 	for (let condition of conditionsToProcess) {
@@ -1085,25 +1101,32 @@ Zotero.Search.prototype._buildQuery = async function () {
 					// Handled in Search.search()
 					continue;
 				
-				// For quicksearch block markers
-				case 'blockStart':
-					conditions.push({name:'blockStart'});
+				// Group markers, passed through to the condition tree assembled after the
+				// main loop. Reset lastCondition so inline-filter merging doesn't combine
+				// conditions across a group boundary.
+				case 'joinMode':
+					lastCondition = null;
+					conditions.push({ name: 'joinMode', operator: condition.operator });
 					continue;
-				case 'blockEnd':
-					conditions.push({name:'blockEnd'});
+				case 'groupStart':
+					lastCondition = null;
+					conditions.push({ name: 'groupStart' });
+					continue;
+				case 'groupEnd':
+					lastCondition = null;
+					conditions.push({ name: 'groupEnd' });
 					continue;
 				
 				case 'anyField':
 					// We expand this condition to the same underlying set of conditions as 'quicksearch-fields'
 					// (although we don't detect keys or split into quoted and unquoted segments). 'quicksearch-fields'
 					// is expanded in addCondition(), but we can't do that with this condition because we don't want
-					// to save the conditions it expands to in the search object
-					if (this._joinMode == 'all') {
-						// If joinMode is 'any', do not wrap conditions in quickSearch block so that
-						// they become just a series of OR statements. Otherwise, "Any Field" will
-						// conflict with all other conditions (if multiple conditions are present).
-						conditionsToProcess.push({ condition: 'blockStart' });
-					}
+					// to save the conditions it expands to in the search object.
+					// Always wrap in an OR-group: "Any Field" means "matches in any one of
+					// these fields", which is correct whether the surrounding join mode is
+					// 'all' or 'any' (an OR-group nested in an 'any' group flattens out).
+					conditionsToProcess.push({ condition: 'groupStart', operator: 'true', value: '' });
+					conditionsToProcess.push({ condition: 'joinMode', operator: 'any' });
 					conditionsToProcess.push({
 						condition: 'field',
 						operator: condition.operator,
@@ -1128,9 +1151,7 @@ Zotero.Search.prototype._buildQuery = async function () {
 						value: condition.value,
 						required: false
 					});
-					if (this._joinMode == 'all') {
-						conditionsToProcess.push({ condition: 'blockEnd' });
-					}
+					conditionsToProcess.push({ condition: 'groupEnd', operator: 'true', value: '' });
 					continue;
 			}
 			
@@ -1208,9 +1229,27 @@ Zotero.Search.prototype._buildQuery = async function () {
 	}
 	
 	if (this._hasPrimaryConditions) {
-		sql += " AND ";
-		
+		// Each condition produces a self-contained "itemID [NOT] IN (...)" predicate.
+		// Markers and predicates are collected here in document order, then assembled
+		// into a (possibly nested) tree of AND/OR groups below.
+		let builtConditions = [];
+
 		for (let condition of Object.values(conditions)){
+				// Group markers and per-group join modes are handled when the tree is
+				// assembled, not as SQL predicates
+				if (condition.name == 'groupStart') {
+					builtConditions.push({ marker: 'groupStart' });
+					continue;
+				}
+				if (condition.name == 'groupEnd') {
+					builtConditions.push({ marker: 'groupEnd' });
+					continue;
+				}
+				if (condition.name == 'joinMode') {
+					builtConditions.push({ marker: 'joinMode', operator: condition.operator });
+					continue;
+				}
+
 				var skipOperators = false;
 				var openParens = 0;
 				var condSQL = '';
@@ -1476,12 +1515,6 @@ Zotero.Search.prototype._buildQuery = async function () {
 					
 					case 'tempTable':
 						condSQL += "itemID IN (SELECT id FROM " + condition.value + ")";
-						skipOperators = true;
-						break;
-						
-					// For quicksearch blocks
-					case 'blockStart':
-					case 'blockEnd':
 						skipOperators = true;
 						break;
 				}
@@ -1788,64 +1821,120 @@ Zotero.Search.prototype._buildQuery = async function () {
 					condSQL += ')';
 				}
 				
-				// Little hack to support multiple quicksearch words
-				if (condition['name'] == 'blockStart') {
-					var inQS = true;
-					var qsSQL = '';
-					var qsParams = [];
-					continue;
-				}
-				else if (condition['name'] == 'blockEnd') {
-					inQS = false;
-					// Strip ' OR ' from last condition
-					qsSQL = qsSQL.substring(0, qsSQL.length-4);
-					
-					// Add to existing quicksearch words
-					if (!quicksearchSQLSet) {
-						var quicksearchSQLSet = [];
-						var quicksearchParamsSet = [];
-					}
-					quicksearchSQLSet.push(qsSQL);
-					quicksearchParamsSet.push(qsParams);
-				}
-				else if (inQS) {
-					qsSQL += condSQL + ' OR ';
-					qsParams = qsParams.concat(condSQLParams);
-				}
-				// Keep non-required conditions separate if in ANY mode
-				else if (!condition.required && this._joinMode == 'any') {
-					anySQL += condSQL + ' OR ';
-					anySQLParams = anySQLParams.concat(condSQLParams);
-				}
-				else {
-					condSQL += ' AND ';
-					sql += condSQL;
-					sqlParams = sqlParams.concat(condSQLParams);
-				}
+				builtConditions.push({
+					sql: condSQL,
+					params: condSQLParams,
+					required: condition.required
+				});
 		}
-		
-		// Add on ANY conditions
-		if (anySQL){
-			sql += '(' + anySQL;
-			sqlParams = sqlParams.concat(anySQLParams);
-			sql = sql.substring(0, sql.length-4); // remove last ' OR '
-			sql += ')';
-		}
-		else {
-			sql = sql.substring(0, sql.length-5); // remove last ' AND '
-		}
-		
-		// Add on quicksearch conditions
-		if (quicksearchSQLSet) {
-			sql = "SELECT itemID FROM items WHERE itemID IN (" + sql + ") "
-				+ "AND ((" + quicksearchSQLSet.join(') AND (') + "))";
-			
-			for (var k=0; k<quicksearchParamsSet.length; k++) {
-				sqlParams = sqlParams.concat(quicksearchParamsSet[k]);
-			}
+
+		// Combine the collected predicates and group markers into a single predicate
+		// (see Zotero.Search.combineConditions)
+		let combined = Zotero.Search.combineConditions(builtConditions);
+		if (combined.sql) {
+			sql += " AND " + combined.sql;
+			sqlParams = sqlParams.concat(combined.params);
 		}
 	}
 	
 	this._sql = sql;
 	this._sqlParams = sqlParams.length ? sqlParams : false;
+};
+
+
+/**
+ * Combine an ordered list of built condition predicates and group markers into a single SQL
+ * predicate.
+ *
+ * Each item in `builtConditions` is either a predicate { sql, params, required } or a group
+ * marker { marker: 'groupStart' | 'groupEnd' | 'joinMode', operator }. groupStart/groupEnd
+ * delimit nested groups and a 'joinMode' marker sets its enclosing group's mode.
+ *
+ * For example, conditions built as
+ *
+ *   search.addCondition('joinMode', 'all');
+ *   search.addCondition('title', 'contains', 'foo');
+ *   search.addCondition('groupStart', 'true', '');
+ *   search.addCondition('joinMode', 'any');
+ *   search.addCondition('tag', 'is', 'x');
+ *   search.addCondition('tag', 'is', 'y');
+ *   search.addCondition('groupEnd', 'true', '');
+ *
+ * combine to "title contains 'foo' AND (tag is 'x' OR tag is 'y')". The 'true' operator on the
+ * group markers is an unused placeholder -- they carry no value, but a condition's operator
+ * can't be empty.
+ *
+ * In 'all' mode a group's children are ANDed; in 'any' mode they're ORed, except 'required'
+ * conditions, which are always ANDed (legacy behavior, ultimately subsumable by grouping).
+ *
+ * @param {Object[]} builtConditions
+ * @return {{ sql: String, params: Array }} Combined predicate (sql is '' if nothing to combine)
+ */
+Zotero.Search.combineConditions = function (builtConditions) {
+	let root = { joinMode: 'all', children: [] };
+	let groupStack = [root];
+	for (let item of builtConditions) {
+		let group = groupStack[groupStack.length - 1];
+		if (item.marker == 'groupStart') {
+			let child = { joinMode: 'all', children: [] };
+			group.children.push(child);
+			groupStack.push(child);
+		}
+		else if (item.marker == 'groupEnd') {
+			// Ignore an unbalanced end marker rather than popping the root
+			if (groupStack.length > 1) {
+				groupStack.pop();
+			}
+		}
+		else if (item.marker == 'joinMode') {
+			group.joinMode = item.operator;
+		}
+		else {
+			group.children.push(item);
+		}
+	}
+
+	// Reduce a group node to a single { sql, params } predicate
+	let combineGroup = (node) => {
+		let requiredParts = [];
+		let requiredParams = [];
+		let optionalParts = [];
+		let optionalParams = [];
+		for (let child of node.children) {
+			let result = child.children ? combineGroup(child) : child;
+			if (!result.sql) {
+				continue;
+			}
+			if (node.joinMode == 'all' || result.required) {
+				requiredParts.push(result.sql);
+				requiredParams = requiredParams.concat(result.params);
+			}
+			else {
+				optionalParts.push(result.sql);
+				optionalParams = optionalParams.concat(result.params);
+			}
+		}
+		let parts = [];
+		let params = [];
+		if (requiredParts.length) {
+			parts.push(requiredParts.join(' AND '));
+			params = params.concat(requiredParams);
+		}
+		if (optionalParts.length) {
+			parts.push(optionalParts.length > 1
+				? '(' + optionalParts.join(' OR ') + ')'
+				: optionalParts[0]);
+			params = params.concat(optionalParams);
+		}
+		if (!parts.length) {
+			return { sql: '', params: [], required: false };
+		}
+		return {
+			sql: parts.length > 1 ? '(' + parts.join(' AND ') + ')' : parts[0],
+			params: params,
+			required: false
+		};
+	};
+
+	return combineGroup(root);
 };

--- a/chrome/content/zotero/xpcom/data/search.js
+++ b/chrome/content/zotero/xpcom/data/search.js
@@ -1075,7 +1075,9 @@ Zotero.Search.prototype._buildQuery = async function () {
 		}
 	}
 	
-	for (let condition of conditionsToProcess) {
+	// Index-based so anyField can splice its expansion in place (see below)
+	for (let conditionIndex = 0; conditionIndex < conditionsToProcess.length; conditionIndex++) {
+		let condition = conditionsToProcess[conditionIndex];
 		let name = condition.condition;
 		let conditionData = Zotero.SearchConditions.get(name);
 		
@@ -1209,54 +1211,30 @@ Zotero.Search.prototype._buildQuery = async function () {
 					conditions.push({ name: 'groupEnd' });
 					continue;
 				
-				case 'anyField':
-					// We expand this condition to the same underlying set of conditions as 'quicksearch-fields'
-					// (although we don't detect keys or split into quoted and unquoted segments). 'quicksearch-fields'
-					// is expanded in addCondition(), but we can't do that with this condition because we don't want
-					// to save the conditions it expands to in the search object.
-					// Always wrap in an OR-group: "Any Field" means "matches in any one of
-					// these fields", which is correct whether the surrounding join mode is
-					// 'all' or 'any' (an OR-group nested in an 'any' group flattens out).
-					conditionsToProcess.push({ condition: 'groupStart', operator: 'true', value: '' });
-					conditionsToProcess.push({ condition: 'joinMode', operator: 'any' });
-					conditionsToProcess.push({
-						condition: 'field',
-						operator: condition.operator,
-						value: condition.value,
-						required: false
-					});
-					conditionsToProcess.push({
-						condition: 'tag',
-						operator: condition.operator,
-						value: condition.value,
-						required: false
-					});
-					conditionsToProcess.push({
-						condition: 'note',
-						operator: condition.operator,
-						value: condition.value,
-						required: false
-					});
-					conditionsToProcess.push({
-						condition: 'annotationText',
-						operator: condition.operator,
-						value: condition.value,
-						required: false
-					});
-					conditionsToProcess.push({
-						condition: 'annotationComment',
-						operator: condition.operator,
-						value: condition.value,
-						required: false
-					});
-					conditionsToProcess.push({
-						condition: 'creator',
-						operator: condition.operator,
-						value: condition.value,
-						required: false
-					});
-					conditionsToProcess.push({ condition: 'groupEnd', operator: 'true', value: '' });
+				case 'anyField': {
+					// Expand to the same field set as 'quicksearch-fields' (without key
+					// detection or quoted/unquoted splitting). Done here rather than in
+					// addCondition() so the expansion isn't saved in the search object.
+					// Splice it in right after this condition so it's processed at the same
+					// nesting depth -- "Any Field" inside a group stays in that group.
+					// Always an OR-group: "Any Field" means "matches in any one of these
+					// fields", correct whether the surrounding join mode is 'all' or 'any'
+					// (an OR-group nested in an 'any' group flattens out).
+					let op = condition.operator;
+					let val = condition.value;
+					conditionsToProcess.splice(conditionIndex + 1, 0,
+						{ condition: 'groupStart', operator: 'true', value: '' },
+						{ condition: 'joinMode', operator: 'any' },
+						{ condition: 'field', operator: op, value: val },
+						{ condition: 'tag', operator: op, value: val },
+						{ condition: 'note', operator: op, value: val },
+						{ condition: 'annotationText', operator: op, value: val },
+						{ condition: 'annotationComment', operator: op, value: val },
+						{ condition: 'creator', operator: op, value: val },
+						{ condition: 'groupEnd', operator: 'true', value: '' }
+					);
 					continue;
+				}
 			}
 			
 			throw new Error('Unhandled special condition ' + name);

--- a/chrome/content/zotero/xpcom/data/search.js
+++ b/chrome/content/zotero/xpcom/data/search.js
@@ -1053,7 +1053,12 @@ Zotero.Search.prototype._buildQuery = async function () {
 	// conditions are left in the stream rather than spliced out here. Only the
 	// top-level joinMode counts here, so skip any nested inside a group.
 	this._joinMode = 'all';
+	// The result level the whole search returns. A top-level 'resultLevel' condition sets it;
+	// the default 'any' keeps the existing mixed-level behavior (no mapping, no
+	// level constraint on the result set).
+	let resultLevel = 'any';
 	let groupDepth = 0;
+	let foundJoinMode = false;
 	for (let cond of conditionsToProcess) {
 		if (cond.condition == 'groupStart') {
 			groupDepth++;
@@ -1061,9 +1066,12 @@ Zotero.Search.prototype._buildQuery = async function () {
 		else if (cond.condition == 'groupEnd') {
 			groupDepth--;
 		}
-		else if (cond.condition == 'joinMode' && groupDepth == 0) {
+		else if (groupDepth == 0 && cond.condition == 'joinMode' && !foundJoinMode) {
 			this._joinMode = cond.operator;
-			break;
+			foundJoinMode = true;
+		}
+		else if (groupDepth == 0 && cond.condition == 'resultLevel') {
+			resultLevel = cond.operator;
 		}
 	}
 	
@@ -1071,9 +1079,8 @@ Zotero.Search.prototype._buildQuery = async function () {
 		let name = condition.condition;
 		let conditionData = Zotero.SearchConditions.get(name);
 		
-		// Has a table (or 'savedSearch', which doesn't have a table but isn't special)
-		// TEMP: Or 'tag', which needs to match annotation parents
-		if (conditionData.table || name == 'savedSearch' || name == 'tempTable' || name == 'tag') {
+		// Has a table (or 'savedSearch'/'tempTable', which don't have a table but aren't special)
+		if (conditionData.table || name == 'savedSearch' || name == 'tempTable') {
 			// For conditions with an inline filter using 'is'/'isNot', combine with last condition
 			// if the same
 			if (lastCondition
@@ -1098,7 +1105,9 @@ Zotero.Search.prototype._buildQuery = async function () {
 				value: condition.value,
 				flags: conditionData.flags,
 				required: condition.required,
-				inlineFilter: conditionData.inlineFilter
+				inlineFilter: conditionData.inlineFilter,
+				// Item level(s) this condition matches at, for cross-level mapping
+				level: Zotero.Search._conditionLevel(name, conditionData)
 			};
 			conditions.push(lastCondition);
 			
@@ -1154,10 +1163,12 @@ Zotero.Search.prototype._buildQuery = async function () {
 					continue;
 				
 				case 'fulltextContent':
-					// A fulltextContent inside a group is materialized into an itemID
-					// predicate so it joins the SQL AND/OR tree; a top-level one is left
-					// for the post-filter in search() (unchanged behavior)
-					if (loopDepth > 0) {
+					// A fulltextContent inside a group -- or at the top level when a result
+					// level is set -- is materialized into an itemID predicate so it joins
+					// the SQL AND/OR tree and can be mapped to that level (full-text is
+					// indexed per attachment). A plain top-level one with no result level is
+					// left for the post-filter in search() (unchanged behavior).
+					if (loopDepth > 0 || resultLevel != 'any') {
 						let matchIDs = await this._fullTextContentMatches(
 							condition.value, condition.mode
 						);
@@ -1167,7 +1178,10 @@ Zotero.Search.prototype._buildQuery = async function () {
 							name: '_fulltextContentPredicate',
 							operator: condition.operator,
 							matchIDs,
-							required: condition.required
+							required: condition.required,
+							// Full-text content is indexed per attachment, so matches are at
+							// the attachment level for cross-level mapping
+							level: 'attachment'
 						});
 						this._hasPrimaryConditions = true;
 					}
@@ -1179,6 +1193,10 @@ Zotero.Search.prototype._buildQuery = async function () {
 				case 'joinMode':
 					lastCondition = null;
 					conditions.push({ name: 'joinMode', operator: condition.operator });
+					continue;
+				case 'resultLevel':
+					lastCondition = null;
+					conditions.push({ name: 'resultLevel', operator: condition.operator });
 					continue;
 				case 'groupStart':
 					lastCondition = null;
@@ -1301,7 +1319,27 @@ Zotero.Search.prototype._buildQuery = async function () {
 		sql += " AND (itemID IN (SELECT itemID FROM items WHERE libraryID=?))";
 		sqlParams.push(this.libraryID);
 	}
-	
+
+	// Result level: constrain the result set to one item level. The default
+	// ('any') leaves the mixed-level result unchanged.
+	switch (resultLevel) {
+		case 'item':
+			// Top-level items only (exclude child attachments/notes and annotations)
+			sql += " AND (itemID NOT IN (SELECT itemID FROM itemAttachments WHERE parentItemID IS NOT NULL) "
+				+ "AND itemID NOT IN (SELECT itemID FROM itemNotes WHERE parentItemID IS NOT NULL) "
+				+ "AND itemID NOT IN (SELECT itemID FROM itemAnnotations))";
+			break;
+		case 'attachment':
+			sql += " AND (itemID IN (SELECT itemID FROM itemAttachments))";
+			break;
+		case 'note':
+			sql += " AND (itemID IN (SELECT itemID FROM itemNotes))";
+			break;
+		case 'annotation':
+			sql += " AND (itemID IN (SELECT itemID FROM itemAnnotations))";
+			break;
+	}
+
 	if (this._hasPrimaryConditions) {
 		// Each condition produces a self-contained "itemID [NOT] IN (...)" predicate.
 		// Markers and predicates are collected here in document order, then assembled
@@ -1323,6 +1361,10 @@ Zotero.Search.prototype._buildQuery = async function () {
 					builtConditions.push({ marker: 'joinMode', operator: condition.operator });
 					continue;
 				}
+				if (condition.name == 'resultLevel') {
+					builtConditions.push({ marker: 'resultLevel', operator: condition.operator });
+					continue;
+				}
 				// A grouped fulltextContent materialized into an itemID set (above)
 				if (condition.name == '_fulltextContentPredicate') {
 					let sql;
@@ -1334,7 +1376,7 @@ Zotero.Search.prototype._buildQuery = async function () {
 						let op = condition.operator == 'doesNotContain' ? 'NOT IN' : 'IN';
 						sql = 'itemID ' + op + ' (' + condition.matchIDs.join(',') + ')';
 					}
-					builtConditions.push({ sql, params: [], required: condition.required });
+					builtConditions.push({ sql, params: [], required: condition.required, level: condition.level });
 					continue;
 				}
 
@@ -1359,29 +1401,20 @@ Zotero.Search.prototype._buildQuery = async function () {
 					}
 					condSelectSQL += 'IN (';
 					selectOpenParens = 1;
-					
-					// TEMP: Don't match annotations for negation operators, since it would result in
-					// all parent attachments being returned
-					if (isNegationOperator) {
+
+					// A negation matches every item that lacks the value, including annotations,
+					// which almost never carry item metadata or tags -- so a bare negation would
+					// otherwise return nearly every annotation in the library. Exclude them. When
+					// a result level is set, the result-level constraint already restricts to that
+					// level (and the cross-level mapping handles negation), so this only applies to
+					// the default path.
+					if (isNegationOperator && resultLevel == 'any') {
 						condSelectSQL += "SELECT itemID FROM items WHERE itemTypeID="
 							+ Zotero.ItemTypes.getID('annotation') + " UNION ";
 					}
-					
-					switch (condition.name) {
-						case 'tag':
-							condSQL += "SELECT itemID FROM itemTags "
-								+ "LEFT JOIN itemAnnotations IAnT USING (itemID) WHERE (";
-							break;
-						
-						case 'annotationText':
-						case 'annotationComment':
-							condSQL += `SELECT itemID FROM ${condition.table} WHERE (`
-							break;
-							
-						default:
-							condSQL += `SELECT itemID FROM ${condition.table} WHERE (`;
-					}
-					
+
+					condSQL += `SELECT itemID FROM ${condition.table} WHERE (`;
+
 					openParens = 1;
 				}
 				
@@ -1912,13 +1945,15 @@ Zotero.Search.prototype._buildQuery = async function () {
 				builtConditions.push({
 					sql: condSQL,
 					params: condSQLParams,
-					required: condition.required
+					required: condition.required,
+					level: condition.level || 'item',
+					negate: condition.operator == 'isNot' || condition.operator == 'doesNotContain'
 				});
 		}
 
 		// Combine the collected predicates and group markers into a single predicate
 		// (see Zotero.Search.combineConditions)
-		let combined = Zotero.Search.combineConditions(builtConditions);
+		let combined = Zotero.Search.combineConditions(builtConditions, resultLevel);
 		if (combined.sql) {
 			sql += " AND " + combined.sql;
 			sqlParams = sqlParams.concat(combined.params);
@@ -1955,10 +1990,18 @@ Zotero.Search.prototype._buildQuery = async function () {
  * In 'all' mode a group's children are ANDed; in 'any' mode they're ORed, except 'required'
  * conditions, which are always ANDed (legacy behavior, ultimately subsumable by grouping).
  *
+ * A group may also carry a 'resultLevel' marker (a level: 'item'/'attachment'/'note'/'annotation'),
+ * placed inside the group like 'joinMode'. When the result level is a descendant level of the
+ * enclosing row, the group's conditions are matched against descendants and mapped up to
+ * the parent (see Zotero.Search.mapPredicate) -- e.g., "the item has an annotation
+ * matching these conditions".
+ *
  * @param {Object[]} builtConditions
+ * @param {String} [rootLevel='any'] - The result level the whole search returns ('any' leaves
+ *     the mixed-level default unchanged; otherwise each condition is mapped to this level)
  * @return {{ sql: String, params: Array }} Combined predicate (sql is '' if nothing to combine)
  */
-Zotero.Search.combineConditions = function (builtConditions) {
+Zotero.Search.combineConditions = function (builtConditions, rootLevel = 'any') {
 	let root = { joinMode: 'all', children: [] };
 	let groupStack = [root];
 	for (let item of builtConditions) {
@@ -1977,29 +2020,47 @@ Zotero.Search.combineConditions = function (builtConditions) {
 		else if (item.marker == 'joinMode') {
 			group.joinMode = item.operator;
 		}
+		else if (item.marker == 'resultLevel') {
+			group.level = item.operator;
+		}
 		else {
 			group.children.push(item);
 		}
 	}
 
-	// Reduce a group node to a single { sql, params } predicate
-	let combineGroup = (node) => {
+	// Reduce a group node to a single { sql, params } predicate. parentLevel is the level the
+	// enclosing row is at; the root is a top-level item.
+	let combineGroup = (node, parentLevel) => {
+		// The level this group's children are matched at -- its own result level if set, otherwise
+		// the enclosing level
+		let level = node.level || parentLevel;
 		let requiredParts = [];
 		let requiredParams = [];
 		let optionalParts = [];
 		let optionalParams = [];
 		for (let child of node.children) {
-			let result = child.children ? combineGroup(child) : child;
+			let result = child.children ? combineGroup(child, level) : child;
 			if (!result.sql) {
 				continue;
 			}
+			// A leaf condition's predicate selects itemIDs at its own natural level; if that
+			// differs from this group's level, map it to that level so the group's
+			// children combine at a single level. Nested groups are already mapped to
+			// their own level by the combineGroup() call above.
+			let childSQL = result.sql;
+			if (!child.children) {
+				childSQL = Zotero.Search.mapPredicate(childSQL, result.level || 'item', level, result.negate);
+			}
+			// When mapping reduces a predicate to a constant ('0'/'1' -- e.g., a condition
+			// whose level can't reach the result level), its placeholders are gone, so drop its params
+			let childParams = (childSQL === '0' || childSQL === '1') ? [] : result.params;
 			if (node.joinMode == 'all' || result.required) {
-				requiredParts.push(result.sql);
-				requiredParams = requiredParams.concat(result.params);
+				requiredParts.push(childSQL);
+				requiredParams = requiredParams.concat(childParams);
 			}
 			else {
-				optionalParts.push(result.sql);
-				optionalParams = optionalParams.concat(result.params);
+				optionalParts.push(childSQL);
+				optionalParams = optionalParams.concat(childParams);
 			}
 		}
 		let parts = [];
@@ -2017,12 +2078,271 @@ Zotero.Search.combineConditions = function (builtConditions) {
 		if (!parts.length) {
 			return { sql: '', params: [], required: false };
 		}
+		let sql = parts.length > 1 ? '(' + parts.join(' AND ') + ')' : parts[0];
+		// Map this group to the enclosing row's level. A 'any' enclosing level (the
+		// mixed-level default) has no row level of its own, so a descendant group with a result level
+		// anchors to the top-level item ("the item has a descendant match").
+		let target = parentLevel == 'any' ? 'item' : parentLevel;
+		if (node.level && node.level != 'any' && node.level != target) {
+			sql = Zotero.Search.mapPredicate(sql, node.level, target);
+		}
 		return {
-			sql: parts.length > 1 ? '(' + parts.join(' AND ') + ')' : parts[0],
-			params: params,
+			sql,
+			// Mapping to a constant drops the placeholders, so drop the params too
+			params: (sql === '0' || sql === '1') ? [] : params,
 			required: false
 		};
 	};
 
-	return combineGroup(root);
+	return combineGroup(root, rootLevel);
+};
+
+
+// The item hierarchy used for cross-level mapping: each child level maps to its parent
+// level via (itemID -> parentItemID) in the given table. 'item' is the top level.
+Zotero.Search._levelParent = {
+	annotation: 'attachment',
+	attachment: 'item',
+	note: 'item'
+};
+Zotero.Search._levelChildTable = {
+	annotation: 'itemAnnotations',
+	attachment: 'itemAttachments',
+	note: 'itemNotes'
+};
+// Attachments and notes can be top-level (parentItemID NULL); annotations always have a parent
+Zotero.Search._levelCanBeStandalone = {
+	annotation: false,
+	attachment: true,
+	note: true
+};
+
+/**
+ * Whether `anc` is an ancestor level of `desc` in the item hierarchy (e.g., 'item' is an
+ * ancestor of 'annotation'; 'attachment' is an ancestor of 'annotation'; 'note' and
+ * 'annotation' are unrelated).
+ */
+Zotero.Search._isAncestorLevel = function (anc, desc) {
+	let l = desc;
+	while (l != 'item') {
+		l = Zotero.Search._levelParent[l];
+		if (!l) {
+			return false;
+		}
+		if (l == anc) {
+			return true;
+		}
+	}
+	return false;
+};
+
+/**
+ * The number of parent hops between two levels in either direction, or null if they're on
+ * unrelated branches (e.g., note and annotation).
+ */
+Zotero.Search._levelDistance = function (a, b) {
+	let l = a;
+	let d = 0;
+	while (l && l != b) {
+		l = Zotero.Search._levelParent[l];
+		d++;
+	}
+	if (l == b) {
+		return d;
+	}
+	l = b;
+	d = 0;
+	while (l && l != a) {
+		l = Zotero.Search._levelParent[l];
+		d++;
+	}
+	return l == a ? d : null;
+};
+
+/**
+ * Given the levels a condition matches at, return the one closest (fewest hops) to `toLevel`,
+ * or null if none is related to it. Used to map a multi-level field from a single level.
+ */
+Zotero.Search._closestRelatedLevel = function (levels, toLevel) {
+	let best = null;
+	let bestDist = Infinity;
+	for (let level of levels) {
+		if (level == 'any') {
+			continue;
+		}
+		let d = Zotero.Search._levelDistance(level, toLevel);
+		if (d !== null && d < bestDist) {
+			best = level;
+			bestDist = d;
+		}
+	}
+	return best;
+};
+
+/**
+ * The item level(s) a condition matches at, for cross-level mapping. A condition
+ * definition can set `level` explicitly; otherwise it defaults to the top-level item, except
+ * for the few itemData fields that attachments also have (title, url, accessDate per the
+ * schema), which match at either the item or the attachment level.
+ */
+Zotero.Search._conditionLevel = function (name, conditionData) {
+	if (conditionData.level) {
+		return conditionData.level;
+	}
+	if (conditionData.table == 'itemData') {
+		let fieldID = Zotero.ItemFields.getID(name);
+		if (fieldID
+				&& Zotero.ItemFields.isValidForType(fieldID, Zotero.ItemTypes.getID('attachment'))) {
+			return ['item', 'attachment'];
+		}
+	}
+	return 'item';
+};
+
+/**
+ * Rewrite a predicate that selects itemIDs at `fromLevel` so it instead constrains itemIDs at
+ * `toLevel`, mapping through the item hierarchy:
+ *
+ *   - `toLevel` of 'any', or `toLevel` is one of the levels the condition matches at -- the
+ *     condition natively selects rows at the result level, so it's returned unchanged (the
+ *     result-level FROM filters to the right rows). This is how a multi-level field like title
+ *     matches item titles at the item level and attachment titles at the attachment level.
+ *   - `fromLevel` 'any' (level-agnostic, e.g., tag) -- the match rolls UP to the result level:
+ *     a `toLevel` item matches if it or any descendant carries it. Up only -- a parent's tag
+ *     isn't the child's. Skipped for a negated match (rolling up "isn't tagged" is ambiguous).
+ *   - `toLevel` an ancestor of `fromLevel` -- "the row has a descendant matching" (map up)
+ *   - `toLevel` a descendant of `fromLevel` -- "the row's ancestor matches" (map down)
+ *   - unrelated branches (e.g., note vs annotation) -- nothing can satisfy both, so '0'
+ *
+ * @param {String} sql - A predicate in terms of the `fromLevel` itemID
+ * @param {String|String[]} fromLevel - The level(s) the predicate selects ('item'/'attachment'/
+ *     'note'/'annotation'/'any'); an array for a field that exists at more than one level
+ * @param {String} toLevel - The level to constrain instead
+ * @param {Boolean} [negated] - Whether the predicate is a negation (isNot/doesNotContain); a
+ *     negated level-agnostic match is left at its own level rather than rolled up
+ * @return {String} A predicate in terms of the `toLevel` itemID
+ */
+Zotero.Search.mapPredicate = function (sql, fromLevel, toLevel, negated = false) {
+	if (toLevel == 'any') {
+		return sql;
+	}
+
+	// A condition may match at more than one level (e.g., an itemData field like title, which
+	// exists on both top-level items and attachments), so normalize to an array
+	let fromLevels = Array.isArray(fromLevel) ? fromLevel : [fromLevel];
+
+	if (fromLevels.length == 1 && fromLevels[0] == 'any') {
+		// Level-agnostic (e.g., tag): roll a positive match up to the result level; leave a
+		// negation at its carrying level (see above)
+		return negated ? sql : Zotero.Search._rollUpAnyToLevel(sql, toLevel);
+	}
+
+	// The condition already selects rows at the result level (it natively matches there), so
+	// the result-level FROM filters to the right rows -- no mapping needed
+	if (fromLevels.includes(toLevel)) {
+		return sql;
+	}
+
+	// Otherwise map from the one level in the set closest to the result level -- a
+	// descendant match up or an ancestor match down. Referencing the predicate's SQL exactly
+	// once keeps its bound parameters from being duplicated, so map from a single level.
+	let from = Zotero.Search._closestRelatedLevel(fromLevels, toLevel);
+	if (!from) {
+		// No level in the set is related to the result level (e.g., note vs annotation)
+		return '0';
+	}
+
+	// itemIDs at `from` matching the predicate
+	let matches = `SELECT itemID FROM items WHERE ${sql}`;
+
+	// Walk a child level up to its parent: SELECT the parentItemID of matching child rows.
+	// A standalone-capable level (attachment/note) can be a top-level item itself, so map a
+	// standalone row (no parent) to its own itemID rather than dropping it, matching the
+	// level-agnostic roll-up in _rollUpAnyToLevel.
+	let mapUp = (inner, from, to) => {
+		let l = from;
+		let s = inner;
+		while (l != to) {
+			let table = Zotero.Search._levelChildTable[l];
+			let select = Zotero.Search._levelCanBeStandalone[l]
+				? 'COALESCE(parentItemID, itemID)' : 'parentItemID';
+			s = `SELECT ${select} FROM ${table} WHERE itemID IN (${s})`;
+			l = Zotero.Search._levelParent[l];
+			if (!l) {
+				return null;
+			}
+		}
+		return s;
+	};
+
+	// Walk an ancestor level down to a descendant: SELECT the child rows whose parent matches,
+	// repeated for each step from `from` down to `to`
+	let mapDown = (inner, from, to) => {
+		let path = [];
+		let l = to;
+		while (l != from) {
+			path.push(l);
+			l = Zotero.Search._levelParent[l];
+			if (!l) {
+				return null;
+			}
+		}
+		let s = inner;
+		for (let i = path.length - 1; i >= 0; i--) {
+			let table = Zotero.Search._levelChildTable[path[i]];
+			s = `SELECT itemID FROM ${table} WHERE parentItemID IN (${s})`;
+		}
+		return s;
+	};
+
+	let mapped = Zotero.Search._isAncestorLevel(toLevel, from)
+		? mapUp(matches, from, toLevel)
+		: mapDown(matches, from, toLevel);
+	if (mapped === null) {
+		return '0';
+	}
+	return `itemID IN (${mapped})`;
+};
+
+
+/**
+ * Roll a level-agnostic predicate (e.g., tag) up to a result level: select `toLevel` items
+ * that themselves -- or any descendant -- match. Up only (an ancestor's match doesn't count).
+ *
+ * The predicate's own SQL is referenced exactly once (inside a subquery) so its bound
+ * parameters aren't duplicated.
+ *
+ * @param {String} sql - A predicate in terms of an itemID at any level
+ * @param {String} toLevel - 'item' / 'attachment' / 'note' / 'annotation'
+ * @return {String} A predicate in terms of the `toLevel` itemID
+ */
+Zotero.Search._rollUpAnyToLevel = function (sql, toLevel) {
+	let matches = `SELECT itemID FROM items WHERE ${sql}`;
+	switch (toLevel) {
+		// No descendants below these, so only a match at the level itself counts
+		case 'annotation':
+			return `itemID IN (SELECT itemID FROM itemAnnotations WHERE itemID IN (${matches}))`;
+		case 'note':
+			return `itemID IN (SELECT itemID FROM itemNotes WHERE itemID IN (${matches}))`;
+		// An attachment matches if it, or one of its annotations, matches
+		case 'attachment':
+			return "itemID IN ("
+				+ "SELECT COALESCE(att.itemID, annot.parentItemID) "
+				+ `FROM (${matches}) m `
+				+ "LEFT JOIN itemAttachments att ON att.itemID = m.itemID "
+				+ "LEFT JOIN itemAnnotations annot ON annot.itemID = m.itemID "
+				+ "WHERE att.itemID IS NOT NULL OR annot.itemID IS NOT NULL)";
+		// A top-level item matches if it, or any descendant (attachment, note, or an
+		// annotation of an attachment), matches
+		case 'item':
+		default:
+			return "itemID IN ("
+				+ "SELECT COALESCE(aAtt.parentItemID, att.parentItemID, note.parentItemID, m.itemID) "
+				+ `FROM (${matches}) m `
+				+ "LEFT JOIN itemAttachments att ON att.itemID = m.itemID AND att.parentItemID IS NOT NULL "
+				+ "LEFT JOIN itemNotes note ON note.itemID = m.itemID AND note.parentItemID IS NOT NULL "
+				+ "LEFT JOIN itemAnnotations annot ON annot.itemID = m.itemID "
+				+ "LEFT JOIN itemAttachments aAtt ON aAtt.itemID = annot.parentItemID AND aAtt.parentItemID IS NOT NULL"
+				+ ")";
+	}
 };

--- a/chrome/content/zotero/xpcom/data/search.js
+++ b/chrome/content/zotero/xpcom/data/search.js
@@ -305,12 +305,6 @@ Zotero.Search.prototype.addCondition = function (condition, operator, value, req
 	
 	// Shortcut to add a condition on every table -- does not return an id
 	if (condition.match(/^quicksearch/)) {
-		// The full-text content post-filter in search() isn't group-aware, so it can't
-		// tell that a quicksearch's full-text matches sit inside per-word 'any' groups.
-		// This flag tells it to merge them as a union even though the top-level join mode
-		// is 'all'. Once full-text conditions participate in the group tree, this flag and
-		// the post-filter special case both go away, leaving quicksearch as plain groups.
-		this._hasQuicksearch = true;
 		var parts = Zotero.SearchConditions.parseSearchString(value);
 
 		for (let part of parts) {
@@ -568,12 +562,12 @@ Zotero.Search.prototype.search = async function (asTempTable) {
 		this._requireData('conditions');
 	}
 	try {
-		if (!this._sql){
+		// Rebuild each run when a grouped fulltextContent is materialized into the SQL, so
+		// its matches reflect current full-text content rather than a cached set
+		if (!this._sql || this._hasEagerFullText){
 			await this._buildQuery();
 		}
 		
-		// Set true by the quicksearch expansion in addCondition()
-		var hasQuicksearch = !!this._hasQuicksearch;
 		// Set some variables for conditions to avoid further lookups
 		for (let condition of Object.values(this._conditions)) {
 			switch (condition.condition) {
@@ -663,22 +657,25 @@ Zotero.Search.prototype.search = async function (asTempTable) {
 		//Zotero.debug(ids);
 		//Zotero.debug('Join mode: ' + this._joinMode);
 		
-		// Filter results with full-text search
+		// Filter top-level fulltextContent conditions with a full-text search (grouped
+		// ones are already in the SQL; see _buildQuery).
 		//
-		// If join mode ALL, return the (intersection of main and full-text word search)
-		// filtered by full-text content.
+		// If join mode ALL, return the intersection of the main search and full-text word
+		// search, filtered by full-text content.
 		//
-		// If join mode ANY or there's a quicksearch (which we assume fulltextContent is part of)
-		// and the main search is filtered by other conditions, return the union of the main search
-		// and (separate full-text word searches filtered by fulltext content).
+		// If join mode ANY and the main search is filtered by other conditions, return the
+		// union of the main search and (separate full-text word searches filtered by
+		// full-text content).
 		//
-		// If join mode ANY or there's a quicksearch and the main search isn't filtered, return just
-		// the union of (separate full-text word searches filtered by full-text content).
+		// If join mode ANY and the main search isn't filtered, return just the union of
+		// (separate full-text word searches filtered by full-text content).
 		var fullTextResults;
-		var joinModeAny = this._joinMode == 'any' || hasQuicksearch;
+		var joinModeAny = this._joinMode == 'any';
 		for (let condition of Object.values(this._conditions)) {
 			if (condition.condition != 'fulltextContent') continue;
-			
+			// Grouped fulltextContent is already in the SQL (materialized in _buildQuery)
+			if (this._eagerFullTextConditionIDs.has(condition.id)) continue;
+
 			if (!fullTextResults) {
 				// For join mode ANY, if we already filtered the main set, add those as results.
 				// Otherwise, start with an empty set.
@@ -976,12 +973,68 @@ Zotero.Search.idsToTempTable = async function (ids, { idColumn = 'itemID' } = {}
 };
 
 
+/**
+ * Resolve the itemIDs in this search's library/scope whose full-text content matches `value`
+ * (per `mode`). Used to materialize a fulltextContent condition that sits inside a group, so it
+ * can take part in the SQL AND/OR tree (see _buildQuery). Always returns the *matching* set; the
+ * caller applies IN/NOT IN for the contains/doesNotContain operator.
+ */
+Zotero.Search.prototype._fullTextContentMatches = async function (value, mode) {
+	var scopeIDs;
+	// Regexp can't use the word index, so scan every item in the library/scope
+	if (mode && mode.startsWith('regexp')) {
+		let s = new Zotero.Search();
+		if (this.libraryID !== null) {
+			s.libraryID = this.libraryID;
+		}
+		if (this._scope) {
+			s.setScope(this._scope, true);
+		}
+		scopeIDs = await s.search();
+	}
+	// Otherwise narrow to items matching the words via the full-text word index
+	else {
+		let splits = Zotero.Fulltext.semanticSplitter(value);
+		if (!splits.length) {
+			return [];
+		}
+		let s = new Zotero.Search();
+		if (this.libraryID !== null) {
+			s.libraryID = this.libraryID;
+		}
+		for (let split of splits) {
+			s.addCondition('fulltextWord', 'contains', split);
+		}
+		if (this._scope) {
+			s.setScope(this._scope, true);
+		}
+		scopeIDs = await s.search();
+		// A single word is fully resolved by the word index -- no phrase to verify
+		if (splits.length == 1) {
+			return scopeIDs;
+		}
+	}
+	if (!scopeIDs.length) {
+		return [];
+	}
+	let found = await Zotero.Fulltext.findTextInItems(scopeIDs, value, mode);
+	return found.map(x => x.id);
+};
+
+
 /*
  * Build the SQL query for the search
  */
 Zotero.Search.prototype._buildQuery = async function () {
 	this._requireData('conditions');
-	
+
+	// fulltextContent conditions nested inside a group are materialized into the SQL tree
+	// below (a plain itemID IN/NOT IN predicate) so they combine like any other condition.
+	// Track them so search()'s post-filter skips them, and so the query is rebuilt each run
+	// (full-text then reflects current content, as the post-filter does for top-level ones).
+	this._eagerFullTextConditionIDs = new Set();
+	this._hasEagerFullText = false;
+
 	var sql = 'SELECT itemID FROM items';
 	
 	var sqlParams = [];
@@ -989,6 +1042,9 @@ Zotero.Search.prototype._buildQuery = async function () {
 	var conditions = [];
 
 	let lastCondition;
+	// Group nesting depth as the conditions are processed, so a fulltextContent inside a
+	// group can be told apart from a top-level one
+	let loopDepth = 0;
 	let conditionsToProcess = Object.values(this._conditions);
 
 	// The search's top-level join mode, used by the full-text result merging in
@@ -1098,9 +1154,25 @@ Zotero.Search.prototype._buildQuery = async function () {
 					continue;
 				
 				case 'fulltextContent':
-					// Handled in Search.search()
+					// A fulltextContent inside a group is materialized into an itemID
+					// predicate so it joins the SQL AND/OR tree; a top-level one is left
+					// for the post-filter in search() (unchanged behavior)
+					if (loopDepth > 0) {
+						let matchIDs = await this._fullTextContentMatches(
+							condition.value, condition.mode
+						);
+						this._eagerFullTextConditionIDs.add(condition.id);
+						this._hasEagerFullText = true;
+						conditions.push({
+							name: '_fulltextContentPredicate',
+							operator: condition.operator,
+							matchIDs,
+							required: condition.required
+						});
+						this._hasPrimaryConditions = true;
+					}
 					continue;
-				
+
 				// Group markers, passed through to the condition tree assembled after the
 				// main loop. Reset lastCondition so inline-filter merging doesn't combine
 				// conditions across a group boundary.
@@ -1110,10 +1182,12 @@ Zotero.Search.prototype._buildQuery = async function () {
 					continue;
 				case 'groupStart':
 					lastCondition = null;
+					loopDepth++;
 					conditions.push({ name: 'groupStart' });
 					continue;
 				case 'groupEnd':
 					lastCondition = null;
+					loopDepth--;
 					conditions.push({ name: 'groupEnd' });
 					continue;
 				
@@ -1247,6 +1321,20 @@ Zotero.Search.prototype._buildQuery = async function () {
 				}
 				if (condition.name == 'joinMode') {
 					builtConditions.push({ marker: 'joinMode', operator: condition.operator });
+					continue;
+				}
+				// A grouped fulltextContent materialized into an itemID set (above)
+				if (condition.name == '_fulltextContentPredicate') {
+					let sql;
+					if (!condition.matchIDs.length) {
+						// No matches: 'contains' matches nothing, 'doesNotContain' matches all
+						sql = condition.operator == 'doesNotContain' ? '1' : '0';
+					}
+					else {
+						let op = condition.operator == 'doesNotContain' ? 'NOT IN' : 'IN';
+						sql = 'itemID ' + op + ' (' + condition.matchIDs.join(',') + ')';
+					}
+					builtConditions.push({ sql, params: [], required: condition.required });
 					continue;
 				}
 

--- a/chrome/content/zotero/xpcom/data/search.js
+++ b/chrome/content/zotero/xpcom/data/search.js
@@ -1235,6 +1235,28 @@ Zotero.Search.prototype._buildQuery = async function () {
 					);
 					continue;
 				}
+				
+				case 'titleCreatorYear': {
+					// Expand to the same field set as 'quicksearch-titleCreatorYear' (without
+					// key detection or the top-level-only restriction, which the result level
+					// now handles). Spliced in after this condition like 'anyField' above, as
+					// an OR-group so it matches in any one of these fields.
+					let op = condition.operator;
+					let val = condition.value;
+					conditionsToProcess.splice(conditionIndex + 1, 0,
+						{ condition: 'groupStart', operator: 'true', value: '' },
+						{ condition: 'joinMode', operator: 'any' },
+						{ condition: 'title', operator: op, value: val },
+						{ condition: 'publicationTitle', operator: op, value: val },
+						{ condition: 'shortTitle', operator: op, value: val },
+						{ condition: 'court', operator: op, value: val },
+						{ condition: 'year', operator: op, value: val },
+						{ condition: 'citationKey', operator: op, value: val },
+						{ condition: 'creator', operator: op, value: val },
+						{ condition: 'groupEnd', operator: 'true', value: '' }
+					);
+					continue;
+				}
 			}
 			
 			throw new Error('Unhandled special condition ' + name);

--- a/chrome/content/zotero/xpcom/data/search.js
+++ b/chrome/content/zotero/xpcom/data/search.js
@@ -1238,6 +1238,18 @@ Zotero.Search.prototype._buildQuery = async function () {
 						required: false
 					});
 					conditionsToProcess.push({
+						condition: 'annotationText',
+						operator: condition.operator,
+						value: condition.value,
+						required: false
+					});
+					conditionsToProcess.push({
+						condition: 'annotationComment',
+						operator: condition.operator,
+						value: condition.value,
+						required: false
+					});
+					conditionsToProcess.push({
 						condition: 'creator',
 						operator: condition.operator,
 						value: condition.value,

--- a/chrome/content/zotero/xpcom/data/searchConditions.js
+++ b/chrome/content/zotero/xpcom/data/searchConditions.js
@@ -229,17 +229,25 @@ Zotero.SearchConditions = new function () {
 				noLoad: true
 			},
 			
-			// Quicksearch block markers
+			// Condition group markers. groupStart/groupEnd delimit a nested group of
+			// conditions; the group's join mode is a separate 'joinMode' condition placed
+			// inside the group, exactly as at the top level. Unlike the quicksearch block
+			// markers above, these are saved with the search, so they're not noLoad. The
+			// operator is an unused placeholder, since the sync server rejects an empty one.
 			{
-				name: 'blockStart',
-				noLoad: true
+				name: 'groupStart',
+				operators: {
+					true: true
+				}
 			},
-			
+
 			{
-				name: 'blockEnd',
-				noLoad: true
+				name: 'groupEnd',
+				operators: {
+					true: true
+				}
 			},
-			
+
 			// Shortcuts for adding collections and searches by id
 			{
 				name: 'collectionID',

--- a/chrome/content/zotero/xpcom/data/searchConditions.js
+++ b/chrome/content/zotero/xpcom/data/searchConditions.js
@@ -521,7 +521,19 @@ Zotero.SearchConditions = new function () {
 				},
 				special: false
 			},
-			
+
+			{
+				name: 'titleCreatorYear',
+				operators: {
+					is: true,
+					isNot: true,
+					contains: true,
+					doesNotContain: true,
+					beginsWith: true
+				},
+				special: false
+			},
+
 			{
 				name: 'datefield',
 				operators: {

--- a/chrome/content/zotero/xpcom/data/searchConditions.js
+++ b/chrome/content/zotero/xpcom/data/searchConditions.js
@@ -248,6 +248,22 @@ Zotero.SearchConditions = new function () {
 				}
 			},
 
+			// Optional level a group's conditions are evaluated at, placed inside the group
+			// like 'joinMode'. When a group's result level is a descendant level of the surrounding
+			// row (e.g., 'annotation' within a top-level item search), the group's conditions
+			// are matched against descendants and the match is mapped up to the parent --
+			// i.e., "the item has a descendant match for these conditions". The level
+			// rides in the operator, as with 'joinMode'. Saved with the search, so not noLoad.
+			{
+				name: 'resultLevel',
+				operators: {
+					item: true,
+					attachment: true,
+					note: true,
+					annotation: true
+				}
+			},
+
 			// Shortcuts for adding collections and searches by id
 			{
 				name: 'collectionID',
@@ -361,7 +377,9 @@ Zotero.SearchConditions = new function () {
 					isNot: true
 				},
 				table: 'itemAttachments',
-				field: 'fileTypeID'
+				field: 'fileTypeID',
+				// Matches attachment items; see 'level' handling in search.js
+				level: 'attachment'
 			},
 			
 			{
@@ -384,7 +402,9 @@ Zotero.SearchConditions = new function () {
 					doesNotContain: true
 				},
 				table: 'itemTags',
-				field: 'name'
+				field: 'name',
+				// Tags apply to items at any level, so a tag match is never mapped
+				level: 'any'
 			},
 			
 			{
@@ -396,7 +416,8 @@ Zotero.SearchConditions = new function () {
 				table: 'itemNotes',
 				// Exclude note prefix and suffix
 				field: `SUBSTR(note, ${1 + Zotero.Notes.notePrefix.length}, `
-					+ `LENGTH(note) - ${Zotero.Notes.notePrefix.length + Zotero.Notes.noteSuffix.length})`
+					+ `LENGTH(note) - ${Zotero.Notes.notePrefix.length + Zotero.Notes.noteSuffix.length})`,
+				level: 'note'
 			},
 			
 			{
@@ -594,6 +615,7 @@ Zotero.SearchConditions = new function () {
 				table: 'itemAnnotations',
 				field: 'text',
 				special: false,
+				level: 'annotation'
 			},
 			
 			{
@@ -605,6 +627,7 @@ Zotero.SearchConditions = new function () {
 				table: 'itemAnnotations',
 				field: 'comment',
 				special: false,
+				level: 'annotation'
 			},
 			
 			{

--- a/chrome/content/zotero/xpcom/data/searchConditions.js
+++ b/chrome/content/zotero/xpcom/data/searchConditions.js
@@ -773,16 +773,6 @@ Zotero.SearchConditions = new function () {
 	}
 	
 	
-	/**
-	 * Compare two API JSON condition objects
-	 */
-	this.equals = function (data1, data2) {
-		return data1.condition === data2.condition
-			&& data1.operator === data2.operator
-			&& data1.value === data2.value;
-	}
-	
-	
 	/*
 	 * Parses a search into words and "double-quoted phrases"
 	 *

--- a/chrome/content/zotero/xpcom/data/searches.js
+++ b/chrome/content/zotero/xpcom/data/searches.js
@@ -122,7 +122,7 @@ Zotero.Searches = function () {
 	
 	
 	this._loadConditions = async function (libraryID, ids, idSQL) {
-		var sql = "SELECT savedSearchID, searchConditionID, condition, operator, value, required "
+		var sql = "SELECT savedSearchID, searchConditionID, condition, operator, value "
 			+ "FROM savedSearches LEFT JOIN savedSearchConditions USING (savedSearchID) "
 			+ "WHERE libraryID=?" + idSQL
 			+ "ORDER BY savedSearchID, searchConditionID";
@@ -179,8 +179,7 @@ Zotero.Searches = function () {
 					condition: conditionName,
 					mode: mode,
 					operator: condition.operator,
-					value: condition.value,
-					required: !!condition.required
+					value: condition.value
 				};
 			}
 			search._loaded.conditions = true;
@@ -210,8 +209,7 @@ Zotero.Searches = function () {
 						searchConditionID,
 						condition: row.getResultByIndex(2),
 						operator: row.getResultByIndex(3),
-						value: row.getResultByIndex(4),
-						required: row.getResultByIndex(5)
+						value: row.getResultByIndex(4)
 					});
 				}.bind(this)
 			}

--- a/chrome/content/zotero/xpcom/schema.js
+++ b/chrome/content/zotero/xpcom/schema.js
@@ -3531,6 +3531,18 @@ Zotero.Schema = new function () {
 				await Zotero.DB.queryAsync("UPDATE groups SET version = 0");
 			}
 
+			// The condition 'required' flag was removed, but its savedSearchConditions column
+			// is kept for now so older code can still read the database (it SELECTs the column
+			// when loading saved searches). TODO: with the next userdata compatibility bump,
+			// bump the version and uncomment the migration below to drop the column.
+			//
+			// else if (i == 126) {
+			// 	await Zotero.DB.queryAsync("ALTER TABLE savedSearchConditions RENAME TO savedSearchConditionsOld");
+			// 	await Zotero.DB.queryAsync("CREATE TABLE savedSearchConditions (\n    savedSearchID INT NOT NULL,\n    searchConditionID INT NOT NULL,\n    condition TEXT NOT NULL,\n    operator TEXT,\n    value TEXT,\n    PRIMARY KEY (savedSearchID, searchConditionID),\n    FOREIGN KEY (savedSearchID) REFERENCES savedSearches(savedSearchID) ON DELETE CASCADE\n)");
+			// 	await Zotero.DB.queryAsync("INSERT INTO savedSearchConditions SELECT savedSearchID, searchConditionID, condition, operator, value FROM savedSearchConditionsOld");
+			// 	await Zotero.DB.queryAsync("DROP TABLE savedSearchConditionsOld");
+			// }
+
 			// If breaking compatibility or doing anything dangerous, clear minorUpdateFrom
 		}
 		

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -1997,8 +1997,80 @@ var ZoteroPane = new function () {
 		}
 		await this.setAdvancedSearchState(state);
 	};
-	
-	
+
+
+	/**
+	 * Open the Advanced Search pane seeded from the quick search text, reproducing
+	 * the current quick search mode as editable conditions.
+	 *
+	 * The quick search field is cleared, since its text now lives in the Advanced
+	 * Search. Closing the Advanced Search resets to an unfiltered view rather than
+	 * restoring the quick search.
+	 *
+	 * @param {String} searchText
+	 * @param {String} [mode='fields'] - The quick search mode to reproduce
+	 */
+	this.openAdvancedSearchFromQuickSearch = async function (searchText, mode = 'fields') {
+		// Split into words (keeping quoted phrases intact), as the quick search does
+		let parts = Zotero.SearchConditions.parseSearchString(searchText);
+		if (!parts.length) {
+			await this.toggleAdvancedSearchState('open');
+			return;
+		}
+
+		let deck = document.getElementById('zotero-advanced-search-pane-deck');
+		let search = new Zotero.Search();
+		let libraryID = this.getSelectedLibraryID();
+		if (libraryID) {
+			search.libraryID = libraryID;
+		}
+
+		// Reproduce the quick search mode as editable conditions, one per word joined
+		// with "all": Title/Creator/Year and All Fields & Tags each map to a single
+		// condition, Everything to an "any" group of Any Field plus full-text.
+		// Title/Creator/Year matches only top-level items, so set the result level to item.
+		if (mode === 'titleCreatorYear') {
+			search.addCondition('resultLevel', 'item');
+		}
+		for (let part of parts) {
+			if (mode === 'everything') {
+				search.addCondition('groupStart', 'true', '');
+				search.addCondition('joinMode', 'any');
+				search.addCondition('anyField', 'contains', part.text);
+				search.addCondition('fulltextContent', 'contains', part.text);
+				search.addCondition('groupEnd', 'true', '');
+			}
+			else if (mode === 'titleCreatorYear') {
+				search.addCondition('titleCreatorYear', 'contains', part.text);
+			}
+			else {
+				search.addCondition('anyField', 'contains', part.text);
+			}
+		}
+
+		// Show the Advanced Search and seed it, without yet touching the items list,
+		// so that the quick search results stay visible until they're replaced below
+		deck.selectedSearchType = 'temporary';
+		deck.state = 'open';
+		deck.pane.search = search;
+		deck.pane.refresh();
+
+		// Clear the quick search text and the row's filter (without its own refresh),
+		// so the field doesn't flash empty and closing Advanced Search returns to an
+		// unfiltered view. The submit() below replaces the results in place.
+		let searchBox = document.getElementById('zotero-tb-search');
+		searchBox.updateMode();
+		searchBox.value = '';
+		this.itemsView.collectionTreeRow.setSearch('');
+
+		Zotero_Tabs.select('zotero-pane');
+		// Keep focus in the builder (on the first condition) rather than the results,
+		// so the user can refine the seeded search
+		await deck.pane.submit({ focusResults: false });
+		deck.pane.focus();
+	};
+
+
 	/**
 	 * @param {'open' | 'closed'} state
 	 */

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -902,9 +902,13 @@ first-run-guidance-authorMenu = { -app-name } lets you specify editors and trans
 first-run-guidance-readAloud = { -app-name } can now read your documents to you using natural-sounding voices.
 
 advanced-search-remove-btn =
-    .tooltiptext = { general-remove }
+    .tooltiptext = Remove Condition
 advanced-search-add-btn =
-    .tooltiptext = { general-add }
+    .tooltiptext = Add Condition
+advanced-search-group-btn =
+    .tooltiptext = Add Condition Group
+advanced-search-remove-group-btn =
+    .tooltiptext = Remove Group
 advanced-search-conditions-menu =
     .aria-label = Search condition
     .label = { $label }

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -909,6 +909,57 @@ advanced-search-group-btn =
     .tooltiptext = Add Condition Group
 advanced-search-remove-group-btn =
     .tooltiptext = Remove Group
+advanced-search-result-level-menu =
+    .aria-label = Result type
+advanced-search-result-level-prefix-root =
+    .value = Find
+advanced-search-join-prefix-root =
+    .value = matching
+advanced-search-result-level-any =
+    .label = any items
+advanced-search-result-level-item =
+    .label = top-level items
+advanced-search-result-level-attachment =
+    .label = attachments
+advanced-search-result-level-note =
+    .label = notes
+advanced-search-result-level-annotation =
+    .label = annotations
+advanced-search-binding-menu =
+    .aria-label = Match against the same item
+advanced-search-binding-separate =
+    .label = separately
+advanced-search-binding-same-attachment =
+    .label = in the same attachment
+advanced-search-binding-same-note =
+    .label = in the same note
+advanced-search-binding-same-annotation =
+    .label = in the same annotation
+# Shown before the binding menu so a bound group reads "Match all of the following in the same
+# annotation" (the legacy "of the following:" -- with the colon -- is kept for a plain group)
+advanced-search-of-the-following =
+    .value = of the following
+advanced-search-binding-hint-attachment =
+    .value = These conditions can match separate attachments.
+advanced-search-binding-hint-note =
+    .value = These conditions can match separate notes.
+advanced-search-binding-hint-annotation =
+    .value = These conditions can match separate annotations.
+advanced-search-level-warning-mixed = These conditions cannot all match the same item, so this search will never return results. Try matching “{ $matchAny }” of them, or set the result type to “{ $topLevelItems }”.
+advanced-search-level-warning-unreachable = This search has a condition that cannot apply to the chosen result type. Set the result type to “{ $topLevelItems }” or remove the incompatible condition.
+advanced-search-group-warning-unreachable =
+    A condition here cannot be in the same { $entity ->
+        [attachment] attachment
+        [note] note
+       *[annotation] annotation
+    }. Match these separately or remove the incompatible condition.
+advanced-search-group-warning-mixed = These conditions cannot all match the same item, so this group will never match. Try matching “{ $matchAny }” of them, or set the result type to “{ $topLevelItems }”.
+advanced-search-bind-same-attachment =
+    .label = Match the same attachment
+advanced-search-bind-same-note =
+    .label = Match the same note
+advanced-search-bind-same-annotation =
+    .label = Match the same annotation
 advanced-search-conditions-menu =
     .aria-label = Search condition
     .label = { $label }

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -997,6 +997,7 @@ search-conditions-lastRead = Attachment Last Read
 search-conditions-annotationText = Annotation Text
 search-conditions-annotationComment = Annotation Comment
 search-conditions-anyField = Any Field
+search-conditions-titleCreatorYear = Title, Creator, Year
 
 find-pdf-files-added = { $count ->
     [one] { $count } file added

--- a/chrome/skin/default/zotero/16/universal/group-condition.svg
+++ b/chrome/skin/default/zotero/16/universal/group-condition.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M7 3C2.8 5 2.8 11 7 13C4.6 11 4.6 5 7 3ZM9 3C13.2 5 13.2 11 9 13C11.4 11 11.4 5 9 3Z" fill="context-fill"/>
+</svg>

--- a/scss/elements/_advancedSearchPane.scss
+++ b/scss/elements/_advancedSearchPane.scss
@@ -12,7 +12,7 @@ advanced-search-deck {
 
 advanced-search-pane {
 	@include inactive-opacity;
-	
+
 	flex-direction: column;
 	// Inline padding is further down the tree so focus rings work with overflow: auto
 	padding-block: 8px;

--- a/scss/elements/_zoteroSearch.scss
+++ b/scss/elements/_zoteroSearch.scss
@@ -10,6 +10,9 @@ zoterosearch {
 	gap: 8px;
 	overflow: auto;
 	max-height: 33vh;
+	// Keep the whole builder a comfortable width on a wide window (left-aligned) rather
+	// than stretching the rows across the full width. The value field flexes within this.
+	max-width: 64em;
 	@include macOS-normalize-controls;
 
 	// Use the full pane width
@@ -23,6 +26,9 @@ zoterosearch {
 		// Zero the toolkit groupbox margin/padding
 		margin: 0;
 		padding: 0;
+		// The XUL groupbox shrink-wraps to content by default; fill its parent so the
+		// conditions box (and the value field) can use the available width
+		width: -moz-available;
 
 		.conditions {
 			min-width: fit-content; // Grow with content, don't overflow
@@ -118,6 +124,76 @@ zoterosearch {
 		}
 	}
 	
+	.level-warning {
+		// Each group's own warning, in a contained box below its conditions (the root's sits at
+		// the bottom; a nested group's sits inside its box) rather than as loose text. A light
+		// red callout mirrors the binding hint's light blue one, but at full size (vs the hint's
+		// smaller text) since this is a hard error -- the search can never match -- not a hint.
+		color: var(--accent-red);
+		// 10px inline is a small visual nudge to bring the text slightly in (it doesn't line up
+		// with anything exactly); 8px block keeps the two-line message from cramping.
+		padding: 8px 10px;
+		background: var(--accent-red10);
+		border-radius: 6px;
+		// Fill the pane width but contribute no intrinsic (max-content) width of its own, so
+		// showing/hiding this notice can't widen the search pane and shrink the collections
+		// pane. (Its long text would otherwise push the pane to its max-width.)
+		box-sizing: border-box;
+		width: 0;
+		min-width: 100%;
+
+		description {
+			// Wrap to the available width instead of overflowing the pane; min-width: 0 lets
+			// it shrink within the flex row rather than contributing an intrinsic width
+			flex: 1;
+			min-width: 0;
+			margin: 0;
+			white-space: normal;
+		}
+	}
+
+	// A nested group's warning sits inside the outer box, so leave room below it rather than
+	// letting it butt against the box's bottom edge. (The root's warning is below the box.)
+	search-condition-group:not([root]) .level-warning {
+		margin-block-end: 6px;
+	}
+
+	#search-binding-hint {
+		// A distinct suggestion callout under the conditions (not plain body text): a light
+		// blue, rounded block with slightly smaller text, one "[statement] [button]" line per
+		// bindable level. Fills the pane width but contributes no intrinsic width (like the
+		// warning) so its line can't widen the search pane.
+		display: flex;
+		flex-direction: column;
+		// Each row hugs its content (so the button sits right next to the text) while the
+		// box itself still fills the pane width
+		align-items: flex-start;
+		gap: 8px;
+		padding: 8px;
+		font-size: 0.9em;
+		background: var(--accent-blue10);
+		border-radius: 6px;
+		box-sizing: border-box;
+		width: 0;
+		min-width: 100%;
+
+		hbox {
+			display: flex;
+			align-items: center;
+			gap: 5px;
+		}
+
+		button {
+			margin: 0;
+		}
+
+		// The explicit `display: flex` above overrides the `hidden` attribute's display:none,
+		// so re-assert it -- otherwise the empty box shows when there's nothing to suggest
+		&[hidden] {
+			display: none;
+		}
+	}
+
 	#search-option-checkboxes {
 		flex-direction: row;
 		flex-wrap: wrap;
@@ -143,6 +219,13 @@ zoterosearch {
 
 		label {
 			margin: 0;
+		}
+
+		// Native menulists sit a couple pixels high relative to the inline label text
+		// ("Find ... matching ... of the following:"); baseline/align-self alignment is
+		// locked by the platform, so nudge them down to sit on the text
+		menulist {
+			margin-block-start: 2px;
 		}
 	}
 
@@ -180,8 +263,24 @@ zoterosearch {
 			position: absolute;
 		}
 
-		.valuefield, .valuemenu, .value-date-age {
+		.valuemenu, .value-date-age {
 			flex: 1;
+		}
+
+		// The text value field grows to use the available row width (the overall cap is on
+		// the builder, not here). It's a flex container itself so the inner stack/input
+		// fills the host.
+		.valuefield {
+			display: flex;
+			flex: 1;
+			min-width: 12em;
+
+			// The `display: flex` above overrides the `hidden` attribute's display:none, so
+			// re-assert it -- otherwise the textbox shows alongside the value menu for
+			// menu-based conditions (Collection, Item Type, Attachment File Type)
+			&[hidden] {
+				display: none;
+			}
 		}
 	}
 
@@ -193,8 +292,14 @@ zoterosearch {
 		width: 15em;
 	}
 	
-	#operatorsmenu, #valuemenu, #valuefield, .search-in-the-last {
+	#operatorsmenu, #valuemenu, .search-in-the-last {
 		width: 12em;
+	}
+
+	// Fill the flexed value field (host -> stack -> input)
+	#search-textbox {
+		flex: 1;
+		width: 100%;
 	}
 	
 	#valuemenu::part(icon) {

--- a/scss/elements/_zoteroSearch.scss
+++ b/scss/elements/_zoteroSearch.scss
@@ -12,38 +12,96 @@ zoterosearch {
 	max-height: 33vh;
 	@include macOS-normalize-controls;
 
+	// Use the full pane width
+	search-condition-group {
+		display: flex;
+		flex-direction: column;
+	}
+
 	.search-condition-group {
 		gap: 8px;
-		// Zero the toolkit groupbox margin so a nested group lines up flush with the
-		// left edge of the condition rows above it (reads as the next condition)
+		// Zero the toolkit groupbox margin/padding
 		margin: 0;
 		padding: 0;
 
-		// The conditions container (root keeps id="conditions"; nested groups use the
-		// class) -- a rounded, filled box that nests as groups nest
 		.conditions {
 			min-width: fit-content; // Grow with content, don't overflow
-			padding: 8px;
-			// Roomier spacing between items (conditions and nested groups alike) so the
-			// list reads clearly without needing divider lines
-			gap: 12px;
-			background: var(--fill-senary);
-			border: var(--material-border-quinary);
-			border-radius: 6px;
+			// Rows abut, separated by full-width dividers (below)
+			gap: 0;
 		}
 
-		// A nested group sits inside its parent's conditions box, indented so its
-		// caption and box line up with the condition controls above it (which are
-		// themselves inset by the row's leading gap). A group is just another item in
-		// the list, so it keeps the same spacing from its siblings as conditions do.
-		.search-condition-group {
-			gap: 4px;
-			margin-inline-start: 8px;
+		// A nested group has no box of its own. Each nesting level sets an indent that the
+		// rows and headers below apply to their own content -- not to the container -- so
+		// every row stays full width and its divider spans edge to edge. A group's
+		// conditions hold the level's indent; its header inherits the parent's, so the
+		// header lines up with the condition before it while the conditions step in one
+		// more level. (Custom properties can't accumulate by self-reference, so each level
+		// is set explicitly.)
+		@for $depth from 1 through 6 {
+			$sel: "";
+			@for $i from 1 through $depth {
+				$sel: "#{$sel}.search-condition-group ";
+			}
+			#{$sel}.conditions {
+				--indent: #{$depth * 20}px;
+			}
+		}
+
+		// The caption's remove-group/add-condition buttons, laid out so they line up in
+		// the same columns as a condition row's remove/add buttons. The placeholder
+		// reserves the trailing "( )" wrap-button column that rows have but captions don't.
+		.group-actions {
+			display: flex;
+			align-items: center;
+			gap: 8px;
+		}
+
+		.group-action-placeholder {
+			width: 20px;
 		}
 
 		.remove-group {
 			margin: 0;
 		}
+	}
+
+	// Full-width dividers between rows and groups. They sit on the row/group wrappers,
+	// which run the full width, so the lines span edge to edge regardless of how deeply
+	// the content is indented. The first item in a box has no line above it; a group's
+	// header is divided from its conditions by a line below the caption.
+	.conditions > * {
+		border-top: var(--material-border-quinary);
+	}
+
+	.conditions > *:first-child {
+		border-top: 0;
+	}
+
+	search-condition-group:not([root]) > .search-condition-group {
+		gap: 0;
+
+		> caption {
+			border-bottom: var(--material-border-quinary);
+		}
+	}
+
+	// Only the root group draws the surrounding frame; nested groups are shown by
+	// indentation
+	search-condition-group[root] > .search-condition-group > .conditions {
+		// No vertical padding: the rows' own 6px block padding sets the gap to the frame,
+		// matching the gap to a divider, so the first and last rows are centered in their
+		// bands just like the rows between dividers
+		padding: 0 8px;
+		background: var(--fill-senary);
+		border: var(--material-border-quinary);
+		border-radius: 6px;
+	}
+
+	// The root header sits above the box, so indent it to the box's content edge
+	// (border + padding, 9px) plus the menulist label inset (5px) so "Match" lines up
+	// with the condition dropdowns' labels inside
+	search-condition-group[root] > .search-condition-group > caption {
+		padding-left: 14px !important;
 	}
 
 	// The per-condition "group" button (wraps the condition in a new group)
@@ -75,7 +133,13 @@ zoterosearch {
 		align-items: center;
 		gap: 4px;
 		margin: 0 !important;
-		padding-left: 0 !important;
+		// Vertical breathing room around the divider lines
+		padding-block: 6px;
+		// A nested group's header inherits its parent's indent, so it lines up with the
+		// sibling condition above it (the root header is re-indented to the box below).
+		// The extra 5px matches the menulist's internal label inset, so "Match" aligns
+		// with the condition dropdown's label rather than its (slightly wider) box.
+		padding-inline-start: calc(var(--indent, 0px) + 5px) !important;
 
 		label {
 			margin: 0;
@@ -103,6 +167,18 @@ zoterosearch {
 		display: flex;
 		align-items: center;
 		gap: 8px;
+		// Vertical breathing room around the divider lines
+		padding-block: 6px;
+		// Indent the row's content by its nesting level (see --indent above) while the
+		// row itself stays full width, so the divider below it spans edge to edge
+		padding-inline-start: var(--indent, 0px);
+
+		// The per-row tooltip container shouldn't take a flex slot (and the row's gap
+		// after it), which would push the condition menu right of the "Match" header.
+		// Take it out of flow rather than display:none, which would hide the tooltips.
+		popupset {
+			position: absolute;
+		}
 
 		.valuefield, .valuemenu, .value-date-age {
 			flex: 1;

--- a/scss/elements/_zoteroSearch.scss
+++ b/scss/elements/_zoteroSearch.scss
@@ -12,16 +12,51 @@ zoterosearch {
 	max-height: 33vh;
 	@include macOS-normalize-controls;
 
-	groupbox {
+	.search-condition-group {
 		gap: 8px;
+		// Zero the toolkit groupbox margin so a nested group lines up flush with the
+		// left edge of the condition rows above it (reads as the next condition)
+		margin: 0;
+		padding: 0;
 
-		& > #conditions {
+		// The conditions container (root keeps id="conditions"; nested groups use the
+		// class) -- a rounded, filled box that nests as groups nest
+		.conditions {
 			min-width: fit-content; // Grow with content, don't overflow
 			padding: 8px;
-			gap: 8px;
+			// Roomier spacing between items (conditions and nested groups alike) so the
+			// list reads clearly without needing divider lines
+			gap: 12px;
 			background: var(--fill-senary);
 			border: var(--material-border-quinary);
 			border-radius: 6px;
+		}
+
+		// A nested group sits inside its parent's conditions box, indented so its
+		// caption and box line up with the condition controls above it (which are
+		// themselves inset by the row's leading gap). A group is just another item in
+		// the list, so it keeps the same spacing from its siblings as conditions do.
+		.search-condition-group {
+			gap: 4px;
+			margin-inline-start: 8px;
+		}
+
+		.remove-group {
+			margin: 0;
+		}
+	}
+
+	// The per-condition "group" button (wraps the condition in a new group)
+	.search-group-button {
+		@include svgicon-menu("group-condition", "universal", "16");
+		width: 20px;
+		margin: 0;
+		border: 0 !important;
+		border-radius: 2px;
+		color: var(--fill-secondary);
+
+		.toolbarbutton-text {
+			display: none;
 		}
 	}
 	
@@ -39,6 +74,7 @@ zoterosearch {
 		font: inherit;
 		align-items: center;
 		gap: 4px;
+		margin: 0 !important;
 		padding-left: 0 !important;
 
 		label {
@@ -73,7 +109,7 @@ zoterosearch {
 		}
 	}
 
-	#joinModeMenu {
+	.join-mode-menu {
 		min-width: 60px;
 	}
 	

--- a/scss/themes/_dark.scss
+++ b/scss/themes/_dark.scss
@@ -8,6 +8,7 @@ $-colors: (
     accent-green: #39bf68d9,
     accent-orange: #ff794cd9,
     accent-red: #db2c3ae5,
+    accent-red10: #db2c3a4d,
     accent-teal: #59adc4e5,
     accent-white: #fff,
     accent-wood-dark: #996b6f,

--- a/scss/themes/_light.scss
+++ b/scss/themes/_light.scss
@@ -8,6 +8,7 @@ $-colors: (
     accent-green: #39bf68,
     accent-orange: #ff794c,
     accent-red: #db2c3a,
+    accent-red10: #db2c3a1a,
     accent-teal: #59adc4,
     accent-white: #fff,
     accent-wood-dark: #996b6f,

--- a/test/tests/advancedSearchTest.js
+++ b/test/tests/advancedSearchTest.js
@@ -455,7 +455,7 @@ describe("Advanced Search", function () {
 			await zp.toggleAdvancedSearchState('open');
 			pane = deck.pane;
 			searchBox = pane.querySelector('zoterosearch');
-			conditions = searchBox.querySelector('#conditions');
+			conditions = searchBox.querySelector('.conditions');
 		});
 		
 		after(async function () {
@@ -681,6 +681,22 @@ describe("Advanced Search", function () {
 			});
 		});
 
+		it("should insert a condition right after the row whose + is clicked", function () {
+			var s = new Zotero.Search();
+			s.libraryID = Zotero.Libraries.userLibraryID;
+			s.addCondition('title', 'contains', 'a');
+			s.addCondition('title', 'contains', 'b');
+			pane.search = s;
+			assert.lengthOf(conditions.children, 2);
+
+			conditions.children[0].onAddClicked({ preventDefault() {} });
+
+			// New (empty) condition lands between the two, not at the end
+			var values = [...conditions.children]
+				.map(row => row.querySelector('#valuefield').value);
+			assert.deepEqual(values, ['a', '', 'b']);
+		});
+
 		describe("Collection", function () {
 			it("should show collections and saved searches", async function () {
 				var col1 = await createDataObject('collection', { name: "A" });
@@ -875,7 +891,7 @@ describe("Advanced Search", function () {
 			it("shouldn't appear", async function () {
 				var searchCondition = conditions.firstChild;
 				var conditionsMenu = searchCondition.querySelector('#conditionsmenu');
-				
+
 				// Make sure "Saved Search" isn't present
 				for (let i = 0; i < conditionsMenu.itemCount; i++) {
 					let menuitem = conditionsMenu.getItemAtIndex(i);
@@ -883,6 +899,120 @@ describe("Advanced Search", function () {
 						assert.fail();
 					}
 				}
+			});
+		});
+
+		describe("Groups", function () {
+			function groupedSearch() {
+				var s = new Zotero.Search();
+				s.libraryID = Zotero.Libraries.userLibraryID;
+				s.addCondition('title', 'contains', 'foo');
+				s.addCondition('groupStart', 'true', '');
+				s.addCondition('joinMode', 'any');
+				s.addCondition('tag', 'is', 'x');
+				s.addCondition('tag', 'is', 'y');
+				s.addCondition('groupEnd', 'true', '');
+				return s;
+			}
+
+			it("should render a nested group from group markers", function () {
+				pane.search = groupedSearch();
+
+				// Root holds the title row plus one nested group
+				assert.lengthOf(conditions.children, 2);
+				var group = conditions.querySelector('search-condition-group');
+				assert.equal(group.joinMode, 'any');
+				assert.lengthOf(group.conditionsContainer.children, 2);
+				assert.equal(group.conditionsContainer.firstChild.selectedCondition, 'tag');
+			});
+
+			it("should serialize a nested group back to markers", function () {
+				pane.search = groupedSearch();
+				searchBox.updateSearch();
+
+				var sequence = Object.values(searchBox.search.getConditions())
+					.map(c => c.condition);
+				assert.deepEqual(sequence,
+					['title', 'groupStart', 'joinMode', 'tag', 'tag', 'groupEnd']);
+			});
+
+			it("should wrap a condition in a new group in its place", function () {
+				var s = new Zotero.Search();
+				s.libraryID = Zotero.Libraries.userLibraryID;
+				s.addCondition('title', 'contains', 'foo');
+				pane.search = s;
+
+				conditions.firstChild.onGroupClicked({ preventDefault() {} });
+
+				// The condition is now the sole member of a group in its old place,
+				// keeping its value
+				assert.lengthOf(conditions.children, 1);
+				var group = conditions.querySelector('search-condition-group');
+				assert.lengthOf(group.conditionsContainer.children, 1);
+				var row = group.conditionsContainer.firstChild;
+				assert.equal(row.selectedCondition, 'title');
+				assert.equal(row.querySelector('#valuefield').value, 'foo');
+			});
+
+			it("should remove a group when its last condition is removed", function () {
+				pane.search = groupedSearch();
+
+				var group = conditions.querySelector('search-condition-group');
+				group.conditionsContainer.firstChild.onRemoveClicked();
+				// Removing the group's first tag leaves it with the second
+				assert.ok(conditions.querySelector('search-condition-group'));
+				group.conditionsContainer.firstChild.onRemoveClicked();
+
+				// With no conditions left, the group itself is gone
+				assert.notOk(conditions.querySelector('search-condition-group'));
+				// The root's title condition remains
+				assert.lengthOf(conditions.children, 1);
+				assert.equal(conditions.firstChild.selectedCondition, 'title');
+			});
+
+			it("should reset the root to an empty condition when its last group empties", function () {
+				// A search whose only content is a single group with a single condition
+				var s = new Zotero.Search();
+				s.libraryID = Zotero.Libraries.userLibraryID;
+				s.addCondition('groupStart', 'true', '');
+				s.addCondition('tag', 'is', 'x');
+				s.addCondition('groupEnd', 'true', '');
+				pane.search = s;
+
+				var group = conditions.querySelector('search-condition-group');
+				group.conditionsContainer.firstChild.onRemoveClicked();
+
+				// The emptied group is gone and the root falls back to one empty condition
+				assert.notOk(conditions.querySelector('search-condition-group'));
+				assert.lengthOf(conditions.children, 1);
+				assert.equal(conditions.firstChild.selectedCondition, 'title');
+				assert.equal(conditions.firstChild.querySelector('#valuefield').value, '');
+			});
+
+			it("should add a sibling condition outside the group from the group's +", function () {
+				var s = new Zotero.Search();
+				s.libraryID = Zotero.Libraries.userLibraryID;
+				s.addCondition('title', 'contains', 'foo');
+				pane.search = s;
+
+				// The root has no parent, so its caption "+" stays hidden
+				assert.isTrue(searchBox.rootGroup.addConditionButton.hidden);
+
+				// Wrap the only root condition, so the root now holds just the group
+				conditions.firstChild.onGroupClicked({ preventDefault() {} });
+				assert.lengthOf(conditions.children, 1);
+				var group = conditions.querySelector('search-condition-group');
+
+				// The group's "+" adds a sibling in the parent (root), not inside the group
+				group.onAddSiblingClicked();
+
+				assert.lengthOf(conditions.children, 2);
+				var rows = [...conditions.children]
+					.filter(c => c.localName === 'zoterosearchcondition');
+				assert.lengthOf(rows, 1);
+				assert.equal(rows[0].selectedCondition, 'title');
+				// Nothing was added inside the group
+				assert.lengthOf(group.conditionsContainer.children, 1);
 			});
 		});
 	});

--- a/test/tests/advancedSearchTest.js
+++ b/test/tests/advancedSearchTest.js
@@ -52,7 +52,82 @@ describe("Advanced Search", function () {
 		await otherItem.eraseTx();
 	});
 	
+	it("should seed from the quick search text and reset on close", async function () {
+		var match = await createDataObject('item', { title: "alpha beta" });
+		var partial = await createDataObject('item', { title: "alpha gamma" });
+		var neither = await createDataObject('item', { title: "delta" });
+
+		var searchBox = win.document.getElementById('zotero-tb-search');
+		searchBox.value = 'alpha beta';
+		await zp.itemsView.setFilter('search', 'alpha beta');
+
+		await zp.openAdvancedSearchFromQuickSearch('alpha beta', 'fields');
+		var iv = zp.itemsView;
+		await iv.waitForLoad();
+
+		// One "Any Field" condition per word, joined with "all"
+		var conditions = Object.values(deck.pane.search.getConditions())
+			.filter(c => c.condition === 'anyField');
+		assert.lengthOf(conditions, 2);
+		assert.sameMembers(conditions.map(c => c.value), ['alpha', 'beta']);
+
+		// Only the item matching both words, and the quick search field is cleared
+		assert.equal(iv.rowCount, 1);
+		assert.isNumber(iv.getRowIndexByID(match.id));
+		assert.equal(searchBox.value, '');
+
+		// Closing resets to an unfiltered view (doesn't restore the quick search)
+		await zp.setAdvancedSearchState('closed');
+		await iv.waitForLoad();
+		assert.equal(iv.rowCount, 3);
+
+		await Zotero.Items.erase([match.id, partial.id, neither.id]);
+	});
 	
+	it("should seed an \"Everything\" quick search as full-text groups", async function () {
+		await zp.openAdvancedSearchFromQuickSearch('alpha beta', 'everything');
+		await zp.itemsView.waitForLoad();
+
+		// Each word -> an "any" group of [Any Field, Full Text Content]
+		var conds = Object.values(deck.pane.search.getConditions());
+		assert.lengthOf(conds.filter(c => c.condition === 'groupStart'), 2);
+		assert.lengthOf(conds.filter(c => c.condition === 'anyField'), 2);
+		assert.sameMembers(
+			conds.filter(c => c.condition === 'fulltextContent').map(c => c.value),
+			['alpha', 'beta']
+		);
+
+		await zp.setAdvancedSearchState('closed');
+	});
+	it("should prefill a Title/Creator/Year quick search, restricted to top-level items", async function () {
+		// A top-level item whose title matches both words, and an item whose only match is a
+		// child attachment's title (which shouldn't broaden a top-level-only search)
+		var topMatch = await createDataObject('item', { title: "alpha beta" });
+		var childOnly = await createDataObject('item', { title: "zzznomatch" });
+		var attachment = await importPDFAttachment(childOnly);
+		attachment.setField('title', 'alpha beta');
+		await attachment.saveTx();
+
+		await zp.openAdvancedSearchFromQuickSearch('alpha beta', 'titleCreatorYear');
+		var iv = zp.itemsView;
+		await iv.waitForLoad();
+
+		// One "Title, Creator, Year" condition per word, plus a result level of item
+		var conds = Object.values(deck.pane.search.getConditions());
+		var tcy = conds.filter(c => c.condition === 'titleCreatorYear');
+		assert.lengthOf(tcy, 2);
+		assert.sameMembers(tcy.map(c => c.value), ['alpha', 'beta']);
+		assert.isTrue(conds.some(c => c.condition === 'resultLevel' && c.operator === 'item'));
+
+		// The top-level title matches; the child attachment's matching title doesn't broaden it
+		assert.equal(iv.rowCount, 1);
+		assert.isNumber(iv.getRowIndexByID(topMatch.id));
+
+		await zp.setAdvancedSearchState('closed');
+		await topMatch.eraseTx();
+		await childOnly.eraseTx();
+	});
+
 	it("should run a cross-level search across a multi-collection selection", async function () {
 		var word = 'zmc' + Zotero.Utilities.randomString();
 		var makeMatch = async function (collection) {
@@ -102,6 +177,7 @@ describe("Advanced Search", function () {
 		await Zotero.Collections.erase([c1.id, c2.id, c3.id]);
 	});
 	
+
 	it("shouldn't show trashed items outside the trash", async function () {
 		var item = await createDataObject('item', { setTitle: true });
 		item.deleted = true;

--- a/test/tests/advancedSearchTest.js
+++ b/test/tests/advancedSearchTest.js
@@ -52,6 +52,56 @@ describe("Advanced Search", function () {
 		await otherItem.eraseTx();
 	});
 	
+	
+	it("should run a cross-level search across a multi-collection selection", async function () {
+		var word = 'zmc' + Zotero.Utilities.randomString();
+		var makeMatch = async function (collection) {
+			var item = await createDataObject('item', { collections: [collection.id] });
+			var attachment = await importPDFAttachment(item);
+			await createAnnotation('highlight', attachment, { comment: 'foo ' + word + ' bar' });
+			return item;
+		};
+		var c1 = await createDataObject('collection');
+		var c2 = await createDataObject('collection');
+		var c3 = await createDataObject('collection');
+		var itemA = await makeMatch(c1);
+		var itemB = await makeMatch(c2);
+		var itemC = await makeMatch(c3); // in an unselected collection
+		
+		// Select c1 and c2, leaving c3 out
+		var cv = zp.collectionsView;
+		await cv.selectByID("C" + c1.id);
+		await waitForItemsLoad(win);
+		cv.selection.toggleSelect(cv.getRowIndexByID("C" + c2.id));
+		await zp.onCollectionSelected();
+		await zp.itemsView.waitForLoad();
+		
+		// Top-level items with a descendant annotation matching the comment
+		var s = new Zotero.Search();
+		s.libraryID = Zotero.Libraries.userLibraryID;
+		s.addCondition('resultLevel', 'item');
+		s.addCondition('annotationComment', 'contains', word);
+		
+		var iv = zp.itemsView;
+		await iv.setFilter('advanced-search', s);
+		await iv.waitForLoad();
+		
+		// The view merges getItems() across the selected rows (collectionViewItemTree),
+		// so the cross-level search runs scoped to each collection and the results union:
+		// both selected collections' matching items, but not the unselected one's
+		var rows = zp.getCollectionTreeRows();
+		var ids = new Set();
+		for (let arr of await Promise.all(rows.map(row => row.getItems()))) {
+			for (let item of arr) ids.add(item.id);
+		}
+		assert.sameMembers([...ids], [itemA.id, itemB.id]);
+		
+		await iv.setFilter('advanced-search', null);
+		await selectLibrary(win);
+		await Zotero.Items.erase([itemA.id, itemB.id, itemC.id]);
+		await Zotero.Collections.erase([c1.id, c2.id, c3.id]);
+	});
+	
 	it("shouldn't show trashed items outside the trash", async function () {
 		var item = await createDataObject('item', { setTitle: true });
 		item.deleted = true;
@@ -486,6 +536,23 @@ describe("Advanced Search", function () {
 			// Focus moves to the new condition's drop-down
 			assert.equal(win.document.activeElement, newRow.querySelector('#conditionsmenu'));
 		});
+		it("should hide the value textbox for a menu-based condition", async function () {
+			var s = new Zotero.Search();
+			s.libraryID = Zotero.Libraries.userLibraryID;
+			s.addCondition('title', 'is', '');
+			pane.search = s;
+			
+			var row = conditions.firstChild;
+			row.onConditionSelected('fileTypeID');
+			
+			// File Type uses a value menu, so the textbox must actually be hidden, not just
+			// sitting alongside the menu
+			var valuefield = row.querySelector('#valuefield');
+			assert.isTrue(valuefield.hidden);
+			assert.equal(win.getComputedStyle(valuefield).display, 'none');
+			assert.isFalse(row.querySelector('#valuemenu').hidden);
+		});
+		
 
 		describe("Find-as-you-type", function () {
 			function typeInMenu(menu, str) {
@@ -987,6 +1054,295 @@ describe("Advanced Search", function () {
 				assert.lengthOf(conditions.children, 1);
 				assert.equal(conditions.firstChild.selectedCondition, 'title');
 				assert.equal(conditions.firstChild.querySelector('#valuefield').value, '');
+			});
+
+			it("should default a fresh search to the top-level item result level", function () {
+				// Opening a new (unseeded) advanced search defaults the result level to
+				// top-level items, so child conditions map up without grouping
+				pane.search = null;
+				assert.equal(searchBox.rootGroup.resultLevel, 'item');
+			});
+
+			it("should render and serialize the root result level", function () {
+				var s = new Zotero.Search();
+				s.libraryID = Zotero.Libraries.userLibraryID;
+				s.addCondition('resultLevel', 'annotation');
+				s.addCondition('annotationText', 'contains', 'foo');
+				pane.search = s;
+
+				assert.equal(searchBox.rootGroup.resultLevel, 'annotation');
+
+				searchBox.updateSearch();
+				var sequence = Object.values(searchBox.search.getConditions())
+					.map(c => c.condition);
+				assert.deepEqual(sequence, ['resultLevel', 'annotationText']);
+				var scopeCond = Object.values(searchBox.search.getConditions())
+					.find(c => c.condition == 'resultLevel');
+				assert.equal(scopeCond.operator, 'annotation');
+			});
+
+			it("should render and serialize a nested group result level", function () {
+				var s = new Zotero.Search();
+				s.libraryID = Zotero.Libraries.userLibraryID;
+				s.addCondition('creator', 'contains', 'Smith');
+				s.addCondition('groupStart', 'true', '');
+				s.addCondition('resultLevel', 'annotation');
+				s.addCondition('annotationText', 'contains', 'foo');
+				s.addCondition('groupEnd', 'true', '');
+				pane.search = s;
+
+				var group = conditions.querySelector('search-condition-group');
+				assert.equal(group.resultLevel, 'annotation');
+
+				searchBox.updateSearch();
+				var sequence = Object.values(searchBox.search.getConditions())
+					.map(c => c.condition);
+				assert.deepEqual(sequence,
+					['creator', 'groupStart', 'resultLevel', 'annotationText', 'groupEnd']);
+			});
+
+			it("should show a binding menu for a group of same-level descendant conditions", function () {
+				var s = new Zotero.Search();
+				s.libraryID = Zotero.Libraries.userLibraryID;
+				s.addCondition('resultLevel', 'item'); // result level
+				s.addCondition('groupStart', 'true', '');
+				s.addCondition('annotationText', 'contains', 'foo');
+				s.addCondition('annotationComment', 'contains', 'bar');
+				s.addCondition('groupEnd', 'true', '');
+				pane.search = s;
+
+				var group = conditions.querySelector('search-condition-group');
+				assert.isFalse(group.bindingMenu.hidden);
+				var values = [...group.bindingMenu.querySelectorAll('menuitem')].map(i => i.value);
+				assert.includeMembers(values, ['any', 'annotation']);
+				// No attachment conditions, so it isn't offered
+				assert.notInclude(values, 'attachment');
+
+				// Bind to the same annotation and confirm it serializes
+				group.resultLevel = 'annotation';
+				searchBox.updateSearch();
+				var seq = Object.values(searchBox.search.getConditions()).map(c => c.condition);
+				assert.deepEqual(seq,
+					['resultLevel', 'groupStart', 'resultLevel', 'annotationText', 'annotationComment', 'groupEnd']);
+				var groupScope = Object.values(searchBox.search.getConditions())
+					.filter(c => c.condition == 'resultLevel')[1];
+				assert.equal(groupScope.operator, 'annotation');
+			});
+
+			it("should not show a binding menu for a group of item-level conditions", function () {
+				var s = new Zotero.Search();
+				s.libraryID = Zotero.Libraries.userLibraryID;
+				s.addCondition('resultLevel', 'item');
+				s.addCondition('groupStart', 'true', '');
+				s.addCondition('title', 'contains', 'a');
+				s.addCondition('title', 'contains', 'b');
+				s.addCondition('groupEnd', 'true', '');
+				pane.search = s;
+
+				var group = conditions.querySelector('search-condition-group');
+				assert.isTrue(group.bindingMenu.hidden);
+			});
+
+			it("should render a stored group binding into the menu", function () {
+				var s = new Zotero.Search();
+				s.libraryID = Zotero.Libraries.userLibraryID;
+				s.addCondition('resultLevel', 'item');
+				s.addCondition('groupStart', 'true', '');
+				s.addCondition('resultLevel', 'annotation');
+				s.addCondition('annotationText', 'contains', 'foo');
+				s.addCondition('annotationComment', 'contains', 'bar');
+				s.addCondition('groupEnd', 'true', '');
+				pane.search = s;
+
+				var group = conditions.querySelector('search-condition-group');
+				assert.isFalse(group.bindingMenu.hidden);
+				assert.equal(group.resultLevel, 'annotation');
+				assert.equal(group.bindingMenu.value, 'annotation');
+			});
+
+			it("should offer a binding hint for ungrouped sibling descendant conditions", function () {
+				var s = new Zotero.Search();
+				s.libraryID = Zotero.Libraries.userLibraryID;
+				s.addCondition('resultLevel', 'item');
+				s.addCondition('annotationText', 'contains', 'foo');
+				s.addCondition('annotationComment', 'contains', 'bar');
+				pane.search = s;
+
+				var hint = searchBox.querySelector('#search-binding-hint');
+				assert.isFalse(hint.hidden);
+				// One bindable level (annotation), so one suggestion line with one button
+				assert.lengthOf([...hint.querySelectorAll('button')], 1);
+			});
+
+			it("should not offer a binding hint for item-level sibling conditions", function () {
+				var s = new Zotero.Search();
+				s.libraryID = Zotero.Libraries.userLibraryID;
+				s.addCondition('resultLevel', 'item');
+				s.addCondition('title', 'contains', 'a');
+				s.addCondition('title', 'contains', 'b');
+				pane.search = s;
+
+				assert.isTrue(searchBox.querySelector('#search-binding-hint').hidden);
+			});
+
+			it("should not offer a binding hint for an unpopulated condition", function () {
+				// One populated annotation condition plus an empty one: not enough to suggest
+				// binding until the second is actually filled in
+				var s = new Zotero.Search();
+				s.libraryID = Zotero.Libraries.userLibraryID;
+				s.addCondition('resultLevel', 'item');
+				s.addCondition('annotationText', 'contains', 'foo');
+				s.addCondition('annotationComment', 'contains', '');
+				pane.search = s;
+
+				assert.isTrue(searchBox.querySelector('#search-binding-hint').hidden);
+			});
+
+			it("should wrap conditions into a bound group when the hint is taken", function () {
+				var s = new Zotero.Search();
+				s.libraryID = Zotero.Libraries.userLibraryID;
+				s.addCondition('resultLevel', 'item');
+				s.addCondition('annotationText', 'contains', 'foo');
+				s.addCondition('annotationComment', 'contains', 'bar');
+				pane.search = s;
+
+				searchBox.rootGroup.bindSameEntity('annotation');
+
+				// The two conditions are now one group bound to annotation
+				var group = conditions.querySelector('search-condition-group');
+				assert.ok(group);
+				assert.equal(group.resultLevel, 'annotation');
+				assert.lengthOf(
+					[...group.conditionsContainer.children].filter(c => c.localName == 'zoterosearchcondition'),
+					2);
+
+				searchBox.updateSearch();
+				var seq = Object.values(searchBox.search.getConditions()).map(c => c.condition);
+				assert.deepEqual(seq,
+					['resultLevel', 'groupStart', 'resultLevel', 'annotationText', 'annotationComment', 'groupEnd']);
+
+				// Conditions are no longer ungrouped siblings, so the hint is gone
+				assert.isTrue(searchBox.querySelector('#search-binding-hint').hidden);
+			});
+
+			it("should fold a legacy noChildren into the result level", function () {
+				var s = new Zotero.Search();
+				s.libraryID = Zotero.Libraries.userLibraryID;
+				s.addCondition('noChildren', 'true');
+				s.addCondition('title', 'contains', 'foo');
+				pane.search = s;
+
+				// Shown as result level = top-level items, no separate checkbox
+				assert.equal(searchBox.rootGroup.resultLevel, 'item');
+
+				searchBox.updateSearch();
+				var seq = Object.values(searchBox.search.getConditions()).map(c => c.condition);
+				assert.notInclude(seq, 'noChildren');
+				assert.deepEqual(seq, ['resultLevel', 'title']);
+			});
+
+
+			it("should warn when ALL conditions can't match the same item at a mixed result level", function () {
+				// No result type (mixed), so an item-level and an annotation-level condition
+				// can't both be true of one row
+				var s = new Zotero.Search();
+				s.libraryID = Zotero.Libraries.userLibraryID;
+				s.addCondition('title', 'contains', 'a');
+				s.addCondition('annotationText', 'contains', 'b');
+				pane.search = s;
+
+				assert.isFalse(searchBox.querySelector('.level-warning').hidden);
+			});
+
+			it("should not warn when a result type lets the conditions combine", function () {
+				// Result type item: the annotation condition maps up, so it's satisfiable
+				var s = new Zotero.Search();
+				s.libraryID = Zotero.Libraries.userLibraryID;
+				s.addCondition('resultLevel', 'item');
+				s.addCondition('title', 'contains', 'a');
+				s.addCondition('annotationText', 'contains', 'b');
+				pane.search = s;
+
+				assert.isTrue(searchBox.querySelector('.level-warning').hidden);
+			});
+
+			it("should warn when a condition can't reach the result type", function () {
+				// A note can never be (or be under) an attachment
+				var s = new Zotero.Search();
+				s.libraryID = Zotero.Libraries.userLibraryID;
+				s.addCondition('resultLevel', 'attachment');
+				s.addCondition('note', 'contains', 'a');
+				pane.search = s;
+
+				assert.isFalse(searchBox.querySelector('.level-warning').hidden);
+			});
+
+			it("should warn on the group when a condition can't reach its binding", function () {
+				// A group bound to "same annotation" with a note condition: the conflict is the
+				// group's binding, so the warning belongs on the group, not at the root.
+				var s = new Zotero.Search();
+				s.libraryID = Zotero.Libraries.userLibraryID;
+				s.addCondition('resultLevel', 'item');
+				s.addCondition('groupStart', 'true', '');
+				s.addCondition('resultLevel', 'annotation');
+				s.addCondition('annotationComment', 'contains', 'a');
+				s.addCondition('note', 'contains', 'b');
+				s.addCondition('groupEnd', 'true', '');
+				pane.search = s;
+
+				var group = conditions.querySelector('search-condition-group');
+				assert.isFalse(group.levelWarning.hidden);
+				assert.isTrue(searchBox.rootGroup.levelWarning.hidden);
+			});
+
+			it("should not warn for a \"separately\" group whose conditions roll up", function () {
+				// "Separately" inherits the result level (item), so annotations and a note all
+				// roll up independently -- satisfiable, no warning (so "match separately" really
+				// does clear the bound-group warning)
+				var s = new Zotero.Search();
+				s.libraryID = Zotero.Libraries.userLibraryID;
+				s.addCondition('resultLevel', 'item');
+				s.addCondition('groupStart', 'true', '');
+				s.addCondition('annotationComment', 'contains', 'a');
+				s.addCondition('annotationComment', 'contains', 'b');
+				s.addCondition('note', 'contains', 'c');
+				s.addCondition('groupEnd', 'true', '');
+				pane.search = s;
+
+				assert.isTrue(conditions.querySelector('search-condition-group').levelWarning.hidden);
+			});
+
+			it("should not warn for an ordinary search", function () {
+				pane.search = null;
+				assert.isTrue(searchBox.querySelector('.level-warning').hidden);
+			});
+
+			it("should keep a legacy includeParentsAndChildren editable and round-tripping", function () {
+				var s = new Zotero.Search();
+				s.libraryID = Zotero.Libraries.userLibraryID;
+				s.addCondition('title', 'contains', 'foo');
+				s.addCondition('includeParentsAndChildren', 'true');
+				pane.search = s;
+
+				assert.isFalse(searchBox.querySelector('#search-legacy-options').hidden);
+				assert.isTrue(searchBox.querySelector('#includeParentsAndChildrenCheckbox').checked);
+
+				searchBox.updateSearch();
+				var seq = Object.values(searchBox.search.getConditions()).map(c => c.condition);
+				assert.include(seq, 'includeParentsAndChildren');
+			});
+
+			it("should drop includeParentsAndChildren when its legacy checkbox is unchecked", function () {
+				var s = new Zotero.Search();
+				s.libraryID = Zotero.Libraries.userLibraryID;
+				s.addCondition('title', 'contains', 'foo');
+				s.addCondition('includeParentsAndChildren', 'true');
+				pane.search = s;
+
+				searchBox.querySelector('#includeParentsAndChildrenCheckbox').checked = false;
+				searchBox.updateSearch();
+				var seq = Object.values(searchBox.search.getConditions()).map(c => c.condition);
+				assert.notInclude(seq, 'includeParentsAndChildren');
 			});
 
 			it("should add a sibling condition outside the group from the group's +", function () {

--- a/test/tests/dataObjectUtilitiesTest.js
+++ b/test/tests/dataObjectUtilitiesTest.js
@@ -345,7 +345,44 @@ describe("Zotero.DataObjectUtilities", function () {
 					Zotero.debug(changes);
 					assert.lengthOf(changes, 0);
 				})
-				
+
+				it("should diff conditions as an ordered unit, not an unordered set", function () {
+					// Condition order and group markers are structural, so the same conditions
+					// with the group wrapping a different one is a real change the diff must catch.
+					var json1 = {
+						conditions: [
+							{ condition: 'title', operator: 'contains', value: 'foo' },
+							{ condition: 'groupStart', operator: 'true', value: '' },
+							{ condition: 'tag', operator: 'is', value: 'x' },
+							{ condition: 'groupEnd', operator: 'true', value: '' }
+						]
+					};
+					var json2 = {
+						conditions: [
+							{ condition: 'groupStart', operator: 'true', value: '' },
+							{ condition: 'title', operator: 'contains', value: 'foo' },
+							{ condition: 'groupEnd', operator: 'true', value: '' },
+							{ condition: 'tag', operator: 'is', value: 'x' }
+						]
+					};
+					var changes = Zotero.DataObjectUtilities.diff(json1, json2);
+					assert.lengthOf(changes, 1);
+					assert.equal(changes[0].field, 'conditions');
+					assert.equal(changes[0].op, 'modify');
+					assert.deepEqual(changes[0].value, json2.conditions);
+				})
+
+				it("should show no change for identical conditions", function () {
+					var json1 = {
+						conditions: [{ condition: 'title', operator: 'is', value: 'A' }]
+					};
+					var json2 = {
+						conditions: [{ condition: 'title', operator: 'is', value: 'A' }]
+					};
+					var changes = Zotero.DataObjectUtilities.diff(json1, json2);
+					assert.lengthOf(changes, 0);
+				})
+
 				/*it("should not show an empty conditions object and a missing one as different", function () {
 					var json1 = {
 						conditions: []
@@ -738,82 +775,25 @@ describe("Zotero.DataObjectUtilities", function () {
 		// Search conditions
 		//
 		describe("conditions", function () {
-			it("should add a condition", function () {
+			// Conditions are applied as a whole ordered array (op: 'modify'), not merged
+			// member-by-member, so group structure (order + marker pairing) is preserved
+			it("should replace conditions with the modified array", function () {
 				var json = {
 					conditions: [
-						{
-							condition: "title",
-							op: "contains",
-							value: "A"
-						}
+						{ condition: "title", operator: "contains", value: "A" }
 					]
 				};
+				var newConditions = [
+					{ condition: "title", operator: "contains", value: "A" },
+					{ condition: "groupStart", operator: "true", value: "" },
+					{ condition: "tag", operator: "is", value: "x" },
+					{ condition: "groupEnd", operator: "true", value: "" }
+				];
 				var changes = [
-					{
-						field: "conditions",
-						op: "member-add",
-						value: {
-							condition: "title",
-							op: "contains",
-							value: "B"
-						}
-					}
+					{ field: "conditions", op: "modify", value: newConditions }
 				];
 				Zotero.DataObjectUtilities.applyChanges(json, changes);
-				assert.sameDeepMembers(
-					json.conditions,
-					[
-						{
-							condition: "title",
-							op: "contains",
-							value: "A"
-						},
-						{
-							condition: "title",
-							op: "contains",
-							value: "B"
-						}
-					]
-				);
-			})
-			
-			it("should remove a condition", function () {
-				var json = {
-					conditions: [
-						{
-							condition: "title",
-							op: "contains",
-							value: "A"
-						},
-						{
-							condition: "title",
-							op: "contains",
-							value: "B"
-						}
-					]
-				};
-				var changes = [
-					{
-						field: "conditions",
-						op: "member-remove",
-						value: {
-							condition: "title",
-							op: "contains",
-							value: "B"
-						}
-					}
-				];
-				Zotero.DataObjectUtilities.applyChanges(json, changes);
-				assert.sameDeepMembers(
-					json.conditions,
-					[
-						{
-							condition: "title",
-							op: "contains",
-							value: "A"
-						}
-					]
-				);
+				assert.deepEqual(json.conditions, newConditions);
 			})
 		})
 	})

--- a/test/tests/searchTest.js
+++ b/test/tests/searchTest.js
@@ -1201,6 +1201,29 @@ describe("Zotero.Search", function () {
 					assert.include(matches, annotation.id);
 				});
 			});
+			describe("titleCreatorYear", function () {
+				it("should match title, creator, and year but not other fields", async function () {
+					var word = 'ztcy' + Zotero.Utilities.randomString();
+					// Matches via title
+					var byTitle = await createDataObject('item', { title: 'a ' + word + ' b' });
+					// Matches via creator
+					var byCreator = await createDataObject('item', {
+						creators: [{ creatorType: 'author', lastName: word, firstName: 'X' }]
+					});
+					// Has the word only in a field outside the title/creator/year set
+					var byOther = await createDataObject('item');
+					byOther.setField('abstractNote', 'a ' + word + ' b');
+					await byOther.saveTx();
+					
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('titleCreatorYear', 'contains', word);
+					assert.sameMembers(await s.search(), [byTitle.id, byCreator.id]);
+					
+					await Zotero.Items.erase([byTitle.id, byCreator.id, byOther.id]);
+				});
+			});
+			
 			
 			describe("savedSearch", function () {
 				it("should return items in the saved search", async function () {

--- a/test/tests/searchTest.js
+++ b/test/tests/searchTest.js
@@ -122,6 +122,43 @@ describe("Zotero.Search", function () {
 		});
 	});
 
+	describe("#combineConditions()", function () {
+		function pred(sql, params = []) {
+			return { sql, params };
+		}
+
+		it("should AND predicates in 'all' mode", function () {
+			var r = Zotero.Search.combineConditions([pred('A'), pred('B')]);
+			assert.equal(r.sql, 'A AND B');
+		});
+
+		it("should OR and parenthesize predicates in 'any' mode", function () {
+			var r = Zotero.Search.combineConditions([
+				{ marker: 'joinMode', operator: 'any' }, pred('A'), pred('B')
+			]);
+			assert.equal(r.sql, '(A OR B)');
+		});
+
+		it("should combine a nested group", function () {
+			var r = Zotero.Search.combineConditions([
+				pred('A'),
+				{ marker: 'groupStart' },
+				{ marker: 'joinMode', operator: 'any' },
+				pred('B'),
+				pred('C'),
+				{ marker: 'groupEnd' }
+			]);
+			assert.equal(r.sql, 'A AND (B OR C)');
+		});
+
+		it("should collect params in order", function () {
+			var r = Zotero.Search.combineConditions([pred('A=?', [1]), pred('B=?', [2])]);
+			assert.equal(r.sql, 'A=? AND B=?');
+			assert.deepEqual(r.params, [1, 2]);
+		});
+
+	});
+
 	describe("#search()", function () {
 		var userLibraryID;
 		var fooItem;
@@ -158,6 +195,65 @@ describe("Zotero.Search", function () {
 		});
 		
 		describe("Conditions", function () {
+			describe("Nested condition groups", function () {
+				it("should match A AND (B OR C)", async function () {
+					var ab = await createDataObject('item', { title: 'zgrpA', tags: [{ tag: 'zgrpB' }] });
+					var ac = await createDataObject('item', { title: 'zgrpA', tags: [{ tag: 'zgrpC' }] });
+					await createDataObject('item', { title: 'zgrpA' });
+					await createDataObject('item', { tags: [{ tag: 'zgrpB' }] });
+
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('joinMode', 'all');
+					s.addCondition('title', 'contains', 'zgrpA');
+					s.addCondition('groupStart', 'true', '');
+					s.addCondition('joinMode', 'any');
+					s.addCondition('tag', 'is', 'zgrpB');
+					s.addCondition('tag', 'is', 'zgrpC');
+					s.addCondition('groupEnd', 'true', '');
+					assert.sameMembers(await s.search(), [ab.id, ac.id]);
+				});
+
+				it("should match A OR (B AND C)", async function () {
+					var a = await createDataObject('item', { title: 'zg2A' });
+					var bc = await createDataObject('item', { title: 'zg2B', tags: [{ tag: 'zg2C' }] });
+					await createDataObject('item', { title: 'zg2B' });
+
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('joinMode', 'any');
+					s.addCondition('title', 'contains', 'zg2A');
+					s.addCondition('groupStart', 'true', '');
+					s.addCondition('joinMode', 'all');
+					s.addCondition('title', 'contains', 'zg2B');
+					s.addCondition('tag', 'is', 'zg2C');
+					s.addCondition('groupEnd', 'true', '');
+					assert.sameMembers(await s.search(), [a.id, bc.id]);
+				});
+
+				it("should match nested groups A AND (B OR (C AND D))", async function () {
+					var ab = await createDataObject('item', { title: 'zg3A', tags: [{ tag: 'zg3B' }] });
+					var acd = await createDataObject('item', { title: 'zg3A zg3C', tags: [{ tag: 'zg3D' }] });
+					await createDataObject('item', { title: 'zg3A zg3C' });
+
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('joinMode', 'all');
+					s.addCondition('title', 'contains', 'zg3A');
+					s.addCondition('groupStart', 'true', '');
+					s.addCondition('joinMode', 'any');
+					s.addCondition('tag', 'is', 'zg3B');
+					s.addCondition('groupStart', 'true', '');
+					s.addCondition('joinMode', 'all');
+					s.addCondition('title', 'contains', 'zg3C');
+					s.addCondition('tag', 'is', 'zg3D');
+					s.addCondition('groupEnd', 'true', '');
+					s.addCondition('groupEnd', 'true', '');
+					assert.sameMembers(await s.search(), [ab.id, acd.id]);
+				});
+
+			});
+
 			describe("collection", function () {
 				it("should find item in collection", async function () {
 					var col = await createDataObject('collection');

--- a/test/tests/searchTest.js
+++ b/test/tests/searchTest.js
@@ -73,7 +73,6 @@ describe("Zotero.Search", function () {
 			assert.propertyVal(condition, 'condition', 'title')
 			assert.propertyVal(condition, 'operator', 'is')
 			assert.propertyVal(condition, 'value', 'test')
-			assert.propertyVal(condition, 'required', false)
 		});
 		
 		it("should add a condition to an existing search", async function () {

--- a/test/tests/searchTest.js
+++ b/test/tests/searchTest.js
@@ -1113,6 +1113,25 @@ describe("Zotero.Search", function () {
 			});
 
 			describe("anyField", function () {
+				it("should expand an 'any field' within its own group", async function () {
+					// (anyField contains "znestfoo" OR title contains "zzznomatch") -> the
+					// item matches via Any Field. If the Any Field expansion leaked to the
+					// top level (ANDed) instead of staying in this OR-group, the
+					// non-matching title would exclude it.
+					var item = await createDataObject('item', { title: "znestfoo" });
+
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('groupStart', 'true', '');
+					s.addCondition('joinMode', 'any');
+					s.addCondition('anyField', 'contains', "znestfoo");
+					s.addCondition('title', 'contains', "zzznomatch");
+					s.addCondition('groupEnd', 'true', '');
+					var matches = await s.search();
+					assert.includeMembers(matches, [item.id]);
+
+					await item.eraseTx();
+				});
 				it("should return matches for multiple 'any field' conditions with joinMode=any", async function () {
 					var itemOne = await createDataObject('item', { title: "one" });
 					var itemTwo = await createDataObject('item', { title: "two" });

--- a/test/tests/searchTest.js
+++ b/test/tests/searchTest.js
@@ -494,6 +494,56 @@ describe("Zotero.Search", function () {
 					assert.notIncludeMembers(matches, [foobarItem.id]);
 					assert.includeMembers(matches, [fooItem.id, bazItem.id]);
 				});
+
+				// fulltextContent inside a group must combine with its siblings under the
+				// group's own join mode, not the search's top-level mode (it used to be
+				// applied as a global post-filter keyed on the top-level join mode)
+				it("should obey the group join mode for a grouped fulltextContent", async function () {
+					// OR: (title is foo.html OR full-text "foo bar") matches the title item and the text item
+					var orSearch = new Zotero.Search();
+					orSearch.libraryID = userLibraryID;
+					orSearch.addCondition('groupStart', 'true', '');
+					orSearch.addCondition('joinMode', 'any');
+					orSearch.addCondition('title', 'is', fooItem.getField('title'));
+					orSearch.addCondition('fulltextContent', 'contains', 'foo bar');
+					orSearch.addCondition('groupEnd', 'true', '');
+					assert.sameMembers(await orSearch.search(), [fooItem.id, foobarItem.id]);
+
+					// AND: title is foo.html OR (title is foobar.html AND full-text "nomatchphrase").
+					// The group's full-text doesn't match, so only fooItem (the OR branch) matches.
+					var andSearch = new Zotero.Search();
+					andSearch.libraryID = userLibraryID;
+					andSearch.addCondition('joinMode', 'any');
+					andSearch.addCondition('title', 'is', fooItem.getField('title'));
+					andSearch.addCondition('groupStart', 'true', '');
+					andSearch.addCondition('joinMode', 'all');
+					andSearch.addCondition('title', 'is', foobarItem.getField('title'));
+					andSearch.addCondition('fulltextContent', 'contains', 'nomatchphrase');
+					andSearch.addCondition('groupEnd', 'true', '');
+					assert.sameMembers(await andSearch.search(), [fooItem.id]);
+				});
+
+				it("should compose a grouped fulltextContent in doesNotContain and regexp modes", async function () {
+					// doesNotContain: (full-text doesNotContain "foo" AND title is baz.pdf) -> bazItem
+					var neg = new Zotero.Search();
+					neg.libraryID = userLibraryID;
+					neg.addCondition('groupStart', 'true', '');
+					neg.addCondition('joinMode', 'all');
+					neg.addCondition('fulltextContent', 'doesNotContain', 'foo');
+					neg.addCondition('title', 'is', bazItem.getField('title'));
+					neg.addCondition('groupEnd', 'true', '');
+					assert.sameMembers(await neg.search(), [bazItem.id]);
+
+					// regexp: (title is foo.html OR full-text regexp "foo.+bar") -> both
+					var re = new Zotero.Search();
+					re.libraryID = userLibraryID;
+					re.addCondition('groupStart', 'true', '');
+					re.addCondition('joinMode', 'any');
+					re.addCondition('title', 'is', fooItem.getField('title'));
+					re.addCondition('fulltextContent/regexp', 'contains', 'foo.+bar');
+					re.addCondition('groupEnd', 'true', '');
+					assert.sameMembers(await re.search(), [fooItem.id, foobarItem.id]);
+				});
 			});
 			
 			describe("annotationText", function () {

--- a/test/tests/searchTest.js
+++ b/test/tests/searchTest.js
@@ -1150,7 +1150,7 @@ describe("Zotero.Search", function () {
 				it("should return matches for two 'any field' condition with joinMode=all", async function () {
 					var itemOne = await createDataObject('item', { title: "six-seven" });
 					var itemTwo = await createDataObject('item', { title: "seven-six" });
-					
+
 					var s = new Zotero.Search();
 					s.libraryID = userLibraryID;
 					s.addCondition('anyField', 'contains', "six");
@@ -1158,6 +1158,28 @@ describe("Zotero.Search", function () {
 					s.addCondition('joinMode', 'all');
 					var matches = await s.search();
 					assert.sameMembers(matches, [itemOne.id, itemTwo.id]);
+				});
+				it("should return matches for annotation text", async function () {
+					var attachment = await importPDFAttachment();
+					var annotation = await createAnnotation('highlight', attachment);
+					var str = annotation.annotationText.substr(0, 7);
+
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('anyField', 'contains', str);
+					var matches = await s.search();
+					assert.include(matches, annotation.id);
+				});
+				it("should return matches for annotation comment", async function () {
+					var attachment = await importPDFAttachment();
+					var annotation = await createAnnotation('note', attachment);
+					var str = annotation.annotationComment.substr(0, 7);
+
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('anyField', 'contains', str);
+					var matches = await s.search();
+					assert.include(matches, annotation.id);
 				});
 			});
 			

--- a/test/tests/searchTest.js
+++ b/test/tests/searchTest.js
@@ -159,6 +159,32 @@ describe("Zotero.Search", function () {
 
 	});
 
+	describe("#mapPredicate()", function () {
+		var c = (sql, from, to, neg) => Zotero.Search.mapPredicate(sql, from, to, neg);
+
+		it("should leave a predicate unchanged when the result level is 'any'", function () {
+			assert.equal(c('X', 'item', 'any'), 'X');
+			assert.equal(c('X', 'any', 'any'), 'X');
+		});
+
+		it("should not roll up a negated level-agnostic condition", function () {
+			assert.equal(c('X', 'any', 'item', true), 'X');
+		});
+
+		it("should match nothing for unrelated branches (note vs annotation)", function () {
+			assert.equal(c('X', 'note', 'annotation'), '0');
+		});
+
+		it("should leave a multi-level field unchanged at a level it matches at", function () {
+			// e.g., title exists on both items and attachments, so at either result level the
+			// predicate is used as-is (the result-level FROM filters to the right rows)
+			assert.equal(c('X', ['item', 'attachment'], 'item'), 'X');
+			assert.equal(c('X', ['item', 'attachment'], 'attachment'), 'X');
+			assert.equal(c('X', ['item', 'attachment'], 'any'), 'X');
+		});
+
+	});
+
 	describe("#search()", function () {
 		var userLibraryID;
 		var fooItem;
@@ -252,6 +278,390 @@ describe("Zotero.Search", function () {
 					assert.sameMembers(await s.search(), [ab.id, acd.id]);
 				});
 
+			});
+
+			describe("Cross-level scope", function () {
+				it("should match a top-level item by a condition on a descendant annotation", async function () {
+					var text = 'zscopematch' + Zotero.Utilities.randomString();
+
+					// Author Smith, with a matching annotation on a child PDF -- should match
+					var item = await createDataObject('item', {
+						creators: [{ lastName: 'Zscopesmith', creatorType: 'author' }]
+					});
+					var attachment = await importPDFAttachment(item);
+					var annotation = await createAnnotation('highlight', attachment);
+					annotation.annotationText = text;
+					await annotation.saveTx();
+
+					// Author Smith, but no matching annotation -- shouldn't match
+					var noAnnotation = await createDataObject('item', {
+						creators: [{ lastName: 'Zscopesmith', creatorType: 'author' }]
+					});
+
+					// Matching annotation, but a different author -- shouldn't match
+					var other = await createDataObject('item', {
+						creators: [{ lastName: 'Zscopejones', creatorType: 'author' }]
+					});
+					var otherAttachment = await importPDFAttachment(other);
+					var otherAnnotation = await createAnnotation('highlight', otherAttachment);
+					otherAnnotation.annotationText = text;
+					await otherAnnotation.saveTx();
+
+					// creator is Smith AND (has an annotation whose text matches)
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('creator', 'contains', 'Zscopesmith');
+					s.addCondition('groupStart', 'true', '');
+					s.addCondition('resultLevel', 'annotation');
+					s.addCondition('annotationText', 'contains', text);
+					s.addCondition('groupEnd', 'true', '');
+					assert.sameMembers(await s.search(), [item.id]);
+
+					await item.eraseTx();
+					await noAnnotation.eraseTx();
+					await other.eraseTx();
+				});
+
+				it("should return descendant annotations as results with a top-level condition", async function () {
+					var text = 'zresult' + Zotero.Utilities.randomString();
+
+					// Smith item with two matching and one non-matching annotation
+					var item = await createDataObject('item', {
+						creators: [{ lastName: 'Zresultsmith', creatorType: 'author' }]
+					});
+					var attachment = await importPDFAttachment(item);
+					var match1 = await createAnnotation('highlight', attachment);
+					match1.annotationText = text;
+					await match1.saveTx();
+					var match2 = await createAnnotation('highlight', attachment);
+					match2.annotationText = text;
+					await match2.saveTx();
+					await createAnnotation('highlight', attachment); // random text -- no match
+
+					// Different author with a matching annotation -- shouldn't match
+					var other = await createDataObject('item', {
+						creators: [{ lastName: 'Zresultjones', creatorType: 'author' }]
+					});
+					var otherAttachment = await importPDFAttachment(other);
+					var otherAnnotation = await createAnnotation('highlight', otherAttachment);
+					otherAnnotation.annotationText = text;
+					await otherAnnotation.saveTx();
+
+					// Result level annotations: the matching annotations on Smith's items
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('resultLevel', 'annotation');
+					s.addCondition('creator', 'contains', 'Zresultsmith');
+					s.addCondition('annotationText', 'contains', text);
+					assert.sameMembers(await s.search(), [match1.id, match2.id]);
+
+					await item.eraseTx();
+					await other.eraseTx();
+				});
+
+				it("should match annotations for a negated annotation condition at the annotation result level", async function () {
+					// At the annotation result level, a negated annotation condition matches
+					// the annotations that lack the value
+					var text = 'zneg' + Zotero.Utilities.randomString();
+					var item = await createDataObject('item');
+					var attachment = await importPDFAttachment(item);
+					var withText = await createAnnotation('highlight', attachment);
+					withText.annotationText = text;
+					await withText.saveTx();
+					var withoutText = await createAnnotation('highlight', attachment);
+					withoutText.annotationText = 'zsomethingelse';
+					await withoutText.saveTx();
+
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('resultLevel', 'annotation');
+					s.addCondition('annotationText', 'doesNotContain', text);
+					assert.sameMembers(await s.search(), [withoutText.id]);
+
+					await item.eraseTx();
+				});
+
+				it("should match an item in a collection by a child attachment's content", async function () {
+					// Collection (item-level) and Attachment Content (rolls up from the
+					// attachment) both resolve at the top-level item and intersect there
+					var collection = await createDataObject('collection');
+					// In the collection, with a child attachment whose content matches
+					var match = await createDataObject('item', { collections: [collection.id] });
+					await importFileAttachment("search/foobar.html", { parentID: match.id });
+					// In the collection, but no matching attachment content
+					var noContent = await createDataObject('item', { collections: [collection.id] });
+					// Has the matching content, but isn't in the collection
+					var notInCollection = await createDataObject('item');
+					await importFileAttachment("search/foobar.html", { parentID: notInCollection.id });
+
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('resultLevel', 'item');
+					s.addCondition('collection', 'is', collection.key);
+					s.addCondition('fulltextContent', 'contains', 'foo bar');
+					assert.sameMembers(await s.search(), [match.id]);
+
+					await match.eraseTx();
+					await noContent.eraseTx();
+					await notInCollection.eraseTx();
+				});
+
+				it("should return a collection's matching descendants at a descendant result level", async function () {
+					// Collection (item-level) maps down to the annotation result level, so
+					// a matching annotation under a collection item is returned even though the
+					// top-level item doesn't itself match the annotation condition
+					var text = 'zcoll' + Zotero.Utilities.randomString();
+					var collection = await createDataObject('collection');
+					var item = await createDataObject('item', { collections: [collection.id] });
+					var attachment = await importPDFAttachment(item);
+					var match = await createAnnotation('highlight', attachment);
+					match.annotationText = text;
+					await match.saveTx();
+					// A matching annotation, but its item isn't in the collection
+					var other = await createDataObject('item');
+					var otherAttachment = await importPDFAttachment(other);
+					var otherAnnotation = await createAnnotation('highlight', otherAttachment);
+					otherAnnotation.annotationText = text;
+					await otherAnnotation.saveTx();
+
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('resultLevel', 'annotation');
+					s.addCondition('collection', 'is', collection.key);
+					s.addCondition('annotationText', 'contains', text);
+					assert.sameMembers(await s.search(), [match.id]);
+
+					await item.eraseTx();
+					await other.eraseTx();
+				});
+
+				it("should match an itemData field at the item or attachment level it lives at", async function () {
+					// title (like url/accessDate) exists on both top-level items and
+					// attachments, so it matches the right thing at each result level without
+					// rolling an attachment title up to its parent (or a parent title down)
+					var itemTitle = 'zti' + Zotero.Utilities.randomString();
+					var attTitle = 'zta' + Zotero.Utilities.randomString();
+					var item = await createDataObject('item', { title: itemTitle });
+					var attachment = await importPDFAttachment(item);
+					attachment.setField('title', attTitle);
+					await attachment.saveTx();
+
+					let search = (level, value) => {
+						var s = new Zotero.Search();
+						s.libraryID = userLibraryID;
+						s.addCondition('resultLevel', level);
+						s.addCondition('title', 'contains', value);
+						return s.search();
+					};
+
+					// Attachment result level matches the attachment's own title, not its parent's
+					assert.sameMembers(await search('attachment', attTitle), [attachment.id]);
+					assert.sameMembers(await search('attachment', itemTitle), []);
+					// Item result level matches the item's own title, and an attachment title
+					// does not roll up to the item (option C: no rollup)
+					assert.sameMembers(await search('item', itemTitle), [item.id]);
+					assert.sameMembers(await search('item', attTitle), []);
+
+					await item.eraseTx();
+				});
+
+				it("should map a bare descendant condition to the result level (no group)", async function () {
+					var text = 'zbarecorr' + Zotero.Utilities.randomString();
+					var item = await createDataObject('item', { title: 'zbarecorritem' });
+					var attachment = await importPDFAttachment(item);
+					var annotation = await createAnnotation('highlight', attachment);
+					annotation.annotationText = text;
+					await annotation.saveTx();
+
+					// Result level item + a plain annotation condition (no group) rolls up
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('resultLevel', 'item');
+					s.addCondition('annotationText', 'contains', text);
+					assert.sameMembers(await s.search(), [item.id]);
+
+					await item.eraseTx();
+				});
+
+				it("should match an item by its tag and a descendant annotation's comment", async function () {
+					// A cross-level search combining levels: a top-level item that itself has a
+					// given tag AND has a descendant annotation whose comment contains a word, returned
+					// at the item result level. The tag (level-agnostic) and the annotation
+					// comment (annotation level) both resolve at the item and intersect there.
+					var tag = 'ztag' + Zotero.Utilities.randomString();
+					var word = 'zword' + Zotero.Utilities.randomString();
+
+					// Tagged, with a descendant annotation whose comment contains the word
+					var item = await createDataObject('item', { tags: [{ tag }] });
+					var attachment = await importPDFAttachment(item);
+					await createAnnotation('highlight', attachment, { comment: 'foo ' + word + ' bar' });
+
+					// Tagged, but no matching annotation comment
+					var tagOnly = await createDataObject('item', { tags: [{ tag }] });
+					await importPDFAttachment(tagOnly);
+
+					// Has the matching annotation comment, but not the tag
+					var annotationOnly = await createDataObject('item');
+					var annAttachment = await importPDFAttachment(annotationOnly);
+					await createAnnotation('highlight', annAttachment, { comment: 'foo ' + word + ' bar' });
+
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('resultLevel', 'item');
+					s.addCondition('tag', 'is', tag);
+					s.addCondition('annotationComment', 'contains', word);
+					assert.sameMembers(await s.search(), [item.id]);
+
+					await item.eraseTx();
+					await tagOnly.eraseTx();
+					await annotationOnly.eraseTx();
+				});
+
+				it("should map a bare full-text condition to the result level (no group)", async function () {
+					// A top-level full-text condition matches the item that owns the matching
+					// attachment, materializing and mapping to the result level
+					var item = await createDataObject('item', { title: 'zbareft' });
+					await importFileAttachment("search/foobar.html", { parentID: item.id });
+
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('resultLevel', 'item');
+					s.addCondition('fulltextContent', 'contains', 'foo bar');
+					// The standalone foobarItem also matches and is itself a top-level item, so it's
+					// returned alongside the child attachment's parent
+					assert.sameMembers(await s.search(), [item.id, foobarItem.id]);
+
+					await item.eraseTx();
+				});
+
+				it("should return a standalone attachment whose annotation matches, at the item result level", async function () {
+					// A standalone (top-level) attachment is itself a top-level item, so its annotation
+					// maps up to the attachment's own id and the attachment is returned
+					var word = 'zsa' + Zotero.Utilities.randomString();
+					var standalone = await importPDFAttachment(); // top-level PDF, no parent
+					await createAnnotation('highlight', standalone, { comment: 'x ' + word + ' y' });
+					
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('resultLevel', 'item');
+					s.addCondition('annotationComment', 'contains', word);
+					assert.sameMembers(await s.search(), [standalone.id]);
+					
+					await standalone.eraseTx();
+				});
+				
+
+				it("should bind a same-entity group below a non-item result level", async function () {
+					// Result level attachment + a group scoped to annotation: find attachments
+					// that have a single annotation matching all of the group's conditions.
+					// Exercises mapping where the parent level is 'attachment', not 'item'.
+					var text = 'zsame' + Zotero.Utilities.randomString();
+					var comment = 'zsamec' + Zotero.Utilities.randomString();
+					var item = await createDataObject('item', { title: 'zsameitem' });
+
+					// One annotation matches both text and comment -> this attachment matches
+					var attachmentBoth = await importPDFAttachment(item);
+					var both = await createAnnotation('highlight', attachmentBoth, { comment });
+					both.annotationText = text;
+					await both.saveTx();
+
+					// Two separate annotations, one matching each -> shouldn't match
+					var attachmentSplit = await importPDFAttachment(item);
+					var hasText = await createAnnotation('highlight', attachmentSplit);
+					hasText.annotationText = text;
+					await hasText.saveTx();
+					await createAnnotation('highlight', attachmentSplit, { comment });
+
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('resultLevel', 'attachment'); // result level = attachments
+					s.addCondition('groupStart', 'true', '');
+					s.addCondition('resultLevel', 'annotation'); // the same annotation
+					s.addCondition('annotationText', 'contains', text);
+					s.addCondition('annotationComment', 'contains', comment);
+					s.addCondition('groupEnd', 'true', '');
+					assert.sameMembers(await s.search(), [attachmentBoth.id]);
+
+					await item.eraseTx();
+				});
+
+				it("should roll a tag on a descendant up to the result item", async function () {
+					var tag = 'zroll' + Zotero.Utilities.randomString();
+					// Tagged child attachment (the item itself is untagged)
+					var viaChild = await createDataObject('item', { title: 'zrollchild' });
+					var attachment = await importPDFAttachment(viaChild);
+					attachment.addTag(tag);
+					await attachment.saveTx();
+					// Tagged directly
+					var viaSelf = await createDataObject('item', { title: 'zrollself', tags: [{ tag }] });
+					// Untagged
+					var untagged = await createDataObject('item', { title: 'zrollmiss' });
+
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('resultLevel', 'item');
+					s.addCondition('tag', 'is', tag);
+					// The child's tag rolls up to its item; the directly tagged item matches too
+					assert.sameMembers(await s.search(), [viaChild.id, viaSelf.id]);
+
+					await viaChild.eraseTx();
+					await viaSelf.eraseTx();
+					await untagged.eraseTx();
+				});
+
+				it("should not propagate a tag down to descendant result items", async function () {
+					var tag = 'zdown' + Zotero.Utilities.randomString();
+					// The item is tagged, but its attachment is not
+					var item = await createDataObject('item', { title: 'zdownitem', tags: [{ tag }] });
+					await importPDFAttachment(item);
+
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('resultLevel', 'attachment');
+					s.addCondition('tag', 'is', tag);
+					// Rollup is up-only: a parent's tag must not match its child attachment
+					assert.lengthOf(await s.search(), 0);
+
+					await item.eraseTx();
+				});
+
+				it("should not error when a condition can't reach the result level", async function () {
+					// A note can't be (or be under) an attachment, so this is empty -- but it
+					// must not throw a SQL param error: the dead predicate drops to the constant
+					// '0', and its bound value param must be dropped with it
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('resultLevel', 'attachment');
+					s.addCondition('joinMode', 'any');
+					s.addCondition('note', 'contains', 'zsqltest');
+					assert.lengthOf(await s.search(), 0);
+
+					// Same in 'all' mode
+					var s2 = new Zotero.Search();
+					s2.libraryID = userLibraryID;
+					s2.addCondition('resultLevel', 'attachment');
+					s2.addCondition('note', 'contains', 'zsqltest');
+					assert.lengthOf(await s2.search(), 0);
+				});
+
+				it("should project to all descendant annotations when there's no annotation condition", async function () {
+					// Result level annotations with only a top-level condition -> every
+					// annotation under matching items
+					var item = await createDataObject('item', {
+						creators: [{ lastName: 'Zprojsmith', creatorType: 'author' }]
+					});
+					var attachment = await importPDFAttachment(item);
+					var a1 = await createAnnotation('highlight', attachment);
+					var a2 = await createAnnotation('highlight', attachment);
+
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('resultLevel', 'annotation');
+					s.addCondition('creator', 'contains', 'Zprojsmith');
+					assert.sameMembers(await s.search(), [a1.id, a2.id]);
+
+					await item.eraseTx();
+				});
 			});
 
 			describe("collection", function () {
@@ -647,6 +1057,47 @@ describe("Zotero.Search", function () {
 					s.addCondition('includeParentsAndChildren', 'true');
 					var matches = await s.search();
 					assert.lengthOf(matches, 0);
+				});
+
+				it("should include a match's parents and children", async function () {
+					var itemTitle = 'zincp' + Zotero.Utilities.randomString();
+					var attTitle = 'zinca' + Zotero.Utilities.randomString();
+					var item = await createDataObject('item', { title: itemTitle });
+					var attachment = await importPDFAttachment(item);
+					attachment.setField('title', attTitle);
+					await attachment.saveTx();
+
+					let run = (value) => {
+						var s = new Zotero.Search();
+						s.libraryID = userLibraryID;
+						s.addCondition('title', 'is', value);
+						s.addCondition('includeParentsAndChildren', 'true');
+						return s.search();
+					};
+					// Matching the parent pulls in its child, and matching the child its parent
+					assert.sameMembers(await run(itemTitle), [item.id, attachment.id]);
+					assert.sameMembers(await run(attTitle), [item.id, attachment.id]);
+
+					await item.eraseTx();
+				});
+			});
+
+			describe("noChildren", function () {
+				it("should keep only top-level items", async function () {
+					var title = 'znochild' + Zotero.Utilities.randomString();
+					var item = await createDataObject('item', { title });
+					var attachment = await importPDFAttachment(item);
+					attachment.setField('title', title);
+					await attachment.saveTx();
+
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('title', 'contains', title);
+					s.addCondition('noChildren', 'true');
+					// The child attachment matches the title too, but noChildren excludes it
+					assert.sameMembers(await s.search(), [item.id]);
+
+					await item.eraseTx();
 				});
 			});
 			

--- a/test/tests/syncLocalTest.js
+++ b/test/tests/syncLocalTest.js
@@ -2324,12 +2324,19 @@ describe("Zotero.Sync.Data.Local", function () {
 						},
 						{
 							field: "conditions",
-							op: "member-add",
-							value: {
-								condition: "place",
-								operator: "is",
-								value: "Chicago"
-							}
+							op: "modify",
+							value: [
+								{
+									condition: "title",
+									operator: "contains",
+									value: "A"
+								},
+								{
+									condition: "place",
+									operator: "is",
+									value: "Chicago"
+								}
+							]
 						}
 					]
 				);
@@ -2401,21 +2408,19 @@ describe("Zotero.Sync.Data.Local", function () {
 					[
 						{
 							field: "conditions",
-							op: "member-add",
-							value: {
-								condition: "place",
-								operator: "is",
-								value: "New York"
-							}
-						},
-						{
-							field: "conditions",
-							op: "member-remove",
-							value: {
-								condition: "place",
-								operator: "is",
-								value: "Chicago"
-							}
+							op: "modify",
+							value: [
+								{
+									condition: "title",
+									operator: "contains",
+									value: "A"
+								},
+								{
+									condition: "place",
+									operator: "is",
+									value: "New York"
+								}
+							]
 						}
 					]
 				);
@@ -2568,12 +2573,19 @@ describe("Zotero.Sync.Data.Local", function () {
 						},
 						{
 							field: "conditions",
-							op: "member-add",
-							value: {
-								condition: "place",
-								operator: "is",
-								value: "Chicago"
-							}
+							op: "modify",
+							value: [
+								{
+									condition: "title",
+									operator: "contains",
+									value: "A"
+								},
+								{
+									condition: "place",
+									operator: "is",
+									value: "Chicago"
+								}
+							]
 						}
 					]
 				);

--- a/test/tests/zoteroPaneTest.js
+++ b/test/tests/zoteroPaneTest.js
@@ -1043,7 +1043,7 @@ describe("ZoteroPane", function () {
 			var c = searchBox.search.getCondition(
 				searchBox.search.addCondition("title", "contains", "foo")
 			);
-			searchBox.addCondition(c);
+			searchBox.rootGroup.addCondition(c);
 			await pane.save();
 		}
 		


### PR DESCRIPTION
Adds nested condition groups to saved searches and Advanced Search, allowing searches to combine conditions with arbitrary nesting and per-group match modes, such as `title contains "foo" AND (tag is "x" OR tag is "y")`.

A search can also now be given a result level — top-level item, attachment, note, or annotation — and each condition will be mapped to that level, so one search can mix conditions that match at different levels of the item hierarchy (e.g., a top-level item with a given author *and* a red annotation on one of its PDFs). The Advanced Search UI exposes this through a top-level result-level menu, per-group controls for binding descendant conditions to the same item, and warnings for combinations that would never produce results.

Opening Advanced Search from a non-empty quick search now seeds it with editable conditions matching the current mode. The quick-search modes are now represented as ordinary grouped searches rather than being special internal cases. (This also addresses the ancient feature request of wanting to pin quick searches across collections. Now you can just click the filter button and switch collections, and the advanced search persists.)

This removes various legacy features, including "Show top-level items" (result level = top-level item — migrated on save), the awful "Include parent and child items" hack (no result-level equivalent, so it keeps working and round-trips on existing searches but isn't offered on new ones), the unused `required` flag, and various hacks (the tag→annotation-parent map, the special quick-search handling).

## TODO before merge

- [ ] Bump the schema version on all three clients (desktop, iOS, Android)
- [x] Update the dataserver to return `invalidProp` for searches that contain group markers (`groupStart`/`groupEnd`) to clients below the new schema version. iOS/Android never run searches and tolerate unknown conditions, but without a bump they would show a spurious "saved in a newer version" error for grouped searches they don't even display.