### PR TITLE
Accent-insensitive search (#1300)

### DIFF
--- a/chrome/content/zotero/collectionTree.jsx
+++ b/chrome/content/zotero/collectionTree.jsx
@@ -2826,7 +2826,7 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 		let collectionTable = document.getElementById("collection-tree").firstElementChild;
 		let isEmpty = this._isFilterEmpty();
 		let willBeEmpty = filterText.length == 0;
-		this._filter = filterText.toLowerCase();
+		this._filter = Zotero.Utilities.Internal.normalizeForSearch(filterText);
 		let currentRow = this.getRow(this.selection.focused) || this._hiddenFocusedRow;
 		let currentRowDisplayed = currentRow && this._includedInTree(currentRow.ref);
 		let shouldRestoreScrollPosition = willBeEmpty && !isEmpty && !this._treeWasFocused;
@@ -3077,14 +3077,15 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 		if (this._filterResultsCache[objectID] && !resetCache) {
 			return this._filterResultsCache[objectID];
 		}
-		// Filtering is case insensitive
-		let objectName = (object.name || "").toLowerCase();
+		// Filtering is case- and accent-insensitive
+		let normalize = Zotero.Utilities.Internal.normalizeForSearch;
+		let objectName = normalize(object.name || "");
 		// Special treatment to fetch the name for My Library or Feeds
 		if (objectID[0] == 'L' && object._ObjectType !== "Group") {
-			objectName = Zotero.getString('pane.collections.library').toLowerCase();
+			objectName = normalize(Zotero.getString('pane.collections.library'));
 		}
 		else if (objectID == 'feeds') {
-			objectName = Zotero.getString('pane.collections.feedLibraries').toLowerCase();
+			objectName = normalize(Zotero.getString('pane.collections.feedLibraries'));
 		}
 		let filterValue = this._filter;
 

--- a/chrome/content/zotero/containers/tagSelectorContainer.jsx
+++ b/chrome/content/zotero/containers/tagSelectorContainer.jsx
@@ -584,10 +584,10 @@ Zotero.TagSelector = class TagSelectorContainer extends React.PureComponent {
 		});
 		tags = coloredTags.concat(tags);
 		
-		// Filter
+		// Filter (case- and accent-insensitive, matching search conditions)
 		if (this.state.searchString) {
-			let lcStr = this.state.searchString.toLowerCase();
-			tags = tags.filter(tag => tag.tag.toLowerCase().includes(lcStr));
+			let normalizedStr = Zotero.Utilities.Internal.normalizeForSearch(this.state.searchString);
+			tags = tags.filter(tag => Zotero.Utilities.Internal.normalizeForSearch(tag.tag).includes(normalizedStr));
 		}
 		
 		// Prepare tag objects for list component

