### PR TITLE
Add open-access DocumentResolver with Unpaywall, arXiv, and PubMed Central

### DIFF
--- a/chrome/content/zotero/xpcom/documentResolver.mjs
+++ b/chrome/content/zotero/xpcom/documentResolver.mjs
@@ -1,0 +1,270 @@
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2024 Corporation for Digital Scholarship
+					 Vienna, Virginia, USA
+					 https://digitalscholar.org
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+import { unpaywallSource } from "./openAccessSources/unpaywall.mjs";
+import { arxivSource } from "./openAccessSources/arxiv.mjs";
+import { pubmedCentralSource } from "./openAccessSources/pubmedcentral.mjs";
+
+/**
+ * Orchestrates open-access document resolution across multiple sources.
+ * Plugins can register custom sources via the PluginAPI.
+ */
+Zotero.DocumentResolver = new function () {
+	const lazy = {};
+	ChromeUtils.defineESModuleGetters(lazy, {
+		Zotero: "chrome://zotero/content/zotero.mjs",
+	});
+
+	// Built-in sources
+	let _sources = [
+		unpaywallSource,
+		pubmedCentralSource,
+		arxivSource,
+	];
+
+	let _customSources = new Map(); // pluginID -> source
+
+	/**
+	 * Initialize the document resolver
+	 */
+	this.init = async function () {
+		lazy.Zotero.debug("DocumentResolver initialized with " + _sources.length + " sources");
+	};
+
+	/**
+	 * Find an open-access PDF for an item by querying all enabled sources
+	 * in priority order.
+	 *
+	 * @param {Zotero.Item} item
+	 * @param {Object} [options]
+	 * @param {string[]} [options.sourceIDs] - Only search these sources
+	 * @param {boolean} [options.skipDisabled] - Skip disabled sources (default: true)
+	 * @return {Promise<Object|null>} - { url: string, sourceID: string } or null
+	 */
+	this.findDocument = async function (item, options = {}) {
+		const skipDisabled = options.skipDisabled !== false;
+		let sources = _sources.concat(Array.from(_customSources.values()));
+
+		if (options.sourceIDs) {
+			sources = sources.filter(s => options.sourceIDs.includes(s.id));
+		}
+
+		// Sort by priority (higher first)
+		sources.sort((a, b) => b.priority - a.priority);
+
+		for (let source of sources) {
+			if (skipDisabled && !source.enabled) {
+				continue;
+			}
+
+			try {
+				const configured = await source.isConfigured();
+				if (!configured) {
+					lazy.Zotero.debug(`DocumentResolver: Skipping ${source.id} (not configured)`);
+					continue;
+				}
+
+				const url = await source.findPDF(item);
+				if (url) {
+					lazy.Zotero.debug(`DocumentResolver: Found PDF from ${source.id}`);
+					return {
+						url,
+						sourceID: source.id,
+						sourceName: source.name,
+					};
+				}
+			}
+			catch (e) {
+				lazy.Zotero.debug(`DocumentResolver error in ${source.id}: ${e.message}`);
+			}
+		}
+
+		return null;
+	};
+
+	/**
+	 * Get all registered sources (built-in and custom)
+	 * @return {Object[]}
+	 */
+	this.getSources = function () {
+		return _sources.concat(Array.from(_customSources.values()))
+			.map(s => ({
+				id: s.id,
+				name: s.name,
+				description: s.description,
+				enabled: s.enabled,
+				priority: s.priority,
+				isCustom: _customSources.has(s.id),
+				requiresAuth: s.requiresAuth(),
+			}));
+	};
+
+	/**
+	 * Enable/disable a source
+	 * @param {string} sourceID
+	 * @param {boolean} enabled
+	 */
+	this.setSourceEnabled = function (sourceID, enabled) {
+		const source = _sources.find(s => s.id === sourceID) ||
+			_customSources.get(sourceID);
+		if (source) {
+			source.enabled = enabled;
+		}
+	};
+
+	/**
+	 * Register a custom source (from plugin)
+	 * @param {OpenAccessSourceBase} source
+	 * @param {string} pluginID
+	 */
+	this.registerSource = function (source, pluginID) {
+		if (!source.id || !source.name) {
+			throw new Error("Source must have id and name properties");
+		}
+		source.pluginID = pluginID;
+		_customSources.set(source.id, source);
+		lazy.Zotero.debug(`DocumentResolver: Registered custom source ${source.id} from ${pluginID}`);
+	};
+
+	/**
+	 * Unregister a custom source
+	 * @param {string} sourceID
+	 */
+	this.unregisterSource = function (sourceID) {
+		if (_customSources.has(sourceID)) {
+			_customSources.delete(sourceID);
+			lazy.Zotero.debug(`DocumentResolver: Unregistered source ${sourceID}`);
+		}
+	};
+
+	/**
+	 * Get a source by ID
+	 * @param {string} sourceID
+	 * @return {Object|null}
+	 */
+	this.getSource = function (sourceID) {
+		return _sources.find(s => s.id === sourceID) || _customSources.get(sourceID) || null;
+	};
+
+	/**
+	 * Download and attach a document to an item
+	 * @param {Zotero.Item} item - The parent item
+	 * @param {string} url - URL to the PDF
+	 * @param {Object} [options]
+	 * @param {string} [options.title] - Attachment title (default: item title)
+	 * @return {Promise<Zotero.Item>} - The created attachment item
+	 */
+	this.downloadAndAttach = async function (item, url, options = {}) {
+		if (!item.id) {
+			throw new Error("Item must be saved before attaching files");
+		}
+
+		const title = options.title || item.getField('title') || 'PDF';
+
+		// Download to temp file
+		const tempFile = await lazy.Zotero.File.createTempFile({
+			suffix: '.pdf',
+		});
+
+		try {
+			await lazy.Zotero.Attachments.downloadFile(url, tempFile.path, {
+				timeout: 30000,
+			});
+
+			// Import attachment
+			const attachment = await lazy.Zotero.Attachments.importFromFile({
+				file: tempFile,
+				parentItemID: item.id,
+				title: title,
+			});
+
+			return attachment;
+		}
+		catch (e) {
+			lazy.Zotero.debug(`Error downloading document: ${e.message}`);
+			throw e;
+		}
+		finally {
+			try {
+				await lazy.Zotero.File.remove(tempFile.path, { ignoreAbsent: true });
+			}
+			catch (e) {
+				// Ignore cleanup errors
+			}
+		}
+	};
+
+	/**
+	 * Find and attach an open-access document to an item
+	 * Combines findDocument() and downloadAndAttach()
+	 *
+	 * @param {Zotero.Item} item
+	 * @param {Object} [options]
+	 * @return {Promise<Zotero.Item|null>} - The attachment item, or null if not found
+	 */
+	this.findAndAttach = async function (item, options = {}) {
+		if (!item.id) {
+			throw new Error("Item must be saved");
+		}
+
+		// Skip if already has PDF attachment
+		if (await this._hasPDFAttachment(item)) {
+			lazy.Zotero.debug("Item already has PDF attachment, skipping");
+			return null;
+		}
+
+		const result = await this.findDocument(item, options);
+		if (!result) {
+			return null;
+		}
+
+		try {
+			const attachment = await this.downloadAndAttach(item, result.url, {
+				title: `PDF (${result.sourceName})`,
+			});
+			return attachment;
+		}
+		catch (e) {
+			lazy.Zotero.debug(`Failed to attach document: ${e.message}`);
+			return null;
+		}
+	};
+
+	/**
+	 * Check if item already has a PDF attachment
+	 * @param {Zotero.Item} item
+	 * @return {Promise<boolean>}
+	 */
+	this._hasPDFAttachment = async function (item) {
+		const attachments = item.getAttachments();
+		for (let attachmentID of attachments) {
+			const attachment = await lazy.Zotero.Items.getAsync(attachmentID);
+			if (attachment && attachment.attachmentContentType === 'application/pdf') {
+				return true;
+			}
+		}
+		return false;
+	};
+};

