### PR TITLE
feat: added optional icon to alert call

### DIFF
--- a/chrome/content/zotero/preferences/preferences_account.jsx
+++ b/chrome/content/zotero/preferences/preferences_account.jsx
@@ -879,7 +879,8 @@ Zotero_Preferences.Sync = {
 			Zotero.alert(
 				window,
 				Zotero.getString('sync.storage.serverConfigurationVerified'),
-				Zotero.getString('sync.storage.fileSyncSetUp')
+				Zotero.getString('sync.storage.fileSyncSetUp'),
+				{ icon: 'success' }
 			);
 		}
 		else {

--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -1417,10 +1417,38 @@ const { CommandLineOptions } = ChromeUtils.importESModule("chrome://zotero/conte
 	 * @param {Window}
 	 * @param {String} title
 	 * @param {String} msg
+	 * @param {Object} [options]
+	 * @param {String} [options.icon] - Name of a Zotero icon to display instead of the
+	 *     default alert icon
 	 */
-	this.alert = function (window, title, msg) {
+	this.alert = function (window, title, msg, options = {}) {
 		this.debug(`Alert:\n\n${msg}`);
-		Services.prompt.alert(window, title, msg);
+
+		if (!options.icon) {
+			Services.prompt.alert(window, title, msg);
+			return;
+		}
+
+		let dialogObserverChangeIcon = subject => {
+			let doc = subject.document;
+			if (doc.title != title
+					|| doc.getElementById('infoBody')?.textContent != msg) {
+				return;
+			}
+			let icon = doc.getElementById('infoIcon');
+			icon?.classList.remove('alert-icon');
+			icon?.setAttribute(
+				'src',
+				`chrome://zotero/skin/20/universal/${options.icon}.svg`
+			);
+		};
+		Services.obs.addObserver(dialogObserverChangeIcon, 'common-dialog-loaded');
+		try {
+			Services.prompt.alert(window, title, msg);
+		}
+		finally {
+			Services.obs.removeObserver(dialogObserverChangeIcon, 'common-dialog-loaded');
+		}
 	}
 	
 	


### PR DESCRIPTION
## **Before**
<img width="516" height="254" alt="zotero_failed" src="https://github.com/user-attachments/assets/376d3dc0-a912-41b1-a358-ad78ee61d7fc" />

While finishing a WebDAV setup, I noticed that the alert shown after a successful connection test uses an exclamation mark icon. Since this dialog communicates success rather than a warning, the icon can be misleading and may cause someone who is in a hurry (which was my case) to assume that something went wrong.

## **After**
<img width="411" height="174" alt="zotero_sucess" src="https://github.com/user-attachments/assets/a2e8eee1-f3a1-4ba7-be4f-1faad3fa9add" />

To address this, this PR adds an optional `icon` parameter to `Zotero.alert()`. When provided, callers can choose a more appropriate icon instead of the default exclamation mark, allowing the dialog to better reflect the meaning of the message.

For transparency, I'm not a JavaScript developer and not familiarized to Zotero's codebase, so this is a best-effort implementation that probably needs some polishing, feedback is welcome.
