### PR TITLE
Fix symlink unit tests on NixOS

### DIFF
--- a/chrome/content/zotero/osfile.mjs
+++ b/chrome/content/zotero/osfile.mjs
@@ -233,13 +233,10 @@ export let OS = {
 			);
 			
 			try {
-				// "libc.so" is usually a linker script rather than a real shared object, which
-				// fails with "invalid ELF header", and on some distros (e.g., NixOS) it doesn't
-				// exist at a standard path at all, so use the versioned name
 				const libc = ctypes.open(
 					Services.appinfo.OS === "Darwin" ? "libSystem.B.dylib" : "libc.so.6"
 				);
-
+				
 				const symlink = libc.declare(
 					"symlink",
 					ctypes.default_abi,
@@ -247,7 +244,7 @@ export let OS = {
 					ctypes.char.ptr, // target
 					ctypes.char.ptr //linkpath
 				);
-
+				
 				if (symlink(pathTarget, pathCreate)) {
 					throw new Error("Failed to create symlink at " + pathCreate);
 				}

--- a/chrome/content/zotero/osfile.mjs
+++ b/chrome/content/zotero/osfile.mjs
@@ -233,32 +233,23 @@ export let OS = {
 			);
 			
 			try {
-				if (Services.appinfo.OS === "Darwin") {
-					const libc = ctypes.open(
-						Services.appinfo.OS === "Darwin" ? "libSystem.B.dylib" : "libc.so"
-					);
-					
-					const symlink = libc.declare(
-						"symlink",
-						ctypes.default_abi,
-						ctypes.int, // return value
-						ctypes.char.ptr, // target
-						ctypes.char.ptr //linkpath
-					);
-					
-					if (symlink(pathTarget, pathCreate)) {
-						throw new Error("Failed to create symlink at " + pathCreate);
-					}
-				}
-				// The above is failing with "invalid ELF header" for libc.so on GitHub Actions, so
-				// just use ln -s on non-macOS systems
-				else {
-					let ln = Cc["@mozilla.org/file/local;1"].createInstance(Ci.nsIFile);
-					ln.initWithPath("/bin/ln");
-					let process = Cc["@mozilla.org/process/util;1"].createInstance(Ci.nsIProcess);
-					process.init(ln);
-					let args = ["-s", pathTarget, pathCreate];
-					process.run(true, args, args.length);
+				// "libc.so" is usually a linker script rather than a real shared object, which
+				// fails with "invalid ELF header", and on some distros (e.g., NixOS) it doesn't
+				// exist at a standard path at all, so use the versioned name
+				const libc = ctypes.open(
+					Services.appinfo.OS === "Darwin" ? "libSystem.B.dylib" : "libc.so.6"
+				);
+
+				const symlink = libc.declare(
+					"symlink",
+					ctypes.default_abi,
+					ctypes.int, // return value
+					ctypes.char.ptr, // target
+					ctypes.char.ptr //linkpath
+				);
+
+				if (symlink(pathTarget, pathCreate)) {
+					throw new Error("Failed to create symlink at " + pathCreate);
 				}
 			}
 			catch (e) {

--- a/chrome/content/zotero/xpcom/file.js
+++ b/chrome/content/zotero/xpcom/file.js
@@ -1415,7 +1415,7 @@ Zotero.File = new function () {
 	//
 	// @param {String} sourcePath - The file to create a symlink to
 	// @param {String} targetPath - The location of the symlink to create
-	// @return {Promise<Boolean>} - True if successfully created, false otherwise
+	// @return {Boolean} - True if successfully created, false otherwise
 	this.createSymlink = function (sourcePath, targetPath) {
 		const { ctypes } = ChromeUtils.importESModule(
 			"resource://gre/modules/ctypes.sys.mjs"
@@ -1423,7 +1423,7 @@ Zotero.File = new function () {
 		
 		try {
 			const libc = ctypes.open(
-				Services.appinfo.OS === "Darwin" ? "libSystem.B.dylib" : "libc.so"
+				Services.appinfo.OS === "Darwin" ? "libSystem.B.dylib" : "libc.so.6"
 			);
 			
 			const symlink = libc.declare(

--- a/test/tests/dbTest.js
+++ b/test/tests/dbTest.js
@@ -1239,8 +1239,7 @@ describe("Zotero.DB", function () {
 			await db.closeDatabase(true);
 			await IOUtils.move(targetPath + '.copy', targetPath);
 			await IOUtils.move(targetPath + '.copy-wal', targetPath + '-wal');
-			await Zotero.Utilities.Internal.subprocess('ln', ['-s', targetPath, linkPath]);
-			if (!(await IOUtils.exists(linkPath))) {
+			if (!Zotero.File.createSymlink(targetPath, linkPath)) {
 				// Filesystem doesn't support symlinks (e.g., CIFS)
 				this.skip();
 			}

--- a/test/tests/dbTest.js
+++ b/test/tests/dbTest.js
@@ -1239,7 +1239,7 @@ describe("Zotero.DB", function () {
 			await db.closeDatabase(true);
 			await IOUtils.move(targetPath + '.copy', targetPath);
 			await IOUtils.move(targetPath + '.copy-wal', targetPath + '-wal');
-			await Zotero.Utilities.Internal.subprocess('/bin/ln', ['-s', targetPath, linkPath]);
+			await Zotero.Utilities.Internal.subprocess('ln', ['-s', targetPath, linkPath]);
 			if (!(await IOUtils.exists(linkPath))) {
 				// Filesystem doesn't support symlinks (e.g., CIFS)
 				this.skip();


### PR DESCRIPTION
The unit tests
- should throw error on broken symlink
- should convert the target of a symlinked database file

are failing in the nix world, because it has no `/bin/ln`. I rewired both invocations to support this use case.

Feel free to adapt, change the commit messages etc.; I'd love to see something like that land.