--- a/chrome/content/zotero/xpcom/openAccessSources/arxiv.mjs
+++ b/chrome/content/zotero/xpcom/openAccessSources/arxiv.mjs
@@ -1,0 +1,107 @@
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2024 Corporation for Digital Scholarship
+					 Vienna, Virginia, USA
+					 https://digitalscholar.org
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+import { OpenAccessSourceBase } from "./base.mjs";
+
+const lazy = {};
+ChromeUtils.defineESModuleGetters(lazy, {
+	Zotero: "chrome://zotero/content/zotero.mjs",
+});
+
+/**
+ * arXiv source - Free preprints in physics, mathematics, computer science, biology
+ * API: https://arxiv.org/help/api/user-manual
+ */
+export class ArxivSource extends OpenAccessSourceBase {
+	constructor() {
+		super({
+			id: "arxiv",
+			name: "arXiv",
+			description: "Finds papers from arXiv, a free repository for physics, math, CS, and biology",
+			enabled: true,
+			priority: 70,
+		});
+	}
+
+	async findPDF(item) {
+		const arxivID = this._extractArxivID(item);
+		if (arxivID) {
+			return await this._findByArxivID(arxivID);
+		}
+
+		// Try searching by title + authors
+		const title = item.getField('title');
+		if (title) {
+			return await this._searchByTitle(title);
+		}
+
+		return null;
+	}
+
+	async _findByArxivID(arxivID) {
+		// arXiv PDFs are at https://arxiv.org/pdf/{id}.pdf
+		return `https://arxiv.org/pdf/${arxivID}.pdf`;
+	}
+
+	async _searchByTitle(title) {
+		try {
+			const query = `ti:"${title.replace(/"/g, '\\"')}"`;
+			const encodedQuery = encodeURIComponent(query);
+			const url = `https://export.arxiv.org/api/query?search_query=${encodedQuery}&max_results=5&sortBy=relevance&sortOrder=descending`;
+
+			const response = await lazy.Zotero.HTTP.promise("GET", url, {
+				timeout: 10000,
+				responseType: "text",
+			});
+
+			const entries = response.responseText.match(/<entry>[\s\S]*?<\/entry>/g);
+			if (!entries || entries.length === 0) {
+				return null;
+			}
+
+			// Parse first result (most relevant)
+			const firstEntry = entries[0];
+			const idMatch = firstEntry.match(/<id>https:\/\/arxiv\.org\/abs\/(\d{4}\.\d{4,5})/);
+			if (idMatch) {
+				const arxivID = idMatch[1];
+				return `https://arxiv.org/pdf/${arxivID}.pdf`;
+			}
+
+			return null;
+		}
+		catch (e) {
+			lazy.Zotero.debug(`arXiv search error: ${e.message}`);
+			return null;
+		}
+	}
+
+	async isConfigured() {
+		// arXiv API is free and open
+		return true;
+	}
+}
+
+// Export as singleton
+export const arxivSource = new ArxivSource();

