### PR TITLE
Fix stale `itemType` in `_previousData`

### DIFF
--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -425,6 +425,16 @@ Zotero.Item.prototype._finalizeLoadFromRow = function (row) {
 }
 
 
+Zotero.Item.prototype._clearChanged = function (dataType) {
+	Zotero.DataObject.prototype._clearChanged.call(this, dataType);
+	// setType stores the old type under the 'itemType' alias, which the base
+	// primaryData clearing misses (it matches 'itemTypeID'), so clear it here
+	if (!dataType || dataType === 'primaryData') {
+		delete this._previousData.itemType;
+	}
+}
+
+
 /*
  * Set or change the item's type
  */

--- a/test/tests/attachmentsTest.js
+++ b/test/tests/attachmentsTest.js
@@ -2672,10 +2672,17 @@ describe("Zotero.Attachments", function () {
 				item.setType(Zotero.ItemTypes.getID('journalArticle'));
 				item.saveTx();
 				assert.include(await waitForItemEvent("modify"), item.id);
-				// Renaming the attachment fires a second `modify` event
-				await waitNoLongerThan(waitForItemEvent("modify"), 1000);
-
+				// The attachment is renamed asynchronously, so wait for the filename to update
+				await waitForCallback(() => attachment1.attachmentFilename === 'journalArticle - Lorem.pdf', 100, 3);
 				assert.equal(attachment1.attachmentFilename, 'journalArticle - Lorem.pdf');
+
+				// A second consecutive type change guards against a regression where the old
+				// itemType was left in _previousData after the prior save, so the rename saw a stale type
+				item.setType(Zotero.ItemTypes.getID('case'));
+				item.saveTx();
+				assert.include(await waitForItemEvent("modify"), item.id);
+				await waitForCallback(() => attachment1.attachmentFilename === 'case - Lorem.pdf', 100, 3);
+				assert.equal(attachment1.attachmentFilename, 'case - Lorem.pdf');
 			}
 			finally {
 				await Zotero.SyncedSettings.clear(libraryID, 'attachmentRenameTemplate');

--- a/test/tests/attachmentsTest.js
+++ b/test/tests/attachmentsTest.js
@@ -2672,17 +2672,10 @@ describe("Zotero.Attachments", function () {
 				item.setType(Zotero.ItemTypes.getID('journalArticle'));
 				item.saveTx();
 				assert.include(await waitForItemEvent("modify"), item.id);
-				// The attachment is renamed asynchronously, so wait for the filename to update
-				await waitForCallback(() => attachment1.attachmentFilename === 'journalArticle - Lorem.pdf', 100, 3);
-				assert.equal(attachment1.attachmentFilename, 'journalArticle - Lorem.pdf');
+				// Renaming the attachment fires a second `modify` event
+				await waitNoLongerThan(waitForItemEvent("modify"), 1000);
 
-				// A second consecutive type change guards against a regression where the old
-				// itemType was left in _previousData after the prior save, so the rename saw a stale type
-				item.setType(Zotero.ItemTypes.getID('case'));
-				item.saveTx();
-				assert.include(await waitForItemEvent("modify"), item.id);
-				await waitForCallback(() => attachment1.attachmentFilename === 'case - Lorem.pdf', 100, 3);
-				assert.equal(attachment1.attachmentFilename, 'case - Lorem.pdf');
+				assert.equal(attachment1.attachmentFilename, 'journalArticle - Lorem.pdf');
 			}
 			finally {
 				await Zotero.SyncedSettings.clear(libraryID, 'attachmentRenameTemplate');

--- a/test/tests/itemTest.js
+++ b/test/tests/itemTest.js
@@ -2155,7 +2155,25 @@ describe("Zotero.Item", function () {
 			// "second" -> "third", old value is "second", and we don't notify about "extra" because it's not changed this time
 			assert.deepPropertyVal(extraData[ids[0]], 'changed', { title: 'second' });
 		});
-		
+
+		it("should report the previous itemType in notifier extraData on consecutive type changes", async function () {
+			var item = await createDataObject('item', { itemType: 'book' });
+
+			var promise = waitForNotifierEvent('modify', 'item');
+			item.setType(Zotero.ItemTypes.getID('journalArticle'));
+			await item.saveTx();
+			var { ids, extraData } = await promise;
+			assert.propertyVal(extraData[ids[0]].changed, 'itemType', 'book');
+
+			promise = waitForNotifierEvent('modify', 'item');
+			item.setType(Zotero.ItemTypes.getID('case'));
+			await item.saveTx();
+			({ ids, extraData } = await promise);
+			// Without clearing the 'itemType' alias from _previousData after the prior save,
+			// this would report the stale 'book' instead of 'journalArticle' (#5964)
+			assert.propertyVal(extraData[ids[0]].changed, 'itemType', 'journalArticle');
+		});
+
 		// 'deleted' and 'tags' use a different, newer mechanism for marking changes
 		it("should include changed 'deleted' value in notifier extraData", async function () {
 			var item = await createDataObject('item');


### PR DESCRIPTION
This PR fixes a problem where, on subsequent item type changes, a stale `itemType` is reported by the notifier, and as a result, the filename is not updated by the auto file renaming.