### PR TITLE
Suspend hidden reader tabs and unload tabs on memory pressure

### DIFF
--- a/chrome/content/zotero/tabs.js
+++ b/chrome/content/zotero/tabs.js
@@ -344,9 +344,23 @@ var Zotero_Tabs = new function () {
 		}
 	});
 	
+	// Unload background tabs right away when the OS reports memory pressure
+	// ("low-memory"/"low-memory-ongoing", or "heap-minimize" from about:memory),
+	// instead of waiting for the count/age-based unloading
+	this._memoryPressureObserver = {
+		observe: (subject, topic, data) => {
+			Zotero.debug(`Memory pressure (${data}): unloading background tabs`);
+			for (let tab of this._tabs.slice()) {
+				this.unload(tab.id);
+			}
+		}
+	};
+	Services.obs.addObserver(this._memoryPressureObserver, 'memory-pressure');
+
 	window.addEventListener('unload', () => {
 		Zotero.Notifier.unregisterObserver(this._notifierID);
 		Zotero.Prefs.unregisterObserver(this._prefsObserverID);
+		Services.obs.removeObserver(this._memoryPressureObserver, 'memory-pressure');
 	});
 
 	this._unloadInterval = setInterval(() => {

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -46,6 +46,12 @@ const READ_ALOUD_VOICE_DEFAULTS_PATH = PathUtils.join(Zotero.Profile.dir, 'readA
 // Whether the Read Aloud audio cache has been pruned of stale versions this session
 let readAloudCachePruned = false;
 
+// How long a reader tab can stay hidden before its rendered pages are
+// discarded to reclaim memory. Visible pages re-render when the tab is
+// selected again. Short enough to matter, long enough to avoid re-rendering
+// when quickly switching between tabs
+const SUSPEND_HIDDEN_TAB_AFTER = 60000; // ms
+
 class ReaderInstance {
 	constructor(options) {
 		this.stateFileName = '.zotero-reader-state';
@@ -1964,7 +1970,21 @@ class ReaderTab extends ReaderInstance {
 
 			this._tabContainer.addEventListener('tab-selection-change', (event) => {
 				if (event.detail.selected) {
+					if (this._suspendTimeout) {
+						clearTimeout(this._suspendTimeout);
+						this._suspendTimeout = null;
+					}
+					this._internalReader.setSuspended(false);
 					this._updateLayout();
+				}
+				else {
+					// Discard rendered pages after the tab has been hidden for a while,
+					// since each loaded reader tab otherwise keeps up to 10 rendered
+					// page canvases (plus snapshot copies) in memory indefinitely
+					this._suspendTimeout = setTimeout(() => {
+						this._suspendTimeout = null;
+						this._internalReader.setSuspended(true);
+					}, SUSPEND_HIDDEN_TAB_AFTER);
 				}
 			});
 			if (select) {
@@ -1974,6 +1994,10 @@ class ReaderTab extends ReaderInstance {
 	}
 
 	uninit() {
+		if (this._suspendTimeout) {
+			clearTimeout(this._suspendTimeout);
+			this._suspendTimeout = null;
+		}
 		if (this._window) {
 			this._window.removeEventListener('DOMContentLoaded', this._handleLoad);
 			this._window.removeEventListener('pointerdown', this._handlePointerDown);


### PR DESCRIPTION
## Why idle memory stays high with PDFs open

Four compounding causes, found by tracing the reader stack:

1. **Each open PDF keeps at least 10 fully rendered page canvases.** `PDFPageViewBuffer` (`web/pdf_viewer.js`, `DEFAULT_CACHE_SIZE = 10`) never shrinks below 10 and `update()` only ever grows it. At page-width zoom on a 2x HiDPI display a page canvas is ~2400×3100 device pixels ≈ 30 MB RGBA, capped at `maxCanvasPixels = 2^25` (128 MB). Zoomed pages add a detail-view canvas.
2. **The reader doubles that.** The annotation overlay renderer (`reader/src/pdf/page.js`) keeps a full-size `_snapshotCanvas` copy of every rendered page canvas — captured unconditionally, even for pages with no annotations — plus extracted per-page data in `_pdfPages`. So ~60 MB per buffered page, ~600 MB per loaded PDF tab, before the per-tab pdf.js worker heap (fonts/images).
3. **Hidden tabs release nothing.** On `tab-selection-change` the reader only ran `_updateLayout()` for the newly selected tab; a deselected reader kept its whole canvas buffer, snapshots, and worker heap indefinitely (#5676). pdf.js's idle `_cleanup` doesn't help: `PDFViewer.cleanup()` only resets non-FINISHED views, so finished canvases survive it.
4. **Tab unloading doesn't react to memory pressure** (#3843): `MAX_LOADED_TABS` = 3–5 and `UNLOAD_UNUSED_AFTER` = 24 h, so 3–5 idle tabs × ~600 MB lands right in the 1–4 GB range reported on the forums.

## What this PR does

- **`xpcom/reader.js`**: reader tabs call the reader's new `setSuspended(true)` 60 seconds after being hidden (grace period so quick tab switching doesn't thrash re-renders) and `setSuspended(false)` on selection. Suspension destroys all page views through the existing buffer-eviction path, freeing page canvases, detail-view canvases, snapshot copies, per-page data, and worker-side page/font resources; on selection, visible pages re-render through the normal path. The timer is cleared on tab teardown.
- **`tabs.js`**: a `memory-pressure` observer unloads all background tabs immediately when the OS reports low memory (`low-memory`/`low-memory-ongoing`, or `heap-minimize` from about:memory), complementing the count/age-based unloading. The observer is removed on window unload.

Net effect: a hidden PDF tab drops from ~600 MB of canvases to near zero, and background tabs are shed the moment the system is actually under pressure.

Addresses #5676 and #3843