### PR TITLE
Run tests in parallel CI shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ jobs:
   test:
     name: Test (shard ${{ matrix.shard }})
     runs-on: ubuntu-latest
+    # Same-repo PRs are covered by the push run, so run pull_request jobs only for forks
+    if: >
+      github.event_name != 'pull_request'
+      || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       matrix:
         shard: [1, 2, 3, 4]
@@ -83,6 +87,9 @@ jobs:
   utilities:
     name: Utilities Tests
     runs-on: ubuntu-latest
+    if: >
+      github.event_name != 'pull_request'
+      || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,59 +4,62 @@ concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 jobs:
-  build:
-    name: Build, Upload, Test
+  test:
+    name: Test (shard ${{ matrix.shard }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
           lfs: true
-      
+
       - name: Install Node
         uses: actions/setup-node@v4
         with:
           node-version: 18
           #cache: npm
-      
+
       # On GitHub
       - name: Install xvfb
         if: env.ACT != 'true'
         run: sudo apt update && sudo apt install -y xvfb
-      
+
       # Local via act
       - name: Install packages for act
         if: env.ACT == 'true'
         run: apt update && apt install -y zstd xvfb dbus-x11 libgtk-3-0 libx11-xcb1 libdbus-glib-1-2 libxt6
-      
+
       - name: Cache xulrunner
         id: xulrunner-cache
         uses: actions/cache@v4
         with:
           path: app/xulrunner/firefox-x86_64
           key: xulrunner-${{ hashFiles('app/config.sh', 'app/scripts/fetch_xulrunner') }}
-      
+
       - name: Fetch xulrunner
         if: steps.xulrunner-cache.outputs.cache-hit != 'true'
         run: app/scripts/fetch_xulrunner -p l
-      
+
       - name: Cache Node modules
         id: node-cache
         uses: actions/cache@v4
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}
-        
+
       - name: Install Node modules
         if: steps.node-cache.outputs.cache-hit != 'true'
         run: npm install
-        
+
       - name: Build Zotero
         run: npm run build
         # Currently necessary for document-worker Webpack: https://stackoverflow.com/a/69746937
         env:
           NODE_OPTIONS: --openssl-legacy-provider
-      
+
       # Create deployment ZIP from the build output, then replace build/ with the
       # unzipped contents so that tests run against the same artifact that gets
       # deployed. This catches problems that only manifest after a zip round-trip
@@ -74,18 +77,89 @@ jobs:
           cd build
           unzip ../build.zip
 
-      # Build deployment ZIPs from main, version branches (e.g., 9.0, 10.0), and *-hotfix branches
+      - name: Run tests
+        run: xvfb-run test/runtests.sh -f -r 3 -p ${{ matrix.shard }}/${{ strategy.job-total }}
+
+  utilities:
+    name: Utilities Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Cache utilities Node modules
+        id: utilities-node-cache
+        uses: actions/cache@v4
+        with:
+          path: chrome/content/zotero/xpcom/utilities/node_modules
+          key: utilities-node-modules-${{ hashFiles('chrome/content/zotero/xpcom/utilities/package-lock.json') }}
+
+      - name: Install utilities Node modules
+        if: steps.utilities-node-cache.outputs.cache-hit != 'true'
+        run: npm install --prefix chrome/content/zotero/xpcom/utilities
+
+      - name: Run utilities tests
+        run: |
+          npm test --prefix chrome/content/zotero/xpcom/utilities -- -j resource/schema/global/schema.json
+
+  # Build deployment ZIPs from main, version branches (e.g., 9.0, 10.0), and *-hotfix branches
+  deploy:
+    name: Build, Upload
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.repository == 'zotero/zotero'
+    steps:
       - name: Check if deployment branch
         id: check-deploy
-        if: |
-          env.ACT != 'true'
-          && github.repository == 'zotero/zotero'
-          && github.event_name == 'push'
+        if: env.ACT != 'true'
         run: |
           branch="${GITHUB_REF#refs/heads/}"
           if [[ "$branch" == "main" || "$branch" =~ ^[0-9]+\.[0-9]+$ || "$branch" == *-hotfix ]]; then
             echo "deploy=true" >> "$GITHUB_OUTPUT"
           fi
+
+      - uses: actions/checkout@v4
+        if: steps.check-deploy.outputs.deploy == 'true'
+        with:
+          submodules: recursive
+          lfs: true
+
+      - name: Install Node
+        if: steps.check-deploy.outputs.deploy == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Cache Node modules
+        id: node-cache
+        if: steps.check-deploy.outputs.deploy == 'true'
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Node modules
+        if: steps.check-deploy.outputs.deploy == 'true' && steps.node-cache.outputs.cache-hit != 'true'
+        run: npm install
+
+      - name: Build Zotero
+        if: steps.check-deploy.outputs.deploy == 'true'
+        run: npm run build
+        # Currently necessary for document-worker Webpack: https://stackoverflow.com/a/69746937
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider
+
+      - name: Create deployment ZIP
+        if: steps.check-deploy.outputs.deploy == 'true'
+        run: |
+          cd build
+          zip -r ../build.zip *
+          cd ..
 
       - uses: ruby/setup-ruby@v1
         if: steps.check-deploy.outputs.deploy == 'true'
@@ -103,21 +177,3 @@ jobs:
           cp build.zip build-zip/$GITHUB_SHA.zip
           gem install --no-document dpl -v '>= 2.0'
           dpl s3 --bucket zotero-download --local_dir build-zip --upload_dir ci/client --acl public_read
-
-      - name: Run tests
-        run: xvfb-run test/runtests.sh -f -r 3
-
-      - name: Cache utilities Node modules
-        id: utilities-node-cache
-        uses: actions/cache@v4
-        with:
-          path: chrome/content/zotero/xpcom/utilities/node_modules
-          key: utilities-node-modules-${{ hashFiles('chrome/content/zotero/xpcom/utilities/package-lock.json') }}
-
-      - name: Install utilities Node modules
-        if: steps.utilities-node-cache.outputs.cache-hit != 'true'
-        run: npm install --prefix chrome/content/zotero/xpcom/utilities
-
-      - name: Run utilities tests
-        run: |
-          npm test --prefix chrome/content/zotero/xpcom/utilities -- -j resource/schema/global/schema.json

--- a/app/assets/commandLineHandler.js
+++ b/app/assets/commandLineHandler.js
@@ -50,6 +50,7 @@ if (processTestOptions) {
 	TestOptions.bail = cmdLine.handleFlag("bail", false);
 	TestOptions.startAt = cmdLine.handleFlagWithParam("startAtTestFile", false);
 	TestOptions.stopAt = cmdLine.handleFlagWithParam("stopAtTestFile", false);
+	TestOptions.shard = cmdLine.handleFlagWithParam("shard", false);
 	TestOptions.grep = cmdLine.handleFlagWithParam("grep", false);
 	TestOptions.timeout = cmdLine.handleFlagWithParam("ZoteroTestTimeout", false);
 	TestOptions.retries = cmdLine.handleFlagWithParam("retries", false) || 0;

--- a/chrome/content/zotero/modules/commandLineOptions.mjs
+++ b/chrome/content/zotero/modules/commandLineOptions.mjs
@@ -19,6 +19,7 @@ export var TestOptions = {
 	bail: false,
 	startAt: false,
 	stopAt: false,
+	shard: false,
 	grep: false,
 	timeout: false,
 	retries: 0,

--- a/test/content/runtests.js
+++ b/test/content/runtests.js
@@ -121,7 +121,7 @@ function Reporter(runner) {
 		dump(msg+"\n");
 	});
 
-	runner.on('fail', function(test, err){
+	function cleanErrorStack(err) {
 		// Remove internal code references
 		err.stack = err.stack.replace(/.+(?:zotero-unit\/|\/Task\.jsm|zotero\/bluebird\/).+\n?/g, "");
 		
@@ -136,6 +136,21 @@ function Reporter(runner) {
 		
 		// Make sure there's a blank line after all stack traces
 		err.stack = err.stack.replace(/\s*$/, '\n\n');
+	}
+	
+	runner.on('retry', function (test, err) {
+		cleanErrorStack(err);
+		let indentStr = indent();
+		dump(indentStr
+			// Yellow X for failures that will be retried
+			+ "\x1B[33;40m" + Mocha.reporters.Base.symbols.err + " [FAIL -- retrying]\x1B[0m"
+			+ " " + test.title + "\n"
+			+ indentStr + "  " + err.message + " at\n"
+			+ err.stack.replace(/^/gm, indentStr + "    ").trim() + "\n\n");
+	});
+	
+	runner.on('fail', function(test, err){
+		cleanErrorStack(err);
 		
 		failed++;
 		let indentStr = indent();

--- a/test/content/runtests.js
+++ b/test/content/runtests.js
@@ -256,6 +256,41 @@ if (run && TestOptions.tests) {
 			dump(`Invalid start file ${startFile}\n`);
 		}
 		testFiles = testFiles.slice(startPos, stopPos + 1);
+
+		// Limit to the given shard of the file list (e.g., "2/4")
+		if (TestOptions.shard) {
+			let matches = TestOptions.shard.match(/^([0-9]+)\/([0-9]+)$/);
+			let shard = matches && parseInt(matches[1]);
+			let numShards = matches && parseInt(matches[2]);
+			if (!matches || shard < 1 || shard > numShards) {
+				dump(`Invalid shard ${TestOptions.shard}\n`);
+				run = false;
+				quit(true);
+			}
+			else {
+				// Split the sorted file list into contiguous chunks of roughly equal total file
+				// size, using size as a stand-in for run time. Contiguous chunks preserve the
+				// alphabetical run order of a full run, and a shard can be reproduced locally by
+				// passing its first and last files to -s and -e.
+				let sizes = new Map();
+				let totalSize = 0;
+				for (let fname of testFiles) {
+					let file = testDirectory.clone();
+					file.append(fname);
+					sizes.set(fname, file.fileSize);
+					totalSize += file.fileSize;
+				}
+				// A file belongs to the shard that the midpoint of its size range falls in
+				let cumSize = 0;
+				testFiles = testFiles.filter((fname) => {
+					let midpoint = cumSize + sizes.get(fname) / 2;
+					cumSize += sizes.get(fname);
+					return Math.min(numShards - 1, Math.floor(midpoint / totalSize * numShards)) == shard - 1;
+				});
+				dump(`Running shard ${shard}/${numShards} with ${testFiles.length} test files:\n`
+					+ testFiles.join(' ') + '\n');
+			}
+		}
 	} else {
 		var specifiedTests = TestOptions.tests.split(",");
 		for (let test of specifiedTests) {

--- a/test/content/support.js
+++ b/test/content/support.js
@@ -429,7 +429,7 @@ function waitForCallback(cb, interval, timeout) {
 			deferred.resolve(success);
 		} else if(Date.now() - start > timeout*1000) {
 			clearInterval(id);
-			deferred.reject(new Error("Promise timed out"));
+			deferred.reject(new Error("Promise timed out: " + cb.toString()));
 		}
 	}, interval);
 	return deferred.promise;

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -46,6 +46,7 @@ Options
  -f                  stop after first test failure
  -g                  only run tests matching the given pattern (grep)
  -h                  display this help
+ -p SHARD/TOTAL      run only the given shard of the default test set (e.g., 2/4)
  -r RETRIES          retry failed tests the given number of times (default: 0)
  -s TEST             start at the given test
  -t                  generate test data and quit
@@ -58,7 +59,7 @@ DONE
 DEBUG=false
 DEBUG_LEVEL=5
 RETRIES=0
-while getopts "bcd:e:fg:hr:s:tx:" opt; do
+while getopts "bcd:e:fg:hp:r:s:tx:" opt; do
 	case $opt in
         b)
         	Z_ARGS="$Z_ARGS -ZoteroSkipBundledFiles"
@@ -84,6 +85,12 @@ while getopts "bcd:e:fg:hr:s:tx:" opt; do
 			;;
 		h)
 			usage
+			;;
+		p)
+			if [[ ! "$OPTARG" =~ ^[1-9][0-9]*/[1-9][0-9]*$ ]]; then
+				usage
+			fi
+			Z_ARGS="$Z_ARGS -shard $OPTARG"
 			;;
 		r)
 			RETRIES="$OPTARG"

--- a/test/tests/citationDialogTest.js
+++ b/test/tests/citationDialogTest.js
@@ -19,6 +19,8 @@ describe("Citation Dialog", function () {
 	let dialog, win, doc, IOManager, CitationDataManager, SearchHandler;
 
 	before(async function () {
+		// Zotero.Cite.getLocatorString() requires styles to be initialized
+		await Zotero.Styles.init();
 		// one of helper functions of searchHandler uses zotero pane
 		win = await loadZoteroPane();
 		let dialogPromise = waitForWindow("chrome://zotero/content/integration/citationDialog.xhtml");

--- a/test/tests/itemPaneTest.js
+++ b/test/tests/itemPaneTest.js
@@ -804,11 +804,14 @@ describe("Item pane", function () {
 	describe("Attachments pane", function () {
 		let paneID = "attachments";
 
-		beforeEach(function () {
+		beforeEach(async function () {
 			Zotero.Prefs.set("panes.attachments.open", true);
 			Zotero.Prefs.set("showAttachmentPreview", true);
 			Zotero_Tabs.select("zotero-pane");
 			win.resizeTo(1000, 800);
+			// Wait for the resize to take effect, since some tests shrink the window without
+			// waiting for the restore at the end
+			await waitForCallback(() => win.outerWidth == 1000 && win.outerHeight == 800, 100, 3);
 		});
 
 		afterEach(function () {

--- a/test/tests/itemPaneTest.js
+++ b/test/tests/itemPaneTest.js
@@ -987,6 +987,8 @@ describe("Item pane", function () {
 			await item.saveTx();
 
 			await ZoteroPane.selectItem(item.id);
+			// Scroll to the pane, since pinning doesn't reliably render it if it's out of view
+			await waitForScrollToPane(itemDetails, paneID);
 			// Pass the item id so we don't return early due to a previous item's completed render
 			assert.isTrue(await waitForPreviewBoxRender(attachmentsBox, item.id));
 			// No preview
@@ -1149,6 +1151,8 @@ describe("Item pane", function () {
 			let annotation = await createAnnotation('highlight', attachment1);
 
 			await itemDetails._renderPromise;
+			// Scroll to the pane, since pinning doesn't reliably render it if it's out of view
+			await waitForScrollToPane(itemDetails, paneID);
 			await waitForPreviewBoxReader(attachmentsBox, attachment1.id);
 
 			assert.isFalse(attachmentsBox.hidden);
@@ -1175,6 +1179,7 @@ describe("Item pane", function () {
 
 			// Select item with attachment (no annotation)
 			await itemDetails._renderPromise;
+			await waitForScrollToPane(itemDetails, paneID);
 			await waitForPreviewBoxReader(attachmentsBox, attachment2.id);
 
 			assert.isFalse(attachmentsBox.hidden);
@@ -1194,6 +1199,7 @@ describe("Item pane", function () {
 
 			// Select item without attachment
 			await itemDetails._renderPromise;
+			await waitForScrollToPane(itemDetails, paneID);
 
 			assert.isFalse(attachmentsBox.hidden);
 			assert.equal(attachmentsBox.querySelectorAll("attachment-row").length, 0);
@@ -1201,6 +1207,7 @@ describe("Item pane", function () {
 			// Again, select item with attachment (1 annotation)
 			await ZoteroPane.selectItem(item1.id);
 			await itemDetails._renderPromise;
+			await waitForScrollToPane(itemDetails, paneID);
 			await waitForPreviewBoxReader(attachmentsBox, attachment1.id);
 
 			assert.isFalse(attachmentsBox.hidden);
@@ -1344,10 +1351,13 @@ describe("Item pane", function () {
 
 			// Should be able to render the correct preview
 			await ZoteroPane.selectItem(item1.id);
+			// Scroll to the pane, since pinning doesn't reliably render it if it's out of view
+			await waitForScrollToPane(itemDetails, paneID);
 			await waitForPreviewBoxReader(attachmentsBox, attachment1.id);
 			assert.isTrue(await isPreviewDisplayed(attachmentsBox));
 
 			await ZoteroPane.selectItem(item2.id);
+			await waitForScrollToPane(itemDetails, paneID);
 			await waitForPreviewBoxReader(attachmentsBox, attachment2.id);
 			assert.isTrue(await isPreviewDisplayed(attachmentsBox));
 

--- a/test/tests/itemPaneTest.js
+++ b/test/tests/itemPaneTest.js
@@ -984,7 +984,8 @@ describe("Item pane", function () {
 			await item.saveTx();
 
 			await ZoteroPane.selectItem(item.id);
-			assert.isTrue(await waitForPreviewBoxRender(attachmentsBox));
+			// Pass the item id so we don't return early due to a previous item's completed render
+			assert.isTrue(await waitForPreviewBoxRender(attachmentsBox, item.id));
 			// No preview
 			assert.isFalse(await isPreviewDisplayed(attachmentsBox));
 			// No row

--- a/test/tests/recognizeDocumentTest.js
+++ b/test/tests/recognizeDocumentTest.js
@@ -16,6 +16,8 @@ describe("Document Recognition", function () {
 		
 		this.timeout(60000);
 		Zotero.Prefs.set('autoRenameFiles.onMetadataChange', false); // Prevent auto-rename triggering during recognition
+		// EPUB recognition translates the EPUB's RDF metadata
+		yield Zotero.Translators.init();
 		// Load Zotero pane and install PDF tools
 		yield Promise.all([
 			loadZoteroPane().then(w => win = w)

--- a/test/tests/recognizeDocumentTest.js
+++ b/test/tests/recognizeDocumentTest.js
@@ -39,6 +39,10 @@ describe("Document Recognition", function () {
 		
 		queue.cancel();
 		Zotero.RecognizeDocument._recognize.restore && Zotero.RecognizeDocument._recognize.restore();
+		// Restore stub if a test failed before restoring it, so that retries don't fail with
+		// "Attempted to wrap translate which is already wrapped"
+		Zotero.Translate.Search.prototype.translate.restore
+			&& Zotero.Translate.Search.prototype.translate.restore();
 		Zotero.Prefs.clear('autoRenameFiles.linked');
 	});
 	

--- a/test/tests/translatorsTest.js
+++ b/test/tests/translatorsTest.js
@@ -1,6 +1,10 @@
 "use strict";
 
 describe("Zotero.Translators", function () {
+	before(async function () {
+		await Zotero.Translators.init();
+	});
+
 	describe("#init()", function () {
 		async function testUpdateCache({ translatorID, label1, label2, lastUpdated1, lastUpdated2, expect }) {
 			var translator1 = buildDummyTranslator('web', `function doDetect() {}; function doSearch(); {}`, {


### PR DESCRIPTION
CI runs currently take ~11–12 minutes, almost all of it in the test run. This splits the tests across 4 parallel jobs, bringing a run down to ~5 minutes.

- `runtests.sh` gets a `-p SHARD/TOTAL` option (e.g., `-p 2/4`). The sorted test file list is split into contiguous alphabetical chunks of roughly equal total file size, with size as a stand-in for run time, so new test files are included automatically and no timing data needs to be maintained. Since chunks are contiguous, files run with the same preceding files as in a full run (except at chunk starts), and a shard can be reproduced locally by passing its first and last files to `-s`/`-e`.
- The CI workflow runs a matrix of 4 shard jobs, each doing the same build + ZIP round-trip as before. Each shard builds itself rather than sharing an artifact from an upstream job — with caching the build is ~17s, less than an artifact download would cost, and shards don't have to wait for a separate build job to finish before starting. A failure in one shard cancels the others. The deployment ZIP upload and utilities tests move to separate jobs, and `pull_request` jobs are skipped for same-repo PRs, which are already covered by the push run (fork PRs are unaffected).
- The test reporter now logs failures that will be retried, which previously weren't shown at all, and `waitForCallback` timeout errors include the callback source.

Sharding exposed several tests that depended on state from earlier test files, fixed here:

- `citationDialogTest`, `recognizeDocumentTest`, and `translatorsTest` were missing `Zotero.Styles.init()`/`Zotero.Translators.init()` calls.
- `recognizeDocumentTest` left a sinon stub wrapped after a failure, which broke retries.
- itemPaneTest attachments-pane tests relied on window size from a previous test or on `pinnedPane` to trigger rendering. (Setting `itemDetails.pinnedPane` can silently fail to stick — possibly stale pref observers from destroyed itemDetails instances clearing the pref. Worth a separate look, since it presumably affects actual pinning; the tests now scroll to the pane instead.)

Shard times are currently ~135/171/152/120s; changing the shard count is just editing the matrix list.