### PR TITLE
Fix tree multi-selection collapse/expand behaviour

### DIFF
--- a/chrome/content/zotero/collectionTree.jsx
+++ b/chrome/content/zotero/collectionTree.jsx
@@ -1266,9 +1266,7 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 		if (treeRow.isLibrary(true) || treeRow.isCollection() || treeRow.isFeeds()) {
 			count = await this._expandRow(this._rows, index, true);
 		}
-		if (this.selection.focused > index) {
-			this.selection.select(this.selection.focused + count);
-		}
+		this.selection.adjustForRowInsertion(index, count);
 		this.selection.selectEventsSuppressed = false;
 		
 		this._rows[index].isOpen = true;

--- a/chrome/content/zotero/collectionTree.jsx
+++ b/chrome/content/zotero/collectionTree.jsx
@@ -2724,9 +2724,10 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 		var level = this.getLevel(row);
 		var nextRow = row + 1;
 		
-		// Remove child rows
+		// Remove child rows, remapping any selected ones to the collapsed container
 		while ((nextRow < this._rows.length) && (this.getLevel(nextRow) > level)) {
-			this._removeRow(nextRow, true);
+			this.selection.adjustForRowRemoval(nextRow, true);
+			this._removeRow(nextRow, true, true);
 		}
 		this.selection.selectEventsSuppressed = false;
 		

--- a/chrome/content/zotero/components/virtualized-table.jsx
+++ b/chrome/content/zotero/components/virtualized-table.jsx
@@ -259,6 +259,55 @@ class TreeSelection {
 	}
 
 	/**
+	 * Adjusts selection indexes after a row is removed. If a selected, focused, or
+	 * pivot row is removed, it moves to the previous row, which is generally the
+	 * collapsed parent when removing descendants from top to bottom.
+	 *
+	 * @param {Number} index Removed row index
+	 */
+	adjustForRowRemoval(index) {
+		if (!this.count) return;
+		let previousIndex = Math.max(index - 1, 0);
+		let selected = new Set();
+		for (let selectedIndex of this.selected) {
+			if (selectedIndex == index) {
+				selected.add(previousIndex);
+			}
+			else {
+				selected.add(selectedIndex > index ? selectedIndex - 1 : selectedIndex);
+			}
+		}
+		this.selected = selected;
+		this.focused = this.focused == index
+			? previousIndex
+			: this.focused > index ? this.focused - 1 : this.focused;
+		this.pivot = this.pivot == index
+			? previousIndex
+			: this.pivot > index ? this.pivot - 1 : this.pivot;
+	}
+
+	/**
+	 * Adjusts selection indexes after rows are inserted after a given row.
+	 *
+	 * @param {Number} index Row after which rows were inserted
+	 * @param {Number} count Number of inserted rows
+	 */
+	adjustForRowInsertion(index, count) {
+		if (!this.count) return;
+		let selected = new Set();
+		for (let selectedIndex of this.selected) {
+			selected.add(selectedIndex > index ? selectedIndex + count : selectedIndex);
+		}
+		this.selected = selected;
+		if (this.focused > index) {
+			this.focused += count;
+		}
+		if (this.pivot > index) {
+			this.pivot += count;
+		}
+	}
+
+	/**
 	 * Calls the onSelectionChange prop on the tree
 	 * @param shouldDebounce {Boolean} Whether the update to the tree should be debounced
 	 * @private
@@ -569,7 +618,7 @@ class VirtualizedTable extends React.Component {
 	 *
 	 * @param {Event} e
 	 */