--- a/chrome/content/zotero/xpcom/openAccessSources/base.mjs
+++ b/chrome/content/zotero/xpcom/openAccessSources/base.mjs
@@ -1,0 +1,183 @@
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2024 Corporation for Digital Scholarship
+					 Vienna, Virginia, USA
+					 https://digitalscholar.org
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+/**
+ * Base class for open-access document sources.
+ * Plugins can extend this to provide custom document resolution logic.
+ */
+export class OpenAccessSourceBase {
+	/**
+	 * Unique identifier for this source
+	 * @type {string}
+	 */
+	id;
+
+	/**
+	 * Display name for the source
+	 * @type {string}
+	 */
+	name;
+
+	/**
+	 * Brief description of the source
+	 * @type {string}
+	 */
+	description;
+
+	/**
+	 * Whether this source is enabled by default
+	 * @type {boolean}
+	 */
+	enabled = true;
+
+	/**
+	 * Priority for ordering (higher = checked first)
+	 * @type {number}
+	 */
+	priority = 50;
+
+	/**
+	 * Plugin ID that registered this source (if applicable)
+	 * @type {string|null}
+	 */
+	pluginID = null;
+
+	constructor(config) {
+		Object.assign(this, config);
+		if (!this.id) {
+			throw new Error("OpenAccessSource requires an id");
+		}
+		if (!this.name) {
+			throw new Error("OpenAccessSource requires a name");
+		}
+	}
+
+	/**
+	 * Find an open-access PDF URL for an item based on available metadata.
+	 *
+	 * @param {Zotero.Item} item - The item to find a document for
+	 * @return {Promise<string|null>} - URL to the PDF, or null if not found
+	 */
+	async findPDF(item) {
+		throw new Error("findPDF() must be implemented by subclass");
+	}
+
+	/**
+	 * Helper method to search by DOI
+	 * @param {string} doi
+	 * @return {Promise<string|null>}
+	 */
+	async _findByDOI(doi) {
+		return null;
+	}
+
+	/**
+	 * Helper method to search by arXiv ID
+	 * @param {string} arxivID
+	 * @return {Promise<string|null>}
+	 */
+	async _findByArxivID(arxivID) {
+		return null;
+	}
+
+	/**
+	 * Helper method to search by PMID
+	 * @param {string} pmid
+	 * @return {Promise<string|null>}
+	 */
+	async _findByPMID(pmid) {
+		return null;
+	}
+
+	/**
+	 * Extract metadata from a Zotero item
+	 * @param {Zotero.Item} item
+	 * @return {Object}
+	 */
+	_extractMetadata(item) {
+		return {
+			doi: item.getField('DOI'),
+			title: item.getField('title'),
+			authors: this._extractAuthors(item),
+			year: item.getField('date') || item.getField('publicationDate'),
+			pmid: item.getField('pubmedID'),
+			isbn: item.getField('ISBN'),
+			issn: item.getField('ISSN'),
+			arxivID: this._extractArxivID(item),
+			url: item.getField('url'),
+		};
+	}
+
+	_extractAuthors(item) {
+		try {
+			const creators = item.getCreators();
+			return creators
+				.filter(c => c.creatorTypeID === 1) // Author type
+				.map(c => `${c.lastName} ${c.firstName}`.trim())
+				.slice(0, 3); // First 3 authors
+		}
+		catch (e) {
+			return [];
+		}
+	}
+
+	_extractArxivID(item) {
+		// Check extra field for arXiv ID
+		const extra = item.getField('extra') || '';
+		const arxivMatch = extra.match(/arXiv:\s*(\d{4}\.\d{4,5})/);
+		if (arxivMatch) return arxivMatch[1];
+
+		// Check if the URL contains arXiv
+		const url = item.getField('url') || '';
+		const urlArxivMatch = url.match(/arxiv\.org\/abs\/(\d{4}\.\d{4,5})/);
+		if (urlArxivMatch) return urlArxivMatch[1];
+
+		return null;
+	}
+
+	/**
+	 * Check if source requires authentication/API key
+	 * @return {boolean}
+	 */
+	requiresAuth() {
+		return false;
+	}
+
+	/**
+	 * Validate that the source is properly configured
+	 * @return {Promise<boolean>}
+	 */
+	async isConfigured() {
+		return true;
+	}
+
+	/**
+	 * Get configuration errors if any
+	 * @return {Promise<string[]>}
+	 */
+	async getConfigErrors() {
+		return [];
+	}
+}

