### PR TITLE
Item/collection tree: Resize using ResizeObserver, not debounce

### DIFF
--- a/chrome/content/zotero/components/virtualized-table.jsx
+++ b/chrome/content/zotero/components/virtualized-table.jsx
@@ -1102,9 +1102,8 @@ class VirtualizedTable extends React.Component {
 		this._setXulTooltip();
 
 		this._topDiv.style.setProperty("--first-column-extra-width", `${this.firstColumnExtraWidth}px`);
-		window.addEventListener("resize", () => {
-			this._debouncedRerender();
-		});
+		this._resizeObserver = new ResizeObserver(() => this.rerender());
+		this._resizeObserver.observe(this._jsWindow.targetElement);
 
 		if (this.props.stickySectionHeaders) {
 			this._jsWindow.targetElement.addEventListener('scroll', this._updateStickySectionHeader, { passive: true });
@@ -1117,6 +1116,7 @@ class VirtualizedTable extends React.Component {
 	}
 
 	componentWillUnmount() {
+		this._resizeObserver?.disconnect();
 		if (this.props.stickySectionHeaders && this._jsWindow) {
 			this._jsWindow.targetElement.removeEventListener('scroll', this._updateStickySectionHeader);
 		}
@@ -1588,8 +1588,6 @@ class VirtualizedTable extends React.Component {
 		document.documentElement.removeChild(div);
 		return parseFloat(height.split('px')[0]);
 	}
-	
-	_debouncedRerender = Zotero.Utilities.debounce(this.rerender, 200);
 	
 	_updateWidth() {
 		if (!this.props.showHeader) return;

--- a/chrome/content/zotero/libraryTree.js
+++ b/chrome/content/zotero/libraryTree.js
@@ -252,16 +252,6 @@ var LibraryTree = class LibraryTree extends React.Component {
 		this.tree && this.tree.scrollToRow(index);
 	}
 
-	updateHeight = () => {
-		this.forceUpdate(() => {
-			if (this.tree) {
-				this.tree.rerender();
-			}
-		});
-	};
-
-	updateHeightDebounced = Zotero.Utilities.debounce(this.updateHeight, 200);
-
 	updateFontSize() {
 		this.tree.updateFontSize();
 	}

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -1673,9 +1673,6 @@ var ZoteroPane = new function () {
 			}
 			this.tagSelector.handleResize();
 		}
-		if (this.collectionsView) {
-			this.collectionsView.updateHeightDebounced();
-		}
 	}, 100);
 	
 	
@@ -1947,12 +1944,8 @@ var ZoteroPane = new function () {
 
 		document.getElementById('zotero-tb-search').updateMode();
 		let refreshPromise;
-		if (state === 'open' && oldState === 'collapsed'
-				|| state === 'collapsed' && oldState === 'open') {
-			// State change only causes visual refresh - update the tree height
-			this.itemsView.updateHeight();
-		}
-		else {
+		if (!(state === 'open' && oldState === 'collapsed'
+				|| state === 'collapsed' && oldState === 'open')) {
 			// State change changes displayed items - refresh the tree
 			refreshPromise = this._refreshAdvancedSearchPane();
 		}
@@ -7125,11 +7118,6 @@ var ZoteroPane = new function () {
 		}
 
 		this.updateLayoutConstraints();
-		if (ZoteroPane.itemsView) {
-			// Need to immediately rerender the items here without any debouncing
-			// since tree height will have changed
-			ZoteroPane.itemsView.updateHeight();
-		}
 		ZoteroContextPane.update();
 		Zotero_Tabs.updateSidebarLayout();
 	};
@@ -7313,9 +7301,6 @@ var ZoteroPane = new function () {
 
 		var collectionsPaneWidth = collectionsPane.getBoundingClientRect().width;
 		tagSelector.style.maxWidth = collectionsPaneWidth + 'px';
-		if (ZoteroPane.itemsView) {
-			ZoteroPane.itemsView.updateHeightDebounced();
-		}
 
 		this.handleTagSelectorResize();
 

--- a/resource/require.js
+++ b/resource/require.js
@@ -131,6 +131,7 @@ function ZoteroLoader({
 		clearInterval: win.clearInterval,
 		requestAnimationFrame: win.requestAnimationFrame,
 		cancelAnimationFrame: win.requestAnimationFrame,
+		ResizeObserver: win.ResizeObserver,
 	};
 	for (const name in injectedGlobals) {
 		this.loader.globals[name] = injectedGlobals[name];


### PR DESCRIPTION
And expose `ResizeObserver` in `require()`'d scopes.

Fixes the noticeable lag after collapsing Advanced Search before new rows appear at the bottom, as well as other, less common cases like collapsing the tag selector in the collection tree and collapsing the item pane in Stacked mode.

This may theoretically affect performance a bit during window resize, since we no longer wait 200ms to rerender (and instead do it once per frame via `ResizeObserver`), but to my eyes it looks a *lot* less glitchy and doesn't cause any noticeable lag.

This wasn't a major issue before, since window resizing is relatively uncommon and other interface elements rarely changed the item and collection trees' height, but now that Advanced Search does, I think the tradeoff is worth it.