-	_onKeyDown = (e) => {
+	_onKeyDown = async (e) => {
 		if (this.props.onKeyDown && this.props.onKeyDown(e) === false) return;
 
 		this._preventKeyboardScrolling(e);
@@ -663,6 +712,25 @@ class VirtualizedTable extends React.Component {
 		}
 		
 		if (shiftSelect || moveFocused) return;
+
+		// If selection count is greater than 1 and the focused row wasn't
+		// moved out of the selection - toggle open/closed all rows in that selection
+		// Otherwise if the focused row has moved out of the selection, toggle state
+		// of the focused row (handled below)
+		if (this.selection.count > 1
+				&& this.selection.isSelected(this.selection.focused)
+				&& [Zotero.arrowPreviousKey, Zotero.arrowNextKey].includes(e.key)) {
+			let open = e.key == Zotero.arrowNextKey;
+			let rows = Array.from(this.selection.selected)
+				.filter(index => this.props.isContainer(index)
+					&& !this.props.isContainerEmpty(index)
+					&& (open ? !this.props.isContainerOpen(index) : this.props.isContainerOpen(index)))
+				.sort((a, b) => b - a);
+			for (let index of rows) {
+				await this.toggleOpenState(index);
+			}
+			return;
+		}
 		
 		switch (e.key) {
 		case Zotero.arrowPreviousKey:

--- a/chrome/content/zotero/components/virtualized-table.jsx
+++ b/chrome/content/zotero/components/virtualized-table.jsx
@@ -266,7 +266,6 @@ class TreeSelection {
 	 * @param {Number} index Removed row index
 	 */
 	adjustForRowRemoval(index) {
-		if (!this.count) return;
 		let previousIndex = Math.max(index - 1, 0);
 		let selected = new Set();
 		for (let selectedIndex of this.selected) {
@@ -293,7 +292,6 @@ class TreeSelection {
 	 * @param {Number} count Number of inserted rows
 	 */
 	adjustForRowInsertion(index, count) {
-		if (!this.count) return;
 		let selected = new Set();
 		for (let selectedIndex of this.selected) {
 			selected.add(selectedIndex > index ? selectedIndex + count : selectedIndex);

--- a/chrome/content/zotero/components/virtualized-table.jsx
+++ b/chrome/content/zotero/components/virtualized-table.jsx
@@ -259,22 +259,32 @@ class TreeSelection {
 	}
 
 	/**
-	 * Adjusts selection indexes after a row is removed. If a selected, focused, or
-	 * pivot row is removed, it moves to the previous row, which is generally the
-	 * collapsed parent when removing descendants from top to bottom.
+	 * Adjusts selection indexes after a row is removed. A removed selected row is
+	 * dropped from the selection, or remapped to the previous row when remapToPrevious
+	 * is true (e.g., when collapsing a container remaps removed descendants to the
+	 * container row, which precedes them). If the removal leaves nothing selected, the
+	 * previous row is selected. If the focused or pivot row is removed, it moves to
+	 * the previous row.
 	 *
 	 * @param {Number} index Removed row index
+	 * @param {Boolean} [remapToPrevious=false] Select the previous row in place of a
+	 * 		removed selected row instead of dropping it from the selection
 	 */
-	adjustForRowRemoval(index) {
+	adjustForRowRemoval(index, remapToPrevious = false) {
 		let previousIndex = Math.max(index - 1, 0);
 		let selected = new Set();
 		for (let selectedIndex of this.selected) {
 			if (selectedIndex == index) {
-				selected.add(previousIndex);
+				if (remapToPrevious) {
+					selected.add(previousIndex);
+				}
 			}
 			else {
 				selected.add(selectedIndex > index ? selectedIndex - 1 : selectedIndex);
 			}
+		}
+		if (this.selected.size && !selected.size) {
+			selected.add(previousIndex);
 		}
 		this.selected = selected;
 		this.focused = this.focused == index

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -256,7 +256,7 @@ class ItemTreeRowProvider {
 			let level = this.getLevel(index);
 			// Remove child rows
 			while ((index + 1 < this._rows.length) && (this.getLevel(index + 1) > level)) {
-				this.itemTree.selection.adjustForRowRemoval(index + 1);
+				this.itemTree.selection.adjustForRowRemoval(index + 1, true);
 				this._removeRow(index + 1, true);
 				count++;
 			}

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -256,6 +256,7 @@ class ItemTreeRowProvider {
 			let level = this.getLevel(index);
 			// Remove child rows
 			while ((index + 1 < this._rows.length) && (this.getLevel(index + 1) > level)) {
+				this.itemTree.selection.adjustForRowRemoval(index + 1);
 				this._removeRow(index + 1, true);
 				count++;
 			}
@@ -281,6 +282,7 @@ class ItemTreeRowProvider {
 				count++;
 				this._addRow(childRows[i], index + i + 1, true);
 			}
+			this.itemTree.selection.adjustForRowInsertion(index, count);
 
 			this._rows[index].isOpen = true;
 		}
@@ -290,11 +292,12 @@ class ItemTreeRowProvider {
 	}
 
 	toggleOpenState(index, skipRowMapRefresh = false) {
+		let preserveDetachedFocus = !this.itemTree.selection.isSelected(this.itemTree.selection.focused);
 		this.itemTree._cacheState();
 		this._toggleOpenState(index, skipRowMapRefresh);
 		// Preserve viewport when toggling a container instead of jumping to the current selection.
 		this.runListeners('update', true, {
-			restoreSelection: true,
+			restoreSelection: !preserveDetachedFocus,
 			expandCollapsedParents: false,
 			restoreScroll: true,
 		});
@@ -1362,9 +1365,13 @@ var ItemTree = class ItemTree extends LibraryTree {
 			return false;
 		}
 		
-		// Handle arrow keys specially on multiple selection, since
-		// otherwise the tree just applies it to the last-selected row
-		if (this.selection.count > 1 && ["ArrowLeft", "ArrowRight"].includes(event.key)) {
+		// If selection count is greater than 1 and the focused row wasn't
+		// moved out of the selection - toggle open/closed all rows in that selection
+		// Otherwise if the focused row has moved out of the selection, toggle state
+		// of the focused row (handled in virtualized-table and this conditional should match that)
+		if (this.selection.count > 1
+				&& this.selection.isSelected(this.selection.focused)
+				&& [Zotero.arrowPreviousKey, Zotero.arrowNextKey].includes(event.key)) {
 			if (event.key == Zotero.arrowNextKey) {
 				this.expandSelectedRows();
 			}

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -292,8 +292,10 @@ class ItemTreeRowProvider {
 	}
 
 	toggleOpenState(index, skipRowMapRefresh = false) {
-		let preserveDetachedFocus = !this.itemTree.selection.isSelected(this.itemTree.selection.focused);
+		let selection = this.itemTree.selection;
+		let preserveDetachedFocus = !selection.isSelected(selection.focused);
 		this.itemTree._cacheState();
+		let selectedBefore = this.itemTree._cachedSelection;
 		this._toggleOpenState(index, skipRowMapRefresh);
 		// Preserve viewport when toggling a container instead of jumping to the current selection.
 		this.runListeners('update', true, {
@@ -301,6 +303,15 @@ class ItemTreeRowProvider {
 			expandCollapsedParents: false,
 			restoreScroll: true,
 		});
+		if (preserveDetachedFocus) {
+			// Collapsing a container with selected descendants moves their selection to the
+			// container row, and listeners have to be notified of the new selection
+			let selectedAfter = this.itemTree.getSelectedObjects();
+			if (selectedAfter.length != selectedBefore.length
+					|| selectedAfter.some(ref => !selectedBefore.includes(ref))) {
+				selection._updateTree();
+			}
+		}
 	}
 
 	/**

--- a/chrome/content/zotero/libraryTree.js
+++ b/chrome/content/zotero/libraryTree.js
@@ -195,8 +195,8 @@ var LibraryTree = class LibraryTree extends React.Component {
 		let level = this.getLevel(index);
 
 		// Maintain selection unless specified otherwise
-		if (!skipSelectionUpdate && index <= this.selection.focused) {
-			this.selection.select(this.selection.focused - 1);
+		if (!skipSelectionUpdate) {
+			this.selection.adjustForRowRemoval(index);
 		}
 
 		this._rows.splice(index, 1);

--- a/test/tests/collectionTreeTest.js
+++ b/test/tests/collectionTreeTest.js
@@ -99,6 +99,80 @@ describe("Zotero.CollectionTree", function () {
 			assert.equal(cv.selection.focused, row);
 			assert.ok(cv.isContainerOpen(row));
 		})
+
+		it("should expand/collapse selected containers when focus is on a multi-selection", async function () {
+			let collection1 = await createDataObject('collection');
+			let collection2 = await createDataObject('collection');
+			await createDataObject('collection', { parentID: collection1.id });
+			await createDataObject('collection', { parentID: collection2.id });
+			let collection1Row = cv.getRowIndexByID(collection1.treeViewID);
+			let collection2Row = cv.getRowIndexByID(collection2.treeViewID);
+			if (cv.isContainerOpen(collection1Row)) {
+				await cv.toggleOpenState(collection1Row);
+			}
+			collection2Row = cv.getRowIndexByID(collection2.treeViewID);
+			if (cv.isContainerOpen(collection2Row)) {
+				await cv.toggleOpenState(collection2Row);
+			}
+
+			cv.selection.select(cv.getRowIndexByID(collection1.treeViewID));
+			cv.selection.toggleSelect(cv.getRowIndexByID(collection2.treeViewID));
+			assert.equal(cv.selection.count, 2);
+			assert.isTrue(cv.selection.isSelected(cv.selection.focused));
+			let selectEventCount = 0;
+			let selectListener = () => selectEventCount++;
+			cv.onSelect.addListener(selectListener);
+			cv.tree._onKeyDown({
+				key: Zotero.arrowNextKey,
+				preventDefault: () => {},
+				stopPropagation: () => {}
+			});
+			await waitForCallback(() => selectEventCount
+				&& cv.isContainerOpen(cv.getRowIndexByID(collection1.treeViewID))
+				&& cv.isContainerOpen(cv.getRowIndexByID(collection2.treeViewID)));
+			assert.sameMembers(cv.getSelectedRows().map(row => row.id), [collection1.treeViewID, collection2.treeViewID]);
+
+			selectEventCount = 0;
+			cv.tree._onKeyDown({
+				key: Zotero.arrowPreviousKey,
+				preventDefault: () => {},
+				stopPropagation: () => {}
+			});
+			await waitForCallback(() => selectEventCount
+				&& !cv.isContainerOpen(cv.getRowIndexByID(collection1.treeViewID))
+				&& !cv.isContainerOpen(cv.getRowIndexByID(collection2.treeViewID)));
+			assert.sameMembers(cv.getSelectedRows().map(row => row.id), [collection1.treeViewID, collection2.treeViewID]);
+			cv.onSelect.removeListener(selectListener);
+		})
+
+		it("should preserve selection when focus is on a collapsed/expanded row", async function () {
+			let group = await createGroup();
+			let collection = await createDataObject('collection', { libraryID: group.libraryID });
+			let feed = await createFeed();
+			let groupRow = cv.getRowIndexByID(group.treeViewID);
+			if (!cv.isContainerOpen(groupRow)) {
+				await cv.toggleOpenState(groupRow);
+			}
+			await cv.selectByID(feed.treeViewID);
+			cv.selection.focused = groupRow;
+			cv.selection.pivot = groupRow;
+
+			await cv.toggleOpenState(groupRow);
+			assert.equal(cv.getSelectedRows()[0].id, feed.treeViewID);
+
+			groupRow = cv.getRowIndexByID(group.treeViewID);
+			cv.selection.focused = groupRow;
+			cv.selection.pivot = groupRow;
+			await cv.toggleOpenState(groupRow);
+			assert.equal(cv.getSelectedRows()[0].id, feed.treeViewID);
+
+			await cv.selectByID(collection.treeViewID);
+			groupRow = cv.getRowIndexByID(group.treeViewID);
+			cv.selection.focused = groupRow;
+			cv.selection.pivot = groupRow;
+			await cv.toggleOpenState(groupRow);
+			assert.equal(cv.getSelectedRows()[0].id, group.treeViewID);
+		})
 	})
 	
 	describe("#expandLibrary()", function () {

--- a/test/tests/collectionTreeTest.js
+++ b/test/tests/collectionTreeTest.js
@@ -486,18 +486,35 @@ describe("Zotero.CollectionTree", function () {
 				
 				it(`should maintain selection on trash when ${objectType} is restored`, async function () {
 					var o = await createDataObject(objectType, { deleted: true });
-					
+
 					await cv.selectByID("T1");
-					
+
 					o.deleted = false;
 					await o.saveTx();
-					
+
 					assert.isTrue(zp.getCollectionTreeRows()[0].isTrash());
-					
+
 					// Row should have been added back
 					assert.isAbove(cv.getRowIndexByID(o.treeViewID), 0);
 				});
 			}
+
+			it("should drop a collection from a multi-selection when it's moved to trash", async function () {
+				var ran = Zotero.Utilities.randomString();
+				var o1 = await createDataObject('collection', { name: ran + "AAA" });
+				var o2 = await createDataObject('collection', { name: ran + "BBB" });
+				var o3 = await createDataObject('collection', { name: ran + "CCC" });
+
+				await cv.selectByID(o1.treeViewID);
+				cv.selection.toggleSelect(cv.getRowIndexByID(o3.treeViewID));
+				cv.selection.focused = cv.getRowIndexByID(o1.treeViewID);
+				cv.selection.pivot = cv.selection.focused;
+
+				o3.deleted = true;
+				await o3.saveTx();
+
+				assert.sameMembers(cv.getSelectedRows().map(row => row.id), [o1.treeViewID]);
+			});
 		});
 		
 		for (let objectType of ['collection', 'search']) {

--- a/test/tests/collectionViewItemTreeTest.js
+++ b/test/tests/collectionViewItemTreeTest.js
@@ -624,9 +624,42 @@ describe("CollectionViewItemTree", function () {
 			parentRow = itemsView.getRowIndexByID(parentItem.id);
 			itemsView.selection.focused = parentRow;
 			itemsView.selection.pivot = parentRow;
+			// The selection changes to the parent, so a select event has to fire
+			var selectPromise = itemsView.waitForSelect();
 			await itemsView.toggleOpenState(parentRow);
 			await itemsView.waitForLoad();
+			await selectPromise;
 			assert.sameMembers(itemsView.getSelectedItems(true), [parentItem.id]);
+			assert.equal(itemsView.selection.focused, itemsView.getRowIndexByID(parentItem.id));
+		})
+
+		it("should keep detached focus when collapsing a selected child alongside another selected item", async function () {
+			var collection = await createDataObject('collection');
+			await select(win, collection);
+			itemsView = zp.itemsView;
+
+			var parentItem = await createDataObject('item', { collections: [collection.id] });
+			var attachment = await importFileAttachment('test.png', { parentItemID: parentItem.id });
+			var item1 = await createDataObject('item', { collections: [collection.id] });
+			await waitForItemsLoad(win);
+
+			var parentRow = itemsView.getRowIndexByID(parentItem.id);
+			if (!itemsView.isContainerOpen(parentRow)) {
+				await itemsView.toggleOpenState(parentRow);
+				await itemsView.waitForLoad();
+			}
+			await itemsView.selectItem(item1.id);
+			itemsView.selection.toggleSelect(itemsView.getRowIndexByID(attachment.id));
+			parentRow = itemsView.getRowIndexByID(parentItem.id);
+			itemsView.selection.focused = parentRow;
+			itemsView.selection.pivot = parentRow;
+
+			var selectPromise = itemsView.waitForSelect();
+			await itemsView.toggleOpenState(parentRow);
+			await itemsView.waitForLoad();
+			await selectPromise;
+			assert.sameMembers(itemsView.getSelectedItems(true), [item1.id, parentItem.id]);
+			assert.equal(itemsView.selection.focused, itemsView.getRowIndexByID(parentItem.id));
 		})
 
 		it("shouldn't scroll back to selected row when opening another container", async function () {

--- a/test/tests/collectionViewItemTreeTest.js
+++ b/test/tests/collectionViewItemTreeTest.js
@@ -662,6 +662,40 @@ describe("CollectionViewItemTree", function () {
 			assert.equal(itemsView.selection.focused, itemsView.getRowIndexByID(parentItem.id));
 		})
 
+		it("should adjust focus with an empty selection when toggling a container above it", async function () {
+			var collection = await createDataObject('collection');
+			await select(win, collection);
+			itemsView = zp.itemsView;
+
+			var ran = Zotero.Utilities.randomString();
+			var parentItem = await createDataObject('item', { title: ran + " AAA", collections: [collection.id] });
+			var attachment = await importFileAttachment('test.png', { parentItemID: parentItem.id });
+			var item1 = await createDataObject('item', { title: ran + " ZZZ", collections: [collection.id] });
+			await waitForItemsLoad(win);
+
+			var parentRow = itemsView.getRowIndexByID(parentItem.id);
+			if (!itemsView.isContainerOpen(parentRow)) {
+				await itemsView.toggleOpenState(parentRow);
+				await itemsView.waitForLoad();
+			}
+			var item1Row = itemsView.getRowIndexByID(item1.id);
+			assert.isAbove(item1Row, itemsView.getRowIndexByID(attachment.id));
+			// Empty the selection, leaving focus on the item
+			await itemsView.selectItem(item1.id);
+			itemsView.selection.toggleSelect(item1Row);
+			assert.equal(itemsView.selection.count, 0);
+
+			await itemsView.toggleOpenState(itemsView.getRowIndexByID(parentItem.id));
+			await itemsView.waitForLoad();
+			assert.equal(itemsView.selection.count, 0);
+			assert.equal(itemsView.selection.focused, itemsView.getRowIndexByID(item1.id));
+
+			await itemsView.toggleOpenState(itemsView.getRowIndexByID(parentItem.id));
+			await itemsView.waitForLoad();
+			assert.equal(itemsView.selection.count, 0);
+			assert.equal(itemsView.selection.focused, itemsView.getRowIndexByID(item1.id));
+		})
+
 		it("shouldn't scroll back to selected row when opening another container", async function () {
 			var collection = await createDataObject('collection');
 			await select(win, collection);

--- a/test/tests/collectionViewItemTreeTest.js
+++ b/test/tests/collectionViewItemTreeTest.js
@@ -564,6 +564,71 @@ describe("CollectionViewItemTree", function () {
 	});
 	
 	describe("#toggleOpenState()", function () {
+		it("should preserve selection and detached focus when toggling another container", async function () {
+			var collection = await createDataObject('collection');
+			await select(win, collection);
+			itemsView = zp.itemsView;
+			
+			var parentItem = await createDataObject('item', { collections: [collection.id] });
+			var attachment = await importFileAttachment('test.png', { parentItemID: parentItem.id });
+			var item1 = await createDataObject('item', { collections: [collection.id] });
+			var item2 = await createDataObject('item', { collections: [collection.id] });
+			await waitForItemsLoad(win);
+
+			var parentRow = itemsView.getRowIndexByID(parentItem.id);
+			if (itemsView.isContainerOpen(parentRow)) {
+				await itemsView.toggleOpenState(parentRow);
+				await itemsView.waitForLoad();
+			}
+			await itemsView.selectItem(item1.id);
+			itemsView.selection.toggleSelect(itemsView.getRowIndexByID(item2.id));
+			itemsView.selection.focused = parentRow;
+			itemsView.selection.pivot = parentRow;
+
+			itemsView.tree._onKeyDown({
+				key: Zotero.arrowNextKey,
+				preventDefault: () => {},
+				stopPropagation: () => {}
+			});
+			await itemsView.waitForLoad();
+			assert.isTrue(itemsView.isContainerOpen(itemsView.getRowIndexByID(parentItem.id)));
+			assert.sameMembers(itemsView.getSelectedItems(true), [item1.id, item2.id]);
+			assert.equal(itemsView.selection.focused, itemsView.getRowIndexByID(parentItem.id));
+
+			itemsView.tree._onKeyDown({
+				key: Zotero.arrowPreviousKey,
+				preventDefault: () => {},
+				stopPropagation: () => {}
+			});
+			await itemsView.waitForLoad();
+			assert.isFalse(itemsView.isContainerOpen(itemsView.getRowIndexByID(parentItem.id)));
+			assert.sameMembers(itemsView.getSelectedItems(true), [item1.id, item2.id]);
+			assert.equal(itemsView.selection.focused, itemsView.getRowIndexByID(parentItem.id));
+		})
+
+		it("should select the parent when collapsing a selected child", async function () {
+			var collection = await createDataObject('collection');
+			await select(win, collection);
+			itemsView = zp.itemsView;
+			
+			var parentItem = await createDataObject('item', { collections: [collection.id] });
+			var attachment = await importFileAttachment('test.png', { parentItemID: parentItem.id });
+			await waitForItemsLoad(win);
+
+			var parentRow = itemsView.getRowIndexByID(parentItem.id);
+			if (!itemsView.isContainerOpen(parentRow)) {
+				await itemsView.toggleOpenState(parentRow);
+				await itemsView.waitForLoad();
+			}
+			await itemsView.selectItem(attachment.id);
+			parentRow = itemsView.getRowIndexByID(parentItem.id);
+			itemsView.selection.focused = parentRow;
+			itemsView.selection.pivot = parentRow;
+			await itemsView.toggleOpenState(parentRow);
+			await itemsView.waitForLoad();
+			assert.sameMembers(itemsView.getSelectedItems(true), [parentItem.id]);
+		})
+
 		it("shouldn't scroll back to selected row when opening another container", async function () {
 			var collection = await createDataObject('collection');
 			await select(win, collection);


### PR DESCRIPTION
Closes #5974.

Additional fixes for broken item tree behaviour when multiple items are selected, and changing focus with ctrl/cmd-arrow keys.

Aligned Collection Tree/Virtualized Tree collapse/expand behaviour when mutliple containers are selected, one of them is focused, and arrow key left-right is pressed, to the behaviour in Item Tree - now all of them are collapsed/expanded.