### PR TITLE
Update staged builds in place for faster dev builds

### DIFF
--- a/app/scripts/add_omni_file
+++ b/app/scripts/add_omni_file
@@ -37,11 +37,14 @@ win_path="$STAGE_DIR/Zotero_win-x64"
 linux_path="$STAGE_DIR/Zotero_linux-x86_64"
 
 added=0
+build_id=$(date +%Y%m%d%H%M%S)
 for path in "$mac_path" "$win_path" "$linux_path"; do
 	if [ -d "$path" ]; then
 		echo "$path/app/omni.ja"
 		echo "Updating $(basename $(dirname $(dirname $path)))"
 		zip "$path/app/omni.ja" $files
+		# Bump BuildID so that startup caches are invalidated
+		perl -pi -e "s/^BuildID=.*/BuildID=$build_id/" "$path/app/application.ini"
 		added=1
 	fi
 done

--- a/app/scripts/build_and_run
+++ b/app/scripts/build_and_run
@@ -10,13 +10,23 @@ if [ -n "${ZOTERO_PROFILE:-}" ]; then
 	profile_args=(-p "$ZOTERO_PROFILE")
 fi
 
-REBUILD=0
+FORCE_FULL=0
+NO_REBUILD=0
 SKIP_BUNDLED_FILES=0
 DEBUGGER=0
-while getopts "rbd" opt; do
+while getopts "rfnbd" opt; do
 	case $opt in
 		r)
-			REBUILD=1
+			# Deprecated -- rebuilding is now the default
+			echo "-r is deprecated -- rebuilding is now the default (use -n to skip)" >&2
+			;;
+		
+		f)
+			FORCE_FULL=1
+			;;
+		
+		n)
+			NO_REBUILD=1
 			;;
 		
 		b)
@@ -28,7 +38,6 @@ while getopts "rbd" opt; do
 			;;
 		
 		\?)
-			echo "Invalid option: -$OPTARG" >&2
 			exit 1
 			;;
 	esac
@@ -37,12 +46,15 @@ done
 # Remove options from $@
 shift $((OPTIND-1))
 
-if [ $REBUILD -eq 1 ]; then
+if [ $NO_REBUILD -eq 0 ]; then
 	PARAMS=""
 	if [ $DEBUGGER -eq 1 ]; then
 		PARAMS="-t"
 	fi
-	
+	if [ $FORCE_FULL -eq 1 ]; then
+		PARAMS="$PARAMS -f"
+	fi
+
 	# Check if build watch is running
 	# If not, run now
 	if ! ps u | grep js-build/build.js | grep -v grep > /dev/null; then
@@ -50,16 +62,11 @@ if [ $REBUILD -eq 1 ]; then
 		echo
 		cd $ROOT_DIR
 		# TEMP: --openssl-legacy-provider avoids a build error in pdf.js
-		NODE_OPTIONS=--openssl-legacy-provider npm run build
+		NODE_OPTIONS=--openssl-legacy-provider node js-build/build.js
 		echo
 	fi
-	
-	"$SCRIPT_DIR/dir_build" -q $PARAMS
-	
-	if [ "`uname`" = "Darwin" ]; then
-		# Sign the Word dylib so it works on Apple Silicon
-		"$SCRIPT_DIR/codesign_local" "$APP_ROOT_DIR/staging/Zotero.app"
-	fi
+
+	"$SCRIPT_DIR/dir_build" $PARAMS
 fi
 
 PARAMS=""
@@ -87,4 +94,5 @@ else
 	exit 1
 fi
 
-"$APP_ROOT_DIR/staging/$command" "${profile_args[@]}" -ZoteroDebugText -purgecaches $PARAMS "$@"
+echo
+"$APP_ROOT_DIR/staging/$command" "${profile_args[@]}" -ZoteroDebugText $PARAMS "$@"

--- a/app/scripts/dir_build
+++ b/app/scripts/dir_build
@@ -5,6 +5,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 APP_ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 ROOT_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
 . "$APP_ROOT_DIR/config.sh"
+. "$SCRIPT_DIR/utils.sh"
 
 function usage {
 	cat >&2 <<DONE
@@ -17,7 +18,7 @@ Options
  -p PLATFORM        Platform to build (m=Mac, w=Windows, l=Linux)
  -a ARCH            Target architecture (arm64, x64, i686, win32) — **Windows/Linux only**
  -t                 add devtools
- -q                 quick build (skip compression and other optional steps for faster restarts during development)
+ -f                 force a full rebuild instead of updating the staged build in place
 DONE
 	exit 1
 }