--- a/chrome/content/zotero/xpcom/openAccessSources/pubmedcentral.mjs
+++ b/chrome/content/zotero/xpcom/openAccessSources/pubmedcentral.mjs
@@ -1,0 +1,171 @@
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2024 Corporation for Digital Scholarship
+					 Vienna, Virginia, USA
+					 https://digitalscholar.org
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+import { OpenAccessSourceBase } from "./base.mjs";
+
+const lazy = {};
+ChromeUtils.defineESModuleGetters(lazy, {
+	Zotero: "chrome://zotero/content/zotero.mjs",
+});
+
+/**
+ * PubMed Central source - Free full-text biomedical articles
+ * API: https://www.ncbi.nlm.nih.gov/pmc/tools/developers/
+ */
+export class PubmedCentralSource extends OpenAccessSourceBase {
+	constructor() {
+		super({
+			id: "pubmedcentral",
+			name: "PubMed Central",
+			description: "Finds open-access biomedical articles from PubMed Central",
+			enabled: true,
+			priority: 75,
+		});
+	}
+
+	async findPDF(item) {
+		// Try by PMID first
+		const pmid = item.getField('pubmedID');
+		if (pmid) {
+			const result = await this._findByPMID(pmid);
+			if (result) return result;
+		}
+
+		// Try by DOI
+		const doi = item.getField('DOI');
+		if (doi) {
+			const pmid = await this._searchPMIDByDOI(doi);
+			if (pmid) {
+				const result = await this._findByPMID(pmid);
+				if (result) return result;
+			}
+		}
+
+		// Try by title + authors
+		const title = item.getField('title');
+		if (title) {
+			return await this._searchByTitle(title);
+		}
+
+		return null;
+	}
+
+	async _findByPMID(pmid) {
+		try {
+			// Get PMC ID from PMID
+			const pmcID = await this._getPMCIDFromPMID(pmid);
+			if (!pmcID) {
+				return null;
+			}
+
+			// PubMed Central PDFs are available at:
+			// https://www.ncbi.nlm.nih.gov/pmc/articles/PMC{PMCID}/pdf/
+			return `https://www.ncbi.nlm.nih.gov/pmc/articles/PMC${pmcID}/pdf/`;
+		}
+		catch (e) {
+			lazy.Zotero.debug(`PubMed Central PMID lookup error: ${e.message}`);
+			return null;
+		}
+	}
+
+	async _getPMCIDFromPMID(pmid) {
+		try {
+			const url = `https://www.ncbi.nlm.nih.gov/pmc/utils/idconv/v1.0/?tool=zotero&email=contact@zotero.org&ids=${pmid}&format=json`;
+
+			const response = await lazy.Zotero.HTTP.promise("GET", url, {
+				timeout: 10000,
+			});
+
+			const data = JSON.parse(response.responseText);
+			if (data.records && data.records.length > 0) {
+				const record = data.records[0];
+				if (record.pmcid) {
+					return record.pmcid.replace(/^PMC/, '');
+				}
+			}
+			return null;
+		}
+		catch (e) {
+			lazy.Zotero.debug(`PubMed Central ID conversion error: ${e.message}`);
+			return null;
+		}
+	}
+
+	async _searchPMIDByDOI(doi) {
+		try {
+			const url = `https://www.ncbi.nlm.nih.gov/pmc/utils/idconv/v1.0/?tool=zotero&email=contact@zotero.org&ids=${encodeURIComponent(doi)}&format=json`;
+
+			const response = await lazy.Zotero.HTTP.promise("GET", url, {
+				timeout: 10000,
+			});
+
+			const data = JSON.parse(response.responseText);
+			if (data.records && data.records.length > 0) {
+				const record = data.records[0];
+				if (record.pmid) {
+					return record.pmid;
+				}
+			}
+			return null;
+		}
+		catch (e) {
+			lazy.Zotero.debug(`PubMed Central DOI search error: ${e.message}`);
+			return null;
+		}
+	}
+
+	async _searchByTitle(title) {
+		try {
+			const query = `"${title}"[Title] AND open access[filter]`;
+			const encodedQuery = encodeURIComponent(query);
+			const url = `https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pmc&term=${encodedQuery}&retmax=1&tool=zotero&email=contact@zotero.org&rettype=json`;
+
+			const response = await lazy.Zotero.HTTP.promise("GET", url, {
+				timeout: 10000,
+				responseType: "text",
+			});
+
+			const data = JSON.parse(response.responseText);
+			if (data.esearchresult && data.esearchresult.idlist && data.esearchresult.idlist.length > 0) {
+				const pmcid = data.esearchresult.idlist[0];
+				return `https://www.ncbi.nlm.nih.gov/pmc/articles/PMC${pmcid}/pdf/`;
+			}
+
+			return null;
+		}
+		catch (e) {
+			lazy.Zotero.debug(`PubMed Central title search error: ${e.message}`);
+			return null;
+		}
+	}
+
+	async isConfigured() {
+		// PubMed Central API is free and open
+		return true;
+	}
+}
+
+// Export as singleton
+export const pubmedCentralSource = new PubmedCentralSource();

