### PR TITLE
Ensure emoji detection works as intended with Unicode 17 implementation (ESR 153)

### DIFF
--- a/chrome/content/zotero/xpcom/data/tags.js
+++ b/chrome/content/zotero/xpcom/data/tags.js
@@ -860,8 +860,10 @@ Zotero.Tags = new function () {
 	
 	// Return the first sequence of emojis from a string
 	this.extractEmojiForItemsList = function (str) {
-		// Either match RGI_Emoji (which includes country flags) or any character followed by the Variation Selector-16
-		let re = /(?:(?:\p{RGI_Emoji}|[\p{Extended_Pictographic}--[©®™]])(?!\uFE0F)|.\uFE0F)+/gv;
+		// Either match RGI_Emoji (which includes country flags), a pictographic symbol (see
+		// Zotero.Utilities.Internal.containsEmoji()), or any character followed by the Variation
+		// Selector-16
+		let re = /(?:(?:\p{RGI_Emoji}|[[\p{Extended_Pictographic}[\p{So}&&[☀-➿\u{1F000}-\u{1FAFF}]]]--[©®™\u{1F1E6}-\u{1F1FF}]])(?!\uFE0F)|.\uFE0F)+/gv;
 		return str.match(re)?.[0] || null;
 	};
 

--- a/chrome/content/zotero/xpcom/utilities_internal.js
+++ b/chrome/content/zotero/xpcom/utilities_internal.js
@@ -482,13 +482,13 @@ Zotero.Utilities.Internal = {
 	},
 	
 	containsEmoji: function (str) {
-		let re = /\p{RGI_Emoji}|[\p{Extended_Pictographic}--[©®™]]/gv;
+		let re = /\p{RGI_Emoji}|[[\p{Extended_Pictographic}[\p{So}&&[☀-➿\u{1F000}-\u{1FAFF}]]]--[©®™\u{1F1E6}-\u{1F1FF}]]/gv;
 		return !!str.match(re);
 	},
 
 	includesEmoji: function (str) {
 		// Remove emoji, Zero Width Joiner, and Variation Selector-16 and compare lengths
-		const re = /(?:(?:\p{RGI_Emoji}|[\p{Extended_Pictographic}--[©®™]])(?!\uFE0F)|.\uFE0F)+/gv;
+		const re = /(?:(?:\p{RGI_Emoji}|[[\p{Extended_Pictographic}[\p{So}&&[☀-➿\u{1F000}-\u{1FAFF}]]]--[©®™\u{1F1E6}-\u{1F1FF}]])(?!\uFE0F)|.\uFE0F)+/gv;
 		return str.replace(re, '').length !== str.length;
 	},
 	


### PR DESCRIPTION
Once we update Firefox to the next ESR version (153), current emoji extractions breaks (existing tests will start failing). That's because Unicode 17 reduced the range of `Extended_Pictographic` so it now excludes some symbols that we expect to extract as "emojis".

This PR changes the regex to keep matching the symbols we want that would not be matched with ESR 153 (e.g. "☼") while not still matching symbols we don't want matched (e.g., "©", "®", "™"). The actual range of matched characters is wider than it was (e.g., we now match "✓", "✗" which I believe is actually useful).

This is safe to merge before ESR 153.

Related:
https://github.com/zotero/web-library/commit/5af7c79d0b0b01144b1c51f64e8f092fb2b6da79