@@ -25,8 +26,8 @@ DONE
 platform=""
 arch=""
 devtools=0
-quick_build=0
-while getopts "tp:a:q" opt; do
+force_full=0
+while getopts "tp:a:f" opt; do
 	case $opt in
 		t)
 			devtools=1
@@ -47,12 +48,11 @@ while getopts "tp:a:q" opt; do
 		a)
 			arch="$OPTARG"
 			;;
-		q)
-			quick_build=1
+		f)
+			force_full=1
 			;;
 		\?)
-			echo "Invalid option: -$OPTARG" >&2
-			exit 1
+			usage
 			;;
 	esac
 done
@@ -86,19 +86,84 @@ fi
 
 CHANNEL="source"
 
+# Remove stale symlinks left behind in build/ when source files are deleted,
+# which would otherwise break the build
+if [ -d "$ROOT_DIR/build" ]; then
+	# With -L, -type l matches only broken symlinks
+	stale_links=$(find -L "$ROOT_DIR/build" -type l -print)
+	if [ -n "$stale_links" ]; then
+		echo "Removing stale symlinks from build/:" >&2
+		echo "$stale_links" >&2
+		while IFS= read -r link; do
+			rm "$link"
+		done <<< "$stale_links"
+	fi
+fi
+
+# Try to update the staged build in place instead of doing a full rebuild
+if [[ $force_full -eq 0 ]]; then
+	incr_cmd=("$SCRIPT_DIR/incremental_update" -p "$platform")
+	[[ -n $arch ]] && incr_cmd+=( -a "$arch" )
+	[[ $devtools -eq 1 ]] && incr_cmd+=( -t )
+	set +e
+	"${incr_cmd[@]}"
+	incr_status=$?
+	set -e
+	if [ $incr_status -ne 2 ]; then
+		exit $incr_status
+	fi
+fi
+
 hash=$(git -C "$ROOT_DIR" rev-parse --short HEAD)
 
 build_dir=$(mktemp -d)
-cleanup() { rm -rf "$build_dir"; }
+manifest_tmp=""
+cleanup() {
+	rm -rf "$build_dir"
+	if [ -n "$manifest_tmp" ]; then
+		rm -f "$manifest_tmp"
+	fi
+}
 trap cleanup EXIT
+
+# Snapshot the state of build/ and app/ before the build for later incremental
+# updates
+app_hash=""
+if [ -d "$ROOT_DIR/build" ]; then
+	manifest_tmp=$(mktemp)
+	generate_build_manifest "$ROOT_DIR/build" > "$manifest_tmp"
+	app_hash=$(generate_app_hash "$APP_ROOT_DIR")
+fi
 
 "$SCRIPT_DIR/prepare_build" -s "$ROOT_DIR/build" -o "$build_dir" -c "$CHANNEL" -m "$hash"
 
-build_cmd=("$APP_ROOT_DIR/build.sh" -d "$build_dir" -p "$platform" -c "$CHANNEL" -s)
+build_cmd=("$APP_ROOT_DIR/build.sh" -d "$build_dir" -p "$platform" -c "$CHANNEL" -s -q)
 [[ -n $arch ]] && build_cmd+=( -a "$arch" )
 [[ $devtools -eq 1 ]] && build_cmd+=( -t )
-[[ $quick_build -eq 1 ]] && build_cmd+=( -q )
 
 "${build_cmd[@]}"
+
+# Save manifest for future incremental updates
+if [ -n "$manifest_tmp" ]; then
+	if [[ -z "${ZOTERO_TEST:-}" ]] || [[ "${ZOTERO_TEST:-}" == "0" ]]; then
+		include_tests=0
+	else
+		include_tests=1
+	fi
+	{
+		echo "#format=2"
+		echo "#include_tests=$include_tests"
+		echo "#devtools=$devtools"
+		echo "#app_hash=$app_hash"
+		cat "$manifest_tmp"
+	} > "$STAGE_DIR/.build-manifest"
+fi
+
+# Ad-hoc-sign the Word dylib so it works on Apple Silicon. This only needs to
+# happen when the staged build is fully rebuilt -- incremental updates don't
+# touch the dylib.
+if [[ $platform = "m" ]] && [[ "$(uname -s)" = "Darwin" ]]; then
+	"$SCRIPT_DIR/codesign_local" "$STAGE_DIR/Zotero.app"
+fi
 
 echo Done

