### PR TITLE
Fix zero local data object versions

### DIFF
--- a/chrome/content/zotero/xpcom/data/collection.js
+++ b/chrome/content/zotero/xpcom/data/collection.js
@@ -140,6 +140,7 @@ Zotero.Collection.prototype.loadFromRow = function (row) {
 		
 		// Integer or 0
 		case 'version':
+		case 'clientVersion':
 			val = val ? parseInt(val) : 0;
 			break;
 		

--- a/chrome/content/zotero/xpcom/data/item.js
+++ b/chrome/content/zotero/xpcom/data/item.js
@@ -375,6 +375,7 @@ Zotero.Item.prototype._parseRowData = function (row) {
 			
 			// Integer or 0
 			case 'version':
+			case 'clientVersion':
 				val = val ? parseInt(val) : 0;
 				break;
 			

--- a/chrome/content/zotero/xpcom/data/search.js
+++ b/chrome/content/zotero/xpcom/data/search.js
@@ -143,6 +143,7 @@ Zotero.Search.prototype.loadFromRow = function (row) {
 		
 		// Integer or 0
 		case 'version':
+		case 'clientVersion':
 			val = val ? parseInt(val) : 0;
 			break;
 		

--- a/test/tests/dataObjectTest.js
+++ b/test/tests/dataObjectTest.js
@@ -61,6 +61,23 @@ describe("Zotero.DataObject", function () {
 			}
 		});
 
+		it("should load 0 as a number", async function () {
+			for (let type of types) {
+				let objectsClass = Zotero.DataObjectUtilities.getObjectsClassForObjectType(type);
+				let obj = await createDataObject(type);
+				let id = obj.id;
+				await Zotero.DB.queryAsync(
+					`UPDATE ${objectsClass.table} SET clientVersion=0 WHERE ${objectsClass.idColumn}=?`,
+					id
+				);
+				objectsClass.unload(id);
+				obj = await objectsClass.getAsync(id);
+				assert.strictEqual(obj.clientVersion, 0, type + " clientVersion mismatch");
+				await obj.loadAllData();
+				await obj.eraseTx();
+			}
+		});
+
 		it("should increase after modifying object", async function () {
 			for (let type of types) {
 				let obj = await createDataObject(type);

--- a/test/tests/dataObjectTest.js
+++ b/test/tests/dataObjectTest.js
@@ -73,8 +73,6 @@ describe("Zotero.DataObject", function () {
 				objectsClass.unload(id);
 				obj = await objectsClass.getAsync(id);
 				assert.strictEqual(obj.clientVersion, 0, type + " clientVersion mismatch");
-				await obj.loadAllData();
-				await obj.eraseTx();
 			}
 		});
 


### PR DESCRIPTION
The local `clientVersion` migration initializes existing items, collections, and saved searches to `0`. Their row loaders handle `version` as an integer, but not `clientVersion`, so the generic fallback converts the falsy zero to an empty string. The Local API consequently returns `version: ""` for migrated objects until they are saved.

Handle `clientVersion` alongside `version` in all three loaders, preserving numeric zero. The regression test simulates migrated rows and verifies the value after unloading and reloading each object type.

🤖 **AI disclosure:** This contribution was developed with AI coding assistance. I directed the investigation, reviewed the implementation and tests, and validated the fix against a migrated Zotero database and Zotero’s test suite.
