### PR TITLE
Fix typo: non-existant -> non-existent in tree row error messages

### DIFF
--- a/chrome/content/zotero/collectionViewItemTree.jsx
+++ b/chrome/content/zotero/collectionViewItemTree.jsx
@@ -1272,7 +1272,7 @@ class CollectionViewItemTree extends ItemTree {
 	_getRowData(index) {
 		var treeRow = this.getRow(index);
 		if (!treeRow) {
-			throw new Error(`Attempting to get row data for a non-existant tree row ${index}`);
+			throw new Error(`Attempting to get row data for a non-existent tree row ${index}`);
 		}
 		let itemID = treeRow.id;
 

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -2361,7 +2361,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 	_getRowData(index) {
 		var treeRow = this.getRow(index);
 		if (!treeRow) {
-			throw new Error(`Attempting to get row data for a non-existant tree row ${index}`);
+			throw new Error(`Attempting to get row data for a non-existent tree row ${index}`);
 		}
 		var itemID = treeRow.id;
 		


### PR DESCRIPTION
## Summary
- Fixes a spelling typo ("non-existant" -> "non-existent") in the error messages thrown by `_getRowData` in both `itemTree.jsx` and `collectionViewItemTree.jsx`.

## Test plan
- No behavior change; text-only fix to a thrown `Error` message.