--- a/app/scripts/incremental_update
+++ b/app/scripts/incremental_update
@@ -1,0 +1,322 @@
+#!/bin/bash
+set -euo pipefail
+
+#
+# Incrementally update a staged build in staging/ by zipping changed files from
+# the client build/ directory directly into app/omni.ja, based on a manifest
+# saved by dir_build after the last full build.
+#
+# Only files that are copied into omni.ja unmodified by build.sh can be updated
+# this way. If any other file changed (or a file was removed), a full rebuild
+# is required.
+#
+# Exit codes:
+#   0 -- staged build was updated (or nothing changed)
+#   2 -- a full rebuild is required
+#
+# This is normally run automatically by dir_build, not directly.
+#
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+APP_ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+ROOT_DIR="$(dirname "$APP_ROOT_DIR")"
+. "$APP_ROOT_DIR/config.sh"
+. "$SCRIPT_DIR/utils.sh"
+
+function usage {
+	cat >&2 <<DONE
+Usage: $0 -p PLATFORM [-a ARCH] [-t]
+
+Options
+ -p PLATFORM        platform of the staged build to update (m=Mac, w=Windows, l=Linux)
+ -a ARCH            target architecture (Windows/Linux only)
+ -t                 devtools requested
+DONE
+	exit 1
+}
+
+platform=""
+arch=""
+devtools=0
+while getopts "p:a:t" opt; do
+	case $opt in
+		p)
+			platform="$OPTARG"
+			;;
+		a)
+			arch="$OPTARG"
+			;;
+		t)
+			devtools=1
+			;;
+		*)
+			usage
+			;;
+	esac
+done
+
+if [ -z "$platform" ]; then
+	usage
+fi
+
+BUILD_SRC_DIR="$ROOT_DIR/build"
+MANIFEST_FILE="$STAGE_DIR/.build-manifest"
+
+function fall_back {
+	echo "$1 -- performing full build" >&2
+	exit 2
+}
+
+if [ ! -d "$BUILD_SRC_DIR" ]; then
+	fall_back "No build/ directory"
+fi
+if [ ! -f "$MANIFEST_FILE" ]; then
+	fall_back "No manifest from previous build"
+fi
+if [[ "$(sed -n 's/^#format=//p' "$MANIFEST_FILE")" != "2" ]]; then
+	fall_back "Unsupported manifest format"
+fi
+
+# Make sure a staged build exists for the requested platform
+case $platform in
+	m)
+		app_dir="$STAGE_DIR/Zotero.app/Contents/Resources"
+		;;
+	w)
+		app_dir="$STAGE_DIR/Zotero_$(get_canonical_arch w "$arch")"
+		;;
+	l)
+		app_dir="$STAGE_DIR/Zotero_linux-$(get_canonical_arch l "$arch")"
+		;;
+	*)
+		fall_back "Unknown platform '$platform'"
+		;;
+esac
+if [ ! -f "$app_dir/app/omni.ja" ]; then
+	fall_back "No staged build for requested platform"
+fi
+
+# If the previous build didn't include tests or devtools and they're requested
+# now, files are missing from the staged build
+manifest_tests=$(sed -n 's/^#include_tests=//p' "$MANIFEST_FILE")
+manifest_tests=${manifest_tests:-0}
+manifest_devtools=$(sed -n 's/^#devtools=//p' "$MANIFEST_FILE")
+manifest_devtools=${manifest_devtools:-0}
+if [[ -z "${ZOTERO_TEST:-}" ]] || [[ "${ZOTERO_TEST:-}" == "0" ]]; then
+	want_tests=0
+else
+	want_tests=1
+fi
+if [[ $want_tests -eq 1 ]] && [[ $manifest_tests != "1" ]]; then
+	fall_back "Tests requested but not included in staged build"
+fi
+if [[ $devtools -eq 1 ]] && [[ $manifest_devtools != "1" ]]; then
+	fall_back "Devtools requested but not included in staged build"
+fi
+
+# If anything changed in app/ (build scripts, assets, bundled modules, Firefox
+# runtime), a full rebuild is required
+manifest_app_hash=$(sed -n 's/^#app_hash=//p' "$MANIFEST_FILE")
+app_hash=$(generate_app_hash "$APP_ROOT_DIR")
+if [[ -z "$manifest_app_hash" ]] || [[ "$app_hash" != "$manifest_app_hash" ]]; then
+	fall_back "Files in app/ changed"
+fi
+
+file_list=$(mktemp)
+new_stats=$(mktemp)
+carried=$(mktemp)
+candidates=$(mktemp)
+removed=$(mktemp)
+cand_entries=$(mktemp)
+trap 'rm -f "$file_list" "$new_stats" "$carried" "$candidates" "$removed" "$cand_entries"' EXIT
+
+cd "$BUILD_SRC_DIR"
+
+# Quickly find files that may have changed based on size/mtime, so that only
+# those have to be hashed. Unmodified manifest entries are carried over,
+# new/modified files become candidates, and files no longer present are
+# considered removed.
+build_manifest_file_list > "$file_list"
+stat_file_list < "$file_list" > "$new_stats"
+awk -F'\t' -v carried="$carried" -v candidates="$candidates" -v removed="$removed" '
+	NR==FNR {
+		if (/^#/) next
+		hash[$3] = $1
+		stat[$3] = $2
+		next
+	}
+	{
+		if (!($2 in stat)) {
+			print > candidates
+		}
+		else {
+			if ($1 == stat[$2]) {
+				print hash[$2] "\t" $0 > carried
+			}
+			else {
+				print > candidates
+			}
+			delete stat[$2]
+		}
+	}
+	END {
+		for (path in stat) print path > removed
+	}
+' "$MANIFEST_FILE" "$new_stats"
+
+# Hash the candidates and compare to the previous hashes to find real changes
+# -- A = added, C = changed, R = removed
+if [ -s "$candidates" ]; then
+	paste \
+		<(cut -f2 "$candidates" | sed 's,^,./,' | tr '\n' '\0' | hash_file_list | cut -f1) \
+		"$candidates" \
+		> "$cand_entries"
+fi
+changes=$(
+	if [ -s "$cand_entries" ]; then
+		awk -F'\t' '
+			NR==FNR {
+				if (/^#/) next
+				old[$3] = $1
+				next
+			}
+			{
+				if (!($3 in old)) print "A\t" $3
+				else if (old[$3] != $1) print "C\t" $3
+			}
+		' "$MANIFEST_FILE" "$cand_entries"
+	fi
+	if [ -s "$removed" ]; then
+		awk '{print "R\t" $0}' "$removed"
+	fi
+)
+
+# Make sure all changed files can be zipped directly into omni.ja, and skip
+# ones that aren't included in the staged build
+zip_files=()
+ftl_files=()
+test_copy_files=()
+while IFS=$'\t' read -r status path; do
+	if [ -z "$status" ]; then
+		continue
+	fi
+	if [ "$status" == "R" ]; then
+		case "$path" in
+			test/*)
+				# Ignore removed test files if tests weren't included
+				if [[ $manifest_tests != "1" ]]; then
+					continue
+				fi
+				;;
+		esac
+		fall_back "$path was removed"
+	fi
+	case "$path" in
+		# Copied into localization/ subdirectories by build.sh
+		chrome/locale/*/zotero/mozilla/*)
+			fall_back "Can't update $path in place"
+			;;
+		# Pruned by prepare_build
+		chrome/content/zotero/locale/csl/*)
+			fall_back "Can't update $path in place"
+			;;
+		# Copied to localization/<locale>/ in addition to the chrome path
+		chrome/locale/*/zotero/*.ftl)
+			zip_files+=("$path")
+			ftl_files+=("$path")
+			;;
+		chrome/*|components/*|resource/*)
+			zip_files+=("$path")
+			;;
+		# Appended to the main chrome.manifest by build.sh
+		test/chrome.manifest)
+			fall_back "Can't update $path in place"
+			;;
+		test/*)
+			# If tests weren't included in the staged build, ignore changes
+			# to test files
+			if [[ $manifest_tests == "1" ]]; then
+				zip_files+=("$path")
+				case "$path" in
+					# Also copied to tests/ at the top level of the app
+					test/tests/*)
+						test_copy_files+=("$path")
+						;;
+				esac
+			fi
+			;;
+		*)
+			fall_back "Can't update $path in place"
+			;;
+	esac
+done <<< "$changes"
+
+# Find all staged omni.ja files to update (multiple can exist -- e.g., all
+# Windows architectures)
+omni_files=()
+while IFS= read -r file; do
+	omni_files+=("$file")
+done < <(find "$STAGE_DIR" -path '*/app/omni.ja')
+
+if [ ${#zip_files[@]} -gt 0 ]; then
+	echo "Changed files:"
+	for path in "${zip_files[@]}"; do
+		echo "  $path"
+	done
+	
+	cd "$BUILD_SRC_DIR"
+	for omni_file in "${omni_files[@]}"; do
+		echo "Updating ${omni_file#"$STAGE_DIR"/}"
+		zip -qX "$omni_file" "${zip_files[@]}"
+	done
+	
+	# Copy .ftl files to their localization/ paths
+	if [ ${#ftl_files[@]} -gt 0 ]; then
+		l10n_dir=$(mktemp -d)
+		for path in "${ftl_files[@]}"; do
+			locale=${path#chrome/locale/}
+			locale=${locale%%/*}
+			mkdir -p "$l10n_dir/localization/$locale"
+			cp -L "$path" "$l10n_dir/localization/$locale/$(basename "$path")"
+		done
+		pushd "$l10n_dir" > /dev/null
+		for omni_file in "${omni_files[@]}"; do
+			zip -qrX "$omni_file" localization
+		done
+		popd > /dev/null
+		rm -rf "$l10n_dir"
+	fi
+	
+	# Copy test files to tests/ directories
+	if [ ${#test_copy_files[@]} -gt 0 ]; then
+		for path in "${test_copy_files[@]}"; do
+			for omni_file in "${omni_files[@]}"; do
+				dest="${omni_file%/app/omni.ja}/tests/${path#test/tests/}"
+				mkdir -p "$(dirname "$dest")"
+				cp -L "$path" "$dest"
+			done
+		done
+	fi
+	
+	# Bump BuildID so that startup caches are invalidated even without
+	# -purgecaches
+	build_id=$(date +%Y%m%d%H%M%S)
+	for omni_file in "${omni_files[@]}"; do
+		perl -pi -e "s/^BuildID=.*/BuildID=$build_id/" "$(dirname "$omni_file")/application.ini"
+	done
+	
+	echo "Updated staged build with ${#zip_files[@]} changed file(s)"
+elif [ -n "$changes" ]; then
+	echo "No staged files changed"
+else
+	echo "No changes since last build"
+fi
+
+{
+	echo "#format=2"
+	echo "#include_tests=$manifest_tests"
+	echo "#devtools=$manifest_devtools"
+	echo "#app_hash=$app_hash"
+	LC_ALL=C sort -t$'\t' -k3 "$carried" "$cand_entries"
+} > "$MANIFEST_FILE.tmp"
+mv "$MANIFEST_FILE.tmp" "$MANIFEST_FILE"

--- a/app/scripts/utils.sh
+++ b/app/scripts/utils.sh
@@ -39,6 +39,84 @@ get_canonical_arch() {
 	esac
 }
 
+# Print a sorted NUL-separated list of the files in the current directory to
+# include in the build manifest. Follows symlinks, like the rsync calls in
+# prepare_build and build.sh.
+function build_manifest_file_list {
+	# Exclusions match the rsync call in prepare_build
+	find -L . -mindepth 1 \( -name '.*' -o -name '#*' \) -prune \
+			-o -type f ! -name 'package.json' ! -name 'package-lock.json' -print0 \
+		| LC_ALL=C sort -z
+}
+
+# Read a NUL-separated file list on stdin and print "size|mtime<TAB>path" for
+# each file
+function stat_file_list {
+	if [[ "$OSTYPE" == "darwin"* ]]; then
+		xargs -0 stat -L -f '%z|%Fm|%N'
+	else
+		xargs -0 stat -L -c '%s|%y|%n'
+	fi | sed -E 's,^([0-9]+[|][^|]+)[|](\./)?,\1'$'\t'','
+}
+
+# Read a NUL-separated file list on stdin and print "hash<TAB>path" for each
+# file
+function hash_file_list {
+	local md5_cmd
+	if command -v md5sum > /dev/null 2>&1; then
+		md5_cmd="md5sum"
+	else
+		md5_cmd="md5 -r"
+	fi
+	xargs -0 $md5_cmd | sed -E 's,^([0-9a-f]{32})  ?(\./)?,\1'$'\t'','
+}
+
+# Generate a manifest of a build directory for incremental updates, with one
+# "hash<TAB>size|mtime<TAB>path" line per file, sorted by path
+function generate_build_manifest {
+	local dir=$1
+	(
+		cd "$dir"
+		local file_list
+		file_list=$(mktemp)
+		build_manifest_file_list > "$file_list"
+		paste \
+			<(hash_file_list < "$file_list" | cut -f1) \
+			<(stat_file_list < "$file_list")
+		rm -f "$file_list"
+	)
+}
+
+# Generate a hash of the files in app/ that affect build output, for detecting
+# when a staged build can't be updated incrementally. Since some of the files
+# are large binaries, use file sizes and modification times rather than
+# contents. The xulrunner runtimes are covered by the hash-* files written by
+# fetch_xulrunner.
+function generate_app_hash {
+	local app_dir=$1
+	local md5_cmd
+	if command -v md5sum > /dev/null 2>&1; then
+		md5_cmd="md5sum"
+	else
+		md5_cmd="md5 -r"
+	fi
+	(
+		cd "$app_dir"
+		local paths=(assets build.sh config.sh scripts mac win linux modules update-packaging)
+		if [ -f config-custom.sh ]; then
+			paths+=(config-custom.sh)
+		fi
+		{
+			if [[ "$OSTYPE" == "darwin"* ]]; then
+				find -L "${paths[@]}" -name '.*' -prune -o -type f -print0 | xargs -0 stat -L -f '%N|%z|%m'
+			else
+				find -L "${paths[@]}" -name '.*' -prune -o -type f -print0 | xargs -0 stat -L -c '%n|%s|%Y'
+			fi
+			cat xulrunner/hash-* 2> /dev/null || true
+		} | LC_ALL=C sort | $md5_cmd | awk '{print $1}'
+	)
+}
+
 function check_line {
 	pattern=$1
 	file=$2

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -173,11 +173,11 @@ if [[ -z "$CI" ]] && ! ps | grep js-build/build.js | grep -v grep > /dev/null; t
 	echo
 	echo "Running JS build process"
 	cd "$ROOT_DIR"
-	NODE_OPTIONS=--openssl-legacy-provider npm run build || exit $?
+	NODE_OPTIONS=--openssl-legacy-provider node js-build/build.js || exit $?
 	echo
 fi
 
-ZOTERO_TEST=1 "$ROOT_DIR/app/scripts/dir_build" -q
+ZOTERO_TEST=1 "$ROOT_DIR/app/scripts/dir_build"
 
 makePath FX_PROFILE "$PROFILE"
 MOZ_NO_REMOTE=1 NO_EM_RESTART=1 "$Z_EXECUTABLE" -profile "$FX_PROFILE" \


### PR DESCRIPTION
`dir_build` now saves a manifest of `build/` file hashes and stats after a full build. On subsequent runs, if all changed files are ones that go into `omni.ja` unmodified (`chrome/`, `components/`, `resource/`, and `test/` when tests are staged), it zips just those into the staged `omni.ja` instead of rebuilding — ~15s → ~0.3s on an M1 Mac, for both `build_and_run -r` and `runtests.sh`.

Zotero `.ftl` files are also updated at their `localization/<locale>/` paths, and test files are copied to the staged `tests/` directory.

Anything else falls back to a full rebuild automatically: files transformed by `build.sh` (`defaults/`, `chrome.manifest`, `version`, `translators/`, `styles/`, mozilla `.ftl`s, CSL locales), removed files, changes in `app/` (size/mtime fingerprint; xulrunner covered by the `hash-*` files), or requesting tests/devtools that aren't staged.

Flag changes:

- `dir_build` no longer takes `-q` — it always builds the uncompressed `omni.ja`, since the compressed/optimized version only matters for distribution builds via `build.sh` (unchanged). This also means the incremental path never encounters an optimized jar, which `zip` can't update.
- New `-f` on `dir_build` and `build_and_run` forces a full rebuild.
- `build_and_run` now always rebuilds — `-r` is gone, and a rebuild with no changes only takes ~1s even without the watch process running. New `-n` skips the rebuild and just launches.
- `build_and_run` no longer passes `-purgecaches`: startup caches are invalidated automatically via the BuildID, which is now bumped whenever `omni.ja` changes (including by `add_omni_file`), so relaunches of an unchanged build can use the startup cache.
- `build_and_run` and `runtests.sh` invoke `js-build/build.js` directly instead of via `npm run`, saving ~270ms of npm overhead.

Also fixes `dir_build` to remove broken symlinks left in `build/` by deleted source files, which previously broke the rsync in `prepare_build`.