--- a/chrome/content/zotero/xpcom/openAccessSources/unpaywall.mjs
+++ b/chrome/content/zotero/xpcom/openAccessSources/unpaywall.mjs
@@ -1,0 +1,119 @@
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2024 Corporation for Digital Scholarship
+					 Vienna, Virginia, USA
+					 https://digitalscholar.org
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+import { OpenAccessSourceBase } from "./base.mjs";
+
+const lazy = {};
+ChromeUtils.defineESModuleGetters(lazy, {
+	Zotero: "chrome://zotero/content/zotero.mjs",
+});
+
+/**
+ * Unpaywall source - Identifies free, legal full-text locations for papers
+ * API: https://unpaywall.org/products/api
+ */
+export class UnpaywallSource extends OpenAccessSourceBase {
+	constructor() {
+		super({
+			id: "unpaywall",
+			name: "Unpaywall",
+			description: "Finds free, legal full-text locations for research papers using Unpaywall API",
+			enabled: true,
+			priority: 80,
+		});
+	}
+
+	async findPDF(item) {
+		const doi = item.getField('DOI');
+		if (!doi) {
+			return null;
+		}
+
+		try {
+			const result = await this._findByDOI(doi);
+			return result;
+		}
+		catch (e) {
+			lazy.Zotero.debug(`Unpaywall error for DOI ${doi}: ${e.message}`);
+			return null;
+		}
+	}
+
+	async _findByDOI(doi) {
+		const encodedDOI = encodeURIComponent(doi.toLowerCase());
+		const url = `https://api.unpaywall.org/v2/${encodedDOI}?email=contact@zotero.org`;
+
+		try {
+			const response = await lazy.Zotero.HTTP.promise("GET", url, {
+				timeout: 10000,
+			});
+
+			const data = JSON.parse(response.responseText);
+
+			if (data.is_oa) {
+				// Prefer published version over accepted version
+				if (data.oa_locations && data.oa_locations.length > 0) {
+					// Sort by version (published > accepted > submitted)
+					const sorted = data.oa_locations.sort((a, b) => {
+						const versionPriority = { "publishedVersion": 0, "acceptedVersion": 1, "submittedVersion": 2 };
+						const aPriority = versionPriority[a.version] ?? 3;
+						const bPriority = versionPriority[b.version] ?? 3;
+						return aPriority - bPriority;
+					});
+
+					const location = sorted[0];
+					if (location.pdf_url) {
+						return location.pdf_url;
+					}
+					else if (location.url) {
+						return location.url;
+					}
+				}
+				else if (data.best_oa_location) {
+					if (data.best_oa_location.pdf_url) {
+						return data.best_oa_location.pdf_url;
+					}
+					else if (data.best_oa_location.url) {
+						return data.best_oa_location.url;
+					}
+				}
+			}
+
+			return null;
+		}
+		catch (e) {
+			lazy.Zotero.debug(`Unpaywall API error: ${e.message}`);
+			return null;
+		}
+	}
+
+	async isConfigured() {
+		// Unpaywall doesn't require API key (email-based identification is free)
+		return true;
+	}
+}
+
+// Export as singleton
+export const unpaywallSource = new UnpaywallSource();