--- a/chrome/content/zotero/preferences/preferences_advanced.js
+++ b/chrome/content/zotero/preferences/preferences_advanced.js
@@ -52,13 +52,6 @@ Zotero_Preferences.Advanced = {
 		
 		this.onDataDirLoad();
 
-		document.getElementById('fulltext-rebuildIndex').setAttribute('label',
-			Zotero.getString('zotero.preferences.search.rebuildIndex')
-				+ Zotero.getString('punctuation.ellipsis'));
-		document.getElementById('fulltext-clearIndex').setAttribute('label',
-			Zotero.getString('zotero.preferences.search.clearIndex')
-				+ Zotero.getString('punctuation.ellipsis'));
-		
 		this.updateIndexStats();
 		this.updateLocalAPIUI();
 		document.getElementById('zotero-prefpane-advanced-enable-local-api').addEventListener('synctopreference', () => {
@@ -386,96 +379,55 @@ Zotero_Preferences.Advanced = {
 	},
 	
 	updateIndexStats: async function () {
-		var stats = await Zotero.Fulltext.getIndexStats();
-		document.getElementById('fulltext-stats-indexed')
-			.setAttribute('value', stats.indexed);
-		document.getElementById('fulltext-stats-partial')
-			.setAttribute('value', stats.partial);
-		document.getElementById('fulltext-stats-unindexed')
-			.setAttribute('value', stats.unindexed);
-		document.getElementById('fulltext-stats-words')
-			.setAttribute('value', stats.words);
-	},
-	
-	
-	rebuildIndexPrompt: async function () {
-		var buttons = [
-			document.getElementById('fulltext-rebuildIndex'),
-			document.getElementById('fulltext-clearIndex')
-		];
-		buttons.forEach(b => b.disabled = true);
-		
-		var ps = Services.prompt;
-		var buttonFlags = ps.BUTTON_POS_0 * ps.BUTTON_TITLE_IS_STRING
-			+ ps.BUTTON_POS_1 * ps.BUTTON_TITLE_CANCEL
-			+ ps.BUTTON_POS_2 * ps.BUTTON_TITLE_IS_STRING;
-		
-		var index = ps.confirmEx(null,
-			Zotero.getString('zotero.preferences.search.rebuildIndex'),
-			Zotero.getString('zotero.preferences.search.rebuildWarning',
-				Zotero.getString('zotero.preferences.search.indexUnindexed')),
-			buttonFlags,
-			Zotero.getString('zotero.preferences.search.rebuildIndex'),
-			null,
-			// Position 2 because of https://bugzilla.mozilla.org/show_bug.cgi?id=345067
-			Zotero.getString('zotero.preferences.search.indexUnindexed'),
-			null, {});
-		
-		try {
-			if (index == 0) {
-				await Zotero.Fulltext.rebuildIndex();
-			}
-			else if (index == 2) {
-				await Zotero.Fulltext.rebuildIndex(true)
-			}
-			
-			await this.updateIndexStats();
+		// Stop any pending refresh; we'll reschedule below if indexing is still in progress
+		if (this._indexStatsTimeoutID) {
+			clearTimeout(this._indexStatsTimeoutID);
+			this._indexStatsTimeoutID = null;
 		}
-		catch (e) {
-			Zotero.alert(null, Zotero.getString('general.error'), e);
+		// Bail if the pane is no longer shown (e.g., a scheduled refresh fired after navigating away)
+		let progressBox = document.getElementById('fulltext-stats-progress-box');
+		if (!progressBox) {
+			return;
 		}
-		finally {
-			buttons.forEach(b => b.disabled = false);
-		}
-	},
 
-	clearIndexPrompt: async function () {
-		var buttons = [
-			document.getElementById('fulltext-rebuildIndex'),
-			document.getElementById('fulltext-clearIndex')
-		];
-		buttons.forEach(b => b.disabled = true);
-		
-		var ps = Services.prompt;
-		var buttonFlags = ps.BUTTON_POS_0 * ps.BUTTON_TITLE_IS_STRING
-			+ ps.BUTTON_POS_1 * ps.BUTTON_TITLE_CANCEL
-			+ ps.BUTTON_POS_2 * ps.BUTTON_TITLE_IS_STRING;
-		
-		var index = ps.confirmEx(null,
-			Zotero.getString('zotero.preferences.search.clearIndex'),
-			Zotero.getString('zotero.preferences.search.clearWarning',
-				Zotero.getString('zotero.preferences.search.clearNonLinkedURLs')),
-			buttonFlags,
-			Zotero.getString('zotero.preferences.search.clearIndex'),
-			null,
-			// Position 2 because of https://bugzilla.mozilla.org/show_bug.cgi?id=345067
-			Zotero.getString('zotero.preferences.search.clearNonLinkedURLs'), null, {});
-		
-		try {
-			if (index == 0) {
-				await Zotero.Fulltext.clearIndex();
-			}
-			else if (index == 2) {
-				await Zotero.Fulltext.clearIndex(true);
-			}
-			
-			await this.updateIndexStats();
+		let stats = await Zotero.FullText.getIndexStats();
+		document.getElementById('fulltext-stats-indexed').setAttribute('value', stats.indexed.toLocaleString());
+		document.getElementById('fulltext-stats-partial').setAttribute('value', stats.partial.toLocaleString());
+		document.getElementById('fulltext-stats-notes').setAttribute('value', stats.notesIndexed.toLocaleString());
+		document.getElementById('fulltext-stats-not-available').setAttribute('value', stats.notAvailable.toLocaleString());
+
+		// Indexed + Partial + indexed notes are already what's in the search index, so they're the
+		// bar's numerator. Pending work across the auto-draining queues: extracted content not yet
+		// in the index (remaining), indexable attachments not yet extracted (unindexedQueue), and
+		// notes not yet indexed or edited since their last index update (noteQueue). Show the bar
+		// while anything's pending; otherwise "up to date". Items with no local file or content
+		// aren't counted here -- nothing local can index them -- so "up to date" can sit next to a
+		// nonzero "not available".
+		let inIndex = stats.indexed + stats.partial + stats.notesIndexed;
+		let pending = stats.remaining + stats.unindexedQueue + stats.noteQueue;
+		let total = inIndex + pending;
+		let complete = document.getElementById('fulltext-stats-complete');
+		if (pending > 0 && total > 0) {
+			let progress = document.getElementById('fulltext-stats-progress');
+			progress.max = total;
+			progress.value = inIndex;
+			document.l10n.setAttributes(
+				document.getElementById('fulltext-stats-progress-label'),
+				'fulltext-index-status-indexing',
+				{ indexed: inIndex, total }
+			);
+			progressBox.hidden = false;
+			complete.hidden = true;
+			// While this pane is open, drive the queues actively in small batches rather than
+			// waiting for idle, so they advance as the user watches, then refresh promptly
+			await Zotero.FullText.processAttachmentIndexQueue({ maxTime: 500 });
+			await Zotero.FullText.processAttachmentExtractionQueue({ maxTime: 500 });
+			await Zotero.FullText.processNoteIndexQueue({ maxTime: 500 });
+			this._indexStatsTimeoutID = setTimeout(() => this.updateIndexStats(), 250);
 		}
-		catch (e) {
-			Zotero.alert(null, Zotero.getString('general.error'), e);
-		}
-		finally {
-			buttons.forEach(b => b.disabled = false);
+		else {
+			progressBox.hidden = true;
+			complete.hidden = false;
 		}
 	},
 

--- a/chrome/content/zotero/preferences/preferences_advanced.xhtml
+++ b/chrome/content/zotero/preferences/preferences_advanced.xhtml
@@ -241,15 +241,6 @@
 		<groupbox aria-label="&zotero.preferences.search.fulltextCache;">
 			<label><html:h2>&zotero.preferences.search.fulltextCache;</html:h2></label>
 			
-			<hbox>
-				<button id="fulltext-rebuildIndex" flex="1" oncommand="Zotero_Preferences.Advanced.rebuildIndexPrompt()"
-					data-search-strings="zotero.preferences.search.rebuildWarning"/>
-				<button id="fulltext-clearIndex" flex="1" oncommand="Zotero_Preferences.Advanced.clearIndexPrompt()"
-					data-search-strings="zotero.preferences.search.clearWarning"/>
-			</hbox>
-			
-			<separator/>
-			
 			<hbox align="center">
 				<html:label for="fulltext-maxLength">&zotero.preferences.fulltext.textMaxLength;</html:label>
 				<html:input id="fulltext-maxLength" type="text" size="10" preference="extensions.zotero.fulltext.textMaxLength"/>
@@ -268,18 +259,31 @@
 		<groupbox id="fulltext-stats" tabindex="0" aria-label="&zotero.preferences.search.indexStats;" aria-describedby="fulltext-stats-grid">
 			<label><html:h2>&zotero.preferences.search.indexStats;</html:h2></label>
 			
-			<vbox class="form-grid" id="fulltext-stats-grid">
-				<label value="&zotero.preferences.search.indexStats.indexed;"/>
-				<label id="fulltext-stats-indexed"/>
-	
-				<label value="&zotero.preferences.search.indexStats.partial;"/>
-				<label id="fulltext-stats-partial"/>
-	
-				<label value="&zotero.preferences.search.indexStats.unindexed;"/>
-				<label id="fulltext-stats-unindexed"/>
-	
-				<label value="&zotero.preferences.search.indexStats.words;"/>
-				<label id="fulltext-stats-words"/>
+			<vbox id="fulltext-stats-status">
+				<hbox align="center" id="fulltext-stats-progress-box" hidden="true">
+					<html:progress id="fulltext-stats-progress" value="0" max="1"/>
+					<label id="fulltext-stats-progress-label"/>
+				</hbox>
+				<label id="fulltext-stats-complete" data-l10n-id="fulltext-index-status-complete" hidden="true"/>
+			</vbox>
+
+			<vbox id="fulltext-stats-grid">
+				<hbox>
+					<label value="&zotero.preferences.search.indexStats.indexed;"/>
+					<label id="fulltext-stats-indexed"/>
+				</hbox>
+				<hbox>
+					<label value="&zotero.preferences.search.indexStats.partial;"/>
+					<label id="fulltext-stats-partial"/>
+				</hbox>
+				<hbox>
+					<label data-l10n-id="fulltext-stats-notes-indexed"/>
+					<label id="fulltext-stats-notes"/>
+				</hbox>
+				<hbox>
+					<label data-l10n-id="fulltext-stats-not-available"/>
+					<label id="fulltext-stats-not-available"/>
+				</hbox>
 			</vbox>
 		</groupbox>	
 	</vbox>

--- a/chrome/content/zotero/xpcom/data/creators.js
+++ b/chrome/content/zotero/xpcom/data/creators.js
@@ -109,10 +109,19 @@ Zotero.Creators = new function () {
 		);
 		if (!id && create) {
 			id = Zotero.ID.get('creators');
-			let sql = "INSERT INTO creators (creatorID, firstName, lastName, fieldMode) "
-				+ "VALUES (?, ?, ?, ?)";
+			let sql = "INSERT INTO creators "
+				+ "(creatorID, firstName, lastName, fieldMode, firstNameNormalized, lastNameNormalized) "
+				+ "VALUES (?, ?, ?, ?, ?, ?)";
 			await Zotero.DB.queryAsync(
-				sql, [id, data.firstName, data.lastName, data.fieldMode]
+				sql,
+				[
+					id,
+					data.firstName,
+					data.lastName,
+					data.fieldMode,
+					Zotero.Utilities.Internal.normalizeForSearchStorage(data.firstName),
+					Zotero.Utilities.Internal.normalizeForSearchStorage(data.lastName)
+				]
 			);
 			_cache[id] = data;
 		}

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -1745,7 +1745,7 @@ Zotero.Item.prototype._saveData = async function (env) {
 		let del = [];
 		
 		let valueSQL = "SELECT valueID FROM itemDataValues WHERE value=?";
-		let insertValueSQL = "INSERT INTO itemDataValues VALUES (?,?)";
+		let insertValueSQL = "INSERT INTO itemDataValues (valueID, value, valueNormalized) VALUES (?,?,?)";
 		let replaceSQL = "REPLACE INTO itemData VALUES (?,?,?)";
 		
 		for (let fieldID in this._changed.itemData) {
@@ -1774,7 +1774,8 @@ Zotero.Item.prototype._saveData = async function (env) {
 			let valueID = await Zotero.DB.valueQueryAsync(valueSQL, [value], { debug: true })
 			if (!valueID) {
 				valueID = Zotero.ID.get('itemDataValues');
-				await Zotero.DB.queryAsync(insertValueSQL, [valueID, value], { debug: false });
+				let valueNormalized = Zotero.Utilities.Internal.normalizeForSearchStorage(value);
+				await Zotero.DB.queryAsync(insertValueSQL, [valueID, value, valueNormalized], { debug: false });
 			}
 			
 			await Zotero.DB.queryAsync(replaceSQL, [itemID, fieldID, valueID], { debug: false });
@@ -2266,8 +2267,8 @@ Zotero.Item.prototype._saveData = async function (env) {
 		let isExternal = this._getLatestField('annotationIsExternal');
 		
 		let sql = "REPLACE INTO itemAnnotations "
-			+ "(itemID, parentItemID, type, authorName, text, comment, color, pageLabel, sortIndex, position, isExternal) "
-			+ "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+			+ "(itemID, parentItemID, type, authorName, text, textNormalized, comment, commentNormalized, color, pageLabel, sortIndex, position, isExternal) "
+			+ "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 		await Zotero.DB.queryAsync(
 			sql,
 			[
@@ -2276,7 +2277,9 @@ Zotero.Item.prototype._saveData = async function (env) {
 				typeID,
 				authorName || null,
 				text || null,
+				Zotero.Utilities.Internal.normalizeForSearchStorage(text),
 				comment || null,
+				Zotero.Utilities.Internal.normalizeForSearchStorage(comment),
 				color || Zotero.Annotations.DEFAULT_COLOR,
 				pageLabel || null,
 				sortIndex,

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -2148,7 +2148,12 @@ Zotero.Item.prototype._saveData = async function (env) {
 			params.unshift(itemID);
 		}
 		await Zotero.DB.queryAsync(sql, params);
-		
+
+		// Flag the note as edited since its last full-text index update rather than re-indexing it
+		// on every auto-save while typing. The background queue re-indexes it, and searches match
+		// the flagged note from its cached text in the meantime.
+		await Zotero.FullText.flagNoteStale(itemID, noteText);
+
 		if (parentItemID) {
 			reloadParentChildItems[parentItemID] = true;
 		}
@@ -5580,6 +5585,10 @@ Zotero.Item.prototype._eraseData = async function (env) {
 	if (this.isAttachment()) {
 		await Zotero.Fulltext.clearItemWords(this.id);
 		//Zotero.Fulltext.clearItemContent(this.id);
+	}
+	// Clear the note content index (notes and attachments can both have itemNotes rows)
+	if (this.isNote() || this.isAttachment()) {
+		await Zotero.FullText.clearNoteIndex(this.id);
 	}
 	
 	await Zotero.DB.queryAsync('DELETE FROM items WHERE itemID=?', this.id);

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -4132,7 +4132,7 @@ Zotero.defineProperty(Zotero.Item.prototype, 'attachmentText', {
 			let cacheFile = Zotero.Fulltext.getItemCacheFile(this);
 			if (!cacheFile.exists() || !(await Zotero.FullText.isFullyIndexed(this))) {
 				// Use processor cache file if it exists
-				let processorCacheFile = Zotero.FullText.getItemProcessorCacheFile(this).path;
+				let processorCacheFile = Zotero.FullText.getSyncedContentCacheFile(this).path;
 				if (await OS.File.exists(processorCacheFile)) {
 					let json = await Zotero.File.getContentsAsync(processorCacheFile);
 					let data = JSON.parse(json);

--- a/chrome/content/zotero/xpcom/data/search.js
+++ b/chrome/content/zotero/xpcom/data/search.js
@@ -336,7 +336,12 @@ Zotero.Search.prototype.addCondition = function (condition, operator, value, req
 			else {
 				this.addCondition('field', operator, part.text, false);
 				this.addCondition('tag', operator, part.text, false);
-				this.addCondition('note', operator, part.text, false);
+				// Match note content as a substring via the note index. Like
+				// full-text content below, skip unquoted terms too short for the
+				// index.
+				if (part.inQuotes || Zotero.FullText.canSearchNotes(part.text)) {
+					this.addCondition('note', operator, part.text, false);
+				}
 				this.addCondition('annotationText', operator, part.text, false);
 				this.addCondition('annotationComment', operator, part.text, false);
 			}
@@ -1678,7 +1683,23 @@ Zotero.Search.prototype._buildQuery = async function () {
 						condSQL += "itemID IN (SELECT itemID FROM groupItems WHERE ";
 						openParens++;
 						break;
-					
+
+					// Match note text content via the note FTS index (case- and
+					// diacritic-insensitive) when it can answer the term; otherwise fall
+					// through to the LIKE scan of the note HTML
+					case 'note': {
+						if (typeof condition.value == 'string'
+								&& ['contains', 'doesNotContain'].includes(condition.operator)) {
+							let noteMatch = await Zotero.FullText.getNoteContentSQL(condition.value);
+							if (noteMatch) {
+								condSQL += noteMatch.sql;
+								condSQLParams.push(...noteMatch.params);
+								skipOperators = true;
+							}
+						}
+						break;
+					}
+
 					case 'tempTable':
 						condSQL += "itemID IN (SELECT id FROM " + condition.value + ")";
 						skipOperators = true;

--- a/chrome/content/zotero/xpcom/data/search.js
+++ b/chrome/content/zotero/xpcom/data/search.js
@@ -1114,6 +1114,7 @@ Zotero.Search.prototype._buildQuery = async function () {
 				alias: conditionData.name != name ? name : false,
 				table: conditionData.table,
 				field: conditionData.field,
+				normalizedField: conditionData.normalizedField,
 				operator: condition.operator,
 				value: condition.value,
 				flags: conditionData.flags,
@@ -1874,6 +1875,17 @@ Zotero.Search.prototype._buildQuery = async function () {
 					
 					// Non-date fields
 					else {
+						// For text conditions, match against the normalized shadow column
+						// with a normalized search term, so that e.g. "seance" matches
+						// "séance" and vice versa
+						var useNormalized = condition.normalizedField
+							&& typeof condition.value == 'string'
+							&& ['contains', 'doesNotContain', 'beginsWith']
+								.includes(condition.operator);
+						var searchValue = useNormalized
+							? Zotero.Utilities.Internal.normalizeForSearch(condition.value)
+							: condition.value;
+						
 						switch (condition.operator) {
 							// Cast strings as integers for < and > comparisons,
 							// at least until 
@@ -1891,7 +1903,7 @@ Zotero.Search.prototype._buildQuery = async function () {
 								break;
 								
 							default:
-								condSQL += condition['field'];
+								condSQL += useNormalized ? condition.normalizedField : condition['field'];
 						}
 						
 						switch (condition['operator']){
@@ -1903,10 +1915,10 @@ Zotero.Search.prototype._buildQuery = async function () {
 								if (condition['flags'] &&
 										condition['flags']['leftbound'] &&
 										Zotero.Prefs.get('search.useLeftBound')) {
-									condSQLParams.push(condition['value'] + '%');
+									condSQLParams.push(searchValue + '%');
 								}
 								else {
-									condSQLParams.push('%' + condition['value'] + '%');
+									condSQLParams.push('%' + searchValue + '%');
 								}
 								break;
 								
@@ -1954,7 +1966,7 @@ Zotero.Search.prototype._buildQuery = async function () {
 							
 							case 'beginsWith':
 								condSQL += ' LIKE ?';
-								condSQLParams.push(condition['value'] + '%');
+								condSQLParams.push(searchValue + '%');
 								break;
 							
 							case 'isLessThan':

--- a/chrome/content/zotero/xpcom/data/search.js
+++ b/chrome/content/zotero/xpcom/data/search.js
@@ -342,16 +342,16 @@ Zotero.Search.prototype.addCondition = function (condition, operator, value, req
 			}
 			this.addCondition('creator', operator, part.text, false);
 
-			if (condition == 'quicksearch-everything') {
-				if (part.inQuotes) {
-					this.addCondition('fulltextContent', operator, part.text, false);
-				}
-				else {
-					var splits = Zotero.Fulltext.semanticSplitter(part.text);
-					for (let split of splits) {
-						this.addCondition('fulltextWord', operator, split, false);
-					}
-				}
+			// Match full-text content as a substring (case- and diacritic-insensitive)
+			// via the content index. Skip unquoted terms too short for the index (e.g.
+			// 1-2 characters), which would otherwise force a per-keystroke scan of the
+			// cached text; they're still matched against titles, tags, etc. above.
+			// Quoted term are matched regardless of length: quoting makes the quick
+			// search wait for Enter rather than run on each keystroke, so the scan
+			// isn't per-keystroke.
+			if (condition == 'quicksearch-everything'
+					&& (part.inQuotes || Zotero.FullText.canSearchContent(part.text))) {
+				this.addCondition('fulltextContent', operator, part.text, false);
 			}
 
 			this.addCondition('groupEnd', 'true', '');
@@ -692,85 +692,51 @@ Zotero.Search.prototype.search = async function (asTempTable) {
 					: [];
 			}
 			
+			// The set of items this condition decides over: in ALL mode, the remaining main-search
+			// matches; in ANY mode, items in the library not already in the results
 			let scopeIDs;
-			// Regexp mode -- don't use full-text word index
-			let numSplits;
-			if (condition.mode && condition.mode.startsWith('regexp')) {
-				// In ANY mode, include items that haven't already been found, as long as they're in
-				// the right library
-				if (joinModeAny) {
-					let tmpTable = await Zotero.Search.idsToTempTable(fullTextResults);
-					let sql = "SELECT GROUP_CONCAT(itemID) FROM items WHERE "
-						+ "itemID NOT IN (SELECT itemID FROM " + tmpTable + ")";
-					if (this.libraryID) {
-						sql += " AND libraryID=?";
-					}
-					let res = await Zotero.DB.valueQueryAsync(sql, this.libraryID, { noCache: true });
-					scopeIDs = res ? res.split(",").map(id => parseInt(id)) : [];
-					await Zotero.DB.queryAsync("DROP TABLE " + tmpTable, false, { noCache: true });
-				}
-				// In ALL mode, include remaining items from the main search
-				else {
-					scopeIDs = ids;
-				}
-			}
-			// If not regexp mode, run a new search against the full-text word index for words in
-			// this phrase
-			else {
-				//Zotero.debug('Running subsearch against full-text word index');
-				let s = new Zotero.Search();
+			if (joinModeAny) {
+				let tmpTable = await Zotero.Search.idsToTempTable(fullTextResults);
+				let sql = "SELECT GROUP_CONCAT(itemID) FROM items WHERE "
+					+ "itemID NOT IN (SELECT itemID FROM " + tmpTable + ")";
 				if (this.libraryID) {
-					s.libraryID = this.libraryID;
+					sql += " AND libraryID=?";
 				}
-				let splits = Zotero.Fulltext.semanticSplitter(condition.value);
-				for (let split of splits){
-					s.addCondition('fulltextWord', condition.operator, split);
-				}
-				// If applicable, only search for words within specified scope (e.g. collection)
-				if (this._scope) {
-					s.setScope(this._scope, true);
-				}
-				numSplits = splits.length;
-				let wordMatches = await s.search();
-				
-				//Zotero.debug("Word index matches");
-				//Zotero.debug(wordMatches);
-				
-				// In ANY mode, include hits from word index that aren't already in the results
-				if (joinModeAny) {
-					let resultsSet = new Set(fullTextResults);
-					scopeIDs = wordMatches.filter(id => !resultsSet.has(id));
-				}
-				// In ALL mode, include the intersection of hits from word index and remaining
-				// main search matches
-				else {
-					let wordIDs = new Set(wordMatches);
-					scopeIDs = ids.filter(id => wordIDs.has(id));
-				}
+				let res = await Zotero.DB.valueQueryAsync(sql, this.libraryID, { noCache: true });
+				scopeIDs = res ? res.split(",").map(id => parseInt(id)) : [];
+				await Zotero.DB.queryAsync("DROP TABLE " + tmpTable, false, { noCache: true });
 			}
-			
-			// If only one word, just use the results from the word index
-			let filteredIDs = [];
-			if (numSplits === 1) {
-				filteredIDs = scopeIDs;
+			else {
+				scopeIDs = ids;
 			}
-			// Search the full-text content
-			else if (scopeIDs.length) {
-				let found = new Set(
-					(await Zotero.Fulltext.findTextInItems(
+
+			// Find which of those items match the full-text content. Use the trigram index for
+			// ordinary terms; fall back to scanning the cached text for regexp searches and for
+			// terms too short for the trigram index (findItemsWithContent returns null).
+			let contentMatches;
+			let indexMatches = (condition.mode && condition.mode.startsWith('regexp'))
+				? null
+				: await Zotero.FullText.findItemsWithContent(condition.value, this.libraryID);
+			if (indexMatches !== null) {
+				contentMatches = new Set(indexMatches);
+			}
+			else {
+				contentMatches = new Set(
+					(await Zotero.FullText.findTextInItems(
 						scopeIDs,
 						condition.value,
 						condition.mode
 					)).map(x => x.id)
 				);
-				// Either include or exclude the results, depending on the operator
-				filteredIDs = scopeIDs.filter((id) => {
-					return found.has(id)
-						? condition.operator == 'contains'
-						: condition.operator == 'doesNotContain';
-				});
 			}
-			
+
+			// Either include or exclude the matches, depending on the operator
+			let filteredIDs = scopeIDs.filter((id) => {
+				return contentMatches.has(id)
+					? condition.operator == 'contains'
+					: condition.operator == 'doesNotContain';
+			});
+
 			//Zotero.debug("Filtered IDs:")
 			//Zotero.debug(filteredIDs);
 			
@@ -991,44 +957,37 @@ Zotero.Search.idsToTempTable = async function (ids, { idColumn = 'itemID' } = {}
  * caller applies IN/NOT IN for the contains/doesNotContain operator.
  */
 Zotero.Search.prototype._fullTextContentMatches = async function (value, mode) {
-	var scopeIDs;
-	// Regexp can't use the word index, so scan every item in the library/scope
-	if (mode && mode.startsWith('regexp')) {
-		let s = new Zotero.Search();
-		if (this.libraryID !== null) {
-			s.libraryID = this.libraryID;
-		}
-		if (this._scope) {
-			s.setScope(this._scope, true);
-		}
-		scopeIDs = await s.search();
-	}
-	// Otherwise narrow to items matching the words via the full-text word index
-	else {
-		let splits = Zotero.Fulltext.semanticSplitter(value);
-		if (!splits.length) {
-			return [];
+	// For ordinary terms, match as a substring (case- and diacritic-insensitive) via the trigram
+	// index, then restrict to the search scope (e.g. a collection), if any
+	let indexMatches = (mode && mode.startsWith('regexp'))
+		? null
+		: await Zotero.FullText.findItemsWithContent(value, this.libraryID);
+	if (indexMatches !== null) {
+		if (!this._scope) {
+			return indexMatches;
 		}
 		let s = new Zotero.Search();
 		if (this.libraryID !== null) {
 			s.libraryID = this.libraryID;
 		}
-		for (let split of splits) {
-			s.addCondition('fulltextWord', 'contains', split);
-		}
-		if (this._scope) {
-			s.setScope(this._scope, true);
-		}
-		scopeIDs = await s.search();
-		// A single word is fully resolved by the word index -- no phrase to verify
-		if (splits.length == 1) {
-			return scopeIDs;
-		}
+		s.setScope(this._scope, true);
+		let scopeSet = new Set(await s.search());
+		return indexMatches.filter(id => scopeSet.has(id));
 	}
+	// Regexp, or a term too short for the trigram index -- scan the cached text of every item in
+	// the library/scope
+	let s = new Zotero.Search();
+	if (this.libraryID !== null) {
+		s.libraryID = this.libraryID;
+	}
+	if (this._scope) {
+		s.setScope(this._scope, true);
+	}
+	let scopeIDs = await s.search();
 	if (!scopeIDs.length) {
 		return [];
 	}
-	let found = await Zotero.Fulltext.findTextInItems(scopeIDs, value, mode);
+	let found = await Zotero.FullText.findTextInItems(scopeIDs, value, mode);
 	return found.map(x => x.id);
 };
 
@@ -1177,24 +1136,35 @@ Zotero.Search.prototype._buildQuery = async function () {
 				
 				case 'fulltextContent':
 					// A fulltextContent inside a group -- or at the top level when a result
-					// level is set -- is materialized into an itemID predicate so it joins
-					// the SQL AND/OR tree and can be mapped to that level (full-text is
-					// indexed per attachment). A plain top-level one with no result level is
-					// left for the post-filter in search() (unchanged behavior).
+					// level is set -- becomes an itemID predicate so it joins the SQL AND/OR
+					// tree and can be mapped to that level (full-text is indexed per
+					// attachment). A plain top-level one with no result level is left for the
+					// post-filter in search() (unchanged behavior).
 					if (loopDepth > 0 || resultLevel != 'any') {
-						let matchIDs = await this._fullTextContentMatches(
-							condition.value, condition.mode
-						);
 						this._eagerFullTextConditionIDs.add(condition.id);
 						this._hasEagerFullText = true;
-						conditions.push({
+						// Match via the index as a subquery -- no per-match itemID list to
+						// build or parse. Regexp and too-short terms can't use the index, so
+						// scan the cached text and materialize the matches instead.
+						let subquery = (condition.mode && condition.mode.startsWith('regexp'))
+							? null
+							: Zotero.FullText.getContentSearchSQL(condition.value);
+						let predicate = {
 							name: '_fulltextContentPredicate',
 							operator: condition.operator,
-							matchIDs,
 							// Full-text content is indexed per attachment, so matches are at
 							// the attachment level for cross-level mapping
 							level: 'attachment'
-						});
+						};
+						if (subquery) {
+							predicate.subquery = subquery;
+						}
+						else {
+							predicate.matchIDs = await this._fullTextContentMatches(
+								condition.value, condition.mode
+							);
+						}
+						conditions.push(predicate);
 						this._hasPrimaryConditions = true;
 					}
 					continue;
@@ -1387,18 +1357,23 @@ Zotero.Search.prototype._buildQuery = async function () {
 					builtConditions.push({ marker: 'resultLevel', operator: condition.operator });
 					continue;
 				}
-				// A grouped fulltextContent materialized into an itemID set (above)
+				// A grouped fulltextContent turned into an itemID predicate (above): a direct
+				// index subquery when possible, otherwise a materialized itemID list
 				if (condition.name == '_fulltextContentPredicate') {
-					let sql;
-					if (!condition.matchIDs.length) {
+					let op = condition.operator == 'doesNotContain' ? 'NOT IN' : 'IN';
+					let sql, params = [];
+					if (condition.subquery) {
+						sql = 'itemID ' + op + ' (' + condition.subquery.sql + ')';
+						params = condition.subquery.params;
+					}
+					else if (!condition.matchIDs.length) {
 						// No matches: 'contains' matches nothing, 'doesNotContain' matches all
 						sql = condition.operator == 'doesNotContain' ? '1' : '0';
 					}
 					else {
-						let op = condition.operator == 'doesNotContain' ? 'NOT IN' : 'IN';
 						sql = 'itemID ' + op + ' (' + condition.matchIDs.join(',') + ')';
 					}
-					builtConditions.push({ sql, params: [], level: condition.level });
+					builtConditions.push({ sql, params, level: condition.level });
 					continue;
 				}
 
@@ -1701,12 +1676,6 @@ Zotero.Search.prototype._buildQuery = async function () {
 					// FROM above to items created by the given user
 					case 'annotationAuthor':
 						condSQL += "itemID IN (SELECT itemID FROM groupItems WHERE ";
-						openParens++;
-						break;
-					
-					case 'fulltextWord':
-						condSQL += "wordID IN (SELECT wordID FROM fulltextWords "
-							+ "WHERE ";
 						openParens++;
 						break;
 					

--- a/chrome/content/zotero/xpcom/data/searchConditions.js
+++ b/chrome/content/zotero/xpcom/data/searchConditions.js
@@ -790,20 +790,6 @@ Zotero.SearchConditions = new function () {
 			},
 
 			{
-				name: 'fulltextWord',
-				operators: {
-					contains: true,
-					doesNotContain: true
-				},
-				table: 'fulltextItemWords',
-				field: 'word',
-				flags: {
-					leftbound: true
-				},
-				special: true
-			},
-			
-			{
 				name: 'fulltextContent',
 				operators: {
 					contains: true,

--- a/chrome/content/zotero/xpcom/data/searchConditions.js
+++ b/chrome/content/zotero/xpcom/data/searchConditions.js
@@ -417,6 +417,7 @@ Zotero.SearchConditions = new function () {
 				},
 				table: 'itemTags',
 				field: 'name',
+				normalizedField: 'COALESCE(nameNormalized, name)',
 				// Tags apply to items at any level, so a tag match is never mapped
 				level: 'any'
 			},
@@ -525,7 +526,9 @@ Zotero.SearchConditions = new function () {
 					isNotEmpty: true
 				},
 				table: 'itemCreators',
-				field: "TRIM(firstName || ' ' || lastName)"
+				field: "TRIM(firstName || ' ' || lastName)",
+				normalizedField: "TRIM(COALESCE(firstNameNormalized, firstName) || ' ' "
+					+ "|| COALESCE(lastNameNormalized, lastName))"
 			},
 			
 			{
@@ -538,6 +541,7 @@ Zotero.SearchConditions = new function () {
 				},
 				table: 'itemCreators',
 				field: 'lastName',
+				normalizedField: 'COALESCE(lastNameNormalized, lastName)',
 				special: true
 			},
 			
@@ -552,7 +556,9 @@ Zotero.SearchConditions = new function () {
 					isNotEmpty: true
 				},
 				table: 'itemCreators',
-				field: "TRIM(firstName || ' ' || lastName)"
+				field: "TRIM(firstName || ' ' || lastName)",
+				normalizedField: "TRIM(COALESCE(firstNameNormalized, firstName) || ' ' "
+					+ "|| COALESCE(lastNameNormalized, lastName))"
 			},
 			
 			{
@@ -566,7 +572,9 @@ Zotero.SearchConditions = new function () {
 					isNotEmpty: true
 				},
 				table: 'itemCreators',
-				field: "TRIM(firstName || ' ' || lastName)"
+				field: "TRIM(firstName || ' ' || lastName)",
+				normalizedField: "TRIM(COALESCE(firstNameNormalized, firstName) || ' ' "
+					+ "|| COALESCE(lastNameNormalized, lastName))"
 			},
 			
 			{
@@ -580,7 +588,9 @@ Zotero.SearchConditions = new function () {
 					isNotEmpty: true
 				},
 				table: 'itemCreators',
-				field: "TRIM(firstName || ' ' || lastName)"
+				field: "TRIM(firstName || ' ' || lastName)",
+				normalizedField: "TRIM(COALESCE(firstNameNormalized, firstName) || ' ' "
+					+ "|| COALESCE(lastNameNormalized, lastName))"
 			},
 			
 			{
@@ -596,6 +606,7 @@ Zotero.SearchConditions = new function () {
 				},
 				table: 'itemData',
 				field: 'value',
+				normalizedField: 'COALESCE(valueNormalized, value)',
 				aliases: await Zotero.DB.columnQueryAsync("SELECT fieldName FROM fieldsCombined "
 					+ "WHERE fieldName NOT IN ('accessDate', 'date', 'pages', "
 					+ "'section','seriesNumber','issue')"),
@@ -722,6 +733,7 @@ Zotero.SearchConditions = new function () {
 				},
 				table: 'itemAnnotations',
 				field: 'text',
+				normalizedField: 'COALESCE(textNormalized, text)',
 				special: false,
 				level: 'annotation'
 			},
@@ -734,6 +746,7 @@ Zotero.SearchConditions = new function () {
 				},
 				table: 'itemAnnotations',
 				field: 'comment',
+				normalizedField: 'COALESCE(commentNormalized, comment)',
 				special: false,
 				level: 'annotation'
 			},

--- a/chrome/content/zotero/xpcom/data/tags.js
+++ b/chrome/content/zotero/xpcom/data/tags.js
@@ -119,8 +119,9 @@ Zotero.Tags = new function () {
 		var id = this.getID(data.tag);
 		if (!id) {
 			id = Zotero.ID.get('tags');
-			let sql = "INSERT INTO tags (tagID, name) VALUES (?, ?)";
-			await Zotero.DB.queryAsync(sql, [id, data.tag]);
+			let sql = "INSERT INTO tags (tagID, name, nameNormalized) VALUES (?, ?, ?)";
+			let nameNormalized = Zotero.Utilities.Internal.normalizeForSearchStorage(data.tag);
+			await Zotero.DB.queryAsync(sql, [id, data.tag, nameNormalized]);
 			_tagsByID.set(id, data.tag);
 			_idsByTag.set(data.tag, id);
 		}

--- a/chrome/content/zotero/xpcom/db.js
+++ b/chrome/content/zotero/xpcom/db.js
@@ -105,6 +105,9 @@ Zotero.DBConnection = function (dbNameOrPath) {
 		}
 	};
 	this._dbIsCorrupt = null
+	this._checkingCorruption = false;
+	this._corruptionHandlers = [];
+	this._idleCallbacks = [];
 	this._onlineBackupInProgress = false;
 	this._onConnectCallbacks = [];
 	this._loadedExtensions = new Set();
@@ -910,6 +913,16 @@ Zotero.DBConnection.prototype.observe = async function (subject, topic, data) {
 			try {
 				await this.backUpDatabase({ online: true });
 				await this.vacuum();
+				// The main vacuum covers only the main database, so let callers reclaim space in
+				// their own attached databases (e.g., the full-text index) here too
+				for (let callback of this._idleCallbacks) {
+					try {
+						await callback();
+					}
+					catch (e) {
+						Zotero.logError(e);
+					}
+				}
 			}
 			catch (e) {
 				Zotero.logError(e);
@@ -1092,6 +1105,26 @@ Zotero.DBConnection.prototype.loadExtension = async function (name) {
 
 Zotero.DBConnection.prototype.isCorruptionError = function (e) {
 	return this.DB_CORRUPTION_STRINGS.some(x => e.message.includes(x));
+};
+
+
+/**
+ * Register a callback to run when a corruption error occurs but the main database checks out,
+ * meaning an attached database (e.g., the rebuildable full-text index) is corrupt. The callback
+ * can rebuild it. Run deferred, after the failing operation unwinds.
+ */
+Zotero.DBConnection.prototype.addCorruptionHandler = function (handler) {
+	this._corruptionHandlers.push(handler);
+};
+
+
+/**
+ * Register a callback to run during the database's idle maintenance, after the periodic backup and
+ * vacuum. Lets code with its own attached database do maintenance (e.g., vacuuming) on the same
+ * idle trigger.
+ */
+Zotero.DBConnection.prototype.onIdle = function (callback) {
+	this._idleCallbacks.push(callback);
 };
 
 
@@ -1516,10 +1549,38 @@ Zotero.DBConnection.prototype._getConnectionAsync = async function () {
 
 
 Zotero.DBConnection.prototype._checkException = async function (e) {
-	if (this._externalDB || !this.isCorruptionError(e)) {
+	if (this._externalDB || !this.isCorruptionError(e) || this._checkingCorruption) {
 		return true;
 	}
-	
+
+	// A "malformed" error can come from an attached database (e.g., the rebuildable full-text
+	// index) rather than the main file, so confirm the main database is actually corrupt before
+	// offering to restore it. That way a disposable attached DB's corruption doesn't trigger
+	// main-database recovery; the attaching code detects and rebuilds it instead.
+	var mainOK = false;
+	this._checkingCorruption = true;
+	try {
+		mainOK = (await this.valueQueryAsync("PRAGMA main.quick_check(1)")) == 'ok';
+	}
+	catch (checkError) {
+		Zotero.logError(checkError);
+	}
+	finally {
+		this._checkingCorruption = false;
+	}
+	if (mainOK) {
+		Zotero.logError(e);
+		Zotero.debug("Corruption error but the main database passed a check -- skipping "
+			+ "main-database recovery", 1);
+		// Let owners of attached databases (e.g., the full-text index) rebuild them. Deferred so it
+		// runs after the failing operation unwinds -- a rebuild may need to DETACH, which can't run
+		// inside the transaction the error may have come from.
+		for (let handler of this._corruptionHandlers) {
+			Zotero.Promise.delay(0).then(handler).catch(err => Zotero.logError(err));
+		}
+		return true;
+	}
+
 	const supportURL = 'https://zotero.org/support/kb/corrupted_database';
 	
 	var filename = PathUtils.filename(this._dbPath);

--- a/chrome/content/zotero/xpcom/db.js
+++ b/chrome/content/zotero/xpcom/db.js
@@ -107,6 +107,7 @@ Zotero.DBConnection = function (dbNameOrPath) {
 	this._dbIsCorrupt = null
 	this._onlineBackupInProgress = false;
 	this._onConnectCallbacks = [];
+	this._loadedExtensions = new Set();
 
 	this._transactionPromise = null;
 	
@@ -1071,6 +1072,24 @@ Zotero.DBConnection.prototype.integrityCheck = async function () {
 };
 
 
+/**
+ * Load a bundled SQLite extension (e.g., 'fts5') on the connection.
+ *
+ * Mozilla's mozStorage doesn't compile FTS in by default and disables generic extension loading,
+ * but it does allow loading specific bundled extensions by name. The module is registered per
+ * connection, so call this once: the extension is remembered and re-loaded automatically when the
+ * connection is reopened (e.g., after a vacuum()), before onConnect() callbacks run, so callers
+ * don't have to reload it themselves.
+ */
+Zotero.DBConnection.prototype.loadExtension = async function (name) {
+	var conn = await this._getConnectionAsync();
+	var result = conn._connectionData._dbConn.loadExtension(name);
+	// Remember it so it can be re-loaded on the next reconnect
+	this._loadedExtensions.add(name);
+	return result;
+};
+
+
 Zotero.DBConnection.prototype.isCorruptionError = function (e) {
 	return this.DB_CORRUPTION_STRINGS.some(x => e.message.includes(x));
 };
@@ -1469,6 +1488,18 @@ Zotero.DBConnection.prototype._getConnectionAsync = async function () {
 				.getService(Components.interfaces.nsIUserIdleService);
 			idleService.addIdleObserver(this, 300);
 		});
+	}
+
+	// Re-load any extensions loaded via loadExtension(), which are registered per connection and
+	// so don't survive a reconnect. Done before the onConnect callbacks, which may depend on them
+	// (e.g., creating FTS5 tables).
+	for (let name of this._loadedExtensions) {
+		try {
+			this._connection._connectionData._dbConn.loadExtension(name);
+		}
+		catch (e) {
+			Zotero.logError(e);
+		}
 	}
 
 	for (let callback of this._onConnectCallbacks) {

--- a/chrome/content/zotero/xpcom/fulltext.js
+++ b/chrome/content/zotero/xpcom/fulltext.js
@@ -2846,28 +2846,6 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 
 
 	/**
-	 * Clears the full-text index and all full-text cache files
-	 *
-	 * @return {Promise}
-	 */
-	this.clearIndex = async function () {
-		await Zotero.DB.executeTransaction(async function () {
-			await Zotero.DB.queryAsync("DELETE FROM fulltextItems");
-
-			// Drop content index entries for items no longer in fulltextItems
-			await Zotero.DB.queryAsync("DELETE FROM ftindex.fulltextContent "
-				+ "WHERE rowid NOT IN (SELECT itemID FROM fulltextItems)");
-			await Zotero.DB.queryAsync("DELETE FROM ftindex.fulltextContentCJK "
-				+ "WHERE rowid NOT IN (SELECT itemID FROM fulltextItems)");
-			await Zotero.DB.queryAsync("DELETE FROM ftindex.fulltextIndexState "
-				+ "WHERE itemID NOT IN (SELECT itemID FROM fulltextItems)");
-		});
-
-		await clearCacheFiles();
-	}
-
-
-	/**
 	 * Remove content index entries for items that no longer exist. Normal deletion clears these
 	 * via clearItemWords()/clearNoteIndex(), but the content database can't FK-cascade to
 	 * zotero.sqlite, so this is a periodic safety net for items removed through a path that
@@ -2916,18 +2894,6 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 			catch (e) {
 				Zotero.File.checkFileAccessError(e, cacheFile, 'delete');
 			}
-		}
-	};
-	
-	
-	/*
-	 * Clear cache files for all attachments
-	 */
-	var clearCacheFiles = async function () {
-		var sql = "SELECT itemID FROM itemAttachments";
-		var items = await Zotero.DB.columnQueryAsync(sql);
-		for (var i=0; i<items.length; i++) {
-			await clearCacheFile(items[i]);
 		}
 	};
 	

--- a/chrome/content/zotero/xpcom/fulltext.js
+++ b/chrome/content/zotero/xpcom/fulltext.js
@@ -39,7 +39,14 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 	this.SYNC_STATE_MISSING = 4;
 	
 	const _processorCacheFile = '.zotero-ft-unprocessed';
-	
+
+	// Schema version of the attached content database (fulltext.sqlite)
+	const _contentDBVersion = 1;
+	// Version of the content index format. Bump to force a rebuild of the index from the cached
+	// text (e.g., after a tokenizer or normalization change) -- items recorded at a lower version
+	// in fulltextIndexState are re-indexed by the background queue processor.
+	const _contentIndexVersion = 1;
+
 	const kWbClassSpace =            0;
 	const kWbClassAlphaLetter =      1;
 	const kWbClassPunct =            2;
@@ -55,20 +62,153 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 	
 	var _idleObserverIsRegistered = false;
 	var _idleObserverDelay = 30;
+	// Shorter idle threshold (seconds) for the index drain than the sync content processor's, so
+	// indexing ramps back up a few seconds after the user pauses rather than waiting a full 30
+	var _drainIdleDelay = 3;
 	var _syncContentTimeoutID = null;
+	var _queueDrainTimerID = null;
+	var _indexingInProgress = false;
+	// Ordered itemID cursors for the queue processors, so each drain advances through the source
+	// tables once rather than rescanning already-indexed rows from the start on every batch. Reset
+	// to 0 when a pass reaches the end, to pick up anything re-queued below the cursor.
+	var _attachmentIndexQueueCursor = 0;
+	var _attachmentExtractionQueueCursor = 0;
+	// Flush a content batch to the index once it reaches this many characters, so peak memory stays
+	// bounded by the budget rather than by item size (each up to fulltext.textMaxLength)
+	const _maxContentBatchChars = 2000000;
+	var _processingSyncedContent = false;
+	var _reindexLimitTimeoutIDs = {};
 	var _syncContentBlacklist = {};
 	var _upgradeCheck = true;
 	var _syncLibraryVersion = 0;
 	
 	this.init = async function () {
-		let setUpIndexingDB = async () => {
-			await Zotero.DB.queryAsync("ATTACH ':memory:' AS 'indexing'");
-			await Zotero.DB.queryAsync('CREATE TABLE indexing.fulltextWords (word NOT NULL)');
+		// Set up the full-text content index: a contentless trigram FTS5 table in a separate
+		// attached database (fulltext.sqlite), used for content searching. It's a local,
+		// rebuildable index kept out of zotero.sqlite (so it doesn't bloat the main DB or its
+		// backups), versioned independently via PRAGMA user_version. The original extracted text
+		// still lives in the .zotero-ft-cache files; the index stores only normalized trigrams.
+		//
+		// FTS5 is a bundled SQLite extension. It's loaded once here; DBConnection re-loads it
+		// automatically after a reconnect (before this callback runs), so it's available for the
+		// FTS5 tables below.
+		await Zotero.DB.loadExtension('fts5');
+		let setUpContentDB = async () => {
+			let path = Zotero.DataDirectory.getDatabase('fulltext');
+			await Zotero.DB.queryAsync("ATTACH DATABASE ? AS ftindex", [path]);
+			// The index is keyed by local itemID, which is reassigned whenever zotero.sqlite is
+			// recreated (e.g., deleted and re-synced from the server). An index built against a
+			// different database instance would map its rows to the wrong items, so it has to be
+			// discarded and rebuilt rather than reused. Detect that by comparing the localUserKey
+			// the index was stamped with against the current one. The extracted text still lives in
+			// the .zotero-ft-cache files, so the background queue repopulates the index.
+			let localUserKey = Zotero.Users.getLocalUserKey();
+			let version = await Zotero.DB.valueQueryAsync("PRAGMA ftindex.user_version");
+			let indexedUserKey = version >= _contentDBVersion
+				? await Zotero.DB.valueQueryAsync(
+					"SELECT value FROM ftindex.fulltextIndexMeta WHERE key='localUserKey'")
+				: false;
+			if (version < _contentDBVersion || indexedUserKey != localUserKey) {
+				// Drop any existing tables so a stale or mismatched index is rebuilt from scratch
+				await Zotero.DB.queryAsync("DROP TABLE IF EXISTS ftindex.fulltextContent");
+				await Zotero.DB.queryAsync("DROP TABLE IF EXISTS ftindex.fulltextContentCJK");
+				await Zotero.DB.queryAsync("DROP TABLE IF EXISTS ftindex.fulltextIndexState");
+				await Zotero.DB.queryAsync("DROP TABLE IF EXISTS ftindex.fulltextIndexMeta");
+				// Latin (and CJK runs of 3+ chars): trigram index over the normalized text
+				await Zotero.DB.queryAsync(
+					"CREATE VIRTUAL TABLE ftindex.fulltextContent USING fts5("
+					+ "text, tokenize='trigram', content='', contentless_delete=1)"
+				);
+				// CJK: overlapping 2-grams of CJK runs only, space-separated, indexed with the
+				// ascii tokenizer (which leaves multibyte characters intact and splits on the
+				// spaces). The trigram tokenizer can't match the 1-2-character queries common in
+				// CJK, so those go here instead.
+				await Zotero.DB.queryAsync(
+					"CREATE VIRTUAL TABLE ftindex.fulltextContentCJK USING fts5("
+					+ "text, tokenize='ascii', content='', contentless_delete=1)"
+				);
+				// Records which items are in the content index and at what format version. The
+				// contentless FTS5 tables can't be queried for this, so this side table makes the
+				// queue (items not yet indexed at the current version) a countable,
+				// resumable query.
+				await Zotero.DB.queryAsync(
+					"CREATE TABLE ftindex.fulltextIndexState (\n"
+					+ "    itemID INTEGER PRIMARY KEY,\n"
+					+ "    version INT NOT NULL\n"
+					+ ")"
+				);
+				// Index metadata, including the localUserKey the index was built against (above)
+				await Zotero.DB.queryAsync(
+					"CREATE TABLE ftindex.fulltextIndexMeta (\n"
+					+ "    key TEXT PRIMARY KEY,\n"
+					+ "    value NOT NULL\n"
+					+ ")"
+				);
+				await Zotero.DB.queryAsync(
+					"REPLACE INTO ftindex.fulltextIndexMeta (key, value) VALUES ('localUserKey', ?)",
+					[localUserKey]
+				);
+				await Zotero.DB.queryAsync("PRAGMA ftindex.user_version = " + _contentDBVersion);
+			}
 		};
-		await setUpIndexingDB();
-		// ATTACHed databases don't survive a connection reopen (e.g., after vacuum), so
-		// re-run the setup on every reconnect
-		Zotero.DB.onConnect(setUpIndexingDB);
+		// Rebuild the index if its file is found corrupt. A malformed page can surface from any
+		// query -- setup, a search, or the background queue -- so recovery is driven by the
+		// corruption handler: drop the file and recreate it (it's derived, so the queue repopulates
+		// it from the cache files). DBConnection confirms the main
+		// database is intact before calling this, so a disposable index failure never triggers
+		// main-database recovery.
+		let rebuildingContentDB = false;
+		let rebuildContentDB = async () => {
+			if (rebuildingContentDB) {
+				return;
+			}
+			rebuildingContentDB = true;
+			try {
+				Zotero.debug("Rebuilding corrupt full-text index", 1);
+				let path = Zotero.DataDirectory.getDatabase('fulltext');
+				// Detach before touching the file. If this fails (e.g., a transaction is in
+				// progress), stop rather than delete a still-attached database or reattach under a
+				// name that's still in use -- the index stays as it was, and a later corruption
+				// error or the next startup retries.
+				await Zotero.DB.queryAsync("DETACH DATABASE ftindex");
+				// Best-effort removal; if it fails, setUpContentDB reattaches the old file and a
+				// later corruption error retries, rather than leaving ftindex detached
+				try {
+					await IOUtils.remove(path, { ignoreAbsent: true });
+					await IOUtils.remove(path + "-wal", { ignoreAbsent: true });
+					await IOUtils.remove(path + "-shm", { ignoreAbsent: true });
+				}
+				catch (e) {
+					Zotero.logError(e);
+				}
+				await setUpContentDB();
+				this.registerQueueDrainObserver();
+			}
+			catch (e) {
+				Zotero.logError(e);
+			}
+			finally {
+				rebuildingContentDB = false;
+			}
+		};
+		Zotero.DB.addCorruptionHandler(rebuildContentDB);
+		// A corrupt index throws when first read here; the handler rebuilds it (deferred, after this
+		// unwinds). Any non-corruption error is unexpected.
+		try {
+			await setUpContentDB();
+		}
+		catch (e) {
+			if (!Zotero.DB.isCorruptionError(e)) {
+				throw e;
+			}
+			Zotero.logError(e);
+		}
+		// An ATTACHed database doesn't survive a connection reopen (e.g., after vacuum), so re-run
+		// the setup on every reconnect
+		Zotero.DB.onConnect(setUpContentDB);
+		// The main-database vacuum doesn't reach the attached index, so reclaim its space during the
+		// same idle maintenance
+		Zotero.DB.onIdle(() => this.vacuumContentIndex());
 
 		let pdfConverterFileName = "pdftotext";
 		let pdfInfoFileName = "pdfinfo";
@@ -114,6 +254,30 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 					this.unregisterSyncContentProcessor();
 				}
 			});
+
+			// When a full-text limit is raised, re-extract just the items it affects rather than
+			// forcing a full rebuild (which would re-upload everything). Debounced and reading the
+			// settled value, so adjusting the limit -- or typing it in digit by digit -- only acts
+			// once it stops changing; bumping it up and back down doesn't trigger re-extraction.
+			// Gated in tests, which toggle these prefs without wanting indexing side effects.
+			if (!Zotero.test) {
+				let scheduleReindex = (type, pref) => {
+					if (_reindexLimitTimeoutIDs[type]) {
+						clearTimeout(_reindexLimitTimeoutIDs[type]);
+					}
+					_reindexLimitTimeoutIDs[type] = setTimeout(() => {
+						_reindexLimitTimeoutIDs[type] = null;
+						this.reindexTruncated(type, Zotero.Prefs.get(pref))
+							.catch(e => Zotero.logError(e));
+					}, 5000);
+				};
+				Zotero.Prefs.registerObserver('fulltext.textMaxLength', () => {
+					scheduleReindex('chars', 'fulltext.textMaxLength');
+				});
+				Zotero.Prefs.registerObserver('fulltext.pdfMaxPages', () => {
+					scheduleReindex('pages', 'fulltext.pdfMaxPages');
+				});
+			}
 			
 			// Stop content processor during syncs
 			Zotero.Notifier.registerObserver(
@@ -124,12 +288,28 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 						}
 						else if (event == 'stop') {
 							this.registerSyncContentProcessor();
+							// Index any content the sync just delivered right away, rather than
+							// waiting for the idle observer -- the user may want to search it, and
+							// in on-demand file-download mode it's their only searchable source.
+							// Not awaited; runs in the background.
+							if (!Zotero.test) {
+								this.processSyncedContentNow();
+							}
 						}
 					}.bind(this)
 				},
 				['sync'],
 				'fulltext'
 			);
+		});
+
+		// Bring the content index up to date for items full-text indexed before the index existed
+		// (or before a format-version bump), then index any never-before-indexed attachments on
+		// idle. Independent of full-text content syncing -- it indexes local text.
+		Zotero.uiReadyPromise.then(async () => {
+			await Zotero.Promise.delay(5000);
+			Zotero.addShutdownListener(this.unregisterQueueDrainObserver.bind(this));
+			await this.startQueueDrain();
 		});
 	};
 	
@@ -237,25 +417,16 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 	
 	
 	/**
-	 * Index multiple words at once
+	 * Record an item's full-text indexing stats (indexed/total chars and pages, sync state) in
+	 * fulltextItems
 	 *
 	 * @requireTransaction
 	 * @param {Number} itemID
-	 * @param {Array<string>} words
 	 * @return {Promise}
 	 */
-	var indexWords = async function (itemID, words, stats, version, synced) {
+	var setFulltextItem = async function (itemID, stats, version, synced) {
 		Zotero.DB.requireTransaction();
-		let chunk;
-		await Zotero.DB.queryAsync("DELETE FROM indexing.fulltextWords");
-		while (words.length > 0) {
-			chunk = words.splice(0, 100);
-			await Zotero.DB.queryAsync('INSERT INTO indexing.fulltextWords (word) ' + chunk.map(x => 'SELECT ?').join(' UNION '), chunk);
-		}
-		await Zotero.DB.queryAsync('INSERT OR IGNORE INTO fulltextWords (word) SELECT word FROM indexing.fulltextWords');
-		await Zotero.DB.queryAsync('DELETE FROM fulltextItemWords WHERE itemID = ?', [itemID]);
-		await Zotero.DB.queryAsync('INSERT OR IGNORE INTO fulltextItemWords (wordID, itemID) SELECT wordID, ? FROM fulltextWords JOIN indexing.fulltextWords USING(word)', [itemID]);
-		
+
 		var cols = ['itemID', 'version', 'synced'];
 		var params = [
 			itemID,
@@ -271,8 +442,6 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 		var sql = `REPLACE INTO fulltextItems (${cols.join(', ')}) `
 			+ `VALUES (${cols.map(_ => '?').join(', ')})`;
 		await Zotero.DB.queryAsync(sql, params);
-		
-		await Zotero.DB.queryAsync("DELETE FROM indexing.fulltextWords");
 	};
 	
 	
@@ -284,21 +453,18 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 			throw new Error("itemID not provided");
 		}
 		
-		var words = this.semanticSplitter(text);
-		
 		while (Zotero.DB.inTransaction()) {
 			await Zotero.DB.waitForTransaction('indexString()');
 		}
-		
+
 		await Zotero.DB.executeTransaction(async function () {
-			this.clearItemWords(itemID, true);
-			await indexWords(itemID, words, stats, version, synced);
-			
-			/*
-			var sql = "REPLACE INTO fulltextContent (itemID, textContent) VALUES (?,?)";
-			Zotero.DB.query(sql, [itemID, {string:text}]);
-			*/
-			
+			await this.clearItemWords(itemID, true);
+			await setFulltextItem(itemID, stats, version, synced);
+
+			// Index the extracted text for content searching (FTS5 trigram + CJK 2-gram tables,
+			// plus the index-state row). The original text stays in the .zotero-ft-cache file.
+			await setContentIndex(itemID, text);
+
 			Zotero.Notifier.queue('index', 'item', itemID);
 			Zotero.Notifier.queue('refresh', 'item', itemID);
 		}.bind(this));
@@ -939,6 +1105,11 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 	 * @return {Boolean}  TRUE if there's more content to process; FALSE otherwise
 	 */
 	this.processSyncedContent = async function (itemIDs) {
+		// Defer to a prompt post-sync burst if one is running, so the two don't process the same
+		// items concurrently
+		if (!itemIDs && _processingSyncedContent) {
+			return;
+		}
 		// Idle observer can take a little while to trigger and may not cancel the setTimeout()
 		// in time, so check idle time directly
 		var idleService = Components.classes["@mozilla.org/widget/useridleservice;1"]
@@ -986,7 +1157,47 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 		// when Zotero is in the background this can be throttled to 10 seconds.
 		_syncContentTimeoutID = setTimeout(() => this.processSyncedContent(itemIDs), 200);
 	};
-	
+
+
+	/**
+	 * Process sync-delivered full-text content (marked SYNC_STATE_TO_PROCESS) into the index right
+	 * away, without waiting for the idle observer. Called when a sync finishes, since the user may
+	 * want to search the content they just synced -- and in on-demand file-download mode synced
+	 * content is their only searchable source. Yields between items so it doesn't block the UI, and
+	 * stops if another sync starts.
+	 *
+	 * @return {Promise}
+	 */
+	this.processSyncedContentNow = async function () {
+		// One drain at a time; the idle observer defers to this while it's running
+		if (_processingSyncedContent) {
+			return;
+		}
+		_processingSyncedContent = true;
+		try {
+			let sql = "SELECT itemID FROM fulltextItems WHERE synced=" + this.SYNC_STATE_TO_PROCESS;
+			let itemIDs = (await Zotero.DB.columnQueryAsync(sql))
+				.filter(id => !(id in _syncContentBlacklist));
+			if (itemIDs.length) {
+				Zotero.debug("Processing " + itemIDs.length + " "
+					+ Zotero.Utilities.pluralize(itemIDs.length, 'item') + " of synced full-text content");
+			}
+			for (let itemID of itemIDs) {
+				// A new sync started -- leave the rest to it and the idle observer
+				if (Zotero.Sync.Runner.syncInProgress) {
+					break;
+				}
+				await this.indexSyncedContent(itemID);
+			}
+		}
+		catch (e) {
+			Zotero.logError(e);
+		}
+		finally {
+			_processingSyncedContent = false;
+		}
+	};
+
 	this._syncContentIdleObserver = {
 		observe: function (subject, topic, data) {
 			// On idle, start the background processor
@@ -999,7 +1210,528 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 			}
 		}.bind(this)
 	};
-	
+
+
+	//
+	// Content index queue
+	//
+	// Builds the content FTS5 indexes from the cached text of items that were full-text indexed
+	// before the index existed (or before a format-version bump). The work list is a query against
+	// fulltextIndexState, so progress is countable and resumable across restarts. New indexing goes
+	// through indexString(), which keeps the index current; this only drains the queue.
+	//
+
+	/**
+	 * Number of full-text-indexed items not yet in the content index at the current version
+	 * (i.e., the size of the content index queue). Suitable for showing indexing progress.
+	 *
+	 * @return {Promise<Integer>}
+	 */
+	this.getAttachmentIndexQueueCount = async function () {
+		return Zotero.DB.valueQueryAsync(
+			"SELECT COUNT(*) FROM fulltextItems FI "
+			+ "LEFT JOIN ftindex.fulltextIndexState S USING (itemID) "
+			+ "WHERE S.itemID IS NULL OR S.version<?",
+			[_contentIndexVersion]
+		);
+	};
+
+
+	/**
+	 * Process the content index queue, reading each item's cached text and indexing it.
+	 *
+	 * @param {Object} [options]
+	 * @param {Integer} [options.maxTime] - Stop after roughly this many ms (for a bounded startup
+	 *     burst); omit to drain the whole queue
+	 * @param {Boolean} [options.checkIdle] - Stop as soon as the user is no longer idle (for the
+	 *     idle-driven drain)
+	 * @return {Promise<Integer>} The number of items processed
+	 */
+	this.processAttachmentIndexQueue = async function ({ maxTime = null, checkIdle = false, onProgress = null } = {}) {
+		// Only one drain at a time -- the startup burst, the idle observer, and the prefs pane can
+		// all call this (and the unindexed-items pass below), and concurrent runs would process the
+		// same items or pile on the load
+		if (_indexingInProgress) {
+			return 0;
+		}
+		_indexingInProgress = true;
+		let start = Date.now();
+		let processed = 0;
+		try {
+			while (true) {
+				// Don't compete with syncing -- especially full-text content downloads, which would
+				// otherwise race with re-extraction here. Resume on a later idle once sync is done.
+				if (Zotero.Sync.Runner.syncInProgress) {
+					return processed;
+				}
+				if (checkIdle && !_canDrainIndex()) {
+					return processed;
+				}
+				let itemIDs = await Zotero.DB.columnQueryAsync(
+					"SELECT FI.itemID FROM fulltextItems FI "
+					+ "LEFT JOIN ftindex.fulltextIndexState S USING (itemID) "
+					+ "WHERE (S.itemID IS NULL OR S.version<?) AND FI.itemID>? "
+					+ "ORDER BY FI.itemID LIMIT 50",
+					[_contentIndexVersion, _attachmentIndexQueueCursor]
+				);
+				if (!itemIDs.length) {
+					// Nothing left above the cursor; restart from the beginning to catch anything
+					// re-queued below it, and stop only when a full pass finds nothing
+					if (_attachmentIndexQueueCursor) {
+						_attachmentIndexQueueCursor = 0;
+						continue;
+					}
+					Zotero.debug("No queued full-text content to index");
+					return processed;
+				}
+				Zotero.debug("Indexing " + itemIDs.length + " "
+					+ Zotero.Utilities.pluralize(itemIDs.length, 'item') + " into the full-text content index");
+				// Read text and write it in batched transactions, but cap each batch at a
+				// character budget so peak memory doesn't scale with item size
+				let batch = [];
+				let batchChars = 0;
+				let flushBatch = async () => {
+					if (!batch.length) {
+						return;
+					}
+					await Zotero.DB.executeTransaction(async function () {
+						for (let [itemID, text] of batch) {
+							await setContentIndex(itemID, text);
+						}
+					});
+					processed += batch.length;
+					batch = [];
+					batchChars = 0;
+				};
+				for (let itemID of itemIDs) {
+					let text = await _readContentForIndex(itemID);
+					// null -> re-extracted from the file by indexItems(), which already wrote it
+					if (text === null) {
+						processed++;
+						continue;
+					}
+					batch.push([itemID, text]);
+					batchChars += text.length;
+					if (batchChars >= _maxContentBatchChars) {
+						await flushBatch();
+					}
+				}
+				await flushBatch();
+				// The whole batch is indexed now (re-extracted or written above), so advance past it
+				_attachmentIndexQueueCursor = itemIDs[itemIDs.length - 1];
+				if (onProgress) {
+					onProgress(processed);
+				}
+				if (maxTime && (Date.now() - start) >= maxTime) {
+					return processed;
+				}
+			}
+		}
+		finally {
+			_indexingInProgress = false;
+		}
+	};
+
+
+	// Query for indexable attachments with no fulltextItems row yet -- the work list for
+	// processAttachmentExtractionQueue and the pending count. Skips types whose extraction is currently turned
+	// off, so they neither loop nor count as pending: a textMaxLength of 0 disables all indexing
+	// (returns null), and a pdfMaxPages of 0 disables PDFs. They become eligible again if the limit
+	// is raised.
+	function _attachmentExtractionSQL(select) {
+		if (!Zotero.Prefs.get('fulltext.textMaxLength')) {
+			return null;
+		}
+		// The text types use a LIKE, which the DB layer requires be a bound parameter, so 'text/%' is
+		// passed by callers rather than inlined alongside the other content types here
+		let types = Zotero.Prefs.get('fulltext.pdfMaxPages') > 0
+			? "contentType IN ('application/pdf', 'application/epub+zip') OR contentType LIKE ?"
+			: "contentType = 'application/epub+zip' OR contentType LIKE ?";
+		return "SELECT " + select + " FROM itemAttachments "
+			+ "WHERE linkMode != " + Zotero.Attachments.LINK_MODE_LINKED_URL + " "
+			+ "AND (" + types + ") "
+			+ "AND itemID NOT IN (SELECT itemID FROM fulltextItems)";
+	}
+
+
+	// Record an attachment as having no indexable content: an empty fulltextItems row (marked
+	// missing) plus an empty content-index entry, so it leaves both the unindexed queue and the
+	// content index queue.
+	async function recordMissingContent(itemID) {
+		await Zotero.DB.executeTransaction(async function () {
+			await Zotero.DB.queryAsync(
+				"INSERT OR IGNORE INTO fulltextItems (itemID, version, synced) VALUES (?, 0, ?)",
+				[itemID, Zotero.FullText.SYNC_STATE_MISSING]
+			);
+			await setContentIndex(itemID, '');
+		});
+	}
+
+
+	/**
+	 * Number of indexable attachments with no full-text content yet (no fulltextItems row). These
+	 * are extracted (or marked missing) by processAttachmentExtractionQueue() on the same triggers as the
+	 * content index queue.
+	 *
+	 * @return {Promise<Integer>}
+	 */
+	this.getAttachmentExtractionQueueCount = async function () {
+		let sql = _attachmentExtractionSQL("COUNT(*)");
+		if (!sql) {
+			return 0;
+		}
+		return Zotero.DB.valueQueryAsync(sql, ['text/%']);
+	};
+
+
+	/**
+	 * Index attachments that have no full-text content yet: extract any with a local file, and
+	 * record those with no local file (and therefore no cache) as missing, so they leave the queue
+	 * and are left for full-text content or file sync to fill in. Runs alongside the content index
+	 * queue, on the same startup/idle/prefs-pane triggers.
+	 *
+	 * @param {Object} [options]
+	 * @param {Integer} [options.maxTime] - Stop after roughly this many ms
+	 * @param {Boolean} [options.checkIdle] - Stop as soon as the user is no longer idle
+	 * @return {Promise<Integer>} The number of items processed
+	 */
+	this.processAttachmentExtractionQueue = async function ({ maxTime = null, checkIdle = false } = {}) {
+		if (_indexingInProgress) {
+			return 0;
+		}
+		_indexingInProgress = true;
+		let start = Date.now();
+		let processed = 0;
+		try {
+			let sql = _attachmentExtractionSQL("itemID");
+			// Indexing is turned off entirely (textMaxLength is 0) -- nothing to extract
+			if (!sql) {
+				return processed;
+			}
+			while (true) {
+				if (Zotero.Sync.Runner.syncInProgress) {
+					return processed;
+				}
+				let itemIDs = await Zotero.DB.columnQueryAsync(
+					sql + " AND itemID>? ORDER BY itemID LIMIT 50", ['text/%', _attachmentExtractionQueueCursor]
+				);
+				if (!itemIDs.length) {
+					// Nothing left above the cursor; restart from the beginning to catch anything
+					// newly unindexed below it
+					if (_attachmentExtractionQueueCursor) {
+						_attachmentExtractionQueueCursor = 0;
+						continue;
+					}
+					Zotero.debug("No attachments awaiting full-text extraction");
+					return processed;
+				}
+				Zotero.debug("Extracting full-text content for " + itemIDs.length + " "
+					+ Zotero.Utilities.pluralize(itemIDs.length, 'attachment'));
+				for (let itemID of itemIDs) {
+					if (checkIdle && !_canDrainIndex()) {
+						return processed;
+					}
+					let item = await Zotero.Items.getAsync(itemID);
+					if (await item.getFilePathAsync()) {
+						await this.indexItems([itemID], { ignoreErrors: true });
+						// indexItems() writes nothing when there's no text to index -- an unreadable
+						// file, a scanned PDF with no text, or an extraction error. Record an empty
+						// entry so the item leaves the queue instead of being retried every pass; it
+						// can be reindexed from its context menu or once its file changes.
+						if (!(await Zotero.DB.valueQueryAsync(
+								"SELECT 1 FROM fulltextItems WHERE itemID=?", itemID))) {
+							await recordMissingContent(itemID);
+						}
+					}
+					else {
+						// No local file -- and so no cache -- so there's nothing to index. Record it
+						// as missing (with an empty index entry, so it leaves both queues); full-text
+						// content or file sync will fill it in later.
+						await recordMissingContent(itemID);
+					}
+					processed++;
+					// Advance per item, not per batch, since this loop can return mid-batch
+					_attachmentExtractionQueueCursor = itemID;
+					if (maxTime && (Date.now() - start) >= maxTime) {
+						return processed;
+					}
+				}
+			}
+		}
+		finally {
+			_indexingInProgress = false;
+		}
+	};
+
+
+	/**
+	 * Index an item into the content tables for the queue, recording it in fulltextIndexState.
+	 * Normally this reads the item's already-extracted cache file (cheap). If the cache file is
+	 * missing but the attachment file is present, it re-extracts from the file instead, which
+	 * writes the cache and indexes the content. With no text available at all, the item is still
+	 * recorded (with no content) so it leaves the queue; it'll be re-indexed normally if its text
+	 * later arrives.
+	 */
+	// Read an item's already-extracted text for the content index, so the caller can write a
+	// batch of items in one transaction. Returns the text to index (possibly ''), or null if the
+	// item was re-extracted here (indexItems() already wrote it, so there's nothing to batch).
+	async function _readContentForIndex(itemID) {
+		try {
+			let item = await Zotero.Items.getAsync(itemID);
+			if (item && item.isAttachment()) {
+				let maxLength = Zotero.Prefs.get('fulltext.textMaxLength');
+				let mimeType = item.attachmentContentType;
+				// PDFs/EPUBs/HTML keep their extracted text in the cache file; plain-text types are
+				// read from the file itself -- same sources findTextInItems() uses
+				if (Zotero.FullText.isCachedMIMEType(mimeType)) {
+					let cacheFile = Zotero.FullText.getItemCacheFile(item).path;
+					if (await OS.File.exists(cacheFile)) {
+						return await Zotero.File.getContentsAsync(cacheFile, 'utf-8', maxLength);
+					}
+					else if (await item.getFilePathAsync()) {
+						// Re-extract from the file; indexItems() writes the cache and indexes it
+						await Zotero.FullText.indexItems([itemID]);
+						return null;
+					}
+				}
+				else if (Zotero.MIME.isTextType(mimeType)) {
+					let path = await item.getFilePathAsync();
+					if (path) {
+						return await Zotero.File.getContentsAsync(path, item.attachmentCharset, maxLength);
+					}
+				}
+			}
+		}
+		catch (e) {
+			Zotero.logError(e);
+		}
+		return '';
+	}
+
+
+	function _isUserIdle() {
+		let idleService = Components.classes["@mozilla.org/widget/useridleservice;1"]
+			.getService(Components.interfaces.nsIUserIdleService);
+		return idleService.idleTime >= _drainIdleDelay * 1000;
+	}
+
+
+	function _isZoteroActive() {
+		// Whether the user is currently interacting with a Zotero window, so the DB may be serving
+		// their actions. document.hasFocus() is true only when a Zotero window is the focused window
+		// of the foreground app, so this is false whenever Zotero is in the background.
+		for (let win of Zotero.getMainWindows()) {
+			if (win.document && win.document.hasFocus()) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+
+	function _canDrainIndex() {
+		// Background indexing competes with the user's own queries only through the shared DB
+		// connection, so the goal is just to not add latency to their actions: index when Zotero is
+		// in the background (their input is going elsewhere) or when it's focused but they've gone
+		// idle. Sync is handled separately, in the drain loops.
+		return !_isZoteroActive() || _isUserIdle();
+	}
+
+
+	/**
+	 * Bring the content index up to date after an upgrade by draining the already-extracted text
+	 * into the search index, then hand any never-before-indexed attachments to the idle observer.
+	 */
+	this.startQueueDrain = async function () {
+		if (Zotero.test) return;
+		let progressWin;
+		let itemProgress;
+		let startTime = Date.now();
+		try {
+			// Restore content search after an upgrade by draining the queue of already-extracted
+			// text into the search index. Run this to completion proactively -- not gated on idle
+			// like the background work below -- because until it finishes content search is
+			// incomplete. Pause for syncs so it doesn't compete with full-text content downloads.
+			let total = await this.getAttachmentIndexQueueCount();
+			// Items drained so far, tracked across processor calls so the bar can advance after each
+			// batch within a call rather than only once per loop iteration
+			let done = 0;
+			let updateProgress = (n) => {
+				if (itemProgress && total > 0) {
+					itemProgress.setProgress(Math.min(100, Math.round(n / total * 100)));
+				}
+			};
+			while (true) {
+				if (Zotero.Sync.Runner.syncInProgress) {
+					await Zotero.Promise.delay(5000);
+					continue;
+				}
+				let remaining = await this.getAttachmentIndexQueueCount();
+				if (remaining == 0) {
+					break;
+				}
+				// Run at full speed while the user isn't actively using Zotero (idle or in another
+				// app), but yield between slices when they are, so the migration doesn't tie up the
+				// shared connection and main thread. It still always runs to completion.
+				if (!_canDrainIndex()) {
+					await Zotero.Promise.delay(250);
+				}
+				// Show a progress window once it's clear this will take a moment (like the
+				// normalized-column backfill), tracking progress as the queue drains
+				if (!progressWin && Date.now() - startTime > 1500) {
+					progressWin = new Zotero.ProgressWindow({ closeOnClick: false });
+					progressWin.changeHeadline(Zotero.getString('upgrade.status'));
+					itemProgress = new progressWin.ItemProgress(
+						'journalArticle',
+						Zotero.getString('search-normalization-progress-message')
+					);
+					progressWin.show();
+				}
+				updateProgress(done);
+				let base = done;
+				done = base + await this.processAttachmentIndexQueue(
+					{ maxTime: 1000, onProgress: n => updateProgress(base + n) }
+				);
+			}
+			if (itemProgress) {
+				itemProgress.setProgress(100);
+			}
+			await this.optimizeContentIndex();
+			if (total > 0) {
+				Zotero.debug("Indexed " + done + " " + Zotero.Utilities.pluralize(done, 'item')
+					+ " for search in " + (Date.now() - startTime) + " ms");
+			}
+			if (progressWin) {
+				progressWin.startCloseTimer(3000);
+			}
+			// Index never-before-indexed attachments (e.g., added while indexing was off) gently in
+			// the background -- they were never searchable, so unlike the migration above they can
+			// wait for idle
+			if ((await this.getAttachmentIndexQueueCount()) > 0
+					|| (await this.getAttachmentExtractionQueueCount()) > 0) {
+				this.registerQueueDrainObserver();
+			}
+		}
+		catch (e) {
+			Zotero.logError(e);
+			if (itemProgress) {
+				itemProgress.setError();
+			}
+		}
+	};
+
+
+	/**
+	 * Merge the content index's FTS5 segments into one for faster queries. Called when the content
+	 * index queue drains, which can insert a burst of rows that FTS5 leaves as many segments for
+	 * searches to merge on the fly; 'optimize' merges them once instead. The trickle of inline
+	 * indexing during normal use doesn't need this -- FTS5 auto-merges those incremental writes --
+	 * and the extracted text lives in the cache files regardless, so a failure here is harmless.
+	 */
+	this.optimizeContentIndex = async function () {
+		try {
+			await Zotero.DB.queryAsync(
+				"INSERT INTO ftindex.fulltextContent(fulltextContent) VALUES('optimize')"
+			);
+			await Zotero.DB.queryAsync(
+				"INSERT INTO ftindex.fulltextContentCJK(fulltextContentCJK) VALUES('optimize')"
+			);
+		}
+		catch (e) {
+			Zotero.logError(e);
+		}
+	};
+
+
+	/**
+	 * Reclaim disk space in the content index. The FTS5 tables reuse freed pages but never return
+	 * them to the OS, so a large drop in indexed content (e.g., adding and then deleting many
+	 * items) can leave fulltext.sqlite much bigger than its contents. The main database vacuum
+	 * covers only the main database, so the attached content index is vacuumed here. Like that
+	 * vacuum, this is gated on the freelist threshold, which makes it self-throttling: a vacuum
+	 * empties the freelist, so it won't run again until content drops substantially. Called from
+	 * the idle maintenance pass; pass force to skip the checks (e.g., from tests).
+	 *
+	 * @param {Object} [options]
+	 * @param {Boolean} [options.force] - Skip the freelist and disk-space checks
+	 * @return {Promise<Boolean>} - Whether the index was vacuumed
+	 */
+	this.vacuumContentIndex = async function ({ force = false } = {}) {
+		if (!force) {
+			let freelistCount = await Zotero.DB.valueQueryAsync("PRAGMA ftindex.freelist_count");
+			let pageCount = await Zotero.DB.valueQueryAsync("PRAGMA ftindex.page_count");
+			let threshold = Zotero.Prefs.get('vacuum.freelistThreshold') || 10;
+			if (!(pageCount > 0) || (freelistCount / pageCount * 100) < threshold) {
+				return false;
+			}
+			// In-place VACUUM needs temporary space roughly the size of the database
+			let path = Zotero.DataDirectory.getDatabase('fulltext');
+			let size = (await IOUtils.stat(path)).size;
+			if (Zotero.File.pathToFile(path).diskSpaceAvailable < size) {
+				Zotero.debug("Not enough disk space to vacuum full-text content index -- skipping");
+				return false;
+			}
+		}
+		Zotero.debug("Vacuuming full-text content index");
+		let t = new Date();
+		await Zotero.DB.queryAsync("VACUUM ftindex");
+		Zotero.debug("Vacuumed full-text content index in " + (new Date() - t) + " ms");
+		return true;
+	};
+
+
+	this.registerQueueDrainObserver = function () {
+		if (Zotero.test) return;
+		if (_queueDrainTimerID) {
+			return;
+		}
+		Zotero.debug("Starting full-text content index queue processor");
+		_scheduleQueueDrain(_drainIdleDelay * 1000);
+	};
+
+
+	this.unregisterQueueDrainObserver = function () {
+		if (_queueDrainTimerID) {
+			clearTimeout(_queueDrainTimerID);
+			_queueDrainTimerID = null;
+		}
+	};
+
+
+	// Drain the content and unindexed-item queues in the background on a self-rescheduling timer.
+	// Unlike an OS idle observer, this keeps making progress while Zotero is in the background and
+	// the user works in other apps, and it backs off the moment they return to Zotero.
+	function _scheduleQueueDrain(delay) {
+		_queueDrainTimerID = setTimeout(async () => {
+			_queueDrainTimerID = null;
+			let self = Zotero.FullText;
+			try {
+				if (!_canDrainIndex() || Zotero.Sync.Runner.syncInProgress) {
+					_scheduleQueueDrain(_drainIdleDelay * 1000);
+					return;
+				}
+				if ((await self.getAttachmentIndexQueueCount()) == 0
+						&& (await self.getAttachmentExtractionQueueCount()) == 0) {
+					// Drained -- compact the index and stop
+					await self.optimizeContentIndex();
+					return;
+				}
+				Zotero.debug("Processing full-text index queues in the background ("
+					+ (_isZoteroActive() ? "focused but idle" : "not focused") + ")");
+				await self.processAttachmentIndexQueue({ maxTime: 1000, checkIdle: true });
+				await self.processAttachmentExtractionQueue({ maxTime: 1000, checkIdle: true });
+				_scheduleQueueDrain(250);
+			}
+			catch (e) {
+				// Stop on error instead of retrying, so a persistent failure (e.g., a full disk)
+				// doesn't spin. The drain starts again on the next trigger, such as a restart or a
+				// newly queued item.
+				Zotero.logError(e);
+			}
+		}, delay);
+	}
+
+
 	
 	/**
 	 * @param {Number} itemID
@@ -1093,24 +1825,22 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 				}
 				if (matches){
 					Zotero.debug("Text found");
-					return content.substr(matches.index, 50);
+					return true;
 				}
-				
+
 				break;
-			
+
 			default:
-				// Case-insensitive
-				searchText = searchText.toLowerCase();
-				content = content.toLowerCase();
-				
-				var pos = content.indexOf(searchText);
-				if (pos!=-1){
+				// Case- and diacritic-insensitive, to match the content index (findItemsWithContent)
+				searchText = Zotero.Utilities.Internal.normalizeForSearch(searchText);
+				content = Zotero.Utilities.Internal.normalizeForSearch(content);
+				if (content.includes(searchText)){
 					Zotero.debug('Text found');
-					return content.substr(pos, 50);
+					return true;
 				}
 		}
-		
-		return -1;
+
+		return false;
 	}
 	
 	/**
@@ -1127,9 +1857,181 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 	 *  - Slashes in regex are optional
 	 *  - Add 'Binary' to the mode to search all files, not just text files
 	 *
-	 * @return {Promise<Array<Object>>} A promise for an array of match objects, with 'id' containing
-	 *                                  an itemID and 'match' containing a string snippet
+	 * @return {Promise<Array<Object>>} A promise for an array of objects with an 'id' property
+	 *                                  containing the itemID of each matching item
 	 */
+	// CJK scripts (Han/Hiragana/Katakana/Hangul) -- indexed as 2-grams rather than 3-grams,
+	// since CJK queries are commonly 1-2 characters
+	const _cjkCharRE = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u;
+	const _cjkRunRE = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]+/gu;
+
+	/**
+	 * Build a space-separated list of overlapping 2-grams of the CJK runs in `text`, for the
+	 * ascii-tokenized CJK index. Only CJK characters are bigrammed -- everything else is handled
+	 * by the trigram index -- so non-CJK text produces an empty string.
+	 *
+	 * @param {String} text - Normalized text (via normalizeForSearch)
+	 * @return {String}
+	 */
+	function getCJKBigrams(text) {
+		if (!text) {
+			return '';
+		}
+		let bigrams = [];
+		for (let match of text.matchAll(_cjkRunRE)) {
+			let run = match[0];
+			for (let i = 0; i < run.length - 1; i++) {
+				bigrams.push(run.substr(i, 2));
+			}
+		}
+		return bigrams.join(' ');
+	}
+
+
+	/**
+	 * Index an item's extracted text into the content FTS5 tables and record it in the index-state
+	 * table at the current version. Replaces any existing entries for the item. `text` may be empty
+	 * (e.g., no cache file), in which case the item is simply recorded as indexed with no content.
+	 *
+	 * Must be called within a transaction.
+	 */
+	async function setContentIndex(itemID, text) {
+		await Zotero.DB.queryAsync("DELETE FROM ftindex.fulltextContent WHERE rowid=?", itemID);
+		await Zotero.DB.queryAsync("DELETE FROM ftindex.fulltextContentCJK WHERE rowid=?", itemID);
+		if (text) {
+			// Skip logging the params, which includes the full text
+			let normalized = Zotero.Utilities.Internal.normalizeForSearch(text) || '';
+			await Zotero.DB.queryAsync(
+				"INSERT INTO ftindex.fulltextContent (rowid, text) VALUES (?, ?)",
+				[itemID, normalized],
+				{ debugParams: false }
+			);
+			let cjk = getCJKBigrams(normalized);
+			if (cjk) {
+				await Zotero.DB.queryAsync(
+					"INSERT INTO ftindex.fulltextContentCJK (rowid, text) VALUES (?, ?)",
+					[itemID, cjk],
+					{ debugParams: false }
+				);
+			}
+		}
+		await Zotero.DB.queryAsync(
+			"REPLACE INTO ftindex.fulltextIndexState (itemID, version) VALUES (?, ?)",
+			[itemID, _contentIndexVersion]
+		);
+	}
+
+
+	/**
+	 * Remove an item's entries from the content FTS5 tables and the index-state table.
+	 *
+	 * Must be called within a transaction.
+	 */
+	async function clearContentIndex(itemID) {
+		await Zotero.DB.queryAsync("DELETE FROM ftindex.fulltextContent WHERE rowid=?", itemID);
+		await Zotero.DB.queryAsync("DELETE FROM ftindex.fulltextContentCJK WHERE rowid=?", itemID);
+		await Zotero.DB.queryAsync("DELETE FROM ftindex.fulltextIndexState WHERE itemID=?", itemID);
+	}
+
+
+	/**
+	 * Resolve a search term to the FTS5 table and MATCH expression that find it as a substring
+	 * (case- and diacritic-insensitively, via normalizeForSearch): the trigram index for Latin,
+	 * the 2-gram index for pure CJK. Returns null when the index can't answer the term -- too short
+	 * for the trigram index, or a mix of CJK and non-CJK that neither index covers alone.
+	 *
+	 * @return {Object|null} { table, match } or null
+	 */
+	function getContentMatchClause(searchText) {
+		let normalized = Zotero.Utilities.Internal.normalizeForSearch(searchText);
+		if (!normalized) {
+			return null;
+		}
+		let hasCJK = _cjkCharRE.test(normalized);
+		let hasNonCJK = /[a-z0-9]/.test(normalized);
+		// Pure CJK: match the term's 2-grams as a contiguous phrase against the CJK index
+		if (hasCJK && !hasNonCJK) {
+			let bigrams = getCJKBigrams(normalized);
+			// A single CJK character has no 2-gram
+			if (!bigrams) {
+				return null;
+			}
+			return { table: 'fulltextContentCJK', match: '"' + bigrams + '"' };
+		}
+		// Pure non-CJK: match the whole term as a contiguous phrase (substring) against the
+		// trigram index, which only indexes runs of 3+ characters
+		if (!hasCJK && normalized.length >= 3) {
+			return { table: 'fulltextContent', match: '"' + normalized.replace(/"/g, '""') + '"' };
+		}
+		return null;
+	}
+
+
+	/**
+	 * Whether a term can be matched against the content index rather than needing a fallback scan
+	 * of the cached text. Quick search uses this to skip content matching for terms too short for
+	 * the index, avoiding a per-keystroke scan.
+	 *
+	 * @param {String} searchText
+	 * @return {Boolean}
+	 */
+	this.canSearchContent = function (searchText) {
+		return getContentMatchClause(searchText) !== null;
+	};
+
+
+	/**
+	 * Return the ids of attachment items in the given library whose full-text content contains
+	 * `searchText` as a substring. This is the non-regexp path for the 'fulltextContent' search
+	 * condition; callers intersect the result with their own scope/result sets.
+	 *
+	 * Returns null when the term can't be answered from the index (see getContentMatchClause), so
+	 * the caller can fall back to scanning the cached text.
+	 *
+	 * @param {String} searchText
+	 * @param {Integer|null} [libraryID] - Restrict to this library, or null/undefined for all
+	 * @return {Promise<Integer[]|null>}
+	 */
+	this.findItemsWithContent = async function (searchText, libraryID) {
+		let clause = getContentMatchClause(searchText);
+		if (!clause) {
+			return null;
+		}
+		let sql = "SELECT C.rowid FROM ftindex." + clause.table + " C JOIN items I ON (I.itemID = C.rowid) "
+			+ "WHERE C." + clause.table + " MATCH ?";
+		let params = [clause.match];
+		if (libraryID !== null && libraryID !== undefined) {
+			sql += " AND I.libraryID=?";
+			params.push(libraryID);
+		}
+		return Zotero.DB.columnQueryAsync(sql, params);
+	};
+
+
+	/**
+	 * A subquery selecting the itemIDs whose full-text content matches `searchText` as a substring
+	 * via the content index, for embedding directly in a search's SQL (e.g. `itemID IN (<subquery>)`)
+	 * rather than materializing every match into an itemID list. The caller applies the surrounding
+	 * scope and the IN/NOT IN for the operator.
+	 *
+	 * Returns null when the term can't be answered from the index (see getContentMatchClause), so
+	 * the caller can fall back to scanning the cached text.
+	 *
+	 * @param {String} searchText
+	 * @return {Object|null} { sql, params }
+	 */
+	this.getContentSearchSQL = function (searchText) {
+		let clause = getContentMatchClause(searchText);
+		if (!clause) {
+			return null;
+		}
+		return {
+			sql: "SELECT rowid FROM ftindex." + clause.table + " WHERE " + clause.table + " MATCH ?",
+			params: [clause.match]
+		};
+	};
+
+
 	this.findTextInItems = async function (items, searchText, mode) {
 		if (!searchText){
 			return [];
@@ -1180,12 +2082,8 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 				content = await Zotero.File.getContentsAsync(path, item.attachmentCharset, maxLength);
 			}
 			
-			let match = findTextInString(content, searchText, mode);
-			if (match != -1) {
-				found.push({
-					id: itemID,
-					match: match
-				});
+			if (findTextInString(content, searchText, mode)) {
+				found.push({ id: itemID });
 			}
 		}
 		
@@ -1215,14 +2113,14 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 				"UPDATE fulltextItems SET itemID=? WHERE itemID=?",
 				[toItem.id, fromItem.id]
 			);
-			await Zotero.DB.queryAsync(
-				"UPDATE fulltextItemWords SET itemID=? WHERE itemID=?",
-				[toItem.id, fromItem.id]
-			);
 		}
 		catch (e) {
 			await Zotero.DB.queryAsync("PRAGMA foreign_keys = true");
 		}
+		// The content index is keyed by rowid and can't be re-keyed in place, so drop the source
+		// item's now-orphaned entry; toItem has the moved fulltextItems row but no index entry, so
+		// the queue will re-index it from the moved cache file.
+		await clearContentIndex(fromItem.id);
 	};
 	
 	
@@ -1235,14 +2133,11 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 		var sql = "SELECT rowid FROM fulltextItems WHERE itemID=? LIMIT 1";
 		var indexed = await Zotero.DB.valueQueryAsync(sql, itemID);
 		if (indexed) {
-			await Zotero.DB.queryAsync("DELETE FROM fulltextItemWords WHERE itemID=?", itemID);
 			await Zotero.DB.queryAsync("DELETE FROM fulltextItems WHERE itemID=?", itemID);
 		}
-		
-		if (indexed) {
-			Zotero.Prefs.set('purge.fulltext', true);
-		}
-		
+		// Remove the content index entries too (the content DB can't FK-cascade to zotero.sqlite)
+		await clearContentIndex(itemID);
+
 		if (!skipCacheClear) {
 			// Delete fulltext cache file if there is one
 			await clearCacheFile(itemID);
@@ -1408,25 +2303,35 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 	 * @return {Promise}
 	 */
 	this.getIndexStats = async function () {
-		var sql = "SELECT COUNT(*) FROM fulltextItems WHERE synced != ? AND "
+		// Indexed/Partial count items actually in the search index at the current version (joined to
+		// fulltextIndexState), so they reflect what's searchable rather than just extracted -- which
+		// keeps them disjoint from the backfill still in progress (remaining) and makes their sum the
+		// bar's numerator
+		var sql = "SELECT COUNT(*) FROM fulltextItems FI "
+			+ "JOIN ftindex.fulltextIndexState S USING (itemID) "
+			+ "WHERE S.version >= ? AND FI.synced != ? AND "
 			+ "((indexedPages IS NOT NULL AND indexedPages=totalPages) OR "
-			+ "(indexedChars IS NOT NULL AND indexedChars=totalChars))"
-		var indexed = await Zotero.DB.valueQueryAsync(sql, this.SYNC_STATE_MISSING);
+			+ "(indexedChars IS NOT NULL AND indexedChars=totalChars))";
+		var indexed = await Zotero.DB.valueQueryAsync(sql, [_contentIndexVersion, this.SYNC_STATE_MISSING]);
+
+		var sql = "SELECT COUNT(*) FROM fulltextItems FI "
+			+ "JOIN ftindex.fulltextIndexState S USING (itemID) "
+			+ "WHERE S.version >= ? AND "
+			+ "((indexedPages IS NOT NULL AND indexedPages<totalPages) OR "
+			+ "(indexedChars IS NOT NULL AND indexedChars<totalChars))";
+		var partial = await Zotero.DB.valueQueryAsync(sql, _contentIndexVersion);
 		
-		var sql = "SELECT COUNT(*) FROM fulltextItems WHERE "
-			+ "(indexedPages IS NOT NULL AND indexedPages<totalPages) OR "
-			+ "(indexedChars IS NOT NULL AND indexedChars<totalChars)"
-		var partial = await Zotero.DB.valueQueryAsync(sql);
-		
-		var sql = "SELECT COUNT(*) FROM itemAttachments WHERE itemID NOT IN "
-			+ "(SELECT itemID FROM fulltextItems WHERE synced != ? AND "
-			+ "(indexedPages IS NOT NULL OR indexedChars IS NOT NULL))";
-		var unindexed = await Zotero.DB.valueQueryAsync(sql, this.SYNC_STATE_MISSING);
-		
-		var sql = "SELECT COUNT(*) FROM fulltextWords";
-		var words = await Zotero.DB.valueQueryAsync(sql);
-		
-		return { indexed, partial, unindexed, words };
+		// Items with neither a local file nor full-text content (so nothing to index locally),
+		// recorded as missing -- shown as such rather than as a fixable "not indexed" count
+		var sql = "SELECT COUNT(*) FROM fulltextItems WHERE synced = ?";
+		var notAvailable = await Zotero.DB.valueQueryAsync(sql, this.SYNC_STATE_MISSING);
+
+		// Pending work, both auto-draining: items with extracted content not yet in the search index
+		// (remaining) and indexable attachments not yet extracted (unindexedQueue)
+		var remaining = await this.getAttachmentIndexQueueCount();
+		var unindexedQueue = await this.getAttachmentExtractionQueueCount();
+
+		return { indexed, partial, notAvailable, remaining, unindexedQueue };
 	};
 	
 	
@@ -1516,43 +2421,83 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 		
 		await this.indexItems(itemIDs, { ignoreErrors: true });
 	};
-	
-	
+
+
 	/**
-	 * Clears full-text word index and all full-text cache files
+	 * Re-extract items whose content was truncated by a lower full-text limit, after that limit is
+	 * raised. Only the affected items are re-indexed, so raising a limit doesn't force a blanket
+	 * rebuild-and-reupload of everything. Items truncated by the character limit and the page limit
+	 * are tracked separately, via indexedChars/totalChars and indexedPages/totalPages.
+	 *
+	 * @param {String} type - 'chars' or 'pages'
+	 * @param {Integer} newLimit - The limit's new value
+	 * @return {Promise}
+	 */
+	this.reindexTruncated = async function (type, newLimit) {
+		newLimit = parseInt(newLimit);
+		// 0 (or invalid) means "don't index", which is handled at index time -- nothing to re-extract
+		if (!(newLimit > 0)) {
+			return;
+		}
+		// Items that were truncated (more content exists than was indexed) and that the higher limit
+		// would actually extend (the old ceiling was below the new one)
+		var sql = type == 'chars'
+			? "SELECT itemID FROM fulltextItems "
+				+ "WHERE indexedChars IS NOT NULL AND indexedChars < totalChars AND indexedChars < ?"
+			: "SELECT itemID FROM fulltextItems "
+				+ "WHERE indexedPages IS NOT NULL AND indexedPages < totalPages AND indexedPages < ?";
+		var itemIDs = await Zotero.DB.columnQueryAsync(sql, [newLimit]);
+		if (!itemIDs.length) {
+			return;
+		}
+		Zotero.debug(`Re-extracting ${itemIDs.length} `
+			+ `${Zotero.Utilities.pluralize(itemIDs.length, 'item')} truncated below the new full-text `
+			+ (type == 'chars' ? 'character' : 'page') + ' limit');
+		await this.indexItems(itemIDs, { ignoreErrors: true });
+	};
+
+
+	/**
+	 * Clears the full-text index and all full-text cache files
 	 *
 	 * @return {Promise}
 	 */
-	this.clearIndex = async function (skipLinkedURLs) {
+	this.clearIndex = async function () {
 		await Zotero.DB.executeTransaction(async function () {
-			var sql = "DELETE FROM fulltextItems";
-			if (skipLinkedURLs) {
-				var linkSQL = "SELECT itemID FROM itemAttachments WHERE linkMode ="
-					+ Zotero.Attachments.LINK_MODE_LINKED_URL;
-				
-				sql += " WHERE itemID NOT IN (" + linkSQL + ")";
-			}
-			await Zotero.DB.queryAsync(sql);
-			
-			sql = "DELETE FROM fulltextItemWords";
-			if (skipLinkedURLs) {
-				sql += " WHERE itemID NOT IN (" + linkSQL + ")";
-			}
-			await Zotero.DB.queryAsync(sql);
+			await Zotero.DB.queryAsync("DELETE FROM fulltextItems");
+
+			// Drop content index entries for items no longer in fulltextItems
+			await Zotero.DB.queryAsync("DELETE FROM ftindex.fulltextContent "
+				+ "WHERE rowid NOT IN (SELECT itemID FROM fulltextItems)");
+			await Zotero.DB.queryAsync("DELETE FROM ftindex.fulltextContentCJK "
+				+ "WHERE rowid NOT IN (SELECT itemID FROM fulltextItems)");
+			await Zotero.DB.queryAsync("DELETE FROM ftindex.fulltextIndexState "
+				+ "WHERE itemID NOT IN (SELECT itemID FROM fulltextItems)");
 		});
-		
-		if (skipLinkedURLs) {
-			await this.purgeUnusedWords();
-		}
-		else {
-			await Zotero.DB.queryAsync("DELETE FROM fulltextWords");
-		}
-		
+
 		await clearCacheFiles();
-		await Zotero.DB.queryAsync('VACUUM');
 	}
-	
-	
+
+
+	/**
+	 * Remove content index entries for items that no longer exist. Normal deletion clears these
+	 * via clearItemWords(), but the content database can't FK-cascade to zotero.sqlite, so this is
+	 * a periodic safety net for items removed through a path that bypassed Item.erase().
+	 *
+	 * @return {Promise}
+	 */
+	this.purgeOrphanedContent = async function () {
+		await Zotero.DB.executeTransaction(async function () {
+			await Zotero.DB.queryAsync("DELETE FROM ftindex.fulltextContent "
+				+ "WHERE rowid NOT IN (SELECT itemID FROM fulltextItems)");
+			await Zotero.DB.queryAsync("DELETE FROM ftindex.fulltextContentCJK "
+				+ "WHERE rowid NOT IN (SELECT itemID FROM fulltextItems)");
+			await Zotero.DB.queryAsync("DELETE FROM ftindex.fulltextIndexState "
+				+ "WHERE itemID NOT IN (SELECT itemID FROM fulltextItems)");
+		});
+	};
+
+
 	/*
 	 * Clears cache file for an item
 	 */
@@ -1583,11 +2528,8 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 	/*
 	 * Clear cache files for all attachments
 	 */
-	var clearCacheFiles = async function (skipLinkedURLs) {
+	var clearCacheFiles = async function () {
 		var sql = "SELECT itemID FROM itemAttachments";
-		if (skipLinkedURLs) {
-			sql += " WHERE linkMode != " + Zotero.Attachments.LINK_MODE_LINKED_URL;
-		}
 		var items = await Zotero.DB.columnQueryAsync(sql);
 		for (var i=0; i<items.length; i++) {
 			await clearCacheFile(items[i]);
@@ -1600,22 +2542,6 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 		Zotero.DB.query("DELETE FROM fulltextContent WHERE itemID=" + itemID);
 	}
 	*/
-	
-	
-	/**
-	 * @return {Promise}
-	 */
-	this.purgeUnusedWords = async function () {
-		if (!Zotero.Prefs.get('purge.fulltext')) {
-			return;
-		}
-		
-		var sql = "DELETE FROM fulltextWords WHERE wordID NOT IN "
-					+ "(SELECT wordID FROM fulltextItemWords)";
-		await Zotero.DB.queryAsync(sql);
-		
-		Zotero.Prefs.set('purge.fulltext', false)
-	};
 	
 	
 	async function getPageData(path, contentType) {

--- a/chrome/content/zotero/xpcom/fulltext.js
+++ b/chrome/content/zotero/xpcom/fulltext.js
@@ -55,8 +55,8 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 	
 	var _idleObserverIsRegistered = false;
 	var _idleObserverDelay = 30;
-	var _processorTimeoutID = null;
-	var _processorBlacklist = {};
+	var _syncContentTimeoutID = null;
+	var _syncContentBlacklist = {};
 	var _upgradeCheck = true;
 	var _syncLibraryVersion = 0;
 	
@@ -102,16 +102,16 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 		Zotero.uiReadyPromise.then(async () => {
 			await Zotero.Promise.delay(30000);
 			
-			this.registerContentProcessor();
-			Zotero.addShutdownListener(this.unregisterContentProcessor.bind(this));
+			this.registerSyncContentProcessor();
+			Zotero.addShutdownListener(this.unregisterSyncContentProcessor.bind(this));
 			
 			// Start/stop content processor with full-text content syncing pref
 			Zotero.Prefs.registerObserver('sync.fulltext.enabled', (enabled) => {
 				if (enabled) {
-					this.registerContentProcessor();
+					this.registerSyncContentProcessor();
 				}
 				else {
-					this.unregisterContentProcessor();
+					this.unregisterSyncContentProcessor();
 				}
 			});
 			
@@ -120,10 +120,10 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 				{
 					notify: function (event, type, ids, extraData) {
 						if (event == 'start') {
-							this.unregisterContentProcessor();
+							this.unregisterSyncContentProcessor();
 						}
 						else if (event == 'stop') {
-							this.registerContentProcessor();
+							this.registerSyncContentProcessor();
 						}
 					}.bind(this)
 				},
@@ -305,7 +305,7 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 		
 		// If there's a processor cache file, delete it (whether or not we just used it)
 		var item = await Zotero.Items.getAsync(itemID);
-		var cacheFile = this.getItemProcessorCacheFile(item);
+		var cacheFile = this.getSyncedContentCacheFile(item);
 		if (cacheFile.exists()) {
 			cacheFile.remove(false);
 		}
@@ -496,9 +496,9 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 			let itemID = item.id;
 			
 			// If there's a processor cache file from syncing, use it
-			let processorCacheFile = this.getItemProcessorCacheFile(item).path;
+			let processorCacheFile = this.getSyncedContentCacheFile(item).path;
 			if (await OS.File.exists(processorCacheFile)) {
-				let indexed = await Zotero.Fulltext.indexFromProcessorCache(itemID);
+				let indexed = await Zotero.Fulltext.indexSyncedContent(itemID);
 				if (indexed) {
 					continue;
 				}
@@ -838,7 +838,7 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 		var itemID = item.id;
 		var currentVersion = await this.getItemVersion(itemID)
 		
-		var processorCacheFile = this.getItemProcessorCacheFile(item).path; // .zotero-ft-unprocessed
+		var processorCacheFile = this.getSyncedContentCacheFile(item).path; // .zotero-ft-unprocessed
 		var itemCacheFile = this.getItemCacheFile(item).path; // .zotero-ft-cache
 		
 		// If a storage directory doesn't exist, create it
@@ -883,14 +883,14 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 			);
 		}
 		
-		this.registerContentProcessor();
+		this.registerSyncContentProcessor();
 	};
 	
 	
 	/**
 	 * Start the idle observer for the background content processor
 	 */
-	this.registerContentProcessor = function () {
+	this.registerSyncContentProcessor = function () {
 		// Don't start idle observer during tests
 		if (Zotero.test) return;
 		if (!Zotero.Prefs.get('sync.fulltext.enabled')) return;
@@ -899,33 +899,33 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 			Zotero.debug("Starting full-text content processor");
 			var idleService = Components.classes["@mozilla.org/widget/useridleservice;1"]
 					.getService(Components.interfaces.nsIUserIdleService);
-			idleService.addIdleObserver(this.idleObserver, _idleObserverDelay);
+			idleService.addIdleObserver(this._syncContentIdleObserver, _idleObserverDelay);
 			_idleObserverIsRegistered = true;
 		}
 	}
 	
 	
-	this.unregisterContentProcessor = function () {
+	this.unregisterSyncContentProcessor = function () {
 		if (_idleObserverIsRegistered) {
 			Zotero.debug("Unregistering full-text content processor idle observer");
 			var idleService = Components.classes["@mozilla.org/widget/useridleservice;1"]
 				.getService(Components.interfaces.nsIUserIdleService);
-			idleService.removeIdleObserver(this.idleObserver, _idleObserverDelay);
+			idleService.removeIdleObserver(this._syncContentIdleObserver, _idleObserverDelay);
 			_idleObserverIsRegistered = false;
 		}
 		
-		this.stopContentProcessor();
+		this.stopSyncContentProcessor();
 	}
 	
 	
 	/**
 	 * Stop the idle observer and a running timer, if there is one
 	 */
-	this.stopContentProcessor = function () {
+	this.stopSyncContentProcessor = function () {
 		Zotero.debug("Stopping full-text content processor");
-		if (_processorTimeoutID) {
-			clearTimeout(_processorTimeoutID);
-			_processorTimeoutID = null;
+		if (_syncContentTimeoutID) {
+			clearTimeout(_syncContentTimeoutID);
+			_syncContentTimeoutID = null;
 		}
 	}
 	
@@ -938,7 +938,7 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 	 *                                  to find unprocessed content
 	 * @return {Boolean}  TRUE if there's more content to process; FALSE otherwise
 	 */
-	this.processUnprocessedContent = async function (itemIDs) {
+	this.processSyncedContent = async function (itemIDs) {
 		// Idle observer can take a little while to trigger and may not cancel the setTimeout()
 		// in time, so check idle time directly
 		var idleService = Components.classes["@mozilla.org/widget/useridleservice;1"]
@@ -955,7 +955,7 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 		
 		var origLen = itemIDs.length;
 		itemIDs = itemIDs.filter(function (id) {
-			return !(id in _processorBlacklist);
+			return !(id in _syncContentBlacklist);
 		});
 		if (itemIDs.length < origLen) {
 			let skipped = (origLen - itemIDs.length);
@@ -966,7 +966,7 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 		// If there's no more unprocessed content, stop the idle observer
 		if (!itemIDs.length) {
 			Zotero.debug("No unprocessed full-text content found");
-			this.unregisterContentProcessor();
+			this.unregisterSyncContentProcessor();
 			return;
 		}
 		
@@ -975,7 +975,7 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 		
 		Zotero.debug("Processing full-text content for item " + item.libraryKey);
 		
-		await Zotero.Fulltext.indexFromProcessorCache(itemID);
+		await Zotero.Fulltext.indexSyncedContent(itemID);
 		
 		if (!itemIDs.length || idleService.idleTime < _idleObserverDelay * 1000) {
 			return;
@@ -984,18 +984,18 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 		// If there are remaining items, call self again after a short delay. The delay allows
 		// for processing to be interrupted if the user returns from idle. At least on macOS,
 		// when Zotero is in the background this can be throttled to 10 seconds.
-		_processorTimeoutID = setTimeout(() => this.processUnprocessedContent(itemIDs), 200);
+		_syncContentTimeoutID = setTimeout(() => this.processSyncedContent(itemIDs), 200);
 	};
 	
-	this.idleObserver = {
+	this._syncContentIdleObserver = {
 		observe: function (subject, topic, data) {
 			// On idle, start the background processor
 			if (topic == 'idle') {
-				this.processUnprocessedContent();
+				this.processSyncedContent();
 			}
 			// When back from idle, stop the processor (but keep the idle observer registered)
 			else if (topic == 'active') {
-				this.stopContentProcessor();
+				this.stopSyncContentProcessor();
 			}
 		}.bind(this)
 	};
@@ -1005,10 +1005,10 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 	 * @param {Number} itemID
 	 * @return {Promise<Boolean>}
 	 */
-	this.indexFromProcessorCache = async function (itemID) {
+	this.indexSyncedContent = async function (itemID) {
 		try {
 			var item = await Zotero.Items.getAsync(itemID);
-			var cacheFile = this.getItemProcessorCacheFile(item).path;
+			var cacheFile = this.getSyncedContentCacheFile(item).path;
 			if (!((await OS.File.exists(cacheFile))))  {
 				Zotero.debug("Full-text content processor cache file doesn't exist for item " + itemID);
 				await Zotero.DB.queryAsync(
@@ -1378,7 +1378,7 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 			if (!stats.total && !stats.indexed) {
 				let queued = false;
 				try {
-					queued = await OS.File.exists(this.getItemProcessorCacheFile(item).path);
+					queued = await OS.File.exists(this.getSyncedContentCacheFile(item).path);
 				}
 				catch (e) {
 					Zotero.logError(e);
@@ -1437,7 +1437,7 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 	}
 	
 	
-	this.getItemProcessorCacheFile = function (item) {
+	this.getSyncedContentCacheFile = function (item) {
 		var cacheFile = Zotero.Attachments.getStorageDirectory(item);
 		cacheFile.append(_processorCacheFile);
 		return cacheFile;
@@ -1504,7 +1504,7 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 		if (!unindexedOnly) {
 			for (let itemID of itemIDs) {
 				let item = await Zotero.Items.getAsync(itemID);
-				let cacheFile = this.getItemProcessorCacheFile(item).path;
+				let cacheFile = this.getSyncedContentCacheFile(item).path;
 				try {
 					await OS.File.remove(cacheFile, { ignoreAbsent: true });
 				}

--- a/chrome/content/zotero/xpcom/fulltext.js
+++ b/chrome/content/zotero/xpcom/fulltext.js
@@ -40,11 +40,14 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 	
 	const _processorCacheFile = '.zotero-ft-unprocessed';
 
-	// Schema version of the attached content database (fulltext.sqlite)
-	const _contentDBVersion = 1;
-	// Version of the content index format. Bump to force a rebuild of the index from the cached
-	// text (e.g., after a tokenizer or normalization change) -- items recorded at a lower version
-	// in fulltextIndexState are re-indexed by the background queue processor.
+	// Schema version of the attached index database (fulltext.sqlite), covering the attachment
+	// content and note tables. Bump only for changes that can't be applied in place; adding a table
+	// is done idempotently in setUpContentDB() without a bump.
+	const _indexDBVersion = 1;
+	// Version of the index format. Bump to force a rebuild of the index from the cached text
+	// (e.g., after a tokenizer or normalization change) -- items recorded at a lower version in
+	// fulltextIndexState/fulltextNoteIndexState reenter the queue and are re-indexed at startup,
+	// like the initial migration.
 	const _contentIndexVersion = 1;
 
 	const kWbClassSpace =            0;
@@ -73,10 +76,17 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 	// to 0 when a pass reaches the end, to pick up anything re-queued below the cursor.
 	var _attachmentIndexQueueCursor = 0;
 	var _attachmentExtractionQueueCursor = 0;
+	var _noteIndexQueueCursor = 0;
 	// Flush a content batch to the index once it reaches this many characters, so peak memory stays
 	// bounded by the budget rather than by item size (each up to fulltext.textMaxLength)
 	const _maxContentBatchChars = 2000000;
 	var _processingSyncedContent = false;
+	var _noteIndexReady = false;
+	// Normalized plain text of notes edited since their last index update (version 0), so a search
+	// run before the background queue re-indexes them matches with the same normalized, plain-text
+	// semantics as the index rather than a raw scan of the note HTML. Keyed by itemID; entries are
+	// added when a note is flagged stale and dropped once it's re-indexed or no longer stale.
+	var _staleNoteText = new Map();
 	var _reindexLimitTimeoutIDs = {};
 	var _syncContentBlacklist = {};
 	var _upgradeCheck = true;
@@ -87,7 +97,9 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 		// attached database (fulltext.sqlite), used for content searching. It's a local,
 		// rebuildable index kept out of zotero.sqlite (so it doesn't bloat the main DB or its
 		// backups), versioned independently via PRAGMA user_version. The original extracted text
-		// still lives in the .zotero-ft-cache files; the index stores only normalized trigrams.
+		// still lives in the .zotero-ft-cache files, so the content tables store only normalized
+		// trigrams. Notes, which have no cache file, also store their normalized plain text (see
+		// noteText below), so short and mixed-script note searches have something to scan.
 		//
 		// FTS5 is a bundled SQLite extension. It's loaded once here; DBConnection re-loads it
 		// automatically after a reconnect (before this callback runs), so it's available for the
@@ -104,15 +116,19 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 			// the .zotero-ft-cache files, so the background queue repopulates the index.
 			let localUserKey = Zotero.Users.getLocalUserKey();
 			let version = await Zotero.DB.valueQueryAsync("PRAGMA ftindex.user_version");
-			let indexedUserKey = version >= _contentDBVersion
+			let indexedUserKey = version >= _indexDBVersion
 				? await Zotero.DB.valueQueryAsync(
 					"SELECT value FROM ftindex.fulltextIndexMeta WHERE key='localUserKey'")
 				: false;
-			if (version < _contentDBVersion || indexedUserKey != localUserKey) {
+			if (version < _indexDBVersion || indexedUserKey != localUserKey) {
 				// Drop any existing tables so a stale or mismatched index is rebuilt from scratch
 				await Zotero.DB.queryAsync("DROP TABLE IF EXISTS ftindex.fulltextContent");
 				await Zotero.DB.queryAsync("DROP TABLE IF EXISTS ftindex.fulltextContentCJK");
+				await Zotero.DB.queryAsync("DROP TABLE IF EXISTS ftindex.fulltextNotes");
+				await Zotero.DB.queryAsync("DROP TABLE IF EXISTS ftindex.fulltextNotesCJK");
 				await Zotero.DB.queryAsync("DROP TABLE IF EXISTS ftindex.fulltextIndexState");
+				await Zotero.DB.queryAsync("DROP TABLE IF EXISTS ftindex.fulltextNoteIndexState");
+				await Zotero.DB.queryAsync("DROP TABLE IF EXISTS ftindex.noteText");
 				await Zotero.DB.queryAsync("DROP TABLE IF EXISTS ftindex.fulltextIndexMeta");
 				// Latin (and CJK runs of 3+ chars): trigram index over the normalized text
 				await Zotero.DB.queryAsync(
@@ -127,6 +143,17 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 					"CREATE VIRTUAL TABLE ftindex.fulltextContentCJK USING fts5("
 					+ "text, tokenize='ascii', content='', contentless_delete=1)"
 				);
+				// Note content (text extracted from the note HTML), same scheme as above. Kept in
+				// separate tables because contentless FTS5 tables can't be filtered by an extra
+				// column, so attachment content and notes couldn't be told apart in one table.
+				await Zotero.DB.queryAsync(
+					"CREATE VIRTUAL TABLE ftindex.fulltextNotes USING fts5("
+					+ "text, tokenize='trigram', content='', contentless_delete=1)"
+				);
+				await Zotero.DB.queryAsync(
+					"CREATE VIRTUAL TABLE ftindex.fulltextNotesCJK USING fts5("
+					+ "text, tokenize='ascii', content='', contentless_delete=1)"
+				);
 				// Records which items are in the content index and at what format version. The
 				// contentless FTS5 tables can't be queried for this, so this side table makes the
 				// queue (items not yet indexed at the current version) a countable,
@@ -135,6 +162,32 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 					"CREATE TABLE ftindex.fulltextIndexState (\n"
 					+ "    itemID INTEGER PRIMARY KEY,\n"
 					+ "    version INT NOT NULL\n"
+					+ ")"
+				);
+				// Same, for notes. version 0 marks a note edited since its last index update
+				// ("stale"): note saves just set this flag instead of re-indexing the whole note on
+				// every auto-save, and searches match stale notes in memory while the background
+				// queue catches up.
+				await Zotero.DB.queryAsync(
+					"CREATE TABLE ftindex.fulltextNoteIndexState (\n"
+					+ "    itemID INTEGER PRIMARY KEY,\n"
+					+ "    version INT NOT NULL\n"
+					+ ")"
+				);
+				// A search looks up the stale (version 0) notes on every query, so index them
+				// separately. The partial index stays tiny -- only the currently-stale notes --
+				// so the lookup doesn't scan the full table.
+				await Zotero.DB.queryAsync(
+					"CREATE INDEX ftindex.fulltextNoteIndexState_stale "
+					+ "ON fulltextNoteIndexState(itemID) WHERE version=0"
+				);
+				// Notes are small, so (unlike attachment content) their normalized plain text is also
+				// stored, so short and mixed-script note searches -- which the trigram/CJK indexes
+				// can't answer -- can scan it with a LIKE instead of matching nothing
+				await Zotero.DB.queryAsync(
+					"CREATE TABLE ftindex.noteText (\n"
+					+ "    itemID INTEGER PRIMARY KEY,\n"
+					+ "    text TEXT\n"
 					+ ")"
 				);
 				// Index metadata, including the localUserKey the index was built against (above)
@@ -148,7 +201,11 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 					"REPLACE INTO ftindex.fulltextIndexMeta (key, value) VALUES ('localUserKey', ?)",
 					[localUserKey]
 				);
-				await Zotero.DB.queryAsync("PRAGMA ftindex.user_version = " + _contentDBVersion);
+				await Zotero.DB.queryAsync("PRAGMA ftindex.user_version = " + _indexDBVersion);
+				// The rebuilt note index has to be backfilled before searches can rely on it, and
+				// any in-memory stale-note text no longer applies to a freshly attached database
+				_noteIndexReady = false;
+				_staleNoteText.clear();
 			}
 		};
 		// Rebuild the index if its file is found corrupt. A malformed page can surface from any
@@ -1509,6 +1566,105 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 	}
 
 
+	/**
+	 * Number of notes not yet in the note index at the current version, including notes marked
+	 * stale by an edit (version 0). Like the content index queue, this is countable and resumable.
+	 *
+	 * @return {Promise<Integer>}
+	 */
+	this.getNoteIndexQueueCount = async function () {
+		return Zotero.DB.valueQueryAsync(
+			"SELECT COUNT(*) FROM itemNotes N "
+			+ "LEFT JOIN ftindex.fulltextNoteIndexState S USING (itemID) "
+			+ "WHERE S.itemID IS NULL OR S.version<?",
+			[_contentIndexVersion]
+		);
+	};
+
+
+	/**
+	 * Process the note index queue, indexing the text content of notes that aren't in the note
+	 * index yet or were edited since their last index update. Note saves only mark the note stale
+	 * (so a note isn't re-indexed on every auto-save while typing); this does the actual indexing.
+	 *
+	 * @param {Object} [options]
+	 * @param {Integer} [options.maxTime] - Stop after roughly this many ms
+	 * @param {Boolean} [options.checkIdle] - Stop as soon as the user is no longer idle
+	 * @return {Promise<Integer>} The number of notes processed
+	 */
+	this.processNoteIndexQueue = async function ({ maxTime = null, checkIdle = false, onProgress = null } = {}) {
+		if (_indexingInProgress) {
+			return 0;
+		}
+		_indexingInProgress = true;
+		let start = Date.now();
+		let processed = 0;
+		try {
+			while (true) {
+				if (Zotero.Sync.Runner.syncInProgress) {
+					return processed;
+				}
+				if (checkIdle && !_canDrainIndex()) {
+					return processed;
+				}
+				let itemIDs = await Zotero.DB.columnQueryAsync(
+					"SELECT N.itemID FROM itemNotes N "
+					+ "LEFT JOIN ftindex.fulltextNoteIndexState S USING (itemID) "
+					+ "WHERE (S.itemID IS NULL OR S.version<?) AND N.itemID>? "
+					+ "ORDER BY N.itemID LIMIT 50",
+					[_contentIndexVersion, _noteIndexQueueCursor]
+				);
+				if (!itemIDs.length) {
+					// Nothing left above the cursor; restart from the beginning to catch anything
+					// re-queued below it (e.g., a note edited during the drain)
+					if (_noteIndexQueueCursor) {
+						_noteIndexQueueCursor = 0;
+						continue;
+					}
+					Zotero.debug("No queued notes to index");
+					return processed;
+				}
+				Zotero.debug("Indexing " + itemIDs.length + " "
+					+ Zotero.Utilities.pluralize(itemIDs.length, 'note'));
+				let parserUtils = Cc["@mozilla.org/parserutils;1"].getService(Ci.nsIParserUtils);
+				// Read and index each note in one transaction, so a note save can't land between
+				// reading its text and marking it indexed at the current version
+				await Zotero.DB.executeTransaction(async function () {
+					let rows = await Zotero.DB.queryAsync(
+						"SELECT itemID, note FROM itemNotes WHERE itemID IN (" + itemIDs.join(',') + ")"
+					);
+					let noteByID = new Map(rows.map(row => [row.itemID, row.note]));
+					for (let itemID of itemIDs) {
+						// Not in itemNotes anymore -- deleted since it was queued
+						if (!noteByID.has(itemID)) {
+							await Zotero.FullText.clearNoteIndex(itemID);
+							continue;
+						}
+						let note = noteByID.get(itemID);
+						// Index the text content, not the HTML, so markup doesn't match searches.
+						// Block boundaries become line breaks, so words don't join across paragraphs.
+						let text = note
+							? parserUtils.convertToPlainText(note, Ci.nsIDocumentEncoder.OutputRaw, 0)
+							: '';
+						await setNoteIndex(itemID, text);
+					}
+				});
+				processed += itemIDs.length;
+				_noteIndexQueueCursor = itemIDs[itemIDs.length - 1];
+				if (onProgress) {
+					onProgress(processed);
+				}
+				if (maxTime && (Date.now() - start) >= maxTime) {
+					return processed;
+				}
+			}
+		}
+		finally {
+			_indexingInProgress = false;
+		}
+	};
+
+
 	function _isUserIdle() {
 		let idleService = Components.classes["@mozilla.org/widget/useridleservice;1"]
 			.getService(Components.interfaces.nsIUserIdleService);
@@ -1540,7 +1696,8 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 
 	/**
 	 * Bring the content index up to date after an upgrade by draining the already-extracted text
-	 * into the search index, then hand any never-before-indexed attachments to the idle observer.
+	 * and note content into the search index, then hand any never-before-indexed attachments to the
+	 * idle observer.
 	 */
 	this.startQueueDrain = async function () {
 		if (Zotero.test) return;
@@ -1548,11 +1705,15 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 		let itemProgress;
 		let startTime = Date.now();
 		try {
-			// Restore content search after an upgrade by draining the queue of already-extracted
-			// text into the search index. Run this to completion proactively -- not gated on idle
-			// like the background work below -- because until it finishes content search is
-			// incomplete. Pause for syncs so it doesn't compete with full-text content downloads.
-			let total = await this.getAttachmentIndexQueueCount();
+			// Restore content search after an upgrade by draining the queues of already-extracted
+			// text and note content into the search index. Run this to completion proactively --
+			// not gated on idle like the background work below -- because until it finishes content
+			// search is incomplete. Pause for syncs so it doesn't compete with full-text content
+			// downloads.
+			let queueCount = async () => {
+				return (await this.getAttachmentIndexQueueCount()) + (await this.getNoteIndexQueueCount());
+			};
+			let total = await queueCount();
 			// Items drained so far, tracked across processor calls so the bar can advance after each
 			// batch within a call rather than only once per loop iteration
 			let done = 0;
@@ -1566,7 +1727,7 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 					await Zotero.Promise.delay(5000);
 					continue;
 				}
-				let remaining = await this.getAttachmentIndexQueueCount();
+				let remaining = await queueCount();
 				if (remaining == 0) {
 					break;
 				}
@@ -1592,6 +1753,10 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 				done = base + await this.processAttachmentIndexQueue(
 					{ maxTime: 1000, onProgress: n => updateProgress(base + n) }
 				);
+				base = done;
+				done = base + await this.processNoteIndexQueue(
+					{ maxTime: 1000, onProgress: n => updateProgress(base + n) }
+				);
 			}
 			if (itemProgress) {
 				itemProgress.setProgress(100);
@@ -1607,7 +1772,7 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 			// Index never-before-indexed attachments (e.g., added while indexing was off) gently in
 			// the background -- they were never searchable, so unlike the migration above they can
 			// wait for idle
-			if ((await this.getAttachmentIndexQueueCount()) > 0
+			if ((await queueCount()) > 0
 					|| (await this.getAttachmentExtractionQueueCount()) > 0) {
 				this.registerQueueDrainObserver();
 			}
@@ -1630,12 +1795,14 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 	 */
 	this.optimizeContentIndex = async function () {
 		try {
-			await Zotero.DB.queryAsync(
-				"INSERT INTO ftindex.fulltextContent(fulltextContent) VALUES('optimize')"
-			);
-			await Zotero.DB.queryAsync(
-				"INSERT INTO ftindex.fulltextContentCJK(fulltextContentCJK) VALUES('optimize')"
-			);
+			for (let tables of [_contentTables, _noteTables]) {
+				await Zotero.DB.queryAsync(
+					`INSERT INTO ftindex.${tables.trigram}(${tables.trigram}) VALUES('optimize')`
+				);
+				await Zotero.DB.queryAsync(
+					`INSERT INTO ftindex.${tables.cjk}(${tables.cjk}) VALUES('optimize')`
+				);
+			}
 		}
 		catch (e) {
 			Zotero.logError(e);
@@ -1698,9 +1865,10 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 	};
 
 
-	// Drain the content and unindexed-item queues in the background on a self-rescheduling timer.
-	// Unlike an OS idle observer, this keeps making progress while Zotero is in the background and
-	// the user works in other apps, and it backs off the moment they return to Zotero.
+	// Drain the content, unindexed-item, and note queues in the background on a self-rescheduling
+	// timer. Unlike an OS idle observer, this keeps making progress while Zotero is in the
+	// background and the user works in other apps, and it backs off the moment they return to
+	// Zotero.
 	function _scheduleQueueDrain(delay) {
 		_queueDrainTimerID = setTimeout(async () => {
 			_queueDrainTimerID = null;
@@ -1711,7 +1879,8 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 					return;
 				}
 				if ((await self.getAttachmentIndexQueueCount()) == 0
-						&& (await self.getAttachmentExtractionQueueCount()) == 0) {
+						&& (await self.getAttachmentExtractionQueueCount()) == 0
+						&& (await self.getNoteIndexQueueCount()) == 0) {
 					// Drained -- compact the index and stop
 					await self.optimizeContentIndex();
 					return;
@@ -1720,6 +1889,7 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 					+ (_isZoteroActive() ? "focused but idle" : "not focused") + ")");
 				await self.processAttachmentIndexQueue({ maxTime: 1000, checkIdle: true });
 				await self.processAttachmentExtractionQueue({ maxTime: 1000, checkIdle: true });
+				await self.processNoteIndexQueue({ maxTime: 1000, checkIdle: true });
 				_scheduleQueueDrain(250);
 			}
 			catch (e) {
@@ -1888,50 +2058,144 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 	}
 
 
+	// The FTS5 table sets, each a trigram table, a CJK 2-gram table, and an index-state side table
+	const _contentTables = {
+		trigram: 'fulltextContent',
+		cjk: 'fulltextContentCJK',
+		state: 'fulltextIndexState'
+	};
+	const _noteTables = {
+		trigram: 'fulltextNotes',
+		cjk: 'fulltextNotesCJK',
+		state: 'fulltextNoteIndexState',
+		// Notes also store their normalized plain text (see setUpContentDB), for the short- and
+		// mixed-script-term LIKE fallback; attachment content has no equivalent
+		text: 'noteText'
+	};
+
+
 	/**
-	 * Index an item's extracted text into the content FTS5 tables and record it in the index-state
-	 * table at the current version. Replaces any existing entries for the item. `text` may be empty
-	 * (e.g., no cache file), in which case the item is simply recorded as indexed with no content.
+	 * Index an item's text into the given FTS5 tables and record it in the corresponding
+	 * index-state table at the current version. Replaces any existing entries for the item. `text`
+	 * may be empty (e.g., no cache file), in which case the item is simply recorded as indexed
+	 * with no content.
 	 *
 	 * Must be called within a transaction.
 	 */
-	async function setContentIndex(itemID, text) {
-		await Zotero.DB.queryAsync("DELETE FROM ftindex.fulltextContent WHERE rowid=?", itemID);
-		await Zotero.DB.queryAsync("DELETE FROM ftindex.fulltextContentCJK WHERE rowid=?", itemID);
+	async function setIndexEntries(itemID, text, tables) {
+		await Zotero.DB.queryAsync(`DELETE FROM ftindex.${tables.trigram} WHERE rowid=?`, itemID);
+		await Zotero.DB.queryAsync(`DELETE FROM ftindex.${tables.cjk} WHERE rowid=?`, itemID);
+		if (tables.text) {
+			await Zotero.DB.queryAsync(`DELETE FROM ftindex.${tables.text} WHERE itemID=?`, itemID);
+		}
 		if (text) {
 			// Skip logging the params, which includes the full text
 			let normalized = Zotero.Utilities.Internal.normalizeForSearch(text) || '';
 			await Zotero.DB.queryAsync(
-				"INSERT INTO ftindex.fulltextContent (rowid, text) VALUES (?, ?)",
+				`INSERT INTO ftindex.${tables.trigram} (rowid, text) VALUES (?, ?)`,
 				[itemID, normalized],
 				{ debugParams: false }
 			);
 			let cjk = getCJKBigrams(normalized);
 			if (cjk) {
 				await Zotero.DB.queryAsync(
-					"INSERT INTO ftindex.fulltextContentCJK (rowid, text) VALUES (?, ?)",
+					`INSERT INTO ftindex.${tables.cjk} (rowid, text) VALUES (?, ?)`,
 					[itemID, cjk],
+					{ debugParams: false }
+				);
+			}
+			// Stored plain text for the LIKE fallback (notes only)
+			if (tables.text) {
+				await Zotero.DB.queryAsync(
+					`INSERT INTO ftindex.${tables.text} (itemID, text) VALUES (?, ?)`,
+					[itemID, normalized],
 					{ debugParams: false }
 				);
 			}
 		}
 		await Zotero.DB.queryAsync(
-			"REPLACE INTO ftindex.fulltextIndexState (itemID, version) VALUES (?, ?)",
+			`REPLACE INTO ftindex.${tables.state} (itemID, version) VALUES (?, ?)`,
 			[itemID, _contentIndexVersion]
 		);
 	}
 
+	function setContentIndex(itemID, text) {
+		return setIndexEntries(itemID, text, _contentTables);
+	}
+
+	async function setNoteIndex(itemID, text) {
+		await setIndexEntries(itemID, text, _noteTables);
+		// Now indexed at the current version, so it's no longer stale
+		_staleNoteText.delete(itemID);
+	}
+
 
 	/**
-	 * Remove an item's entries from the content FTS5 tables and the index-state table.
+	 * Flag a note as edited since its last index update, without re-indexing it. Called on every
+	 * note save, so it must stay cheap: it writes a one-row version-0 marker (instead of rebuilding
+	 * the note's FTS entries on each auto-save) and caches the note's normalized plain text in
+	 * memory, so a search before the background queue re-indexes the note matches it with the same
+	 * normalized, plain-text semantics as the index. Kicks the queue so the note is re-indexed once
+	 * Zotero is idle.
+	 *
+	 * Must be called within a transaction.
+	 *
+	 * @param {Number} itemID
+	 * @param {String} note - The note's HTML
+	 */
+	this.flagNoteStale = async function (itemID, note) {
+		await Zotero.DB.queryAsync(
+			"REPLACE INTO ftindex.fulltextNoteIndexState (itemID, version) VALUES (?, 0)",
+			itemID
+		);
+		_staleNoteText.set(itemID, _normalizeNoteText(note));
+		this.registerQueueDrainObserver();
+	};
+
+
+	/**
+	 * Extract and normalize a note's searchable plain text from its HTML, matching what the index
+	 * stores: markup is stripped (so it isn't matched) and the text is normalized for case- and
+	 * diacritic-insensitive matching.
+	 */
+	function _normalizeNoteText(note) {
+		if (!note) {
+			return '';
+		}
+		let parserUtils = Cc["@mozilla.org/parserutils;1"].getService(Ci.nsIParserUtils);
+		let text = parserUtils.convertToPlainText(note, Ci.nsIDocumentEncoder.OutputRaw, 0);
+		return Zotero.Utilities.Internal.normalizeForSearch(text) || '';
+	}
+
+
+	/**
+	 * Remove an item's entries from the given FTS5 tables and index-state table.
 	 *
 	 * Must be called within a transaction.
 	 */
-	async function clearContentIndex(itemID) {
-		await Zotero.DB.queryAsync("DELETE FROM ftindex.fulltextContent WHERE rowid=?", itemID);
-		await Zotero.DB.queryAsync("DELETE FROM ftindex.fulltextContentCJK WHERE rowid=?", itemID);
-		await Zotero.DB.queryAsync("DELETE FROM ftindex.fulltextIndexState WHERE itemID=?", itemID);
+	async function clearIndexEntries(itemID, tables) {
+		await Zotero.DB.queryAsync(`DELETE FROM ftindex.${tables.trigram} WHERE rowid=?`, itemID);
+		await Zotero.DB.queryAsync(`DELETE FROM ftindex.${tables.cjk} WHERE rowid=?`, itemID);
+		if (tables.text) {
+			await Zotero.DB.queryAsync(`DELETE FROM ftindex.${tables.text} WHERE itemID=?`, itemID);
+		}
+		await Zotero.DB.queryAsync(`DELETE FROM ftindex.${tables.state} WHERE itemID=?`, itemID);
 	}
+
+	function clearContentIndex(itemID) {
+		return clearIndexEntries(itemID, _contentTables);
+	}
+
+	/**
+	 * Remove an item's entries from the note FTS5 tables and its note-index-state row, e.g., when
+	 * the item is erased (the content database can't FK-cascade to zotero.sqlite).
+	 *
+	 * Must be called within a transaction.
+	 */
+	this.clearNoteIndex = async function (itemID) {
+		await clearIndexEntries(itemID, _noteTables);
+		_staleNoteText.delete(itemID);
+	};
 
 
 	/**
@@ -1942,7 +2206,7 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 	 *
 	 * @return {Object|null} { table, match } or null
 	 */
-	function getContentMatchClause(searchText) {
+	function getMatchClause(searchText, tables) {
 		let normalized = Zotero.Utilities.Internal.normalizeForSearch(searchText);
 		if (!normalized) {
 			return null;
@@ -1956,14 +2220,18 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 			if (!bigrams) {
 				return null;
 			}
-			return { table: 'fulltextContentCJK', match: '"' + bigrams + '"' };
+			return { table: tables.cjk, match: '"' + bigrams + '"' };
 		}
 		// Pure non-CJK: match the whole term as a contiguous phrase (substring) against the
 		// trigram index, which only indexes runs of 3+ characters
 		if (!hasCJK && normalized.length >= 3) {
-			return { table: 'fulltextContent', match: '"' + normalized.replace(/"/g, '""') + '"' };
+			return { table: tables.trigram, match: '"' + normalized.replace(/"/g, '""') + '"' };
 		}
 		return null;
+	}
+
+	function getContentMatchClause(searchText) {
+		return getMatchClause(searchText, _contentTables);
 	}
 
 
@@ -1977,6 +2245,117 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 	 */
 	this.canSearchContent = function (searchText) {
 		return getContentMatchClause(searchText) !== null;
+	};
+
+
+	/**
+	 * Whether a term can be matched against the note index rather than needing a fallback scan of
+	 * the stored note text. Quick search uses this to skip note matching for terms too short for the
+	 * index, avoiding a per-keystroke scan.
+	 *
+	 * @param {String} searchText
+	 * @return {Boolean}
+	 */
+	this.canSearchNotes = function (searchText) {
+		return getMatchClause(searchText, _noteTables) !== null;
+	};
+
+
+	/**
+	 * Resolve a search term to SQL matching it against note text content, for use inside an
+	 * itemNotes subquery by the 'note' search condition.
+	 *
+	 * Returns null only while the note backfill is still running, so the caller falls back to a raw
+	 * LIKE scan of the note HTML and notes stay searchable until the index is built. Once the index
+	 * is ready, a term too short or mixed-script for it (see getMatchClause) is matched by scanning
+	 * notes' normalized plain text instead, so those terms stay searchable without matching markup.
+	 *
+	 * Notes edited since their last index update (marked stale by the save) still hold their
+	 * pre-edit text in the FTS tables, so they're excluded from the index match and matched instead
+	 * against their current normalized plain text held in memory -- the same semantics as the index
+	 * -- so a just-edited note matches consistently before the background queue re-indexes it.
+	 *
+	 * @param {String} searchText
+	 * @return {Promise<Object|null>} { sql, params }, or null to fall back to a raw scan
+	 */
+	this.getNoteContentSQL = async function (searchText) {
+		if (!_noteIndexReady) {
+			// Until every note has an index-state row (indexed or marked stale), the index can't
+			// be relied on, so return null and let the caller fall back to a raw scan -- markup and
+			// all -- to keep notes searchable during the one-time post-upgrade backfill
+			let pending = await Zotero.DB.valueQueryAsync(
+				"SELECT COUNT(*) FROM itemNotes N "
+				+ "LEFT JOIN ftindex.fulltextNoteIndexState S USING (itemID) "
+				+ "WHERE S.itemID IS NULL OR (S.version > 0 AND S.version < ?)",
+				[_contentIndexVersion]
+			);
+			if (pending) {
+				return null;
+			}
+			_noteIndexReady = true;
+		}
+
+		let normalizedTerm = Zotero.Utilities.Internal.normalizeForSearch(searchText);
+		if (!normalizedTerm) {
+			return { sql: '0', params: [] };
+		}
+
+		// Resolve the term to a predicate over the note index. A term the FTS index can answer uses
+		// its MATCH; a term too short (Western) or mixed-script for it -- the trigram index covers
+		// Latin runs of 3+ characters and the CJK index 2+ -- instead LIKEs the stored normalized
+		// plain text. Either way it matches the notes' stripped, normalized text, so markup isn't
+		// matched (e.g. "re" hitting "red" in a style attribute) and matching stays case- and
+		// diacritic-insensitive.
+		let clause = getMatchClause(searchText, _noteTables);
+		let indexMatch, indexParams;
+		if (clause) {
+			indexMatch = "itemID IN (SELECT rowid FROM ftindex." + clause.table
+				+ " WHERE " + clause.table + " MATCH ?)";
+			indexParams = [clause.match];
+		}
+		else {
+			indexMatch = "itemID IN (SELECT itemID FROM ftindex.noteText WHERE text LIKE ? ESCAPE '\\')";
+			indexParams = ['%' + normalizedTerm.replace(/[\\%_]/g, '\\$&') + '%'];
+		}
+
+		// Match stale notes in memory (see above). Their itemIDs are inlined below rather than
+		// re-queried in the search SQL.
+		let staleIDs = await Zotero.DB.columnQueryAsync(
+			"SELECT itemID FROM ftindex.fulltextNoteIndexState WHERE version=0"
+		);
+		let staleMatches = [];
+		if (staleIDs.length) {
+			let staleSet = new Set(staleIDs);
+			// Drop cached text for notes that are no longer stale
+			for (let id of _staleNoteText.keys()) {
+				if (!staleSet.has(id)) {
+					_staleNoteText.delete(id);
+				}
+			}
+			// Fill any cache misses (e.g., notes flagged stale in a previous session)
+			let missing = staleIDs.filter(id => !_staleNoteText.has(id));
+			if (missing.length) {
+				let rows = await Zotero.DB.queryAsync(
+					"SELECT itemID, note FROM itemNotes WHERE itemID IN (" + missing.join(',') + ")"
+				);
+				for (let row of rows) {
+					_staleNoteText.set(row.itemID, _normalizeNoteText(row.note));
+				}
+			}
+			for (let id of staleIDs) {
+				let text = _staleNoteText.get(id);
+				if (text && text.includes(normalizedTerm)) {
+					staleMatches.push(id);
+				}
+			}
+		}
+
+		let excludeStale = staleIDs.length ? "itemID NOT IN (" + staleIDs.join(',') + ") AND " : "";
+		let staleClause = staleMatches.length ? "itemID IN (" + staleMatches.join(',') + ")" : "0";
+		return {
+			sql: "((" + excludeStale + indexMatch + ") OR " + staleClause + ")",
+			params: indexParams
+		};
 	};
 
 
@@ -2326,12 +2705,21 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 		var sql = "SELECT COUNT(*) FROM fulltextItems WHERE synced = ?";
 		var notAvailable = await Zotero.DB.valueQueryAsync(sql, this.SYNC_STATE_MISSING);
 
-		// Pending work, both auto-draining: items with extracted content not yet in the search index
-		// (remaining) and indexable attachments not yet extracted (unindexedQueue)
+		// Notes in the note index at the current version (excluding ones edited since their last
+		// index update, which are counted in noteQueue until they're re-indexed)
+		var sql = "SELECT COUNT(*) FROM itemNotes N "
+			+ "JOIN ftindex.fulltextNoteIndexState S USING (itemID) "
+			+ "WHERE S.version >= ?";
+		var notesIndexed = await Zotero.DB.valueQueryAsync(sql, _contentIndexVersion);
+
+		// Pending work, all auto-draining: items with extracted content not yet in the search index
+		// (remaining), indexable attachments not yet extracted (unindexedQueue), and notes not yet
+		// indexed or edited since their last index update (noteQueue)
 		var remaining = await this.getAttachmentIndexQueueCount();
 		var unindexedQueue = await this.getAttachmentExtractionQueueCount();
+		var noteQueue = await this.getNoteIndexQueueCount();
 
-		return { indexed, partial, notAvailable, remaining, unindexedQueue };
+		return { indexed, partial, notAvailable, notesIndexed, remaining, unindexedQueue, noteQueue };
 	};
 	
 	
@@ -2481,8 +2869,9 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 
 	/**
 	 * Remove content index entries for items that no longer exist. Normal deletion clears these
-	 * via clearItemWords(), but the content database can't FK-cascade to zotero.sqlite, so this is
-	 * a periodic safety net for items removed through a path that bypassed Item.erase().
+	 * via clearItemWords()/clearNoteIndex(), but the content database can't FK-cascade to
+	 * zotero.sqlite, so this is a periodic safety net for items removed through a path that
+	 * bypassed Item.erase().
 	 *
 	 * @return {Promise}
 	 */
@@ -2494,6 +2883,12 @@ Zotero.Fulltext = Zotero.FullText = new function () {
 				+ "WHERE rowid NOT IN (SELECT itemID FROM fulltextItems)");
 			await Zotero.DB.queryAsync("DELETE FROM ftindex.fulltextIndexState "
 				+ "WHERE itemID NOT IN (SELECT itemID FROM fulltextItems)");
+			await Zotero.DB.queryAsync("DELETE FROM ftindex.fulltextNotes "
+				+ "WHERE rowid NOT IN (SELECT itemID FROM itemNotes)");
+			await Zotero.DB.queryAsync("DELETE FROM ftindex.fulltextNotesCJK "
+				+ "WHERE rowid NOT IN (SELECT itemID FROM itemNotes)");
+			await Zotero.DB.queryAsync("DELETE FROM ftindex.fulltextNoteIndexState "
+				+ "WHERE itemID NOT IN (SELECT itemID FROM itemNotes)");
 		});
 	};
 

--- a/chrome/content/zotero/xpcom/schema.js
+++ b/chrome/content/zotero/xpcom/schema.js
@@ -3672,19 +3672,12 @@ Zotero.Schema = new function () {
 				await Zotero.DB.queryAsync("DROP TABLE IF EXISTS fulltextItemWords");
 				await Zotero.DB.queryAsync("DROP TABLE IF EXISTS fulltextWords");
 				Zotero.Prefs.clear('vacuum.lastTime');
-			}
 
-			// The condition 'required' flag was removed, but its savedSearchConditions column
-			// is kept for now so older code can still read the database (it SELECTs the column
-			// when loading saved searches). TODO: with the next userdata compatibility bump,
-			// bump the version and uncomment the migration below to drop the column.
-			//
-			// else if (i == 128) {
-			// 	await Zotero.DB.queryAsync("ALTER TABLE savedSearchConditions RENAME TO savedSearchConditionsOld");
-			// 	await Zotero.DB.queryAsync("CREATE TABLE savedSearchConditions (\n    savedSearchID INT NOT NULL,\n    searchConditionID INT NOT NULL,\n    condition TEXT NOT NULL,\n    operator TEXT,\n    value TEXT,\n    PRIMARY KEY (savedSearchID, searchConditionID),\n    FOREIGN KEY (savedSearchID) REFERENCES savedSearches(savedSearchID) ON DELETE CASCADE\n)");
-			// 	await Zotero.DB.queryAsync("INSERT INTO savedSearchConditions SELECT savedSearchID, searchConditionID, condition, operator, value FROM savedSearchConditionsOld");
-			// 	await Zotero.DB.queryAsync("DROP TABLE savedSearchConditionsOld");
-			// }
+				await Zotero.DB.queryAsync("ALTER TABLE savedSearchConditions RENAME TO savedSearchConditionsOld");
+				await Zotero.DB.queryAsync("CREATE TABLE savedSearchConditions (\n    savedSearchID INT NOT NULL,\n    searchConditionID INT NOT NULL,\n    condition TEXT NOT NULL,\n    operator TEXT,\n    value TEXT,\n    PRIMARY KEY (savedSearchID, searchConditionID),\n    FOREIGN KEY (savedSearchID) REFERENCES savedSearches(savedSearchID) ON DELETE CASCADE\n)");
+				await Zotero.DB.queryAsync("INSERT INTO savedSearchConditions SELECT savedSearchID, searchConditionID, condition, operator, value FROM savedSearchConditionsOld");
+				await Zotero.DB.queryAsync("DROP TABLE savedSearchConditionsOld");
+			}
 
 			// If breaking compatibility or doing anything dangerous, clear minorUpdateFrom
 		}

--- a/chrome/content/zotero/xpcom/schema.js
+++ b/chrome/content/zotero/xpcom/schema.js
@@ -46,7 +46,7 @@ Zotero.Schema = new function () {
 	var _dbVersions = [];
 	var _schemaVersions = [];
 	// Update when adding _updateCompatibility() line to schema update step
-	var _maxCompatibility = 8;
+	var _maxCompatibility = 9;
 	
 	var _repositoryTimerID;
 	var _repositoryNotificationTimerID;
@@ -2099,11 +2099,6 @@ Zotero.Schema = new function () {
 				"DELETE FROM creators WHERE firstName='' AND lastName=''"
 			],
 
-			// Non-attachment items in the full-text index
-			[
-				`SELECT COUNT(*) > 0 FROM fulltextItemWords WHERE itemID NOT IN (SELECT itemID FROM items WHERE itemTypeID=${attachmentID})`,
-				`DELETE FROM fulltextItemWords WHERE itemID NOT IN (SELECT itemID FROM items WHERE itemTypeID=${attachmentID})`
-			],
 			// Full-text items must be attachments
 			[
 				`SELECT COUNT(*) > 0 FROM fulltextItems WHERE itemID NOT IN (SELECT itemID FROM items WHERE itemTypeID=${attachmentID})`,
@@ -3671,12 +3666,20 @@ Zotero.Schema = new function () {
 				await Zotero.DB.queryAsync("REPLACE INTO settings VALUES ('search', 'normalizeBackfill', 1)");
 			}
 
+			else if (i == 127) {
+				await _updateCompatibility(9);
+
+				await Zotero.DB.queryAsync("DROP TABLE IF EXISTS fulltextItemWords");
+				await Zotero.DB.queryAsync("DROP TABLE IF EXISTS fulltextWords");
+				Zotero.Prefs.clear('vacuum.lastTime');
+			}
+
 			// The condition 'required' flag was removed, but its savedSearchConditions column
 			// is kept for now so older code can still read the database (it SELECTs the column
 			// when loading saved searches). TODO: with the next userdata compatibility bump,
 			// bump the version and uncomment the migration below to drop the column.
 			//
-			// else if (i == 127) {
+			// else if (i == 128) {
 			// 	await Zotero.DB.queryAsync("ALTER TABLE savedSearchConditions RENAME TO savedSearchConditionsOld");
 			// 	await Zotero.DB.queryAsync("CREATE TABLE savedSearchConditions (\n    savedSearchID INT NOT NULL,\n    searchConditionID INT NOT NULL,\n    condition TEXT NOT NULL,\n    operator TEXT,\n    value TEXT,\n    PRIMARY KEY (savedSearchID, searchConditionID),\n    FOREIGN KEY (savedSearchID) REFERENCES savedSearches(savedSearchID) ON DELETE CASCADE\n)");
 			// 	await Zotero.DB.queryAsync("INSERT INTO savedSearchConditions SELECT savedSearchID, searchConditionID, condition, operator, value FROM savedSearchConditionsOld");

--- a/chrome/content/zotero/xpcom/schema.js
+++ b/chrome/content/zotero/xpcom/schema.js
@@ -46,7 +46,7 @@ Zotero.Schema = new function () {
 	var _dbVersions = [];
 	var _schemaVersions = [];
 	// Update when adding _updateCompatibility() line to schema update step
-	var _maxCompatibility = 7;
+	var _maxCompatibility = 8;
 	
 	var _repositoryTimerID;
 	var _repositoryNotificationTimerID;
@@ -748,8 +748,136 @@ Zotero.Schema = new function () {
 		
 		Zotero.debug(`Migrated fields from Extra for ${items.length} items in ${new Date() - t} ms`);
 	};
-	
-	
+
+
+	/**
+	 * Populate the normalized search columns added by the userdata 126 migration
+	 *
+	 * Resumable across restarts: a cursor is persisted to the 'normalizeBackfill' setting
+	 * after each chunk, and the setting is only cleared once every table is done. New rows are
+	 * populated at insert time by the data layer, so only pre-existing rows are handled here.
+	 *
+	 * @param {Function} [onProgress] - Called with { progress, progressMax } as rows are processed
+	 */
+	this.populateNormalizedSearchColumns = async function ({ onProgress } = {}) {
+		var flag = await Zotero.DB.valueQueryAsync(
+			"SELECT value FROM settings WHERE setting='search' AND key='normalizeBackfill'"
+		);
+		if (flag === false) {
+			return;
+		}
+
+		Zotero.debug("Populating normalized search columns");
+		var startTime = new Date();
+		var normalize = Zotero.Utilities.Internal.normalizeForSearchStorage;
+
+		// Each table's primary key and the [source, target] column pairs to normalize
+		var tables = [
+			{
+				table: 'itemDataValues',
+				idColumn: 'valueID',
+				columns: [['value', 'valueNormalized']]
+			},
+			{
+				table: 'tags',
+				idColumn: 'tagID',
+				columns: [['name', 'nameNormalized']]
+			},
+			{
+				table: 'creators',
+				idColumn: 'creatorID',
+				columns: [['firstName', 'firstNameNormalized'], ['lastName', 'lastNameNormalized']]
+			},
+			{
+				table: 'itemAnnotations',
+				idColumn: 'itemID',
+				columns: [['text', 'textNormalized'], ['comment', 'commentNormalized']]
+			}
+		];
+
+		// Resume from a persisted cursor, if any
+		var startTableIndex = 0;
+		var startCursor = 0;
+		try {
+			let parsed = JSON.parse(flag);
+			if (parsed && Number.isInteger(parsed.ti)) {
+				startTableIndex = parsed.ti;
+				startCursor = parsed.id || 0;
+			}
+		}
+		catch (e) {}
+
+		const CHUNK_SIZE = 1000;
+		var progress = 0;
+		var progressMax = 0;
+		for (let { table } of tables) {
+			progressMax += await Zotero.DB.valueQueryAsync(`SELECT COUNT(*) FROM ${table}`);
+		}
+		if (onProgress) {
+			onProgress({ progress, progressMax });
+		}
+
+		for (let ti = startTableIndex; ti < tables.length; ti++) {
+			let { table, idColumn, columns } = tables[ti];
+			let sourceColumns = columns.map(c => c[0]);
+			let cursor = ti == startTableIndex ? startCursor : 0;
+
+			while (true) {
+				let rows = await Zotero.DB.queryAsync(
+					`SELECT ${idColumn}, ${sourceColumns.join(', ')} FROM ${table} `
+						+ `WHERE ${idColumn} > ? ORDER BY ${idColumn} LIMIT ?`,
+					[cursor, CHUNK_SIZE]
+				);
+				if (!rows.length) {
+					break;
+				}
+
+				await Zotero.DB.executeTransaction(async function () {
+					for (let row of rows) {
+						let sets = [];
+						let params = [];
+						for (let [source, target] of columns) {
+							let value = normalize(row[source]);
+							// Skip columns that don't need a normalized form
+							if (value !== null) {
+								sets.push(`${target}=?`);
+								params.push(value);
+							}
+						}
+						// Most rows are plain ASCII and need no update at all
+						if (sets.length) {
+							params.push(row[idColumn]);
+							// Skip logging the params, which include the full normalized value
+							await Zotero.DB.queryAsync(
+								`UPDATE ${table} SET ${sets.join(', ')} WHERE ${idColumn}=?`,
+								params,
+								{ debugParams: false }
+							);
+						}
+						cursor = row[idColumn];
+					}
+
+					// Persist the cursor in the same transaction as the updates
+					await Zotero.DB.queryAsync(
+						"REPLACE INTO settings VALUES ('search', 'normalizeBackfill', ?)",
+						JSON.stringify({ ti, id: cursor })
+					);
+				});
+
+				progress += rows.length;
+				if (onProgress) {
+					onProgress({ progress, progressMax });
+				}
+			}
+		}
+
+		await Zotero.DB.queryAsync(
+			"DELETE FROM settings WHERE setting='search' AND key='normalizeBackfill'"
+		);
+		Zotero.debug(`Populated normalized search columns in ${new Date() - startTime} ms`);
+	};
+
+
 	// https://www.zotero.org/support/nsf
 	//
 	// This is mostly temporary
@@ -1970,7 +2098,7 @@ Zotero.Schema = new function () {
 				"SELECT COUNT(*) > 0 FROM creators WHERE firstName='' AND lastName=''",
 				"DELETE FROM creators WHERE firstName='' AND lastName=''"
 			],
-			
+
 			// Non-attachment items in the full-text index
 			[
 				`SELECT COUNT(*) > 0 FROM fulltextItemWords WHERE itemID NOT IN (SELECT itemID FROM items WHERE itemTypeID=${attachmentID})`,
@@ -3531,12 +3659,24 @@ Zotero.Schema = new function () {
 				await Zotero.DB.queryAsync("UPDATE groups SET version = 0");
 			}
 
+			else if (i == 126) {
+				await _updateCompatibility(8);
+
+				await Zotero.DB.queryAsync("ALTER TABLE itemDataValues ADD COLUMN valueNormalized TEXT");
+				await Zotero.DB.queryAsync("ALTER TABLE tags ADD COLUMN nameNormalized TEXT");
+				await Zotero.DB.queryAsync("ALTER TABLE creators ADD COLUMN firstNameNormalized TEXT");
+				await Zotero.DB.queryAsync("ALTER TABLE creators ADD COLUMN lastNameNormalized TEXT");
+				await Zotero.DB.queryAsync("ALTER TABLE itemAnnotations ADD COLUMN textNormalized TEXT");
+				await Zotero.DB.queryAsync("ALTER TABLE itemAnnotations ADD COLUMN commentNormalized TEXT");
+				await Zotero.DB.queryAsync("REPLACE INTO settings VALUES ('search', 'normalizeBackfill', 1)");
+			}
+
 			// The condition 'required' flag was removed, but its savedSearchConditions column
 			// is kept for now so older code can still read the database (it SELECTs the column
 			// when loading saved searches). TODO: with the next userdata compatibility bump,
 			// bump the version and uncomment the migration below to drop the column.
 			//
-			// else if (i == 126) {
+			// else if (i == 127) {
 			// 	await Zotero.DB.queryAsync("ALTER TABLE savedSearchConditions RENAME TO savedSearchConditionsOld");
 			// 	await Zotero.DB.queryAsync("CREATE TABLE savedSearchConditions (\n    savedSearchID INT NOT NULL,\n    searchConditionID INT NOT NULL,\n    condition TEXT NOT NULL,\n    operator TEXT,\n    value TEXT,\n    PRIMARY KEY (savedSearchID, searchConditionID),\n    FOREIGN KEY (savedSearchID) REFERENCES savedSearches(savedSearchID) ON DELETE CASCADE\n)");
 			// 	await Zotero.DB.queryAsync("INSERT INTO savedSearchConditions SELECT savedSearchID, searchConditionID, condition, operator, value FROM savedSearchConditionsOld");

--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -36,6 +36,100 @@ ChromeUtils.defineESModuleGetters(globalThis, {
 Zotero.Utilities.Internal = {
 	SNAPSHOT_SAVE_TIMEOUT: 30000,
 
+	// Characters that NFKD leaves in a non-ASCII form: letters with no decomposition (letter
+	// ligatures and others) and the fraction slash NFKD introduces (½ -> "1⁄2"). Converted via an
+	// explicit map applied after NFKD/lowercasing, so that e.g. a search for "soren" matches
+	// "Søren" and "1/2" matches "½". Typographic ligatures (ﬁ, ﬂ, ...), superscripts, full-width
+	// forms, etc. don't need an entry -- NFKD already reduces those to ASCII.
+	_searchNormalizeMap: {
+		'ø': 'o',
+		'œ': 'oe',
+		'æ': 'ae',
+		'ł': 'l',
+		'đ': 'd',
+		'ð': 'd',
+		'þ': 'th',
+		'ß': 'ss',
+		'ı': 'i',
+		'⁄': '/'
+	},
+
+	// The rich-text formatting tags Zotero supports in item fields (see the rich-text bibliography
+	// support page). Stripped when normalizing so search matches the field's plain text: a phrase
+	// isn't broken across a formatted word (e.g., an italicized species name) and the tag markup
+	// itself isn't matchable. Only this whitelist is stripped, so literal angle brackets in a value
+	// stay searchable.
+	_searchFormattingTagRE: /<\/?(?:i|b|sub|sup)>|<span (?:style="font-variant:small-caps;"|class="nocase")>|<\/span>/g,
+
+
+	/**
+	 * Normalize a string to a case- and accent-insensitive form for searching
+	 *
+	 * Strips Zotero's supported field formatting tags (see _searchFormattingTagRE), then uses
+	 * Unicode NFKD compatibility decomposition (ICU-backed) to split combining marks off their base
+	 * letters and reduce presentation variants (typographic ligatures, superscripts, full-width
+	 * forms, etc.) to plain ASCII, strips the marks, converts a few non-decomposing letters via
+	 * _searchNormalizeMap, and folds typographic quotes and dashes to their ASCII forms. This is the
+	 * form stored in the normalized search columns and applied to search terms, so that e.g.
+	 * "seance" matches "séance", "x2" matches "x²", and "children's" matches a curly apostrophe.
+	 *
+	 * If you change this function or _searchNormalizeMap, add a userdata migration step that
+	 * re-normalizes existing rows whose raw value contains the affected characters (scan with
+	 * GLOB/LIKE).
+	 *
+	 * @param {String} str
+	 * @return {String}
+	 */
+	normalizeForSearch: function (str) {
+		if (!str) {
+			return str;
+		}
+		let map = Zotero.Utilities.Internal._searchNormalizeMap;
+		// Strip supported formatting tags so they don't break phrase matches or match themselves
+		if (str.includes('<')) {
+			str = str.replace(Zotero.Utilities.Internal._searchFormattingTagRE, '');
+		}
+		return str.normalize('NFKD').replace(/[\u0300-\u036f]/g, '').toLowerCase()
+			.replace(/[\u00f8\u0153\u00e6\u0142\u0111\u00f0\u00fe\u00df\u0131\u2044]/g, c => map[c])
+			// Fold typographic quotes and dashes to their ASCII forms, which NFKD leaves alone, so
+			// curly quotes and en/em dashes in stored text (from a word processor or translator)
+			// match the straight quotes and hyphens typed in a search. Dashes all fold to a single
+			// hyphen, since that's what a search is typed with.
+			.replace(/[\u2018\u2019\u201a\u201b\u2032]/g, "'")
+			.replace(/[\u201c\u201d\u201e\u201f\u2033]/g, '"')
+			.replace(/[\u2010\u2011\u2012\u2013\u2014\u2015\u2212]/g, '-')
+			// Recompose (NFC) so kana and Hangul that NFKD split apart -- が into か + dakuten,
+			// 한 into jamo -- are put back together. Otherwise their decomposed forms would
+			// substring-match shorter ones under LIKE/instr (か matching が, 하 matching 한). Latin
+			// folding is unaffected: its diacritics were already stripped above, so nothing is
+			// left to recompose.
+			.normalize('NFC');
+	},
+
+
+	/**
+	 * Compute the value to store in a normalized search column for a given source value
+	 *
+	 * Returns the normalized form only when normalizing changes more than the case of ASCII letters,
+	 * which is all SQLite's default LIKE folds; otherwise returns null, so the bulk of plain-ASCII
+	 * values cost nothing and queries fall back to the raw column via COALESCE. A value with folded
+	 * diacritics, folded forms, or non-ASCII case (Greek, Cyrillic, ...) that LIKE wouldn't fold is
+	 * stored, so a normalized search term still matches it.
+	 *
+	 * @param {String} value
+	 * @return {String|null}
+	 */
+	normalizeForSearchStorage: function (value) {
+		if (typeof value != 'string' || !value) {
+			return null;
+		}
+		let normalized = Zotero.Utilities.Internal.normalizeForSearch(value);
+		// Lowercasing only the ASCII letters, so the comparison treats a case difference as
+		// significant unless LIKE would fold it
+		let asciiLowercased = value.replace(/[A-Z]/g, c => c.toLowerCase());
+		return normalized === asciiLowercased ? null : normalized;
+	},
+
 	/**
 	 * Run a function on chunks of a given size of an array's elements.
 	 *

--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -806,7 +806,24 @@ const { CommandLineOptions } = ChromeUtils.importESModule("chrome://zotero/conte
 					progressWin.startCloseTimer(3000);
 				}
 			});
-			
+
+			// Populate normalized search columns after an upgrade. This is local-only derived
+			// data, so we don't need to wait for sync for correctness, but we run after the
+			// initial auto-sync (like the Extra migration) so the backfill doesn't compete with a
+			// large initial download. It's sub-second for typical libraries and chunked so the UI
+			// stays responsive on large ones, and search degrades gracefully until it finishes --
+			// so it runs silently, without a progress window of its own (the full-text content
+			// index shows one for the slower, more visible pass).
+			Zotero.startupSyncPromise.then(async () => {
+				if (Zotero.test) return;
+				try {
+					await Zotero.Schema.populateNormalizedSearchColumns();
+				}
+				catch (e) {
+					Zotero.logError(e);
+				}
+			});
+
 			return true;
 		}
 		catch (e) {

--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -1894,7 +1894,7 @@ const { CommandLineOptions } = ChromeUtils.importESModule("chrome://zotero/conte
 		await Zotero.DB.executeTransaction(async function () {
 			return Zotero.Tags.purge();
 		});
-		await Zotero.Fulltext.purgeUnusedWords();
+		await Zotero.FullText.purgeOrphanedContent();
 		await Zotero.Items.purge();
 		// DEBUG: this might not need to be permanent
 		//yield Zotero.DB.executeTransaction(async function () {

--- a/chrome/locale/en-US/zotero/preferences.ftl
+++ b/chrome/locale/en-US/zotero/preferences.ftl
@@ -145,3 +145,8 @@ preferences-account-switch-text =
     Switching to a different account will remove all { -app-name } data on this computer. Before continuing, make sure all data and files you wish to keep have been synced with the “{ $username }” account or you have a backup of your { -app-name } data directory.
 preferences-account-switch-confirmation-text = remove local data
 preferences-account-switch-accept = Remove Data and Restart
+
+fulltext-index-status-indexing = Indexing { $indexed } of { $total }…
+fulltext-index-status-complete = Search index is up to date
+fulltext-stats-notes-indexed = Notes indexed:
+fulltext-stats-not-available = File or full-text content not available:

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -1095,6 +1095,8 @@ userjs-pref-warning = Some { -app-name } settings have been overridden using an 
 
 migrate-extra-fields-progress-message = Migrating new fields from Extra field
 
+search-normalization-progress-message = Indexing items for search
+
 long-tag-fixer-window-title =
     .title = Split Tags
 long-tag-fixer-button-dont-split =

--- a/chrome/locale/en-US/zotero/zotero.properties
+++ b/chrome/locale/en-US/zotero/zotero.properties
@@ -699,12 +699,6 @@ zotero.preferences.sync.reset.restartToComplete			= Firefox must be restarted to
 zotero.preferences.sync.reset.fileSyncHistory          = On the next sync, %1$S will check all attachment files in “%2$S” against the storage service. Any remote attachment files that are missing locally will be downloaded, and local attachment files missing remotely will be uploaded.\n\nThis option is not necessary during normal usage.
 zotero.preferences.sync.reset.fileSyncHistory.cleared  = The file sync history for “%S” has been cleared.
 
-zotero.preferences.search.rebuildIndex						= Rebuild Index
-zotero.preferences.search.rebuildWarning					= Do you want to rebuild the entire index? This may take a while.\n\nTo index only items that haven't been indexed, use %S.
-zotero.preferences.search.clearIndex						= Clear Index
-zotero.preferences.search.clearWarning						= After clearing the index, attachment content will no longer be searchable.\n\nWeb link attachments cannot be reindexed without revisiting the page. To leave web links indexed, choose %S.
-zotero.preferences.search.clearNonLinkedURLs				= Clear All Except Web Links
-zotero.preferences.search.indexUnindexed					= Index Unindexed Items
 zotero.preferences.export.quickCopy.citationStyles        = Citation Styles
 zotero.preferences.export.quickCopy.exportFormats			= Export Formats
 zotero.preferences.export.quickCopy.instructions			= Quick Copy allows you to quickly export items in a given format. You can copy selected items to the clipboard by pressing %S or drag items directly into a text box in another program.

--- a/resource/schema/userdata.sql
+++ b/resource/schema/userdata.sql
@@ -1,4 +1,4 @@
--- 125
+-- 126
 
 -- Copyright (c) 2009 Center for History and New Media
 --                    George Mason University, Fairfax, Virginia, USA
@@ -172,7 +172,8 @@ CREATE INDEX items_synced ON items(synced);
 
 CREATE TABLE itemDataValues (
     valueID INTEGER PRIMARY KEY,
-    value UNIQUE
+    value UNIQUE,
+    valueNormalized TEXT
 );
 
 -- Type-specific data for individual items
@@ -229,7 +230,9 @@ CREATE TABLE itemAnnotations (
     type INTEGER NOT NULL,
     authorName TEXT,
     text TEXT,
+    textNormalized TEXT,
     comment TEXT,
+    commentNormalized TEXT,
     color TEXT,
     pageLabel TEXT,
     sortIndex TEXT NOT NULL,
@@ -242,7 +245,8 @@ CREATE INDEX itemAnnotations_parentItemID ON itemAnnotations(parentItemID);
 
 CREATE TABLE tags (
     tagID INTEGER PRIMARY KEY,
-    name TEXT NOT NULL UNIQUE
+    name TEXT NOT NULL UNIQUE,
+    nameNormalized TEXT
 );
 
 CREATE TABLE itemRelations (
@@ -271,6 +275,8 @@ CREATE TABLE creators (
     firstName TEXT,
     lastName TEXT,
     fieldMode INT,
+    firstNameNormalized TEXT,
+    lastNameNormalized TEXT,
     UNIQUE (lastName, firstName, fieldMode)
 );
 

--- a/resource/schema/userdata.sql
+++ b/resource/schema/userdata.sql
@@ -369,7 +369,6 @@ CREATE TABLE savedSearchConditions (
     condition TEXT NOT NULL,
     operator TEXT,
     value TEXT,
-    required NONE,
     PRIMARY KEY (savedSearchID, searchConditionID),
     FOREIGN KEY (savedSearchID) REFERENCES savedSearches(savedSearchID) ON DELETE CASCADE
 );

--- a/resource/schema/userdata.sql
+++ b/resource/schema/userdata.sql
@@ -1,4 +1,4 @@
--- 126
+-- 127
 
 -- Copyright (c) 2009 Center for History and New Media
 --                    George Mason University, Fairfax, Virginia, USA
@@ -453,20 +453,6 @@ CREATE TABLE fulltextItems (
 );
 CREATE INDEX fulltextItems_synced ON fulltextItems(synced);
 CREATE INDEX fulltextItems_version ON fulltextItems(version);
-
-CREATE TABLE fulltextWords (
-    wordID INTEGER PRIMARY KEY,
-    word TEXT UNIQUE
-);
-
-CREATE TABLE fulltextItemWords (
-    wordID INT,
-    itemID INT,
-    PRIMARY KEY (wordID, itemID),
-    FOREIGN KEY (wordID) REFERENCES fulltextWords(wordID),
-    FOREIGN KEY (itemID) REFERENCES items(itemID) ON DELETE CASCADE
-);
-CREATE INDEX fulltextItemWords_itemID ON fulltextItemWords(itemID);
 
 CREATE TABLE syncCache (
     libraryID INT NOT NULL,

--- a/scss/preferences/_advanced.scss
+++ b/scss/preferences/_advanced.scss
@@ -81,12 +81,20 @@
 	margin-top: 0 !important;
 }
 
-#fulltext-stats > .form-grid > label:nth-child(odd)
-{
-	text-align: end;
+#fulltext-stats-grid label + label {
+	margin-inline-start: 0.35em;
 }
 
-#updateButton, #fulltext-clearIndex {
+#fulltext-stats-progress-label {
+	margin-inline-start: 12px;
+}
+
+#fulltext-stats-progress-box,
+#fulltext-stats-complete {
+	margin-bottom: 8px;
+}
+
+#updateButton {
 	margin-inline-start: 6px;
 }
 

--- a/test/tests/collectionTreeTest.js
+++ b/test/tests/collectionTreeTest.js
@@ -1859,6 +1859,15 @@ describe("Zotero.CollectionTree", function () {
 			});
 		}
 
+		it('should match an accented collection name from an unaccented filter', async function () {
+			var collection = await createDataObject('collection', { name: "zdiacrésumé", libraryID: userLibraryID });
+			await cv.setFilter("zdiacresume");
+			let displayedNames = cv._rows.filter(row => row.type == "collection").map(row => row.ref.name);
+			assert.include(displayedNames, "zdiacrésumé");
+			await cv.setFilter("");
+			await collection.eraseTx();
+		});
+
 		it('should show non-passing entries whose children pass the filter', async function () {
 			await cv.setFilter("three");
 			let displayedRowNames = cv._rows.filter(row => row.type == "collection").map(row => row.ref.name);

--- a/test/tests/fulltextTest.js
+++ b/test/tests/fulltextTest.js
@@ -234,7 +234,7 @@ describe("Zotero.FullText", function () {
 		it("should store data in .zotero-ft-unprocessed file", async function () {
 			var item = await importFileAttachment('test.pdf');
 			
-			var processorCacheFile = Zotero.Fulltext.getItemProcessorCacheFile(item).path;
+			var processorCacheFile = Zotero.Fulltext.getSyncedContentCacheFile(item).path;
 			
 			var version = 5;
 			await Zotero.Fulltext.setItemContent(
@@ -266,7 +266,7 @@ describe("Zotero.FullText", function () {
 				[item.id, Zotero.FullText.SYNC_STATE_UNSYNCED]
 			);
 			
-			var processorCacheFile = Zotero.FullText.getItemProcessorCacheFile(item).path;
+			var processorCacheFile = Zotero.FullText.getSyncedContentCacheFile(item).path;
 			var itemCacheFile = Zotero.FullText.getItemCacheFile(item).path;
 			await Zotero.File.putContentsAsync(itemCacheFile, "Test");
 			
@@ -317,7 +317,7 @@ describe("Zotero.FullText", function () {
 				version
 			);
 			
-			var processorCacheFile = Zotero.FullText.getItemProcessorCacheFile(item).path;
+			var processorCacheFile = Zotero.FullText.getSyncedContentCacheFile(item).path;
 			var itemCacheFile = Zotero.FullText.getItemCacheFile(item).path;
 			
 			assert.isTrue(await OS.File.exists(processorCacheFile));
@@ -356,7 +356,7 @@ describe("Zotero.FullText", function () {
 				version
 			);
 			
-			var processorCacheFile = Zotero.FullText.getItemProcessorCacheFile(item).path;
+			var processorCacheFile = Zotero.FullText.getSyncedContentCacheFile(item).path;
 			var itemCacheFile = Zotero.FullText.getItemCacheFile(item).path;
 			
 			assert.isTrue(await OS.File.exists(processorCacheFile));

--- a/test/tests/fulltextTest.js
+++ b/test/tests/fulltextTest.js
@@ -242,6 +242,93 @@ describe("Zotero.FullText", function () {
 			);
 			assert.notInclude(await contentSearch(item, 'instancemismatch'), item.id);
 		});
+
+		describe("Note indexing", function () {
+			async function createNote(noteText) {
+				let item = new Zotero.Item('note');
+				item.setNote(noteText);
+				await item.saveTx();
+				return item;
+			}
+
+			function noteSearch(item, value) {
+				let s = new Zotero.Search();
+				s.libraryID = item.libraryID;
+				s.addCondition('note', 'contains', value);
+				return s.search();
+			}
+
+			it("should match note content case- and diacritic-insensitively via the index", async function () {
+				let item = await createNote("<p>zqnnThe Séance was held at dawn</p>");
+				await Zotero.FullText.processNoteIndexQueue();
+				assert.include(await noteSearch(item, 'zqnnthe seance'), item.id);
+			});
+
+			it("should match a just-edited note before it's re-indexed", async function () {
+				let item = await createNote("<p>zqnnoriginal content</p>");
+				await Zotero.FullText.processNoteIndexQueue();
+				item.setNote('<p style="color: red">zqnnréplacement content</p>');
+				await item.saveTx();
+				// The edit is matched right away, without waiting for background re-indexing, with
+				// the same accent-insensitive matching as the index (é folded)...
+				assert.include(await noteSearch(item, 'zqnnreplacement'), item.id);
+				// ...the old content no longer matches...
+				assert.notInclude(await noteSearch(item, 'zqnnoriginal'), item.id);
+				// ...and markup isn't matched
+				assert.notInclude(await noteSearch(item, 'color: red'), item.id);
+			});
+
+			it("should not match note markup", async function () {
+				let item = await createNote('<p style="color: red">zqnnstyled text</p>');
+				await Zotero.FullText.processNoteIndexQueue();
+				assert.include(await noteSearch(item, 'zqnnstyled'), item.id);
+				assert.notInclude(await noteSearch(item, 'color: red'), item.id);
+			});
+
+			it("should scan plain text but not markup for a term too short for the index", async function () {
+				// "ai" and "re" are too short to index, so they fall back to scanning the note's
+				// normalized plain text. "ai" is in the text and matches; "re" appears only in "red"
+				// in the style attribute, so scanning plain text (not raw HTML) doesn't match it.
+				let item = await createNote('<p style="color: red">zqnn ai content</p>');
+				await Zotero.FullText.processNoteIndexQueue();
+				assert.include(await noteSearch(item, 'ai'), item.id);
+				assert.notInclude(await noteSearch(item, 're'), item.id);
+			});
+
+			it("should match a mixed-script note term via the plain-text fallback", async function () {
+				// A mixed CJK/non-CJK term suits neither index, so it falls back to the plain-text scan
+				let item = await createNote("<p>zqnn研究ai</p>");
+				await Zotero.FullText.processNoteIndexQueue();
+				assert.include(await noteSearch(item, '究ai'), item.id);
+			});
+
+			it("should exclude a matching note with doesNotContain", async function () {
+				let item = await createNote("<p>zqnnexcludable content</p>");
+				await Zotero.FullText.processNoteIndexQueue();
+				let s = new Zotero.Search();
+				s.libraryID = item.libraryID;
+				s.addCondition('note', 'doesNotContain', 'zqnnexcludable');
+				assert.notInclude(await s.search(), item.id);
+			});
+
+			it("should fall back to scanning the HTML until the note backfill finishes", async function () {
+				let item = await createNote("<p>zqnnbackfill séance</p>");
+				// Rebuild the index (as after a delete-and-resync), leaving every note pending
+				// backfill
+				await Zotero.DB.queryAsync(
+					"UPDATE ftindex.fulltextIndexMeta SET value='xxxxxxxx' WHERE key='localUserKey'"
+				);
+				await Zotero.DB.vacuum({ force: true });
+				// The reconnect's index setup (which drops the mismatched tables) runs on the next
+				// query, as at startup before searches resume
+				await Zotero.DB.queryAsync("SELECT 1");
+				// The note isn't in the index yet, but an exact term still matches via the scan
+				assert.include(await noteSearch(item, 'zqnnbackfill'), item.id);
+				// Draining the queue enables diacritic-insensitive index matching
+				await Zotero.FullText.processNoteIndexQueue();
+				assert.include(await noteSearch(item, 'zqnnbackfill seance'), item.id);
+			});
+		});
 	});
 
 	describe("Indexing", function () {

--- a/test/tests/fulltextTest.js
+++ b/test/tests/fulltextTest.js
@@ -1,4 +1,249 @@
 describe("Zotero.FullText", function () {
+	describe("Content database", function () {
+		async function createTextAttachment(content) {
+			let tmpDir = await getTempDirectory();
+			let path = OS.Path.join(tmpDir, Zotero.Utilities.randomString() + ".txt");
+			await Zotero.File.putContentsAsync(path, content);
+			return Zotero.Attachments.importFromFile({
+				file: path,
+				contentType: 'text/plain',
+				charset: 'utf-8'
+			});
+		}
+
+		function contentSearch(item, value) {
+			let s = new Zotero.Search();
+			s.libraryID = item.libraryID;
+			s.addCondition('fulltextContent', 'contains', value);
+			return s.search();
+		}
+
+		it("should match content case- and diacritic-insensitively", async function () {
+			let item = await createTextAttachment("The Séance was held at dawn");
+			assert.include(await contentSearch(item, 'seance'), item.id);
+			assert.include(await contentSearch(item, 'SÉANCE'), item.id);
+		});
+
+		it("should match a substring spanning a word boundary", async function () {
+			let item = await createTextAttachment("the quick brown fox");
+			// "ck bro" spans the space between two words, so the word index can't match it
+			assert.include(await contentSearch(item, 'ck bro'), item.id);
+		});
+
+		it("should match a term too short for the trigram index via fallback", async function () {
+			let item = await createTextAttachment("the quick brown fox");
+			// "fo" is shorter than a trigram, so this exercises the cached-text scan fallback
+			assert.include(await contentSearch(item, 'fo'), item.id);
+		});
+
+		it("should fold diacritics in the short-query fallback", async function () {
+			let item = await createTextAttachment("zzcafé latte");
+			// "fe" is too short for the trigram index, so it hits the cached-text scan; it should
+			// still match "café" (folding é -> e), consistent with the index path
+			assert.include(await contentSearch(item, 'fe'), item.id);
+		});
+
+		it("should match a 2-character CJK query (trigram can't)", async function () {
+			let item = await createTextAttachment("中文搜索系统设计");
+			assert.include(await contentSearch(item, '搜索'), item.id);
+		});
+
+		it("should match a longer CJK substring within a run", async function () {
+			let item = await createTextAttachment("中文搜索系统设计");
+			assert.include(await contentSearch(item, '搜索系统'), item.id);
+		});
+
+		it("should distinguish voiced and unvoiced kana in CJK content", async function () {
+			let item = await createTextAttachment("研究がん");
+			assert.include(await contentSearch(item, 'がん'), item.id);
+			assert.notInclude(await contentSearch(item, 'かん'), item.id);
+		});
+
+		it("should not match an unrelated CJK document", async function () {
+			let item = await createTextAttachment("天气预报很准确");
+			let other = await createTextAttachment("中文搜索系统设计");
+			let results = await contentSearch(item, '搜索');
+			assert.notInclude(results, item.id);
+			assert.include(results, other.id);
+		});
+
+		it("should record an index-state row when indexing", async function () {
+			let item = await createTextAttachment("index state recorded here");
+			let version = await Zotero.DB.valueQueryAsync(
+				"SELECT version FROM ftindex.fulltextIndexState WHERE itemID=?", item.id
+			);
+			assert.equal(version, 1);
+		});
+
+		it("should index queued items missing from the content index", async function () {
+			let item = await createTextAttachment("queued jabberwocky content");
+			// Simulate an item full-text indexed before the content index existed: drop its entries
+			await Zotero.DB.queryAsync("DELETE FROM ftindex.fulltextContent WHERE rowid=?", item.id);
+			await Zotero.DB.queryAsync("DELETE FROM ftindex.fulltextContentCJK WHERE rowid=?", item.id);
+			await Zotero.DB.queryAsync("DELETE FROM ftindex.fulltextIndexState WHERE itemID=?", item.id);
+
+			// It's now in the queue and not findable by content
+			assert.isAbove(await Zotero.FullText.getAttachmentIndexQueueCount(), 0);
+			assert.notInclude(await contentSearch(item, 'jabberwocky'), item.id);
+
+			// Draining the queue re-indexes it from the cached text
+			await Zotero.FullText.processAttachmentIndexQueue();
+
+			assert.include(await contentSearch(item, 'jabberwocky'), item.id);
+			let version = await Zotero.DB.valueQueryAsync(
+				"SELECT version FROM ftindex.fulltextIndexState WHERE itemID=?", item.id
+			);
+			assert.equal(version, 1);
+		});
+
+		it("should re-extract a queued item whose cache file is missing", async function () {
+			let item = await importFileAttachment('test.pdf');
+			let cacheFile = Zotero.FullText.getItemCacheFile(item).path;
+			// Grab a real word from the extracted text to search for after re-extraction
+			let word = (await Zotero.File.getContentsAsync(cacheFile)).match(/[a-z]{5,}/i)[0];
+			// Simulate the storage folder being cleared after indexing (cache gone, file present),
+			// then re-queue the item
+			await OS.File.remove(cacheFile);
+			await Zotero.DB.queryAsync("DELETE FROM ftindex.fulltextContent WHERE rowid=?", item.id);
+			await Zotero.DB.queryAsync("DELETE FROM ftindex.fulltextContentCJK WHERE rowid=?", item.id);
+			await Zotero.DB.queryAsync("DELETE FROM ftindex.fulltextIndexState WHERE itemID=?", item.id);
+
+			// Draining the queue should re-extract from the file (not index empty)
+			await Zotero.FullText.processAttachmentIndexQueue();
+
+			assert.isTrue(await OS.File.exists(cacheFile));
+			assert.include(await contentSearch(item, word), item.id);
+		});
+
+		it("should not count unindexable attachments as not indexed", async function () {
+			let before = (await Zotero.FullText.getIndexStats()).unindexedQueue;
+			// A Word document can't be full-text indexed, so it shouldn't inflate "not indexed"
+			let path = OS.Path.join(await getTempDirectory(), Zotero.Utilities.randomString() + ".doc");
+			await Zotero.File.putContentsAsync(path, "not really a word doc");
+			await Zotero.Attachments.importFromFile({
+				file: path, contentType: 'application/msword'
+			});
+			let after = (await Zotero.FullText.getIndexStats()).unindexedQueue;
+			assert.equal(after, before);
+		});
+
+		it("should index an unindexed attachment that has a local file", async function () {
+			let item = await createTextAttachment("filepresentunindexed content");
+			// Simulate a never-indexed attachment: no fulltextItems row, not in the index
+			await Zotero.DB.queryAsync("DELETE FROM fulltextItems WHERE itemID=?", item.id);
+			await Zotero.DB.queryAsync("DELETE FROM ftindex.fulltextContent WHERE rowid=?", item.id);
+			await Zotero.DB.queryAsync("DELETE FROM ftindex.fulltextIndexState WHERE itemID=?", item.id);
+			assert.notInclude(await contentSearch(item, 'filepresentunindexed'), item.id);
+			await Zotero.FullText.processAttachmentExtractionQueue();
+			assert.include(await contentSearch(item, 'filepresentunindexed'), item.id);
+		});
+
+		it("should record an unindexed attachment with no local file as missing", async function () {
+			let item = await createTextAttachment("nolocalfile content");
+			await Zotero.DB.queryAsync("DELETE FROM fulltextItems WHERE itemID=?", item.id);
+			await Zotero.DB.queryAsync("DELETE FROM ftindex.fulltextContent WHERE rowid=?", item.id);
+			await Zotero.DB.queryAsync("DELETE FROM ftindex.fulltextIndexState WHERE itemID=?", item.id);
+			// Remove the file so there's no local content to index
+			await OS.File.remove(await item.getFilePathAsync());
+			await Zotero.FullText.processAttachmentExtractionQueue();
+			let synced = await Zotero.DB.valueQueryAsync(
+				"SELECT synced FROM fulltextItems WHERE itemID=?", item.id
+			);
+			assert.equal(synced, Zotero.FullText.SYNC_STATE_MISSING);
+		});
+
+		it("should record an attachment as missing when its content can't be extracted", async function () {
+			// A file that isn't a valid EPUB: extraction fails, so the import leaves no fulltextItems
+			// row. The item must still leave the queue (recorded missing) rather than being retried
+			// endlessly.
+			let tmpDir = await getTempDirectory();
+			let path = OS.Path.join(tmpDir, Zotero.Utilities.randomString() + ".epub");
+			await Zotero.File.putContentsAsync(path, "not really an EPUB");
+			let item = await Zotero.Attachments.importFromFile({
+				file: path, contentType: 'application/epub+zip'
+			});
+			assert.isNotOk(await Zotero.DB.valueQueryAsync(
+				"SELECT 1 FROM fulltextItems WHERE itemID=?", item.id
+			));
+			await Zotero.FullText.processAttachmentExtractionQueue();
+			let synced = await Zotero.DB.valueQueryAsync(
+				"SELECT synced FROM fulltextItems WHERE itemID=?", item.id
+			);
+			assert.equal(synced, Zotero.FullText.SYNC_STATE_MISSING);
+			// No longer pending, so the drain won't keep retrying it
+			assert.equal(await Zotero.FullText.getAttachmentExtractionQueueCount(), 0);
+		});
+
+		it("should skip unindexed attachments while indexing is disabled and index them when re-enabled", async function () {
+			let item = await createTextAttachment("disabledpref content");
+			await Zotero.DB.queryAsync("DELETE FROM fulltextItems WHERE itemID=?", item.id);
+			await Zotero.DB.queryAsync("DELETE FROM ftindex.fulltextContent WHERE rowid=?", item.id);
+			await Zotero.DB.queryAsync("DELETE FROM ftindex.fulltextIndexState WHERE itemID=?", item.id);
+			Zotero.Prefs.set('fulltext.textMaxLength', 0);
+			try {
+				// Disabled: not counted as pending, and a pass records nothing (so it can't loop)
+				assert.equal(await Zotero.FullText.getAttachmentExtractionQueueCount(), 0);
+				await Zotero.FullText.processAttachmentExtractionQueue();
+				assert.isNotOk(await Zotero.DB.valueQueryAsync(
+					"SELECT 1 FROM fulltextItems WHERE itemID=?", item.id
+				));
+			}
+			finally {
+				Zotero.Prefs.clear('fulltext.textMaxLength');
+			}
+			// Re-enabled: eligible again and indexed
+			await Zotero.FullText.processAttachmentExtractionQueue();
+			assert.include(await contentSearch(item, 'disabledpref'), item.id);
+		});
+
+		it("should purge content index entries orphaned by item deletion", async function () {
+			let item = await createTextAttachment("orphanpurge content");
+			assert.include(await contentSearch(item, 'orphanpurge'), item.id);
+			// Simulate the FK cascade from a delete that bypassed Item.erase(): drop the
+			// fulltextItems row, leaving the content index entries orphaned
+			await Zotero.DB.queryAsync("DELETE FROM fulltextItems WHERE itemID=?", item.id);
+			await Zotero.FullText.purgeOrphanedContent();
+			assert.notInclude(await contentSearch(item, 'orphanpurge'), item.id);
+		});
+
+		it("should remove content from the index when cleared", async function () {
+			let item = await createTextAttachment("disposable singular content");
+			assert.include(await contentSearch(item, 'disposable'), item.id);
+			await Zotero.DB.executeTransaction(async function () {
+				await Zotero.FullText.clearItemWords(item.id);
+			});
+			assert.notInclude(await contentSearch(item, 'disposable'), item.id);
+		});
+
+		it("should keep content searchable after optimizing the index", async function () {
+			let item = await createTextAttachment("optimizable content");
+			await Zotero.FullText.optimizeContentIndex();
+			assert.include(await contentSearch(item, 'optimizable'), item.id);
+		});
+
+		it("should keep content searchable after vacuuming the index", async function () {
+			let item = await createTextAttachment("vacuumable content");
+			await Zotero.FullText.vacuumContentIndex({ force: true });
+			assert.include(await contentSearch(item, 'vacuumable'), item.id);
+		});
+
+		it("should discard the index when it belongs to a different database instance", async function () {
+			let item = await createTextAttachment("instancemismatch content");
+			assert.include(await contentSearch(item, 'instancemismatch'), item.id);
+			// Simulate an index built against a different zotero.sqlite (e.g., the database was
+			// deleted and re-synced, reassigning local itemIDs) by changing the stored localUserKey
+			await Zotero.DB.queryAsync(
+				"UPDATE ftindex.fulltextIndexMeta SET value='xxxxxxxx' WHERE key='localUserKey'"
+			);
+			// Force a reconnect, which re-runs the content DB setup and detects the mismatch
+			await Zotero.DB.vacuum({ force: true });
+			assert.equal(
+				await Zotero.DB.valueQueryAsync("SELECT COUNT(*) FROM ftindex.fulltextIndexState"), 0
+			);
+			assert.notInclude(await contentSearch(item, 'instancemismatch'), item.id);
+		});
+	});
+
 	describe("Indexing", function () {
 		beforeEach(function () {
 			Zotero.Prefs.clear('fulltext.textMaxLength');
@@ -220,6 +465,43 @@ describe("Zotero.FullText", function () {
 		});
 	})
 	
+	describe("#processSyncedContentNow()", function () {
+		before(() => {
+			Zotero.Prefs.set('fulltext.pdfMaxPages', 0);
+		});
+		after(() => {
+			Zotero.Prefs.clear('fulltext.pdfMaxPages');
+		});
+
+		it("should index sync-delivered content without waiting for idle", async function () {
+			var item = await importFileAttachment('test.pdf');
+			// Simulate content delivered by sync: stored as TO_PROCESS with a processor cache file,
+			// not yet in the search index (PDF indexing is disabled, so it wasn't indexed locally)
+			await Zotero.FullText.setItemContent(
+				item.libraryID,
+				item.key,
+				{ content: "zqpromptsync electrophoresis", indexedChars: 28, totalChars: 28 },
+				5
+			);
+			function search(term) {
+				let s = new Zotero.Search();
+				s.libraryID = item.libraryID;
+				s.addCondition('fulltextContent', 'contains', term);
+				return s.search();
+			}
+			assert.notInclude(await search('zqpromptsync'), item.id);
+
+			// Processing it promptly (as on sync completion) makes it searchable without idle
+			await Zotero.FullText.processSyncedContentNow();
+
+			assert.include(await search('zqpromptsync'), item.id);
+			assert.equal(
+				await Zotero.DB.valueQueryAsync("SELECT synced FROM fulltextItems WHERE itemID=?", item.id),
+				Zotero.FullText.SYNC_STATE_IN_SYNC
+			);
+		});
+	});
+
 	describe("#setItemContent()", function () {
 		before(() => {
 			// Disable PDF indexing

--- a/test/tests/searchTest.js
+++ b/test/tests/searchTest.js
@@ -1355,55 +1355,6 @@ describe("Zotero.Search", function () {
 				});
 			});
 			
-			describe("fulltextWord", function () {
-				it("should return matches with full-text conditions", async function () {
-					let s = new Zotero.Search();
-					s.libraryID = userLibraryID;
-					s.addCondition('fulltextWord', 'contains', 'foo');
-					let matches = await s.search();
-					assert.lengthOf(matches, 2);
-					assert.sameMembers(matches, [fooItem.id, foobarItem.id]);
-				});
-		
-				it("should not return non-matches with full-text conditions", async function () {
-					let s = new Zotero.Search();
-					s.libraryID = userLibraryID;
-					s.addCondition('fulltextWord', 'contains', 'nomatch');
-					let matches = await s.search();
-					assert.lengthOf(matches, 0);
-				});
-		
-				it("should return matches for full-text conditions in ALL mode", async function () {
-					let s = new Zotero.Search();
-					s.libraryID = userLibraryID;
-					s.addCondition('joinMode', 'all');
-					s.addCondition('fulltextWord', 'contains', 'foo');
-					s.addCondition('fulltextWord', 'contains', 'bar');
-					let matches = await s.search();
-					assert.deepEqual(matches, [foobarItem.id]);
-				});
-		
-				it("should not return non-matches for full-text conditions in ALL mode", async function () {
-					let s = new Zotero.Search();
-					s.libraryID = userLibraryID;
-					s.addCondition('joinMode', 'all');
-					s.addCondition('fulltextWord', 'contains', 'mjktkiuewf');
-					s.addCondition('fulltextWord', 'contains', 'zijajkvudk');
-					let matches = await s.search();
-					assert.lengthOf(matches, 0);
-				});
-		
-				it("should return a match that satisfies only one of two full-text condition in ANY mode", async function () {
-					let s = new Zotero.Search();
-					s.libraryID = userLibraryID;
-					s.addCondition('joinMode', 'any');
-					s.addCondition('fulltextWord', 'contains', 'bar');
-					s.addCondition('fulltextWord', 'contains', 'nomatch');
-					let matches = await s.search();
-					assert.deepEqual(matches, [foobarItem.id]);
-				});
-			});
-			
 			describe("includeParentsAndChildren", function () {
 				it("should handle ANY search with no-op condition", async function () {
 					var s = new Zotero.Search();
@@ -1917,6 +1868,43 @@ describe("Zotero.Search", function () {
 						// Only the item from the collection is returned
 						assert.equal(matches.length, 1);
 						assert.equal(matches[0], fooItem.id);
+					});
+
+					async function importTextContent(content) {
+						let path = OS.Path.join(await getTempDirectory(), Zotero.Utilities.randomString() + ".txt");
+						await Zotero.File.putContentsAsync(path, content);
+						return Zotero.Attachments.importFromFile({
+							file: path, contentType: 'text/plain', charset: 'utf-8', title: 'xxxx'
+						});
+					}
+
+					it("should match full-text content as a substring", async function () {
+						let item = await importTextContent("zqs electrophoresis protocol");
+						let s = new Zotero.Search();
+						s.libraryID = userLibraryID;
+						s.addCondition('quicksearch-everything', 'contains', 'lectro');
+						assert.include(await s.search(), item.id);
+					});
+
+					it("should require every word of a multi-word search", async function () {
+						let both = await importTextContent("zqsalpha zqsbeta zqsgamma");
+						let one = await importTextContent("zqsalpha zqsdelta");
+						let s = new Zotero.Search();
+						s.libraryID = userLibraryID;
+						s.addCondition('quicksearch-everything', 'contains', 'zqsalpha zqsgamma');
+						let matches = await s.search();
+						assert.include(matches, both.id);
+						assert.notInclude(matches, one.id);
+					});
+
+					it("should skip content matching for a term too short for the index", async function () {
+						let item = await importTextContent("elephant");
+						let s = new Zotero.Search();
+						s.libraryID = userLibraryID;
+						// "el" is shorter than a trigram, so it isn't matched against content (which
+						// also avoids a per-keystroke scan); the title is "xxxx", so nothing matches
+						s.addCondition('quicksearch-everything', 'contains', 'el');
+						assert.notInclude(await s.search(), item.id);
 					});
 				});
 			});

--- a/test/tests/searchTest.js
+++ b/test/tests/searchTest.js
@@ -1906,6 +1906,27 @@ describe("Zotero.Search", function () {
 						s.addCondition('quicksearch-everything', 'contains', 'el');
 						assert.notInclude(await s.search(), item.id);
 					});
+
+					it("should skip note matching for a short term but honor a quoted one", async function () {
+						let note = new Zotero.Item('note');
+						note.libraryID = userLibraryID;
+						note.setNote('<p>zqsnote re content</p>');
+						await note.saveTx();
+						await Zotero.FullText.processNoteIndexQueue();
+						async function matches(term) {
+							let s = new Zotero.Search();
+							s.libraryID = userLibraryID;
+							s.addCondition('quicksearch-everything', 'contains', term);
+							return s.search();
+						}
+						// A long term matches the note's content
+						assert.include(await matches('zqsnote'), note.id);
+						// "re" is too short for the index, so an unquoted term doesn't scan note
+						// content (avoiding a per-keystroke scan) and nothing else matches it
+						assert.notInclude(await matches('re'), note.id);
+						// Quoting makes the quick search Enter-triggered, so the short term is matched
+						assert.include(await matches('"re"'), note.id);
+					});
 				});
 			});
 			

--- a/test/tests/searchTest.js
+++ b/test/tests/searchTest.js
@@ -1664,6 +1664,150 @@ describe("Zotero.Search", function () {
 				});
 			});
 			
+			describe("Accent-insensitive matching", function () {
+				it("should match accented and unaccented text interchangeably", async function () {
+					// Unaccented term against accented text
+					var item = await createDataObject('item', { title: 'zdiaséance', libraryID: userLibraryID });
+					var s1 = new Zotero.Search();
+					s1.libraryID = userLibraryID;
+					s1.addCondition('title', 'contains', 'zdiaseance');
+					assert.sameMembers(await s1.search(), [item.id]);
+
+					// Accented term against unaccented text
+					var item2 = await createDataObject('item', { title: 'zdiaresume', libraryID: userLibraryID });
+					var s2 = new Zotero.Search();
+					s2.libraryID = userLibraryID;
+					s2.addCondition('title', 'contains', 'zdiarésumé');
+					assert.sameMembers(await s2.search(), [item2.id]);
+				});
+
+				it("should match an accented creator from an unaccented term", async function () {
+					var item = await createDataObject('item', {
+						libraryID: userLibraryID,
+						creators: [{ firstName: 'Étiennezdia', lastName: 'Müllerzdia', creatorType: 'author' }]
+					});
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('creator', 'contains', 'etiennezdia mullerzdia');
+					assert.sameMembers(await s.search(), [item.id]);
+				});
+
+				it("should match an accented tag from an unaccented term", async function () {
+					var item = await createDataObject('item', {
+						libraryID: userLibraryID,
+						tags: [{ tag: 'résumézdia' }]
+					});
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('tag', 'contains', 'resumezdia');
+					assert.sameMembers(await s.search(), [item.id]);
+				});
+
+				it("should match non-ASCII text case-insensitively", async function () {
+					// SQLite's default LIKE folds only ASCII case, so uppercase Greek/Cyrillic values
+					// have to be stored normalized (lowercased) to match a lowercase search term
+					var greek = await createDataObject('item', { title: 'zdiaΘΕΜΑ', libraryID: userLibraryID });
+					var cyrillic = await createDataObject('item', { title: 'zdiaПРИВЕТ', libraryID: userLibraryID });
+					var s1 = new Zotero.Search();
+					s1.libraryID = userLibraryID;
+					s1.addCondition('title', 'contains', 'zdiaθεμα');
+					assert.sameMembers(await s1.search(), [greek.id]);
+					var s2 = new Zotero.Search();
+					s2.libraryID = userLibraryID;
+					s2.addCondition('title', 'contains', 'zdiaпривет');
+					assert.sameMembers(await s2.search(), [cyrillic.id]);
+				});
+
+				it("should match ligatures, superscripts, fractions, and non-decomposing letters", async function () {
+					var item = await createDataObject('item', { title: 'zdiasøren œuvre ﬁle x² ½ straße', libraryID: userLibraryID });
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('title', 'contains', 'zdiasoren oeuvre file x2 1/2 strasse');
+					assert.sameMembers(await s.search(), [item.id]);
+				});
+
+				it("should ignore rich-text formatting tags in item fields", async function () {
+					// A word wrapped in supported formatting (here small-caps) -- the tags shouldn't
+					// break a phrase match across the word or be matchable themselves
+					var item = await createDataObject('item', {
+						title: 'The <span style="font-variant:small-caps;">zdiadrosophila</span> genome',
+						libraryID: userLibraryID
+					});
+					async function titleMatches(term) {
+						var s = new Zotero.Search();
+						s.libraryID = userLibraryID;
+						s.addCondition('title', 'contains', term);
+						return s.search();
+					}
+					// A phrase running from the formatted word into the next one matches
+					assert.sameMembers(await titleMatches('zdiadrosophila genome'), [item.id]);
+					// The tag markup itself isn't matched
+					assert.lengthOf(await titleMatches('small-caps'), 0);
+				});
+
+				it("should fold curly quotes and dashes to their ASCII forms", async function () {
+					// Word processors and translators produce curly quotes and en/em dashes; a
+					// search typed with straight quotes and hyphens should still match
+					var quoted = await createDataObject('item', {
+						title: 'zdia“pp. 10–12”', // curly quotes + en dash: "pp. 10-12"
+						libraryID: userLibraryID
+					});
+					var emDash = await createDataObject('item', {
+						title: 'zdiamind—body problem', // em dash
+						libraryID: userLibraryID
+					});
+					async function titleMatches(term) {
+						var s = new Zotero.Search();
+						s.libraryID = userLibraryID;
+						s.addCondition('title', 'contains', term);
+						return s.search();
+					}
+					// Straight quotes and hyphen match the curly quotes and en dash
+					assert.sameMembers(await titleMatches('zdia"pp. 10-12"'), [quoted.id]);
+					// Em dash folds to a hyphen too
+					assert.sameMembers(await titleMatches('zdiamind-body'), [emDash.id]);
+				});
+
+				it("should distinguish voiced kana and composed Hangul", async function () {
+					// NFKD decomposes が into か + a combining mark and 한 into jamo; without
+					// recomposition, the base character would substring-match the composed one
+					var ja = await createDataObject('item', { title: 'zdiaがん', libraryID: userLibraryID });
+					var ko = await createDataObject('item', { title: 'zdia한국', libraryID: userLibraryID });
+
+					async function titleMatches(term) {
+						var s = new Zotero.Search();
+						s.libraryID = userLibraryID;
+						s.addCondition('title', 'contains', term);
+						return s.search();
+					}
+
+					// The composed character matches itself
+					assert.sameMembers(await titleMatches('zdiaがん'), [ja.id]);
+					assert.sameMembers(await titleMatches('zdia한국'), [ko.id]);
+					// The base character must not match the composed/voiced one
+					assert.lengthOf(await titleMatches('zdiaかん'), 0);
+					assert.lengthOf(await titleMatches('zdia하'), 0);
+				});
+
+				it("should populate normalized columns for existing rows on backfill", async function () {
+					var item = await createDataObject('item', { title: 'zdiabörkbackfill', libraryID: userLibraryID });
+					// Simulate pre-migration data by clearing the normalized column
+					await Zotero.DB.queryAsync(
+						"UPDATE itemDataValues SET valueNormalized=NULL WHERE value=?",
+						'zdiabörkbackfill'
+					);
+					var s = new Zotero.Search();
+					s.libraryID = userLibraryID;
+					s.addCondition('title', 'contains', 'zdiaborkbackfill');
+					assert.lengthOf(await s.search(), 0);
+
+					await Zotero.DB.queryAsync("REPLACE INTO settings VALUES ('search', 'normalizeBackfill', 1)");
+					await Zotero.Schema.populateNormalizedSearchColumns();
+
+					assert.sameMembers(await s.search(), [item.id]);
+				});
+			});
+
 			describe("Quick search", function () {
 				describe("All Fields & Tags", function () {
 					it("should match annotation for tag search", async function () {

--- a/test/tests/syncFullTextEngineTest.js
+++ b/test/tests/syncFullTextEngineTest.js
@@ -75,7 +75,7 @@ describe("Zotero.Sync.Data.FullTextEngine", function () {
 			await attachment.saveTx();
 			
 			var content = generateContent()
-			var spy = sinon.spy(Zotero.Fulltext, "registerContentProcessor")
+			var spy = sinon.spy(Zotero.Fulltext, "registerSyncContentProcessor")
 			
 			var itemFullTextVersion = 10;
 			var libraryVersion = 15;
@@ -141,7 +141,7 @@ describe("Zotero.Sync.Data.FullTextEngine", function () {
 			await attachment.saveTx();
 			
 			content = generateContent()
-			spy = sinon.spy(Zotero.Fulltext, "registerContentProcessor")
+			spy = sinon.spy(Zotero.Fulltext, "registerSyncContentProcessor")
 			
 			itemFullTextVersion = 17;
 			var lastLibraryVersion = libraryVersion;

--- a/test/tests/tagSelectorTest.js
+++ b/test/tests/tagSelectorTest.js
@@ -134,7 +134,29 @@ describe("Tag Selector", function () {
 
 			tagSelector.handleSearch('');
 			await Zotero.Promise.delay(500);
-			
+
+			await item.eraseTx();
+		});
+
+		it("should match accented tags from an unaccented search term", async function () {
+			var collection = await createDataObject('collection');
+			await select(win, collection);
+			var item = createUnsavedDataObject('item', { collections: [collection.id] });
+			item.setTags(['résumé', 'other']);
+			var promise = waitForTagSelector(win);
+			await item.saveTx();
+			await promise;
+
+			promise = waitForTagSelector(win);
+			tagSelector.handleSearch('resume');
+			await promise;
+
+			assert.sameMembers(getRegularTags(), ['résumé']);
+
+			promise = waitForTagSelector(win);
+			tagSelector.handleSearch('');
+			await promise;
+
 			await item.eraseTx();
 		});
 	});


### PR DESCRIPTION
Search now ignores diacritics ("seance" matches "séance"), and adds full-text searching of attachment content and note text. Closes #1300 (and https://www.zotero.org/trac/ticket/1640!) and various others.

Text is normalized with Unicode NFKD (also folding ligatures, superscripts, curly quotes/dashes, etc.) via a shared `normalizeForSearch()`. Item fields, tags, creators, and annotations get normalized shadow columns, and attachment content and note text are indexed into trigram FTS5 tables (and a CJK-bigram companion for short queries) in an attached `fulltext.sqlite`. Index is derived from the existing full-text cache and rebuildable. Indexed on upgrade, in the background when idle, as soon as a sync finishes, and if the index settings pane is open. Items are automatically reextracted and reindexed if the max-char/page settings change.

The collection tree and tag selector filters use the same helper, so they ignore accents/etc. as well.