--- a/chrome/content/zotero/zotero.mjs
+++ b/chrome/content/zotero/zotero.mjs
@@ -72,6 +72,7 @@ const xpcomFilesLocal = [
 	'attachments',
 	'attachmentReadObserver',
 	'browserRequest',
+	'documentResolver',
 	'cite',
 	'citeprocRsBridge',
 	'data/library',

--- a/package-lock.json
+++ b/package-lock.json
@@ -284,7 +284,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
       "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.0",
@@ -1281,7 +1280,6 @@
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2267,7 +2265,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -2594,6 +2591,7 @@
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.1.90"
       }
@@ -3375,7 +3373,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.17.0.tgz",
       "integrity": "sha512-evtlNcpJg+cZLcnVKwsai8fExnqjGPicK7gnUtlNuzu+Fv9bI0aLpND5T44VLQtoMEnI57LoXO9XAkIXwohKrA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6126,8 +6123,7 @@
     "node_modules/monaco-editor": {
       "version": "0.47.0",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.47.0.tgz",
-      "integrity": "sha512-VabVvHvQ9QmMwXu4du008ZDuyLnHs9j7ThVFsiJoXSOQk18+LF89N4ADzPbFenm0W4V2bGHnFBztIRQTgBfxzw==",
-      "peer": true
+      "integrity": "sha512-VabVvHvQ9QmMwXu4du008ZDuyLnHs9j7ThVFsiJoXSOQk18+LF89N4ADzPbFenm0W4V2bGHnFBztIRQTgBfxzw=="
     },
     "node_modules/monacopilot": {
       "version": "1.1.15",
@@ -6806,7 +6802,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6833,7 +6828,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -8970,7 +8964,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
       "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.0",
@@ -9742,8 +9735,7 @@
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -10582,7 +10574,6 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
       "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
       "dev": true,
-      "peer": true,
       "requires": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -11487,7 +11478,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.17.0.tgz",
       "integrity": "sha512-evtlNcpJg+cZLcnVKwsai8fExnqjGPicK7gnUtlNuzu+Fv9bI0aLpND5T44VLQtoMEnI57LoXO9XAkIXwohKrA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -13526,8 +13516,7 @@
     "monaco-editor": {
       "version": "0.47.0",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.47.0.tgz",
-      "integrity": "sha512-VabVvHvQ9QmMwXu4du008ZDuyLnHs9j7ThVFsiJoXSOQk18+LF89N4ADzPbFenm0W4V2bGHnFBztIRQTgBfxzw==",
-      "peer": true
+      "integrity": "sha512-VabVvHvQ9QmMwXu4du008ZDuyLnHs9j7ThVFsiJoXSOQk18+LF89N4ADzPbFenm0W4V2bGHnFBztIRQTgBfxzw=="
     },
     "monacopilot": {
       "version": "1.1.15",
@@ -14064,7 +14053,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }
@@ -14085,7 +14073,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"

--- a/test/tests/documentResolverTest.js
+++ b/test/tests/documentResolverTest.js
@@ -1,0 +1,168 @@
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2024 Corporation for Digital Scholarship
+					 Vienna, Virginia, USA
+					 https://digitalscholar.org
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+describe("DocumentResolver", function () {
+	describe("findDocument", function () {
+		it("should return null for item without DOI or other identifiers", async function () {
+			const item = new Zotero.Item('journalArticle');
+			item.setField('title', 'Random Article');
+			const result = await Zotero.DocumentResolver.findDocument(item);
+			assert.isNull(result);
+		});
+
+		it("should search Unpaywall for items with DOI", async function () {
+			this.timeout(10000);
+			const item = new Zotero.Item('journalArticle');
+			item.setField('title', 'Machine Learning');
+			item.setField('DOI', '10.1038/nature12373'); // A known OA paper
+			const result = await Zotero.DocumentResolver.findDocument(item);
+			// Result may be null if API is unavailable, but shouldn't throw
+			assert(result === null || result.sourceID);
+		});
+
+		it("should search arXiv for items with arXiv ID", async function () {
+			this.timeout(10000);
+			const item = new Zotero.Item('journalArticle');
+			item.setField('title', 'Attention Is All You Need');
+			item.setField('extra', 'arXiv: 1706.03762');
+			const result = await Zotero.DocumentResolver.findDocument(item);
+			// Should find it on arXiv
+			if (result) {
+				assert.equal(result.sourceID, 'arxiv');
+				assert(result.url.includes('arxiv.org'));
+			}
+		});
+
+		it("should skip disabled sources", async function () {
+			const item = new Zotero.Item('journalArticle');
+			item.setField('title', 'Test');
+			item.setField('extra', 'arXiv: 1706.03762');
+
+			Zotero.DocumentResolver.setSourceEnabled('arxiv', false);
+			try {
+				const result = await Zotero.DocumentResolver.findDocument(item);
+				assert.isNull(result);
+			}
+			finally {
+				Zotero.DocumentResolver.setSourceEnabled('arxiv', true);
+			}
+		});
+	});
+
+	describe("getSources", function () {
+		it("should return array of sources", function () {
+			const sources = Zotero.DocumentResolver.getSources();
+			assert.isArray(sources);
+			assert.isAtLeast(sources.length, 3); // Should have at least built-in sources
+		});
+
+		it("should include required properties", function () {
+			const sources = Zotero.DocumentResolver.getSources();
+			sources.forEach(source => {
+				assert(source.id);
+				assert(source.name);
+				assert(typeof source.enabled === 'boolean');
+				assert(typeof source.priority === 'number');
+			});
+		});
+	});
+
+	describe("setSourceEnabled", function () {
+		it("should toggle source enabled state", function () {
+			const sources = Zotero.DocumentResolver.getSources();
+			const source = sources[0];
+
+			const originalState = source.enabled;
+			Zotero.DocumentResolver.setSourceEnabled(source.id, !originalState);
+
+			let updated = Zotero.DocumentResolver.getSources()
+				.find(s => s.id === source.id);
+			assert.equal(updated.enabled, !originalState);
+
+			// Restore
+			Zotero.DocumentResolver.setSourceEnabled(source.id, originalState);
+		});
+	});
+
+	describe("registerSource", function () {
+		it("should register custom source", function () {
+			const MockSource = class {
+				id = 'test-source';
+				name = 'Test Source';
+				description = 'Test';
+				enabled = true;
+				priority = 50;
+				async findPDF() { return null; }
+				async isConfigured() { return true; }
+				async getConfigErrors() { return []; }
+			};
+
+			const source = new MockSource();
+			Zotero.DocumentResolver.registerSource(source, 'test-plugin');
+
+			const sources = Zotero.DocumentResolver.getSources();
+			const registered = sources.find(s => s.id === 'test-source');
+			assert(registered);
+			assert(registered.isCustom);
+
+			// Cleanup
+			Zotero.DocumentResolver.unregisterSource('test-source');
+		});
+
+		it("should throw without id", function () {
+			const source = { name: 'Bad Source' };
+			assert.throws(() => {
+				Zotero.DocumentResolver.registerSource(source, 'plugin');
+			});
+		});
+	});
+
+	describe("ArxivSource", function () {
+		it("should handle arXiv ID extraction", async function () {
+			const item = new Zotero.Item('journalArticle');
+			item.setField('extra', 'arXiv: 2301.00001');
+			const result = await Zotero.DocumentResolver.findDocument(item);
+			// May be null if request fails, but extraction should work
+			assert(result === null || result.url.includes('2301.00001'));
+		});
+
+		it("should handle old arXiv ID format", async function () {
+			const item = new Zotero.Item('journalArticle');
+			item.setField('extra', 'arXiv: math/0510001');
+			const result = await Zotero.DocumentResolver.findDocument(item);
+			assert(result === null || result.url.includes('math/0510001'));
+		});
+	});
+
+	describe("Integration", function () {
+		it("should handle HTTP errors gracefully", async function () {
+			const item = new Zotero.Item('journalArticle');
+			item.setField('DOI', '10.0000/invalid.doi');
+			// Should not throw, just return null
+			const result = await Zotero.DocumentResolver.findDocument(item);
+			assert.isNull(result);
+		});
+	});
+});


### PR DESCRIPTION
Why

Zotero should be able to find and attach legal open-access copies of missing papers automatically. This change adds a reusable, plugin-friendly DocumentResolver that searches reliable OA sources (Unpaywall, arXiv, PubMed Central) and downloads/attaches PDFs when available.

What

- Adds a DocumentResolver orchestration module that queries multiple OA sources in priority order and provides convenience APIs to find, download, and attach PDFs.
- Implements three built-in sources: Unpaywall (DOI-based OA discovery), arXiv (preprint PDF retrieval), and PubMed Central (PMCID/PMID → PDF lookup).
- Adds OpenAccessSourceBase so plugins can register custom sources.
- Adds tests exercising lookup, source registration, enable/disable, and error handling.
- Registers the resolver during startup by loading documentResolver from zotero.mjs.

Approach

The resolver queries enabled sources in priority order and returns the first valid PDF URL. Downloads use Zotero.Attachments.downloadFile and Attachments.importFromFile to ensure files are validated and properly imported. Each source implements a narrow, testable lookup function (by DOI, arXiv ID, PMID, or title) and exposes isConfigured()/getConfigErrors() so UI can validate settings.

Notes and review points

- All sources are legal open-access providers; no functionality for or integration with sites that facilitate piracy is included.
- Added a small change to zotero.mjs to ensure the new module is loaded on startup.
- Tests make live API calls where applicable; CI may need network access for full coverage.
- Local builds may attempt to fetch prebuilt assets (note-editor/document-worker) in the build script; CI or maintainers may need to ensure those upstream artifacts are available or cached.

Files of interest

- chrome/content/zotero/xpcom/documentResolver.mjs
- chrome/content/zotero/xpcom/openAccessSources/base.mjs
- chrome/content/zotero/xpcom/openAccessSources/unpaywall.mjs
- chrome/content/zotero/xpcom/openAccessSources/arxiv.mjs
- chrome/content/zotero/xpcom/openAccessSources/pubmedcentral.mjs
- test/tests/documentResolverTest.js
- chrome/content/zotero/zotero.mjs (small existing-file load change)

Testing

- Unit/integration tests included at test/tests/documentResolverTest.js. Run with: test/runtests.sh documentResolver

If anything should be split into smaller PRs (for example UI integration or additional sources), I can do that in follow-ups.