### PR TITLE
Support multiple main windows

### DIFF
--- a/chrome/content/zotero/ZoteroProtocolHandler.mjs
+++ b/chrome/content/zotero/ZoteroProtocolHandler.mjs
@@ -636,7 +636,7 @@ export function ZoteroProtocolHandler() {
 				throw new Error("Pane not open");
 			}
 			
-			win.Zotero_Tabs.select('zotero-pane');
+			win.Zotero_Tabs.selectLibraryTab();
 			if (params.objectType == 'collection') {
 				return zp.collectionsView.selectCollection(results[0].id);
 			}

--- a/chrome/content/zotero/collectionTree.jsx
+++ b/chrome/content/zotero/collectionTree.jsx
@@ -294,7 +294,6 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 		treeRow.ref.name = treeRow.editingName;
 		delete treeRow.editingName;
 		await treeRow.ref.saveTx({ undoAction: 'undo-action-rename-collection' });
-		window.Zotero_Tabs.rename("zotero-pane", treeRow.ref.name);
 	}
 	
 	startEditing = (treeRow) => {
@@ -2471,7 +2470,7 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 				let promises = [];
 				for (let item of items) {
 					// No transaction, because most time is spent traversing urls
-					promises.push(item.translate(targetLibraryID, targetCollectionID))
+					promises.push(item.translate(targetLibraryID, targetCollectionID, { window }));
 				}
 				return Zotero.Promise.all(promises);	
 			}

--- a/chrome/content/zotero/collectionTree.jsx
+++ b/chrome/content/zotero/collectionTree.jsx
@@ -635,31 +635,47 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 		this.tree.invalidate();
 	}
 	
-	async selectByID(id, ensureRowVisible = true) {
-		var type = id[0];
-		id = parseInt(('' + id).substr(1));
+	/**
+	 * Expand the tree as necessary to show a row
+	 *
+	 * @param {String} id - A collection tree row id
+	 * @return {Promise<Integer|false>} - The row index, or false if the row isn't in the tree
+	 */
+	async _expandToID(id) {
+		var objectID = parseInt(('' + id).substr(1));
 		
-		switch (type) {
-		case 'L':
-			return this.selectLibrary(id);
-		
-		case 'C':
-			await this.expandToCollection(id);
-			break;
-		
-		case 'S':
-			var search = await Zotero.Searches.getAsync(id);
-			await this.expandLibrary(search.libraryID);
-			break;
-		
-		case 'D':
-		case 'U':
-		case 'T':
-			await this.expandLibrary(id);
-			break;
+		switch (id[0]) {
+			case 'C':
+				await this.expandToCollection(objectID);
+				break;
+			
+			case 'S': {
+				let search = await Zotero.Searches.getAsync(objectID);
+				if (search) {
+					await this.expandLibrary(search.libraryID);
+				}
+				break;
+			}
+			
+			case 'D':
+			case 'U':
+			case 'T':
+			case 'Y':
+			case 'R':
+			case 'P':
+				await this.expandLibrary(objectID);
+				break;
 		}
 		
-		var row = this.getRowIndexByID(type + id);
+		return this.getRowIndexByID(id);
+	}
+	
+	async selectByID(id, ensureRowVisible = true) {
+		if (id[0] == 'L') {
+			return this.selectLibrary(parseInt(('' + id).substr(1)));
+		}
+		
+		var row = await this._expandToID(id);
 		if (row === false) {
 			return false;
 		}
@@ -668,6 +684,59 @@ var CollectionTree = class CollectionTree extends LibraryTree {
 		}
 		await this.selectWait(row);
 		
+		return true;
+	}
+	
+	/**
+	 * Reapply a saved selection, expanding the tree as necessary
+	 *
+	 * @param {String[]} ids - Collection tree row ids
+	 * @param {Object} [options]
+	 * @param {String} [options.focusedID] - The row to focus, if it's among the selected rows
+	 * @return {Promise<Boolean>} - True if at least one row was selected
+	 */
+	async restoreSelection(ids, { focusedID } = {}) {
+		var indexes = [];
+		for (let id of ids || []) {
+			let index = await this._expandToID(id);
+			if (index !== false && !indexes.includes(index)) {
+				indexes.push(index);
+			}
+		}
+		if (!indexes.length) {
+			return false;
+		}
+		indexes.sort((a, b) => a - b);
+		
+		var focusedIndex = focusedID ? this.getRowIndexByID(focusedID) : false;
+		if (focusedIndex === false || !indexes.includes(focusedIndex)) {
+			focusedIndex = indexes[0];
+		}
+		
+		var promise = this.waitForSelect();
+		var unsuppress = false;
+		if (!this.selection.selectEventsSuppressed) {
+			unsuppress = this.selection.selectEventsSuppressed = true;
+		}
+		try {
+			this.selection.select(indexes[0]);
+			for (let index of indexes.slice(1)) {
+				this.selection.toggleSelect(index);
+			}
+			this.selection.focused = focusedIndex;
+			this.selection.pivot = focusedIndex;
+		}
+		finally {
+			if (unsuppress) {
+				this.selection.selectEventsSuppressed = false;
+			}
+		}
+		
+		this.ensureRowIsVisible(focusedIndex);
+		
+		if (unsuppress) {
+			await promise;
+		}
 		return true;
 	}
 	

--- a/chrome/content/zotero/components/tagSelector.jsx
+++ b/chrome/content/zotero/components/tagSelector.jsx
@@ -39,6 +39,7 @@ class TagSelector extends React.PureComponent {
 				<TagList
 					ref={this.props.tagListRef}
 					tags={this.props.tags}
+					label={this.props.label}
 					dragObserver={this.props.dragObserver}
 					onSelect={this.props.onSelect}
 					onKeyDown={this.props.onKeyDown}
@@ -83,6 +84,7 @@ TagSelector.propTypes = {
 		disabled: PropTypes.bool,
 		width: PropTypes.number
 	})),
+	label: PropTypes.string,
 	dragObserver: PropTypes.shape({
 		onDragOver: PropTypes.func,
 		onDragExit: PropTypes.func,

--- a/chrome/content/zotero/components/tagSelector/tagSelectorList.jsx
+++ b/chrome/content/zotero/components/tagSelector/tagSelectorList.jsx
@@ -44,6 +44,7 @@ class TagList extends React.PureComponent {
 	constructor(props) {
 		super(props);
 		this.collectionRef = React.createRef();
+		this.listContainerRef = React.createRef();
 		this.scrollToTopOnNextUpdate = false;
 		this.prevTagCount = 0;
 		this.focusedTagIndex = null;
@@ -84,7 +85,7 @@ class TagList extends React.PureComponent {
 	scrollToTop() {
 		if (!this.collectionRef.current) return;
 		// Scroll to the top of the view
-		document.querySelector('.tag-selector-list').scrollTop = 0;
+		this.tagSelectorList().scrollTop = 0;
 		// Reset internal component scroll state to force it to redraw components, since that
 		// doesn't seem to happen automatically as of 9.21.0. Without this, scrolling down and
 		// clicking on a tag blanks out the pane (presumably because it still thinks it's at an
@@ -224,7 +225,9 @@ class TagList extends React.PureComponent {
 	};
 
 	tagSelectorList() {
-		return document.querySelector('.tag-selector-list');
+		return this.listContainerRef.current
+			? this.listContainerRef.current.querySelector('.tag-selector-list')
+			: null;
 	}
 
 	isEmpty() {
@@ -240,7 +243,7 @@ class TagList extends React.PureComponent {
 	// non-disabled tag. If there are no enabled tags, focus the first visible tag.
 	async focus() {
 		if (this.isEmpty()) {
-			document.querySelector('.tag-selector-list').focus();
+			this.tagSelectorList()?.focus();
 			return;
 		}
 		if (this.focusedTagIndex === null) {
@@ -262,7 +265,7 @@ class TagList extends React.PureComponent {
 
 	// Try to refocus a focused tag that was removed due to windowing
 	refocusTag() {
-		let tagsList = document.querySelector('.tag-selector-list');
+		let tagsList = this.tagSelectorList();
 		let tagsNodes = [...tagsList.querySelectorAll(".tag-selector-item")];
 		let tagToFocus = this.props.tags[this.focusedTagIndex];
 		let nodeToFocus = tagsNodes.find(node => node.textContent == tagToFocus.name);
@@ -280,7 +283,7 @@ class TagList extends React.PureComponent {
 	}
 
 	handleSectionRendered = ({ indices }) => {
-		let tagsList = document.querySelector('.tag-selector-list');
+		let tagsList = this.tagSelectorList();
 		// <Collection> sets role="grid" which is not semantically correct
 		tagsList.setAttribute("role", "group");
 
@@ -363,7 +366,7 @@ class TagList extends React.PureComponent {
 					verticalOverscanSize={300}
 					width={this.props.width}
 					height={this.props.height - filterBarHeight}
-					aria-label={document.querySelector("#zotero-tag-selector").getAttribute("label") || ""}
+					aria-label={this.props.label || ""}
 					onSectionRendered={this.handleSectionRendered}
 					scrollToCell={Number.isInteger(this.state.scrollToCell) ? this.state.scrollToCell : undefined}
 				/>
@@ -371,7 +374,7 @@ class TagList extends React.PureComponent {
 		}
 		
 		return (
-			<div className="tag-selector-list-container" onKeyDown={this.handleKeyDown.bind(this)}>
+			<div className="tag-selector-list-container" ref={this.listContainerRef} onKeyDown={this.handleKeyDown.bind(this)}>
 				{tagList}
 			</div>
 		);
@@ -385,6 +388,7 @@ class TagList extends React.PureComponent {
 			disabled: PropTypes.bool,
 			width: PropTypes.number
 		})),
+		label: PropTypes.string,
 		dragObserver: PropTypes.shape({
 			onDragOver: PropTypes.func,
 			onDragExit: PropTypes.func,

--- a/chrome/content/zotero/components/virtualized-table.jsx
+++ b/chrome/content/zotero/components/virtualized-table.jsx
@@ -987,9 +987,9 @@ class VirtualizedTable extends React.Component {
 		const result = this._getResizeColumns();
 		if (!result) return;
 		const [aColumn, bColumn, resizingColumn] = result;
-		const a = document.querySelector(`#${this.props.id} .virtualized-table-header .cell.${window.CSS.escape(aColumn.dataKey)}`);
-		const b = document.querySelector(`#${this.props.id} .virtualized-table-header .cell.${window.CSS.escape(bColumn.dataKey)}`);
-		const resizing = document.querySelector(`#${this.props.id} .virtualized-table-header .cell.${window.CSS.escape(resizingColumn.dataKey)}`);
+		const a = this._topDiv.querySelector(`.virtualized-table-header .cell.${window.CSS.escape(aColumn.dataKey)}`);
+		const b = this._topDiv.querySelector(`.virtualized-table-header .cell.${window.CSS.escape(bColumn.dataKey)}`);
+		const resizing = this._topDiv.querySelector(`.virtualized-table-header .cell.${window.CSS.escape(resizingColumn.dataKey)}`);
 		const aRect = a.getBoundingClientRect();
 		const bRect = b.getBoundingClientRect();
 		const resizingRect = resizing.getBoundingClientRect();
@@ -1089,7 +1089,7 @@ class VirtualizedTable extends React.Component {
 		if (!result) return;
 		let resizeData = {};
 		for (const column of result) {
-			const elem = document.querySelector(`#${this.props.id} .virtualized-table-header .cell.${window.CSS.escape(column.dataKey)}`)
+			const elem = this._topDiv.querySelector(`.virtualized-table-header .cell.${window.CSS.escape(column.dataKey)}`);
 			resizeData[column.dataKey] = elem.getBoundingClientRect().width;
 		}
 		this._columns.onResize(resizeData, true);
@@ -1143,9 +1143,9 @@ class VirtualizedTable extends React.Component {
 	}
 
 	_findColumnDragPosition(x) {
-		const headerRect = document.querySelector(`#${this.props.id} .virtualized-table-header`).getBoundingClientRect();
+		const headerRect = this._topDiv.querySelector(`.virtualized-table-header`).getBoundingClientRect();
 		
-		let coords = Array.from(document.querySelectorAll(`#${this.props.id} .virtualized-table-header .resizer`))
+		let coords = Array.from(this._topDiv.querySelectorAll(`.virtualized-table-header .resizer`))
 			.map((elem) => {
 				const rect = elem.getBoundingClientRect();
 				// accounting for resizer offset
@@ -1669,7 +1669,7 @@ class VirtualizedTable extends React.Component {
 		if (!this.props.showHeader) return;
 		const jsWindow = document.querySelector(`#${this._jsWindowID} .windowed-list`);
 		if (!jsWindow) return;
-		const header = document.querySelector(`#${this.props.id} .virtualized-table-header`);
+		const header = this._topDiv.querySelector(`.virtualized-table-header`);
 		const scrollbarWidth = jsWindow.parentElement.getBoundingClientRect().width - jsWindow.parentElement.clientWidth;
 
 		header.style.setProperty('--scrollbar-width', `${scrollbarWidth}px`);

--- a/chrome/content/zotero/containers/tagSelectorContainer.jsx
+++ b/chrome/content/zotero/containers/tagSelectorContainer.jsx
@@ -44,7 +44,9 @@ const defaults = {
 // first n tags will be measured using DOM method for more accurate measurment (at the cost of performance)
 const FORCE_DOM_TAGS_FOR_COUNT = 200;
 
-Zotero.TagSelector = class TagSelectorContainer extends React.PureComponent {
+// The class closes over this window's React and DOM globals, so each window initializes
+// its tag selector from its own copy.
+window.TagSelectorContainer = class TagSelectorContainer extends React.PureComponent {
 	constructor(props) {
 		super(props);
 		this._notifierID = Zotero.Notifier.registerObserver(

--- a/chrome/content/zotero/containers/tagSelectorContainer.jsx
+++ b/chrome/content/zotero/containers/tagSelectorContainer.jsx
@@ -510,7 +510,7 @@ Zotero.TagSelector = class TagSelectorContainer extends React.PureComponent {
 				this.divMeasure.style.position = 'absolute';
 				this.divMeasure.style.top = '-9999px';
 				this.divMeasure.whiteSpace = 'nowrap';
-				document.querySelector('#zotero-tag-selector').appendChild(this.divMeasure);
+				this.props.element.appendChild(this.divMeasure);
 			}
 
 			this.divMeasure.style.font = font;
@@ -626,6 +626,7 @@ Zotero.TagSelector = class TagSelectorContainer extends React.PureComponent {
 		// Zotero.debug(`Prepared ${tags.length} tags in ${new Date() - d} ms`);
 		return <TagSelector
 			tags={tags}
+			label={this.props.element.getAttribute('label') || ''}
 			searchBoxRef={this.searchBoxRef}
 			tagListRef={this.tagListRef}
 			searchString={this.state.searchString}
@@ -971,6 +972,7 @@ Zotero.TagSelector = class TagSelectorContainer extends React.PureComponent {
 		await new Promise((resolve) => {
 			let root = ReactDOM.createRoot(domEl);
 			opts.root = root;
+			opts.element = domEl;
 			root.render(<TagSelectorContainer ref={(c) => {
 				ref = c;
 				resolve();
@@ -991,6 +993,7 @@ Zotero.TagSelector = class TagSelectorContainer extends React.PureComponent {
 	
 	static propTypes = {
 		container: PropTypes.string.isRequired,
+		element: PropTypes.object.isRequired,
 		onSelection: PropTypes.func.isRequired,
 		root: PropTypes.object,
 	};

--- a/chrome/content/zotero/elements/abstractBox.js
+++ b/chrome/content/zotero/elements/abstractBox.js
@@ -120,12 +120,12 @@
 			Zotero.Notifier.unregisterObserver(this._notifierID);
 		}
 
-		notify(action, type, ids) {
+		notify(action, type, ids, extraData) {
 			if (action == 'modify' && this.item && ids.includes(this.item.id)) {
 				this._forceRenderAll();
 			}
 			if (action === 'select' && type === 'tab' && ids.length > 0) {
-				this._handleTabSelect(ids[0]);
+				this._handleTabSelect(ids[0], extraData);
 			}
 		}
 		
@@ -304,8 +304,9 @@
 			this.save();
 		};
 
-		_handleTabSelect = (tabID) => {
-			if (!this.tabID || typeof Zotero_Tabs === 'undefined') {
+		_handleTabSelect = (tabID, extraData) => {
+			if (!this.tabID || typeof Zotero_Tabs === 'undefined'
+					|| !Zotero_Tabs.isOwnTabEvent(extraData, tabID)) {
 				return;
 			}
 			if (tabID !== this.tabID) {

--- a/chrome/content/zotero/elements/advancedSearchPane.js
+++ b/chrome/content/zotero/elements/advancedSearchPane.js
@@ -119,6 +119,10 @@
 			return this._active;
 		}
 		
+		set active(active) {
+			this._active = !!active;
+		}
+		
 		set search(search) {
 			this._active = false;
 			if (this.type === 'saved') {

--- a/chrome/content/zotero/elements/advancedSearchPane.js
+++ b/chrome/content/zotero/elements/advancedSearchPane.js
@@ -267,7 +267,6 @@
 				search.name = this._nameField.value;
 				await search.saveTx();
 				await ZoteroPane.setSavedSearchEditorState('closed');
-				Zotero_Tabs.rename('zotero-pane', search.name);
 				return;
 			}
 

--- a/chrome/content/zotero/elements/attachmentRow.js
+++ b/chrome/content/zotero/elements/attachmentRow.js
@@ -115,10 +115,13 @@ import { getCSSItemTypeIcon } from 'components/icons';
 			if (pane) {
 				pane._section.open = true;
 			}
-			let win = Zotero.getMainWindow();
+			let win = this.ownerDocument.defaultView;
+			if (!win?.ZoteroPane) {
+				win = Zotero.getMainWindow();
+			}
 			if (win) {
 				win.ZoteroPane.selectItem(this._attachment.id);
-				win.Zotero_Tabs.select('zotero-pane');
+				win.Zotero_Tabs.selectLibraryTab();
 				win.focus();
 			}
 		};

--- a/chrome/content/zotero/elements/contextPane.js
+++ b/chrome/content/zotero/elements/contextPane.js
@@ -120,6 +120,9 @@
 				this._handleItemUpdate(action, type, ids, extraData);
 				return;
 			}
+			if (type == 'tab' && !Zotero_Tabs.isOwnTabEvent(extraData, ids[0])) {
+				return;
+			}
 			if (type == 'tab' && action == 'add') {
 				this._handleTabAdd(action, type, ids, extraData);
 				return;

--- a/chrome/content/zotero/elements/duplicatesMergePane.js
+++ b/chrome/content/zotero/elements/duplicatesMergePane.js
@@ -92,7 +92,7 @@
 				
 				if (!item.isRegularItem() || ['annotation', 'attachment', 'note'].includes(item.itemType)) {
 					let msg = Zotero.getString('pane.item.duplicates.onlyTopLevel');
-					ZoteroPane.itemPane.setItemPaneMessage(msg);
+					this.closest('item-pane').setItemPaneMessage(msg);
 					return false;
 				}
 				
@@ -106,7 +106,7 @@
 						else {
 							msg = Zotero.getString('pane.item.duplicates.onlySameItemType');
 						}
-						ZoteroPane.itemPane.setItemPaneMessage(msg);
+						this.closest('item-pane').setItemPaneMessage(msg);
 						return false;
 					}
 				}

--- a/chrome/content/zotero/elements/itemBox.js
+++ b/chrome/content/zotero/elements/itemBox.js
@@ -417,7 +417,7 @@
 		//
 		// Methods
 		//
-		notify(event, type, ids) {
+		notify(event, type, ids, extraData) {
 			if (event == 'refresh' && type == 'infobox' && this.item?.id) {
 				this.renderCustomRows(ids);
 				return;
@@ -427,7 +427,7 @@
 				this._forceRenderAll();
 			}
 			if (event === 'select' && type === 'tab' && ids.length > 0) {
-				this._handleTabSelect(ids[0]);
+				this._handleTabSelect(ids[0], extraData);
 			}
 		}
 		
@@ -3367,8 +3367,9 @@
 			}
 		};
 
-		_handleTabSelect = (tabID) => {
-			if (!this.tabID || typeof Zotero_Tabs === 'undefined') {
+		_handleTabSelect = (tabID, extraData) => {
+			if (!this.tabID || typeof Zotero_Tabs === 'undefined'
+					|| !Zotero_Tabs.isOwnTabEvent(extraData, tabID)) {
 				return;
 			}
 			if (tabID !== this.tabID) {

--- a/chrome/content/zotero/elements/itemDetails.js
+++ b/chrome/content/zotero/elements/itemDetails.js
@@ -378,7 +378,7 @@
 			this._header.renderCustomHead(callback);
 		}
 
-		notify = async (action, type, ids, _extraData) => {
+		notify = async (action, type, ids, extraData) => {
 			if (action == 'refresh' && this.item) {
 				if (type == 'itempane') {
 					this.renderCustomSections();
@@ -389,7 +389,7 @@
 			}
 
 			if (action == 'select' && type == 'tab') {
-				this._handleTabSelect(ids);
+				this._handleTabSelect(ids, extraData);
 			}
 		};
 
@@ -648,8 +648,9 @@
 			}
 		};
 
-		_handleTabSelect(tabIDs) {
-			if (!this.tabID || typeof Zotero_Tabs === 'undefined') {
+		_handleTabSelect(tabIDs, extraData) {
+			if (!this.tabID || typeof Zotero_Tabs === 'undefined'
+					|| !Zotero_Tabs.isOwnTabEvent(extraData, tabIDs[0])) {
 				return;
 			}
 			let isTabSelected = tabIDs.includes(this.tabID);

--- a/chrome/content/zotero/elements/itemPane.js
+++ b/chrome/content/zotero/elements/itemPane.js
@@ -522,7 +522,8 @@
 			var collectionID = this._translationTarget.objectType == 'collection' ? this._translationTarget.id : undefined;
 			var items = this.data;
 			for (let item of items) {
-				await item.translate(this._translationTarget.libraryID, collectionID);
+				await item.translate(this._translationTarget.libraryID, collectionID,
+					{ window: this.ownerDocument.defaultView });
 			}
 		}
 		

--- a/chrome/content/zotero/elements/itemPane.js
+++ b/chrome/content/zotero/elements/itemPane.js
@@ -187,7 +187,7 @@
 
 		renderAnnotations(annotations) {
 			this.mode = "annotations";
-			let annotationsViewer = document.getElementById("zotero-annotations-pane");
+			let annotationsViewer = this.querySelector("#zotero-annotations-pane");
 			annotationsViewer.items = annotations;
 			annotationsViewer.render();
 			return true;
@@ -196,7 +196,7 @@
 		renderNoteEditor(item) {
 			this.mode = "note";
 
-			let noteEditor = document.getElementById('zotero-note-editor');
+			let noteEditor = this.querySelector('#zotero-note-editor');
 			noteEditor.mode = this.editable ? 'edit' : 'view';
 			noteEditor.viewMode = 'library';
 			noteEditor.parent = null;

--- a/chrome/content/zotero/elements/noteEditor.js
+++ b/chrome/content/zotero/elements/noteEditor.js
@@ -144,6 +144,7 @@
 				state,
 				item: this._item,
 				reloaded,
+				window: this.ownerDocument.defaultView,
 				iframeWindow: this._id('editor-view').contentWindow,
 				popup: this._id('editor-menu'),
 				onNavigate: this._navigateHandler,

--- a/chrome/content/zotero/elements/notesContext.js
+++ b/chrome/content/zotero/elements/notesContext.js
@@ -303,7 +303,7 @@
 		_isNotesListVisible() {
 			let splitter = ZoteroContextPane.splitter;
 			
-			return Zotero_Tabs.selectedID != 'zotero-pane'
+			return Zotero_Tabs.selectedType != 'library'
 				&& ZoteroContextPane.context.mode == "notes"
 				&& this.mode == "notesList"
 				&& splitter.getAttribute('state') != 'collapsed';
@@ -513,7 +513,7 @@
 			switch (event.originalTarget.classList[0]) {
 				case 'context-pane-list-show-in-library':
 					ZoteroPane_Local.selectItem(id);
-					Zotero_Tabs.select('zotero-pane');
+					Zotero_Tabs.selectLibraryTab();
 					break;
 
 				case 'context-pane-list-edit-in-window':

--- a/chrome/content/zotero/elements/quickSearchTextbox.js
+++ b/chrome/content/zotero/elements/quickSearchTextbox.js
@@ -114,7 +114,11 @@
 					// If there's text in the field, seed the Advanced Search with it,
 					// reproducing the current quick search mode as editable conditions.
 					let mode = Zotero.Prefs.get('search.quicksearch-mode');
-					if (this.value) {
+					// Shift-click opens the Advanced Search in a new window
+					if (event.shiftKey) {
+						ZoteroPane.openAdvancedSearchInNewWindow(this.value, mode);
+					}
+					else if (this.value) {
 						ZoteroPane.openAdvancedSearchFromQuickSearch(this.value, mode);
 					}
 					else {

--- a/chrome/content/zotero/elements/relatedBox.js
+++ b/chrome/content/zotero/elements/relatedBox.js
@@ -214,10 +214,13 @@ import { getCSSItemTypeIcon } from 'components/icons';
 		}
 
 		_handleShowItem(id) {
-			let win = Zotero.getMainWindow();
+			let win = this.ownerDocument.defaultView;
+			if (!win?.ZoteroPane) {
+				win = Zotero.getMainWindow();
+			}
 			if (win) {
 				win.ZoteroPane.selectItem(id);
-				win.Zotero_Tabs.select('zotero-pane');
+				win.Zotero_Tabs.selectLibraryTab();
 				win.focus();
 			}
 		}

--- a/chrome/content/zotero/fileInterface.js
+++ b/chrome/content/zotero/fileInterface.js
@@ -668,6 +668,7 @@ var Zotero_File_Interface = new function () {
 		var progress;
 		if (showProgressWindow) {
 			progressWin = new Zotero.ProgressWindow({
+				window,
 				closeOnClick: false
 			});
 			progressWin.changeHeadline(Zotero.getString('fileInterface.importing'));

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -32,15 +32,14 @@ const VirtualizedTable = require('components/virtualized-table');
 const { VirtualizedTree, formatColumnName } = VirtualizedTable;
 const { COLUMNS } = require("zotero/itemTreeColumns");
 const { ItemTreeRow } = require('zotero/itemTreeRow');
-const { OS } = ChromeUtils.importESModule("chrome://zotero/content/osfile.mjs");
 const { ZOTERO_CONFIG } = ChromeUtils.importESModule('resource://zotero/config.mjs');
+const { TreePrefs } = ChromeUtils.importESModule('chrome://zotero/content/modules/treePrefs.mjs');
 
 /**
  * @typedef {import("./itemTreeColumns.jsx").ItemTreeColumnOptions} ItemTreeColumnOptions
  */
 
 const CHILD_INDENT = 16;
-const COLUMN_PREFS_FILEPATH = OS.Path.join(Zotero.Profile.dir, "treePrefs.json");
 
 // Migrate unsuffixed `<id>` keys back to `<id>-default`. Earlier 10.0 betas dropped the `-default`
 // suffix from main-library tree IDs, stranding 9.0.x prefs and breaking version switching.
@@ -48,16 +47,7 @@ const COLUMN_PREFS_FILEPATH = OS.Path.join(Zotero.Profile.dir, "treePrefs.json")
 let _treePrefsMigrationPromise = null;
 function _migrateTreePrefsFile() {
 	if (!_treePrefsMigrationPromise) {
-		_treePrefsMigrationPromise = (async () => {
-			let persistSettings;
-			try {
-				let contents = await Zotero.File.getContentsAsync(COLUMN_PREFS_FILEPATH);
-				persistSettings = JSON.parse(contents);
-			}
-			catch {
-				return;
-			}
-			if (!persistSettings || typeof persistSettings !== 'object') return;
+		_treePrefsMigrationPromise = TreePrefs._updateSettings((persistSettings) => {
 			let knownSuffixes = [
 				'-default',
 				...Object.values(Zotero.CollectionTreeRow.visibilityGroups).map(g => '-' + g),
@@ -75,12 +65,8 @@ function _migrateTreePrefsFile() {
 				delete persistSettings[key];
 				changed = true;
 			}
-			if (changed) {
-				await Zotero.File.putContentsAsync(
-					COLUMN_PREFS_FILEPATH, JSON.stringify(persistSettings)
-				);
-			}
-		})();
+			return changed;
+		});
 	}
 	return _treePrefsMigrationPromise;
 }
@@ -1146,7 +1132,10 @@ var ItemTree = class ItemTree extends LibraryTree {
 			Zotero.Prefs.unregisterObserver(id);
 		}
 		this.clearEventListeners();
-		this._writeColumnPrefsToFile(true);
+		// A pending timeout means unsaved column pref changes
+		if (this._writeColumnsTimeout) {
+			this._writeColumnPrefsToFile(true);
+		}
 	}
 
 	componentDidMount() {
@@ -2498,14 +2487,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 	_loadColumnPrefsFromFile = async () => {
 		if (!this.props.columnPicker) return;
 		await _migrateTreePrefsFile();
-		try {
-			let columnPrefs = await Zotero.File.getContentsAsync(COLUMN_PREFS_FILEPATH);
-			let persistSettings = JSON.parse(columnPrefs);
-			this._columnPrefs = persistSettings[this.id] || {};
-		}
-		catch (e) {
-			this._columnPrefs = {};
-		}
+		this._columnPrefs = await TreePrefs.get(this.id);
 	}
 
 	/**
@@ -2518,22 +2500,13 @@ var ItemTree = class ItemTree extends LibraryTree {
 		if (!this.props.columnPicker) return;
 		await _migrateTreePrefsFile();
 		var writeToFile = async () => {
-			try {
-				let persistSettingsString = await Zotero.File.getContentsAsync(COLUMN_PREFS_FILEPATH);
-				var persistSettings = JSON.parse(persistSettingsString);
-			}
-			catch {
-				persistSettings = {};
-			}
-			persistSettings[this.id] = this._columnPrefs;
-
-			let prefString = JSON.stringify(persistSettings);
-			Zotero.debug(`Writing column prefs of length ${prefString.length} to file ${COLUMN_PREFS_FILEPATH}`);
-
-			return Zotero.File.putContentsAsync(COLUMN_PREFS_FILEPATH, prefString);
+			this._writeColumnsTimeout = null;
+			Zotero.debug(`Writing column prefs of tree ${this.id}`);
+			return TreePrefs.set(this.id, this._columnPrefs);
 		};
 		if (this._writeColumnsTimeout) {
 			clearTimeout(this._writeColumnsTimeout);
+			this._writeColumnsTimeout = null;
 		}
 		if (force) {
 			return writeToFile();

--- a/chrome/content/zotero/modules/treePrefs.mjs
+++ b/chrome/content/zotero/modules/treePrefs.mjs
@@ -1,0 +1,118 @@
+/*
+    ***** BEGIN LICENSE BLOCK *****
+
+    Copyright © 2026 Corporation for Digital Scholarship
+                     Falls Church, Virginia, USA
+                     https://www.zotero.org
+
+    This file is part of Zotero.
+
+    Zotero is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Zotero is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with Zotero.  If not, see <http://www.gnu.org/licenses/>.
+
+    ***** END LICENSE BLOCK *****
+*/
+
+ChromeUtils.defineESModuleGetters(globalThis, {
+	Zotero: "chrome://zotero/content/zotero.mjs"
+});
+
+const FILE_NAME = 'treePrefs.json';
+
+// Settings for all trees, shared by every window in the process
+let _settings = null;
+// Read-modify-write runs one caller at a time
+let _queue = Promise.resolve();
+
+function _enqueue(run) {
+	let promise = _queue.then(run, run);
+	_queue = promise.catch(() => {});
+	return promise;
+}
+
+function getPath() {
+	return PathUtils.join(Zotero.Profile.dir, FILE_NAME);
+}
+
+async function load() {
+	if (!_settings) {
+		try {
+			_settings = JSON.parse(await Zotero.File.getContentsAsync(getPath()));
+		}
+		catch {
+			_settings = null;
+		}
+		if (!_settings || typeof _settings != 'object' || Array.isArray(_settings)) {
+			_settings = {};
+		}
+	}
+	return _settings;
+}
+
+/**
+ * Settings persisted by item trees, stored in a single file in the profile directory and
+ * keyed by tree id
+ */
+export var TreePrefs = {
+
+	/**
+	 * @param {String} id - Tree id
+	 * @return {Promise<Object>}
+	 */
+	async get(id) {
+		let settings;
+		await this._withSettings((all) => {
+			settings = structuredClone(all[id] || {});
+		});
+		return settings;
+	},
+
+	/**
+	 * @param {String} id - Tree id
+	 * @param {Object} prefs
+	 * @return {Promise}
+	 */
+	set(id, prefs) {
+		return this._updateSettings((all) => {
+			all[id] = structuredClone(prefs);
+		});
+	},
+
+	/**
+	 * Run a function with the settings for all trees, one caller at a time
+	 *
+	 * @param {Function} fn - Passed the settings object for all trees
+	 * @return {Promise}
+	 */
+	_withSettings(fn) {
+		return _enqueue(async () => {
+			await fn(await load());
+		});
+	},
+
+	/**
+	 * Run a function that modifies the settings for all trees, one caller at a time, and
+	 * write the file back out, unless the function returns false
+	 *
+	 * @param {Function} fn - Passed the settings object for all trees
+	 * @return {Promise}
+	 */
+	_updateSettings(fn) {
+		return _enqueue(async () => {
+			let settings = await load();
+			if (await fn(settings) !== false) {
+				await Zotero.File.putContentsAsync(getPath(), JSON.stringify(settings));
+			}
+		});
+	}
+};

--- a/chrome/content/zotero/standalone/hiddenWindow.xhtml
+++ b/chrome/content/zotero/standalone/hiddenWindow.xhtml
@@ -54,6 +54,13 @@
 			ww.openWindow(null, 'chrome://zotero/content/about.xhtml', 'about', 'chrome,centerscreen,dialog=yes', null);
 		}
 		
+		// Equivalent to ZoteroPane.newWindow(), but with no view to take the current
+		// collections from
+		function openNewWindow() {
+			const { Zotero } = ChromeUtils.importESModule('chrome://zotero/content/zotero.mjs');
+			Zotero.openMainWindow();
+		}
+		
 		// Equivalent to Zotero.Utilities.Internal.openPreferences()
 		function openPreferences() {
 			let win = Services.wm.getMostRecentWindow('zotero:pref');
@@ -79,6 +86,7 @@
 	</commandset>
 	
 	<keyset id="mainKeyset">
+		<key id="key_newWindow" key="N" oncommand="openNewWindow()" modifiers="accel"/>
 		<key id="key_close" data-l10n-id="close-shortcut" command="cmd_close" modifiers="accel"/>
 		<key id="key_preferencesCmdMac"
 				data-l10n-id="preferences-shortcut"
@@ -106,6 +114,10 @@
 	<menubar id="main-menubar">
 		<menu id="fileMenu" data-l10n-id="menu-file">
 			<menupopup id="menu_FilePopup">
+				<menuitem id="menu_newWindow"
+						data-l10n-id="menu-new-window"
+						key="key_newWindow"
+						oncommand="openNewWindow()"/>
 				<!-- This gets moved to the Application menu automatically -->
 				<menuitem id="aboutName"
 						accesskey="&aboutProduct.accesskey;"

--- a/chrome/content/zotero/standalone/standalone.js
+++ b/chrome/content/zotero/standalone/standalone.js
@@ -59,7 +59,8 @@ const ZoteroStandalone = new function () {
 		this._notifierID = Zotero.Notifier.registerObserver(
 			{
 				notify: async (action, type, ids, extraData) => {
-					if (['select', 'load'].includes(action)) {
+					if (['select', 'load'].includes(action)
+							&& Zotero_Tabs.isOwnTabEvent(extraData, ids[0])) {
 						// Reader doesn't have tabID yet
 						setTimeout(async () => {
 							// Item and other things might not be loaded yet when reopening tabs
@@ -146,12 +147,12 @@ const ZoteroStandalone = new function () {
 		// Switch to library tab if dragging over PDF/EPUB/HTML file(s)
 		window.addEventListener('dragover', function (event) {
 			// TODO: Consider allowing more (or all) file types, although shouldn't interfere with image dragging to note editor
-			if (Zotero_Tabs.selectedID != 'zotero-pane'
+			if (Zotero_Tabs.selectedType != 'library'
 					&& event.dataTransfer.items
 					&& event.dataTransfer.items.length
 					&& !Array.from(event.dataTransfer.items).find(x =>
 						!['application/pdf', 'application/epub+zip', 'text/html'].includes(x.type))) {
-				Zotero_Tabs.select('zotero-pane');
+				Zotero_Tabs.selectLibraryTab();
 			}
 		}, true);
 	}

--- a/chrome/content/zotero/tabs.js
+++ b/chrome/content/zotero/tabs.js
@@ -56,6 +56,10 @@ var Zotero_Tabs = new function () {
 		get: () => document.getElementById('tabs-deck')
 	});
 
+	Object.defineProperty(this, 'windowID', {
+		get: () => this._windowID
+	});
+
 	Object.defineProperty(this, 'numTabs', {
 		get: () => this._tabs.length
 	});
@@ -69,6 +73,8 @@ var Zotero_Tabs = new function () {
 	});
 
 	this._tabBarRef = React.createRef();
+	// Identifies this window in tab notifications and in the session
+	this._windowID = 'win-' + Zotero.Utilities.randomString();
 	this._tabs = [{
 		id: 'zotero-pane',
 		type: 'library',
@@ -105,7 +111,8 @@ var Zotero_Tabs = new function () {
 					tabIndex,
 					allowDuplicate: true,
 					secondViewState: tab.data.secondViewState,
-					preventJumpback: true
+					preventJumpback: true,
+					window
 				});
 				await reader._initPromise;
 			},
@@ -115,7 +122,8 @@ var Zotero_Tabs = new function () {
 					title: tab.title,
 					tabIndex,
 					allowDuplicate: true,
-					preventJumpback: true
+					preventJumpback: true,
+					window
 				});
 				await editorInstance._initPromise;
 			}
@@ -180,24 +188,24 @@ var Zotero_Tabs = new function () {
 			reader: async (tab, _tabIndex) => {
 				Zotero_Tabs.close(tab.id);
 				let { itemID, secondViewState } = tab.data;
-				await Zotero.Reader.open(itemID, null, { openInWindow: true, secondViewState });
+				await Zotero.Reader.open(itemID, null, { openInWindow: true, secondViewState, window });
 			},
 			note: async (tab, _tabIndex) => {
 				Zotero_Tabs.close(tab.id);
 				let { itemID } = tab.data;
-				await Zotero.Notes.open(itemID, null, { openInWindow: true });
+				await Zotero.Notes.open(itemID, null, { openInWindow: true, window });
 			}
 		},
 		duplicate: {
 			reader: async (tab, tabIndex) => {
 				if (tab.data.itemID) {
 					let { secondViewState } = tab.data;
-					await Zotero.Reader.open(tab.data.itemID, null, { tabIndex: tabIndex + 1, allowDuplicate: true, secondViewState });
+					await Zotero.Reader.open(tab.data.itemID, null, { tabIndex: tabIndex + 1, allowDuplicate: true, secondViewState, window });
 				}
 			},
 			note: async (tab, tabIndex) => {
 				if (tab.data.itemID) {
-					await Zotero.Notes.open(tab.data.itemID, null, { tabIndex: tabIndex + 1, allowDuplicate: true });
+					await Zotero.Notes.open(tab.data.itemID, null, { tabIndex: tabIndex + 1, allowDuplicate: true, window });
 				}
 			}
 		},
@@ -209,7 +217,8 @@ var Zotero_Tabs = new function () {
 						{
 							tabIndex,
 							openInBackground: true,
-							allowDuplicate: true
+							allowDuplicate: true,
+							window
 						}
 					);
 					return true;
@@ -223,7 +232,8 @@ var Zotero_Tabs = new function () {
 						{
 							tabIndex,
 							openInBackground: true,
-							allowDuplicate: true
+							allowDuplicate: true,
+							window
 						}
 					);
 					return true;
@@ -286,6 +296,15 @@ var Zotero_Tabs = new function () {
 			}
 		},
 		getTitle: {
+			library: async (tab) => {
+				let collectionTreeRows = ZoteroPane.getCollectionTreeRows();
+				if (!collectionTreeRows.length) {
+					return tab.title;
+				}
+				return collectionTreeRows.length == 1
+					? collectionTreeRows[0].getName()
+					: Zotero.getString('tab-title-multiple-collections');
+			},
 			reader: async (tab) => {
 				let item = Zotero.Items.get(tab.data.itemID);
 				return item ? item.getTabTitle() : "";
@@ -337,8 +356,10 @@ var Zotero_Tabs = new function () {
 		};
 	};
 
-	// Keep track of item modifications to update the title
-	this._notifierID = Zotero.Notifier.registerObserver(this, ['item'], 'tabs');
+	// Keep track of modifications to objects that tabs are named for, to update tab titles
+	this._notifierID = Zotero.Notifier.registerObserver(
+		this, ['item', 'collection', 'search', 'feed', 'group'], 'tabs'
+	);
 
 	// Update the title when pref of title format is changed
 	this._prefsObserverID = Zotero.Prefs.registerObserver('tabs.title.reader', async () => {
@@ -357,6 +378,33 @@ var Zotero_Tabs = new function () {
 		this.unloadUnusedTabs();
 	}, 60000); // Trigger every minute
 
+	/**
+	 * Extra data for a 'tab' notification, tagged with this window's id
+	 *
+	 * @param {String[]} ids - Tab ids the notification is for
+	 * @param {Object} [data] - Extra data for each tab
+	 * @return {Object}
+	 */
+	this._getNotifierExtraData = function (ids, data) {
+		let extraData = {};
+		for (let id of ids) {
+			extraData[id] = Object.assign({}, data, { windowID: this._windowID });
+		}
+		return extraData;
+	};
+	
+	/**
+	 * Whether a 'tab' notification came from this window
+	 *
+	 * @param {Object} extraData
+	 * @param {String} id - Tab id from the notification
+	 * @return {Boolean}
+	 */
+	this.isOwnTabEvent = function (extraData, id) {
+		let windowID = extraData?.[id]?.windowID;
+		return !windowID || windowID === this._windowID;
+	};
+	
 	this._getTab = function (id) {
 		var tabIndex = this._tabs.findIndex(tab => tab.id == id);
 		return { tab: this._tabs[tabIndex], tabIndex };
@@ -553,13 +601,15 @@ var Zotero_Tabs = new function () {
 		this._loadSidebarState();
 	};
 
-	this.destroy = function () {
-		this._saveSidebarState();
-	};
-
-	// When an item is modified, update the title accordingly
+	// When an object that tabs are named for is modified, update the title accordingly
 	this.notify = async (event, type, ids, _) => {
 		if (event !== "modify") return;
+		// A renamed collection, saved search, or library can be what the library tab is
+		// named for, in this window or another one
+		if (type != 'item') {
+			this.rename('zotero-pane');
+			return;
+		}
 		for (let id of ids) {
 			let item = Zotero.Items.get(id);
 			// If a top-level item is updated, update all tabs that have its attachments and notes
@@ -683,7 +733,9 @@ var Zotero_Tabs = new function () {
 		index = index || this._tabs.length;
 		this._tabs.splice(index, 0, tab);
 		this._update();
-		Zotero.Notifier.trigger('add', 'tab', [id], { [id]: Object.assign({}, data, { type }) }, true);
+		Zotero.Notifier.trigger(
+			'add', 'tab', [id], this._getNotifierExtraData([id], Object.assign({}, data, { type })), true
+		);
 		if (select) {
 			let previousID = this._selectedID;
 			this.select(id);
@@ -807,7 +859,7 @@ var Zotero_Tabs = new function () {
 			});
 		}
 		this._history.push(historyEntry);
-		Zotero.Notifier.trigger('close', 'tab', [closedIDs], true);
+		Zotero.Notifier.trigger('close', 'tab', [closedIDs], this._getNotifierExtraData(closedIDs));
 		this._update();
 	};
 
@@ -968,7 +1020,9 @@ var Zotero_Tabs = new function () {
 		this._selectedID = id;
 		this.deck.selectedIndex = Array.from(this.deck.children).findIndex(x => x.id == id);
 		this._update();
-		Zotero.Notifier.trigger('select', 'tab', [tab.id], { [tab.id]: { type: tab.type } }, true);
+		Zotero.Notifier.trigger(
+			'select', 'tab', [tab.id], this._getNotifierExtraData([tab.id], { type: tab.type }), true
+		);
 
 		let currentTabContent = this.getTabContent(id);
 
@@ -1037,7 +1091,9 @@ var Zotero_Tabs = new function () {
 		}
 		let prevType = tab.type;
 		tab.type = tabContentType;
-		Zotero.Notifier.trigger("load", "tab", [id], { [id]: Object.assign({}, tab, { prevType }) }, true);
+		Zotero.Notifier.trigger(
+			"load", "tab", [id], this._getNotifierExtraData([id], Object.assign({}, tab, { prevType })), true
+		);
 	};
 
 	this.unloadUnusedTabs = function () {
@@ -1055,6 +1111,15 @@ var Zotero_Tabs = new function () {
 		for (let tab of tabs) {
 			this.unload(tab.id);
 		}
+	};
+
+	/**
+	 * Select this window's library tab
+	 *
+	 * @param {Object} [options] - Additional options, passed to select()
+	 */
+	this.selectLibraryTab = function (options = {}) {
+		this.select('zotero-pane', false, options);
 	};
 
 	/**

--- a/chrome/content/zotero/tabs.js
+++ b/chrome/content/zotero/tabs.js
@@ -237,6 +237,10 @@ var Zotero_Tabs = new function () {
 				// At first, library tab is added without the icon data. We set it here once we know what it is
 				let libraryTab = this._getTab('zotero-pane');
 				libraryTab.tab.data = tab.data || {};
+				if (libraryTab.tab.data.state) {
+					// Not awaited, so that the other tabs are restored right away
+					ZoteroPane.restoreLibraryTabState(libraryTab.tab.data.state);
+				}
 				return {
 					itemID: null,
 				};
@@ -580,7 +584,30 @@ var Zotero_Tabs = new function () {
 		}
 	};
 
+	/**
+	 * Store the current state of the library view on the library tab
+	 */
+	this._captureLibraryTabState = function () {
+		if (typeof ZoteroPane == 'undefined') {
+			return;
+		}
+		let { tab } = this._getTab('zotero-pane');
+		if (!tab) {
+			return;
+		}
+		try {
+			let state = ZoteroPane.captureLibraryTabState();
+			if (state) {
+				tab.data.state = state;
+			}
+		}
+		catch (e) {
+			Zotero.logError(e);
+		}
+	};
+
 	this.getState = function () {
+		this._captureLibraryTabState();
 		return this._tabs.map((tab) => {
 			let type = tab.type;
 			// If type matches *-unloaded, use the base type

--- a/chrome/content/zotero/xpcom/data/feedItem.js
+++ b/chrome/content/zotero/xpcom/data/feedItem.js
@@ -205,9 +205,10 @@ Zotero.FeedItem.prototype.toggleRead = async function (state) {
  * in the library
  * @param libraryID {Integer} save item in library
  * @param collectionID {Integer} add item to collection
+ * @param options.window {ChromeWindow} main window to show progress in
  * @return {Promise<FeedItem|Item>} translated feed item
  */
-Zotero.FeedItem.prototype.translate = async function (libraryID, collectionID) {
+Zotero.FeedItem.prototype.translate = async function (libraryID, collectionID, { window: win } = {}) {
 	const { RemoteTranslate } = ChromeUtils.importESModule("chrome://zotero/content/RemoteTranslate.mjs");
 	const { HiddenBrowser } = ChromeUtils.importESModule("chrome://zotero/content/HiddenBrowser.mjs");
 
@@ -219,7 +220,7 @@ Zotero.FeedItem.prototype.translate = async function (libraryID, collectionID) {
 
 	let error = function (e) {  };
 	let translate = new RemoteTranslate();
-	var win = Services.wm.getMostRecentWindow("navigator:browser");
+	win = win || Zotero.getMainWindow();
 	let progressWindow = win.ZoteroPane.progressWindow;
 	
 	if (libraryID) {

--- a/chrome/content/zotero/xpcom/data/notes.js
+++ b/chrome/content/zotero/xpcom/data/notes.js
@@ -43,10 +43,10 @@ Zotero.Notes = new function () {
 	 * @returns {Promise<Zotero.EditorInstance | null>} Instance of Zotero.EditorInstance for the note.
 	 * If the note tab is opened in background (unloaded), returns null.
 	 */
-	this.open = async function (itemID, location, { title, tabIndex, tabID, openInBackground, openInWindow, allowDuplicate, preventJumpback, parentItemKey } = {}) {
+	this.open = async function (itemID, location, { title, tabIndex, tabID, openInBackground, openInWindow, allowDuplicate, preventJumpback, parentItemKey, window: ownerWindow } = {}) {
 		let { libraryID } = Zotero.Items.getLibraryAndKeyFromID(itemID);
 		let library = Zotero.Libraries.get(libraryID);
-		let win = Zotero.getMainWindow();
+		let win = ownerWindow || Zotero.getMainWindow();
 
 		if (!win) {
 			openInWindow = true;
@@ -74,7 +74,10 @@ Zotero.Notes = new function () {
 				editorInstance = this._editorInstances.find(r => r.itemID === itemID && r.viewMode === 'window');
 			}
 			else {
-				editorInstance = this._editorInstances.find(r => r.itemID === itemID && r.viewMode === 'tab');
+				// A tab is only a duplicate of another tab in the same window
+				editorInstance = this._editorInstances.find(
+					r => r.itemID === itemID && r.viewMode === 'tab' && r._window === win
+				);
 			}
 		}
 
@@ -85,7 +88,9 @@ Zotero.Notes = new function () {
 				// Wait for the note editor to load
 				let timeout = 3000;
 				for (let i = 0; i < timeout; i += 100) {
-					editorInstance = this._editorInstances.find(r => r.itemID === itemID && r.viewMode === 'tab');
+					editorInstance = this._editorInstances.find(
+						r => r.itemID === itemID && r.viewMode === 'tab' && r._window === win
+					);
 					if (editorInstance) {
 						return editorInstance;
 					}
@@ -179,13 +184,13 @@ Zotero.Notes = new function () {
 
 				container.addEventListener('tab-selection-change', (event) => {
 					if (event.detail.selected) {
-						this._updateLayout();
+						this._updateLayout(win);
 					}
 				});
 			}
 
 			if (select) {
-				this._updateLayout();
+				this._updateLayout(win);
 				noteEditor.focus();
 			}
 		}
@@ -209,8 +214,8 @@ Zotero.Notes = new function () {
 		noteEditor.setContextPaneOpen(open);
 	};
 
-	this._updateLayout = function () {
-		let win = Zotero.getMainWindow();
+	this._updateLayout = function (win) {
+		win = win || Zotero.getMainWindow();
 		win.ZoteroContextPane.update();
 		let { sidebarState } = win.Zotero_Tabs.updateSidebarLayout();
 		this.toggleSidebar(sidebarState.open);

--- a/chrome/content/zotero/xpcom/editorInstance.js
+++ b/chrome/content/zotero/xpcom/editorInstance.js
@@ -88,6 +88,7 @@ class EditorInstance {
 		this._filesReadOnly = !Zotero.Libraries.get(this._item.libraryID).filesEditable;
 		this._disableUI = options.disableUI;
 		this._onReturn = options.onReturn;
+		this._window = options.window;
 		this._iframeWindow = options.iframeWindow;
 		this._popup = options.popup;
 		this._state = options.state;
@@ -363,7 +364,7 @@ class EditorInstance {
 
 		if (type === 'item' && ['delete', 'trash'].includes(event) && this._tabID) {
 			if (this._item && (ids.includes(this._item.id) || ids.includes(this._item.parentItemID))) {
-				Zotero.getMainWindow().Zotero_Tabs.close(this._tabID);
+				this._getMainWindow()?.Zotero_Tabs.close(this._tabID);
 			}
 		}
 
@@ -480,11 +481,21 @@ class EditorInstance {
 		}
 	};
 	
+	/**
+	 * The main window this editor belongs to, or the most recent one if it's not in a main
+	 * window (e.g., a note window)
+	 *
+	 * @return {ChromeWindow|null}
+	 */
+	_getMainWindow() {
+		return this._window?.ZoteroPane ? this._window : Zotero.getMainWindow();
+	}
+	
 	_showInLibrary(ids) {
 		if (!Array.isArray(ids)) {
 			ids = [ids];
 		}
-		let win = Zotero.getMainWindow();
+		let win = this._getMainWindow();
 		if (win) {
 			win.ZoteroPane.selectItems(ids);
 			win.focus();
@@ -671,7 +682,7 @@ class EditorInstance {
 						this.onNavigate(attachmentURI, { position });
 					}
 					else {
-						let zp = Zotero.getActiveZoteroPane();
+						let zp = this._getMainWindow()?.ZoteroPane;
 						if (zp) {
 							let item = await Zotero.URI.getURIItem(attachmentURI);
 							if (item) {
@@ -696,7 +707,7 @@ class EditorInstance {
 						let attachments = await item.getBestAttachments();
 						attachments = attachments.filter(x => x.isPDFAttachment());
 						if (attachments.length) {
-							let zp = Zotero.getActiveZoteroPane();
+							let zp = this._getMainWindow()?.ZoteroPane;
 							if (zp) {
 								zp.viewPDF(attachments[0].id, { pageLabel: citationItem.locator });
 							}
@@ -724,7 +735,7 @@ class EditorInstance {
 				}
 				case 'openURL': {
 					let { url } = message;
-					let zp = Zotero.getActiveZoteroPane();
+					let zp = this._getMainWindow()?.ZoteroPane;
 					if (zp) {
 						zp.loadURI(url);
 					}
@@ -737,8 +748,8 @@ class EditorInstance {
 				case 'openWindow': {
 					// TODO: Can we can avoid creating empty note just to open it in a new window?
 					await this._ensureNoteCreated();
-					let zp = Zotero.getActiveZoteroPane();
-					zp.openNoteWindow(this._item.id);
+					let zp = this._getMainWindow()?.ZoteroPane;
+					zp?.openNoteWindow(this._item.id);
 					return;
 				}
 				case 'update': {
@@ -793,7 +804,7 @@ class EditorInstance {
 					}
 					let openedEmpty = !citation.citationItems.length;
 					if (!citation.citationItems.length) {
-						let win = Zotero.getMainWindow();
+						let win = this._getMainWindow();
 						if (win) {
 							let reader = Zotero.Reader.getByTabID(win.Zotero_Tabs.selectedID);
 							if (reader) {
@@ -838,15 +849,13 @@ class EditorInstance {
 					return;
 				}
 				case 'toggleContextPane': {
-					let win = Zotero.getMainWindow();
-					win.ZoteroContextPane.togglePane();
+					this._getMainWindow()?.ZoteroContextPane.togglePane();
 					return;
 				}
 				case 'focusBack': {
 					// If editor is in a tab, let Zotero_Tabs handle the focus
 					if (this._tabID) {
-						let win = Zotero.getMainWindow();
-						win.Zotero_Tabs.focusBack();
+						this._getMainWindow()?.Zotero_Tabs.focusBack();
 					}
 					// If the editor is in a standalone window, itemPane, or contextPane,
 					// move focus back from the iframe
@@ -860,8 +869,7 @@ class EditorInstance {
 					return;
 				}
 				case 'focusForward': {
-					let win = Zotero.getMainWindow();
-					win.Zotero_Tabs.focusForward();
+					this._getMainWindow()?.Zotero_Tabs.focusForward();
 					return;
 				}
 				case 'return': {

--- a/chrome/content/zotero/xpcom/fileHandlers.js
+++ b/chrome/content/zotero/xpcom/fileHandlers.js
@@ -27,7 +27,7 @@
 
 Zotero.FileHandlers = {
 	async open(item, params) {
-		let { location, openInWindow = false } = params || {};
+		let { location, openInWindow = false, window: ownerWindow } = params || {};
 		
 		let path = await item.getFilePathAsync();
 		if (!path) {
@@ -52,7 +52,8 @@ Zotero.FileHandlers = {
 			Zotero.debug('No external handler for ' + readerType + ' -- opening in Zotero');
 			await Zotero.Reader.open(item.id, location, {
 				openInWindow,
-				allowDuplicate: openInWindow
+				allowDuplicate: openInWindow,
+				window: ownerWindow
 			});
 			return true;
 		}

--- a/chrome/content/zotero/xpcom/prefs.js
+++ b/chrome/content/zotero/xpcom/prefs.js
@@ -375,7 +375,9 @@ Zotero.Prefs = new function () {
 			Zotero.UIProperties.setAll();
 		}],
 		[ "layout", function (val) {
-			Zotero.getActiveZoteroPane().updateLayout();
+			for (let pane of Zotero.getZoteroPanes()) {
+				pane.updateLayout();
+			}
 		}],
 		[ "note.fontSize", function (val) {
 			if (val < 6) {
@@ -400,7 +402,9 @@ Zotero.Prefs = new function () {
 				Zotero.Prefs.set('sync.reminder.autoSync.lastDisplayed', Math.round(Date.now() / 1000));
 			}
 			try {
-				Zotero.getActiveZoteroPane().initSyncReminders(false);
+				for (let pane of Zotero.getZoteroPanes()) {
+					pane.initSyncReminders(false);
+				}
 			}
 			catch (e) {
 				Zotero.logError(e);

--- a/chrome/content/zotero/xpcom/reader.js
+++ b/chrome/content/zotero/xpcom/reader.js
@@ -104,6 +104,15 @@ class ReaderInstance {
 		return this._type;
 	}
 
+	/**
+	 * The main window this reader belongs to, or the most recent one for a reader window
+	 *
+	 * @return {ChromeWindow|null}
+	 */
+	_getMainWindow() {
+		return this._window?.ZoteroPane ? this._window : Zotero.getMainWindow();
+	}
+	
 	async focus() {
 		await this._waitForReader();
 		this._iframeWindow.focus();
@@ -361,10 +370,7 @@ class ReaderInstance {
 					await this._setState(state);
 				}
 				else if (this.tabID) {
-					let win = Zotero.getMainWindow();
-					if (win) {
-						win.Zotero_Tabs.setTabData(this.tabID, { secondViewState: state });
-					}
+					this._window.Zotero_Tabs.setTabData(this.tabID, { secondViewState: state });
 				}
 			},
 			onOpenTagsPopup: (id, x, y) => {
@@ -386,7 +392,7 @@ class ReaderInstance {
 				}
 			},
 			onOpenLink: (url) => {
-				let win = Services.wm.getMostRecentWindow('navigator:browser');
+				let win = this._getMainWindow();
 				if (win) {
 					win.ZoteroPane.loadURI(url);
 				}
@@ -566,20 +572,17 @@ class ReaderInstance {
 			},
 			onToggleContextPane: () => {
 				Zotero.debug('toggle context pane');
-				let win = Zotero.getMainWindow();
-				win.ZoteroContextPane.togglePane();
+				this._window.ZoteroContextPane?.togglePane();
 			},
 			onToolbarShiftTab: () => {
 				// Shift-tab from the toolbar focuses the sync button (if reader instance is opened in a tab)
 				if (!this.tabID) return;
-				let win = Zotero.getMainWindow();
-				win.Zotero_Tabs.focusBack();
+				this._window.Zotero_Tabs.focusBack();
 			},
 			onIframeTab: () => {
 				// Tab after the last tabstop will focus the contextPane (if reader instance is opened in a tab)
 				if (!this.tabID) return;
-				let win = Zotero.getMainWindow();
-				win.Zotero_Tabs.focusForward();
+				this._window.Zotero_Tabs.focusForward();
 			},
 			onSetZoom: (iframe, zoom) => {
 				iframe.browsingContext.textZoom = 1;
@@ -998,12 +1001,14 @@ class ReaderInstance {
 	}
 
 	export() {
-		let zp = Zotero.getActiveZoteroPane();
-		zp.exportPDF(this._item.id);
+		let win = this._getMainWindow();
+		if (win) {
+			win.ZoteroPane.exportPDF(this._item.id);
+		}
 	}
 
 	showInLibrary() {
-		let win = Zotero.getMainWindow();
+		let win = this._getMainWindow();
 		if (win) {
 			let item = Zotero.Items.get(this._item.id);
 			let id = item.parentID || item.id;
@@ -1541,10 +1546,7 @@ class ReaderInstance {
 
 	_updateSecondViewState() {
 		if (this.tabID) {
-			let win = Zotero.getMainWindow();
-			if (win) {
-				win.Zotero_Tabs.setTabData(this.tabID, { secondViewState: this.getSecondViewState() });
-			}
+			this._window.Zotero_Tabs.setTabData(this.tabID, { secondViewState: this.getSecondViewState() });
 		}
 	}
 
@@ -1957,7 +1959,7 @@ class ReaderTab extends ReaderInstance {
 		this._showContextPaneToggle = true;
 		this._readAloudPlaying = false;
 		this._pointerDownWindow = null;
-		this._window = Services.wm.getMostRecentWindow('navigator:browser');
+		this._window = options.window || Services.wm.getMostRecentWindow('navigator:browser');
 		let existingTabID = options.tabID;
 		let select = !options.background;
 		// If an unloaded tab for this item already exists, load the reader in it.
@@ -2210,7 +2212,7 @@ class ReaderWindow extends ReaderInstance {
 		this._bottomPlaceholderHeight = 0;
 		this._onClose = options.onClose;
 
-		let win = Services.wm.getMostRecentWindow('navigator:browser');
+		let win = options.window || Services.wm.getMostRecentWindow('navigator:browser');
 		if (!win) return;
 
 		this._window = win.open(
@@ -2904,10 +2906,10 @@ class Reader {
 		await this.open(item.id, location, options);
 	}
 
-	async open(itemID, location, { title, tabIndex, tabID, openInBackground, openInWindow, allowDuplicate, secondViewState, preventJumpback } = {}) {
+	async open(itemID, location, { title, tabIndex, tabID, openInBackground, openInWindow, allowDuplicate, secondViewState, preventJumpback, window: ownerWindow } = {}) {
 		let { libraryID } = Zotero.Items.getLibraryAndKeyFromID(itemID);
 		let library = Zotero.Libraries.get(libraryID);
-		let win = Zotero.getMainWindow();
+		let win = ownerWindow || Zotero.getMainWindow();
 
 		await library.waitForDataLoad('item');
 
@@ -2919,10 +2921,12 @@ class Reader {
 		this._loadSidebarState();
 		this.triggerAnnotationsImportCheck(itemID);
 		let reader;
+		// A tab is only a duplicate of another tab in the same window
+		let inWindow = r => !(r instanceof ReaderTab) || r._window === win;
 		// If duplicating is not allowed, and no reader instance is loaded for itemID,
 		// try to find an unloaded tab and select it. Zotero.Reader.open will then be called again
 		if (!allowDuplicate && !this._readers.find(
-			r => r.itemID === itemID && (openInWindow || !r._isTabClosed)
+			r => r.itemID === itemID && (openInWindow || (!r._isTabClosed && inWindow(r)))
 		)) {
 			if (win) {
 				let existingTabID = win.Zotero_Tabs.getTabIDByItemID(itemID);
@@ -2937,7 +2941,9 @@ class Reader {
 			reader = this._readers.find(r => r.itemID === itemID && (r instanceof ReaderWindow));
 		}
 		else if (!allowDuplicate) {
-			reader = this._readers.find(r => r.itemID === itemID && !r._isTabClosed);
+			reader = this._readers.find(
+				r => r.itemID === itemID && !r._isTabClosed && inWindow(r)
+			);
 		}
 
 		if (reader) {
@@ -2954,6 +2960,7 @@ class Reader {
 				item,
 				location,
 				secondViewState,
+				window: win,
 				sidebarWidth: this._sidebarWidth,
 				sidebarOpen: this._sidebarOpen,
 				bottomPlaceholderHeight: this._bottomPlaceholderHeight,
@@ -2973,6 +2980,7 @@ class Reader {
 				title,
 				index: tabIndex,
 				tabID,
+				window: win,
 				background: openInBackground,
 				sidebarWidth: this._sidebarWidth,
 				sidebarOpen: this._sidebarOpen,

--- a/chrome/content/zotero/xpcom/server/saveSession.js
+++ b/chrome/content/zotero/xpcom/server/saveSession.js
@@ -70,6 +70,10 @@ Zotero.Server.Connector.SaveSession = class {
 		this._progressItems = {};
 		this._orderedProgressItems = [];
 		this._userAddedNotes = {};
+		// The pane that was active when the save started, so that later updates to the session
+		// keep targeting the same window
+		this._pane = Zotero.getActiveZoteroPane();
+		this._paneWindow = this._pane?.document.defaultView;
 	}
 
 	async saveItems(target) {
@@ -151,6 +155,18 @@ Zotero.Server.Connector.SaveSession = class {
 	}
 
 	/**
+	 * The pane this session saves to, falling back to the active one if its window is gone
+	 *
+	 * @return {ZoteroPane|null}
+	 */
+	_getPane() {
+		if (this._pane && !this._paneWindow.closed) {
+			return this._pane;
+		}
+		return Zotero.getActiveZoteroPane();
+	}
+	
+	/**
 	 * Change the target data for this session and update any items that have already been saved
 	 */
 	async update(targetID, tags, note) {
@@ -160,7 +176,7 @@ Zotero.Server.Connector.SaveSession = class {
 		this._currentNote = note || "";
 		
 		// Select new destination in collections pane
-		var zp = Zotero.getActiveZoteroPane();
+		var zp = this._getPane();
 		if (zp && zp.collectionsView) {
 			await zp.collectionsView.selectByID(targetID);
 		}

--- a/chrome/content/zotero/xpcom/session.js
+++ b/chrome/content/zotero/xpcom/session.js
@@ -32,6 +32,10 @@ Zotero.Session = new function () {
 	};
 	let _initialized = false;
 
+	let _claimedPaneStates = new Set();
+	let _paneStateClaimAttempted = false;
+	let _finalized = false;
+	
 	Zotero.defineProperty(this, 'state', {
 		get: () => {
 			return _state;
@@ -52,25 +56,93 @@ Zotero.Session = new function () {
 		_initialized = true;
 	};
 	
+	function getPaneStates() {
+		return _state.windows.filter(x => x.type == 'pane');
+	}
+	
+	/**
+	 * Take ownership of a saved main-window state, so that no other window restores it
+	 *
+	 * The window opened at startup claims the first saved state; windows opened for the
+	 * remaining states pass the id of the state they were opened for. Windows opened by the
+	 * user don't restore anything.
+	 *
+	 * @param {String} [windowID] - The window id of the state to claim
+	 * @return {Object|null}
+	 */
+	this.claimPaneState = function (windowID) {
+		let state = null;
+		if (windowID) {
+			state = getPaneStates().find(
+				x => x.windowID == windowID && !_claimedPaneStates.has(x)
+			);
+		}
+		else if (!_paneStateClaimAttempted) {
+			state = getPaneStates().find(x => !_claimedPaneStates.has(x));
+		}
+		_paneStateClaimAttempted = true;
+		if (!state) {
+			return null;
+		}
+		_claimedPaneStates.add(state);
+		return state;
+	};
+	
+	/**
+	 * The saved main-window states that no window has claimed yet
+	 *
+	 * @return {Object[]}
+	 */
+	this.getUnclaimedPaneStates = function () {
+		return getPaneStates().filter(x => !_claimedPaneStates.has(x));
+	};
+	
 	this.setLastClosedZoteroPaneState = function (state) {
-		_state.windows = [state];
+		// This is the last open main window, so any other saved pane states are stale
+		_state.windows = _state.windows
+			.filter(x => x.type != 'pane')
+			.concat([state]);
+	};
+	
+	/**
+	 * Forget the saved state of a window that was closed while other windows remained open
+	 *
+	 * @param {String} windowID
+	 */
+	this.removeZoteroPaneState = function (windowID) {
+		_state.windows = _state.windows.filter(x => x.type != 'pane' || x.windowID != windowID);
 	};
 
 	this.debounceSave = Zotero.Utilities.debounce(() => {
 		this.save();
 	}, DEBOUNCED_SAVING_DELAY);
 
-	this.save = async function () {
+	/**
+	 * Save the state at quit and ignore any save requests that arrive while windows are
+	 * closing, which would record the already-emptying window list
+	 */
+	this.saveFinalState = function () {
+		_finalized = true;
+		return this.save(true);
+	};
+
+	this.save = Zotero.serial(async function (force) {
 		// Don't overwrite the saved session if startup failed before the session was loaded
 		if (!_initialized) {
 			return;
 		}
-		
+		if (_finalized && !force) {
+			return;
+		}
 		try {
 			// Saving is triggered in `zotero.js` when a quit event is received,
 			// though if it was triggered by closing a window, ZoteroPane might
 			// be already destroyed at the time
-			let panes = Zotero.getZoteroPanes().map(x => x.getState());
+			// Order pane states with the most recently activated window last: restored
+			// windows are opened in saved order, so the last-used window ends up on top
+			let panes = Zotero.getZoteroPanes()
+				.sort((a, b) => a.lastActivated - b.lastActivated)
+				.map(x => x.getState());
 			let readers = Zotero.Reader.getWindowStates();
 			if (panes.length) {
 				_state.windows = [...readers, ...panes];
@@ -85,5 +157,5 @@ Zotero.Session = new function () {
 		catch (e) {
 			Zotero.logError(e);
 		}
-	};
+	});
 };

--- a/chrome/content/zotero/xpcom/zotero.js
+++ b/chrome/content/zotero/xpcom/zotero.js
@@ -383,7 +383,7 @@ const { CommandLineOptions } = ChromeUtils.importESModule("chrome://zotero/conte
 		
 		Services.obs.addObserver({
 			observe: function () {
-				Zotero.Session.save();
+				Zotero.Session.saveFinalState();
 			}
 		}, "quit-application-granted", false);
 		
@@ -1101,12 +1101,23 @@ const { CommandLineOptions } = ChromeUtils.importESModule("chrome://zotero/conte
 	}
 	
 	
-	this.openMainWindow = function () {
+	/**
+	 * Open a new main window
+	 *
+	 * @param {Object} [args] - Passed to the new window as window.arguments[0]
+	 * @param {String} [args.sessionWindowID] - The id of the session pane state the window
+	 *     should restore
+	 * @param {Object} [args.libraryTabState] - The view state for the window's library tab, as
+	 *     returned by ZoteroPane.captureLibraryTabState()
+	 * @return {ChromeWindow}
+	 */
+	this.openMainWindow = function (args) {
 		var chromeURI = AppConstants.BROWSER_CHROME_URL;
 		var flags = "chrome,all,dialog=no,resizable=yes";
 		var ww = Components.classes['@mozilla.org/embedcomp/window-watcher;1']
 			.getService(Components.interfaces.nsIWindowWatcher);
-		ww.openWindow(null, chromeURI, '_blank', flags, null);
+		// Box the args so they reliably cross openWindow()'s nsISupports argument
+		return ww.openWindow(null, chromeURI, '_blank', flags, args ? { wrappedJSObject: args } : null);
 	}
 	
 	
@@ -1466,7 +1477,7 @@ const { CommandLineOptions } = ChromeUtils.importESModule("chrome://zotero/conte
 			
 			// Display as popup progress window
 			if (popup) {
-				var pw = new Zotero.ProgressWindow();
+				var pw = new Zotero.ProgressWindow({ window: win });
 				pw.changeHeadline(Zotero.getString('general.errorHasOccurred'));
 				pw.addDescription(msg);
 				pw.show();

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -38,12 +38,24 @@ var ZoteroPane = new function () {
 	this._listeners = {};
 	this.__defineGetter__('loaded', function () { return _loaded; });
 	var _lastSelectedItems = [];
+	var _progressQueueListeners = [];
 	// [element, listener] for the collection tree focus listener added in initCollectionsTree()
 	var _collectionsTreeFocusListener = null;
 	var _libraryTabStateRestores = 0;
 	var _libraryTabStatePromise = Promise.resolve();
+	// The saved session state this window took over, if any
+	var _sessionPaneState = null;
+	// The view state this window's library tab starts with, if it was opened with one
+	var _initialLibraryTabState = null;
+	// Identifies this window in the session
+	var _sessionWindowID = null;
+	// Whether this is the startup window restoring the session, which opens windows for the
+	// other saved states
+	var _startupSessionRestore = false;
 	var lastFocusedElement = null;
 	this.lastKeyPress = null;
+	// When this window was last activated, for ordering saved window states
+	this.lastActivated = 0;
 	
 	//Privileged methods
 	this.destroy = destroy;
@@ -99,13 +111,17 @@ var ZoteroPane = new function () {
 				Zotero.ProgressQueues.get(progressQueue.getID()).getDialog().open();
 			}, false);
 			
-			progressQueue.addListener('empty', function () {
+			let emptyListener = function () {
 				button.hidden = true;
-			});
+			};
+			progressQueue.addListener('empty', emptyListener);
+			_progressQueueListeners.push([progressQueue, 'empty', emptyListener]);
 			
-			progressQueue.addListener('nonempty', function () {
+			let nonemptyListener = function () {
 				button.hidden = false;
-			});
+			};
+			progressQueue.addListener('nonempty', nonemptyListener);
+			_progressQueueListeners.push([progressQueue, 'nonempty', nonemptyListener]);
 			
 			progressQueueButtons.appendChild(button);
 		}
@@ -159,6 +175,11 @@ var ZoteroPane = new function () {
 			Zotero.Sync.Runner.registerSyncStatus(this.firstChild);
 			let lastSync = document.querySelector("#zotero-tb-sync-last-sync").value;
 			this.setAttribute("aria-description", lastSync || "");
+		});
+		
+		this.lastActivated = Date.now();
+		window.addEventListener('activate', () => {
+			ZoteroPane.lastActivated = Date.now();
 		});
 		
 		// register an observer for Zotero reload
@@ -534,11 +555,116 @@ var ZoteroPane = new function () {
 	}
 
 	/**
+	 * Whether this is the first main window in the process to take on a piece of startup work,
+	 * so that opening another window doesn't repeat it
+	 *
+	 * @param {String} id
+	 * @return {Boolean}
+	 */
+	function claimStartupTask(id) {
+		if (!Zotero.startupTasks) {
+			Zotero.startupTasks = new Set();
+		}
+		if (Zotero.startupTasks.has(id)) {
+			return false;
+		}
+		Zotero.startupTasks.add(id);
+		return true;
+	}
+	
+	
+	/**
+	 * Take on the saved session state or the library view this window was opened for
+	 *
+	 * The window opened at startup takes the first saved state and opens a window for each of
+	 * the others. Windows opened by the user don't restore a session.
+	 */
+	function takeWindowState() {
+		if (_sessionWindowID) {
+			return;
+		}
+		let args = window.arguments && window.arguments[0];
+		if (args && args.wrappedJSObject) {
+			args = args.wrappedJSObject;
+		}
+		if (!args || typeof args != 'object') {
+			args = {};
+		}
+		_sessionWindowID = Zotero_Tabs.windowID;
+		if (args.libraryTabState) {
+			_initialLibraryTabState = args.libraryTabState;
+			return;
+		}
+		if (!args.sessionWindowID) {
+			if (!claimStartupTask('sessionRestore')) {
+				return;
+			}
+			_startupSessionRestore = true;
+		}
+		_sessionPaneState = Zotero.Session.claimPaneState(args.sessionWindowID);
+		if (_sessionPaneState) {
+			// Keep the id of the state we took over, so that it's replaced and not duplicated
+			// when this window is closed
+			_sessionWindowID = _sessionPaneState.windowID || _sessionWindowID;
+			// The startup window opens with the persisted geometry, which is shared by all
+			// windows and holds the position of whichever closed last, so when the session
+			// contains other windows, use its own saved geometry instead
+			let paneStates = Zotero.Session.state.windows.filter(x => x.type == 'pane');
+			if (args.sessionWindowID || paneStates.length > 1) {
+				restoreWindowGeometry(_sessionPaneState.geometry);
+			}
+		}
+	}
+	
+	
+	/**
+	 * @param {Object} [geometry] - The geometry property of a saved session state
+	 */
+	function restoreWindowGeometry(geometry) {
+		if (!geometry) {
+			return;
+		}
+		try {
+			if (Number.isFinite(geometry.width) && Number.isFinite(geometry.height)) {
+				window.resizeTo(geometry.width, geometry.height);
+			}
+			if (Number.isFinite(geometry.screenX) && Number.isFinite(geometry.screenY)) {
+				window.moveTo(geometry.screenX, geometry.screenY);
+			}
+			if (geometry.sizemode == 'maximized') {
+				window.maximize();
+			}
+			else if (geometry.sizemode == 'fullscreen') {
+				window.fullScreen = true;
+			}
+		}
+		catch (e) {
+			Zotero.logError(e);
+		}
+	}
+	
+	
+	/**
+	 * Open a window for each saved session state that no window has taken over
+	 */
+	function openWindowsForRemainingSessionStates() {
+		for (let state of Zotero.Session.getUnclaimedPaneStates()) {
+			if (!state.windowID) {
+				continue;
+			}
+			Zotero.openMainWindow({ sessionWindowID: state.windowID });
+		}
+	}
+	
+	
+	/**
 	 * Called on window load or when pane has been reloaded after switching into or out of connector
 	 * mode
 	 */
 	async function _loadPane() {
 		if (!Zotero || !Zotero.initialized) return;
+		
+		takeWindowState();
 		
 		// Set flags for hi-res displays
 		Zotero.hiDPI = window.devicePixelRatio > 1;
@@ -641,7 +767,7 @@ var ZoteroPane = new function () {
 		// -- this way the page won't be displayed when they sync their DB to
 		// another profile or if the DB is initialized erroneously (e.g. while
 		// switching data directory locations)
-		else if (Zotero.Prefs.get('firstRun2')) {
+		else if (Zotero.Prefs.get('firstRun2') && claimStartupTask('firstRun')) {
 			if (Zotero.Schema.dbInitialized || !Zotero.Sync.Server.enabled) {
 				setTimeout(function () {
 					ZoteroPane_Local.loadURI(ZOTERO_CONFIG.START_URL);
@@ -669,31 +795,42 @@ var ZoteroPane = new function () {
 			ZoteroPane.showFileRenamingBanner();
 			ZoteroPane.initSyncReminders(true);
 
-			if (Zotero.Prefs.get('reopenAccountPrefsOnRestart')) {
+			if (Zotero.Prefs.get('reopenAccountPrefsOnRestart')
+					&& claimStartupTask('reopenAccountPrefs')) {
 				Zotero.Prefs.clear('reopenAccountPrefsOnRestart');
 				Zotero.Utilities.Internal.openPreferences('zotero-prefpane-account');
 			}
 		});
 		
 		// TEMP: Clean up extra files from Mendeley imports <5.0.51
-		setTimeout(async function () {
-			var needsCleanup = await Zotero.DB.valueQueryAsync(
-				"SELECT COUNT(*) FROM settings WHERE setting='mImport' AND key='cleanup'"
-			)
-			if (!needsCleanup) return;
-			
-			var { Zotero_Import_Mendeley } = ChromeUtils.importESModule(
-				"chrome://zotero/content/import/mendeley/mendeleyImport.mjs"
-			);
-			var importer = new Zotero_Import_Mendeley();
-			importer.deleteNonPrimaryFiles();
-		}, 10000)
+		if (claimStartupTask('mendeleyCleanup')) {
+			setTimeout(async function () {
+				var needsCleanup = await Zotero.DB.valueQueryAsync(
+					"SELECT COUNT(*) FROM settings WHERE setting='mImport' AND key='cleanup'"
+				);
+				if (!needsCleanup) return;
+				
+				var { Zotero_Import_Mendeley } = ChromeUtils.importESModule(
+					"chrome://zotero/content/import/mendeley/mendeleyImport.mjs"
+				);
+				var importer = new Zotero_Import_Mendeley();
+				importer.deleteNonPrimaryFiles();
+			}, 10000);
+		}
 		
 		// Restore pane state
 		try {
-			let state = Zotero.Session.state.windows.find(x => x.type == 'pane');
-			if (state) {
-				Zotero_Tabs.restoreState(state.tabs);
+			if (_initialLibraryTabState) {
+				ZoteroPane.restoreLibraryTabState(_initialLibraryTabState);
+			}
+			else if (_sessionPaneState) {
+				let promise = Zotero_Tabs.restoreState(_sessionPaneState.tabs);
+				// Only the startup window opens windows for the other saved states -- a window
+				// opened for one of those states shouldn't open more
+				if (_startupSessionRestore) {
+					promise = promise.then(() => openWindowsForRemainingSessionStates());
+				}
+				promise.catch(e => Zotero.logError(e));
 			}
 		}
 		catch (e) {
@@ -796,16 +933,32 @@ var ZoteroPane = new function () {
 		if (_apiKeyObserverID) {
 			Zotero.Notifier.unregisterObserver(_apiKeyObserverID);
 		}
+		for (let [progressQueue, name, listener] of _progressQueueListeners) {
+			progressQueue.removeListener(name, listener);
+		}
+		_progressQueueListeners = [];
 		
 		this.uninitContainers();
 		
 		observerService.removeObserver(_reloadObserver, "zotero-reloaded");
+		observerService.removeObserver(_reloadObserver, "zotero-before-reload");
 		
 		ZoteroContextPane.destroy();
-		Zotero_Tabs.destroy();
 
-		if (!Zotero.getZoteroPanes().length) {
+		let panes = Zotero.getZoteroPanes();
+		if (!panes.length) {
 			Zotero.Session.setLastClosedZoteroPaneState(this.getState());
+		}
+		else {
+			// A window closed while others remain open shouldn't come back in the next session
+			if (_sessionWindowID) {
+				Zotero.Session.removeZoteroPaneState(_sessionWindowID);
+			}
+			// The layout is only switched by window size when there's a single window, so
+			// when one window remains, let it recalculate the layout
+			if (panes.length == 1) {
+				panes[0].updateLayoutConstraints();
+			}
 		}
 
 		Zotero_Tabs.closeAll();
@@ -860,7 +1013,8 @@ var ZoteroPane = new function () {
 		
 		// Auto-sync on pane open or if new account
 		let startupSync = false;
-		if (Zotero.Prefs.get('sync.autoSync') || Zotero.initAutoSync) {
+		if (claimStartupTask('autoSync')
+				&& (Zotero.Prefs.get('sync.autoSync') || Zotero.initAutoSync)) {
 			await Zotero.proxyAuthComplete;
 			await Zotero.uiReadyPromise;
 			
@@ -1654,14 +1808,17 @@ var ZoteroPane = new function () {
 	}
 
 	/**
-	 * The library view state from the saved session
+	 * The library view state the window opens with, from the library view it was opened for
+	 * or from the saved session state it took over
 	 *
 	 * @return {Object|null}
 	 */
 	function getSessionLibraryTabState() {
 		try {
-			let state = Zotero.Session.state.windows.find(x => x.type == 'pane');
-			let tab = (state?.tabs || []).find(x => x.type == 'library');
+			if (_initialLibraryTabState) {
+				return _initialLibraryTabState;
+			}
+			let tab = (_sessionPaneState?.tabs || []).find(x => x.type == 'library');
 			return tab?.data?.state || null;
 		}
 		catch (e) {
@@ -1671,7 +1828,7 @@ var ZoteroPane = new function () {
 	}
 
 	/**
-	 * The collection to show at startup
+	 * The collection to show when the window opens
 	 *
 	 * @return {String|null} - A collection tree row id
 	 */
@@ -1705,7 +1862,7 @@ var ZoteroPane = new function () {
 		try {
 			var container = document.getElementById('zotero-tag-selector-container');
 			if (!container.hasAttribute('collapsed')) {
-				this.tagSelector = await Zotero.TagSelector.init(
+				this.tagSelector = await TagSelectorContainer.init(
 					document.getElementById('zotero-tag-selector'),
 					{
 						container: 'zotero-tag-selector-container',
@@ -1892,10 +2049,7 @@ var ZoteroPane = new function () {
 		}
 		
 		// Rename tab
-		let tabName = collectionTreeRows.length == 1
-			? collectionTreeRows[0].getName()
-			: Zotero.getString('tab-title-multiple-collections');
-		Zotero_Tabs.rename('zotero-pane', tabName);
+		Zotero_Tabs.rename('zotero-pane');
 		
 		// Clear quick search and tag selector when switching views
 		document.getElementById('zotero-tb-search').onCollectionSelected();
@@ -2001,7 +2155,7 @@ var ZoteroPane = new function () {
 	
 	
 	/**
-	 * Capture the state of the library view, for the session
+	 * Capture the state of the library view, for the session or for another window
 	 *
 	 * @return {Object|null} - A JSON-serializable snapshot, or null if the view isn't ready
 	 */
@@ -2161,7 +2315,7 @@ var ZoteroPane = new function () {
 			advancedSearchPane.search = null;
 		}
 		else if (state === 'open') {
-			Zotero_Tabs.select('zotero-pane');
+			Zotero_Tabs.selectLibraryTab();
 			advancedSearchPane.focus();
 		}
 		
@@ -2273,7 +2427,7 @@ var ZoteroPane = new function () {
 			collectionTreeRow.setSearch('');
 		}
 
-		Zotero_Tabs.select('zotero-pane');
+		Zotero_Tabs.selectLibraryTab();
 		await deck.pane.submit();
 		// Focus the first condition so the user can refine the seeded search
 		deck.pane.focus();
@@ -2396,6 +2550,44 @@ var ZoteroPane = new function () {
 			.sort((a, b) => a - b)
 			.map(index => this.collectionsView.getRow(index));
 	}
+	
+	
+	/**
+	 * The library view state for the selected collection tree rows
+	 *
+	 * @return {Object|null} - A library view state, or null if no rows are selected
+	 */
+	this._getSelectedCollectionsState = function () {
+		let collectionTreeRows = this.getCollectionTreeRows();
+		if (!collectionTreeRows.length) {
+			return null;
+		}
+		let focusedRow = this.collectionsView.getRow(this.collectionsView.selection.focused);
+		return {
+			collections: collectionTreeRows.map(row => row.id),
+			focusedCollection: focusedRow ? focusedRow.id : null
+		};
+	};
+
+
+	/**
+	 * Open a new main window showing this window's collection selection
+	 */
+	this.newWindow = function () {
+		return Zotero.openMainWindow({ libraryTabState: this._getSelectedCollectionsState() });
+	};
+
+
+	/**
+	 * Open the selected collection tree rows in a new main window
+	 */
+	this.openCollectionsInNewWindow = function () {
+		let state = this._getSelectedCollectionsState();
+		if (!state) {
+			return null;
+		}
+		return Zotero.openMainWindow({ libraryTabState: state });
+	};
 	
 	
 	/**
@@ -3250,7 +3442,6 @@ var ZoteroPane = new function () {
 		feed.cleanupReadAfter = data.cleanupReadAfter;
 		feed.cleanupUnreadAfter = data.cleanupUnreadAfter;
 		await feed.saveTx();
-		Zotero_Tabs.rename("zotero-pane", feed.name);
 	};
 	
 	this.refreshFeed = function () {
@@ -3482,6 +3673,10 @@ var ZoteroPane = new function () {
 						return;
 					}
 					setTimeout(() => {
+						// Remind in one window only
+						if (Zotero.getActiveZoteroPane() !== this) {
+							return;
+						}
 						this.showSetUpSyncReminder();
 						this.showAutoSyncReminder();
 					}, 5000);
@@ -3663,7 +3858,7 @@ var ZoteroPane = new function () {
 		}
 		
 		if (!noTabSwitch) {
-			Zotero_Tabs.select('zotero-pane', false, { focusElementID: ZoteroPane.itemsView.id });
+			Zotero_Tabs.selectLibraryTab({ focusElementID: ZoteroPane.itemsView.id });
 		}
 		return true;
 	};
@@ -3897,6 +4092,13 @@ var ZoteroPane = new function () {
 	// entirely in JS, but various localized strings are only in zotero.dtd, and they're used in
 	// standalone.xul as well, so for now they have to remain as XML entities.
 	var _collectionContextMenuOptions = [
+		{
+			id: "openInNewWindow",
+			oncommand: () => this.openCollectionsInNewWindow()
+		},
+		{
+			id: "sep0",
+		},
 		{
 			id: "sync",
 			label: Zotero.getString('sync.sync'),
@@ -4281,6 +4483,11 @@ var ZoteroPane = new function () {
 			if (library.archived) {
 				show.push('removeLibrary');
 			}
+		}
+
+		// Any row that shows an items list can be opened in its own window
+		if (!collectionTreeRows[0].isHeader()) {
+			show.push('openInNewWindow', 'sep0');
 		}
 
 		if (useHideOrDelete === 'delete') {
@@ -5391,6 +5598,7 @@ var ZoteroPane = new function () {
 
 		return Zotero.Notes.open(itemID, undefined, {
 			openInWindow,
+			window
 		});
 	};
 
@@ -5551,8 +5759,7 @@ var ZoteroPane = new function () {
 				}
 				else {
 					if (file.endsWith(".lnk")) {
-						let win = Services.wm.getMostRecentWindow("navigator:browser");
-						win.ZoteroPane.displayCannotAddShortcutMessage(file);
+						ZoteroPane.displayCannotAddShortcutMessage(file);
 						continue;
 					}
 
@@ -5609,7 +5816,7 @@ var ZoteroPane = new function () {
 	 * Shows progress dialog for a webpage/snapshot save request
 	 */
 	function _showPageSaveStatus(title) {
-		var progressWin = new Zotero.ProgressWindow();
+		var progressWin = new Zotero.ProgressWindow({ window });
 		progressWin.changeHeadline(Zotero.getString('ingester.scraping'));
 		var icon = 'chrome://zotero/skin/treeitem-webpage.png';
 		progressWin.addLines(title, icon)
@@ -5823,6 +6030,7 @@ var ZoteroPane = new function () {
 			await Zotero.FileHandlers.open(item, {
 				location: extraData?.location,
 				openInWindow,
+				window
 			});
 		};
 		
@@ -7552,6 +7760,14 @@ var ZoteroPane = new function () {
 	this.getState = function () {
 		return {
 			type: 'pane',
+			windowID: _sessionWindowID || Zotero_Tabs.windowID,
+			geometry: {
+				screenX: window.screenX,
+				screenY: window.screenY,
+				width: window.outerWidth,
+				height: window.outerHeight,
+				sizemode: document.documentElement.getAttribute('sizemode')
+			},
 			tabs: Zotero_Tabs.getState()
 		};
 	};
@@ -7692,13 +7908,16 @@ var ZoteroPane = new function () {
 		document.documentElement.style.setProperty('--height-of-fixed-components', `${fixedComponentHeight}px`);
 
 		let layoutChanged = false;
+		// The layout is shared by all windows, so only switch it by window size when there's
+		// a single window
+		let canAutoStack = Zotero.getZoteroPanes().length <= 1;
 		// Collections pane + items pane + items pane + sidenav + 3px for draggability
 		const windowAutoStackMinWidth = 930;
 		if (window.innerWidth < windowAutoStackMinWidth) {
 			// Disable layout mode menus because the standard mode is not available
 			layoutModeMenus.forEach(menu => menu.toggleAttribute("disabled", "true"));
 			// If the window is too small in standard mode, enter stack mode temporarily
-			if (!isStackedMode && !isTempStackedMode) {
+			if (canAutoStack && !isStackedMode && !isTempStackedMode) {
 				Zotero.Prefs.set('tempStackedMode', true);
 				Zotero.Prefs.set('layout', 'stacked');
 				layoutChanged = true;
@@ -7706,7 +7925,7 @@ var ZoteroPane = new function () {
 		}
 		else {
 			layoutModeMenus.forEach(menu => menu.removeAttribute("disabled"));
-			if (isTempStackedMode) {
+			if (canAutoStack && isTempStackedMode) {
 				Zotero.Prefs.clear('tempStackedMode');
 				Zotero.Prefs.set('layout', 'standard');
 				layoutChanged = true;

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -821,7 +821,16 @@ var ZoteroPane = new function () {
 		// Restore pane state
 		try {
 			if (_initialLibraryTabState) {
-				ZoteroPane.restoreLibraryTabState(_initialLibraryTabState);
+				let state = _initialLibraryTabState;
+				ZoteroPane.restoreLibraryTabState(state)
+					.then(() => {
+						// Focus an Advanced Search the window was opened with, as opening it
+						// within the window would
+						if (state.advancedSearch) {
+							document.getElementById('zotero-advanced-search-pane-deck').pane.focus();
+						}
+					})
+					.catch(e => Zotero.logError(e));
 			}
 			else if (_sessionPaneState) {
 				let promise = Zotero_Tabs.restoreState(_sessionPaneState.tabs);
@@ -2108,9 +2117,7 @@ var ZoteroPane = new function () {
 
 		deck.pane.refresh();
 
-		let search = deck.state === 'closed' || deck.selectedSearchType !== 'temporary' || !deck.pane.active
-			? null
-			: deck.pane.search;
+		let search = this._getActiveAdvancedSearch();
 		if (collectionTreeRows) {
 			for (let collectionTreeRow of collectionTreeRows) {
 				collectionTreeRow.setAdvancedSearch(search);
@@ -2223,6 +2230,9 @@ var ZoteroPane = new function () {
 			this.setItemsPaneMessage(Zotero.getString('pane.items.loading'));
 		}
 		
+		// Set the Advanced Search first, so that a collection change applies it to the new rows
+		this._restoreAdvancedSearchState(state.advancedSearch);
+		
 		let selected = await this.collectionsView.restoreSelection(state.collections, {
 			focusedID: state.focusedCollection
 		});
@@ -2235,10 +2245,68 @@ var ZoteroPane = new function () {
 		// Let any queued collection selection finish
 		await this.onCollectionSelected();
 		await this.itemsView.waitForLoad();
+		
+		// Apply the Advanced Search to rows the collection change didn't replace
+		let advancedSearch = this._getActiveAdvancedSearch();
+		let changed = false;
+		for (let collectionTreeRow of this.itemsView.collectionTreeRows) {
+			changed = collectionTreeRow.setAdvancedSearch(advancedSearch) || changed;
+		}
+		if (changed) {
+			if (!itemsPaneMessageShown) {
+				itemsPaneMessageShown = true;
+				this.setItemsPaneMessage(Zotero.getString('pane.items.loading'));
+			}
+			await this.itemsView.refresh();
+		}
 		if (itemsPaneMessageShown) {
 			this.clearItemsPaneMessage();
 		}
 	});
+
+
+	/**
+	 * The temporary search shown and applied by the open Advanced Search pane, if any
+	 *
+	 * @return {Zotero.Search|null}
+	 */
+	this._getActiveAdvancedSearch = function () {
+		let deck = document.getElementById('zotero-advanced-search-pane-deck');
+		return deck.state === 'closed' || deck.selectedSearchType !== 'temporary' || !deck.pane.active
+			? null
+			: deck.pane.search;
+	};
+
+
+	/**
+	 * Show or reset the Advanced Search pane for a library tab state
+	 *
+	 * @param {Object} [advancedSearch] - The advancedSearch property of a library view state,
+	 *     with `search` (search JSON or null) and `libraryID`. If present, the pane opens as
+	 *     a temporary search; if not, the pane is reset and closed.
+	 */
+	this._restoreAdvancedSearchState = function (advancedSearch) {
+		let deck = document.getElementById('zotero-advanced-search-pane-deck');
+		deck.selectedSearchType = 'temporary';
+		if (!advancedSearch) {
+			deck.state = 'closed';
+			deck.pane.search = null;
+		}
+		else {
+			deck.state = 'open';
+			let search = null;
+			if (advancedSearch.search) {
+				search = new Zotero.Search();
+				// A library is required to clone the search; the pane's refresh() sets
+				// the one the selected rows belong to
+				search.libraryID = advancedSearch.libraryID || Zotero.Libraries.userLibraryID;
+				search.fromJSON(advancedSearch.search);
+			}
+			deck.pane.search = search;
+			deck.pane.active = !!search;
+		}
+		document.getElementById('zotero-tb-search').updateMode();
+	};
 	
 	
 	/**
@@ -2352,28 +2420,23 @@ var ZoteroPane = new function () {
 
 
 	/**
-	 * Open the Advanced Search pane seeded from the quick search text, reproducing
-	 * the current quick search mode as editable conditions.
-	 *
-	 * The quick search field is cleared, since its text now lives in the Advanced
-	 * Search. Closing the Advanced Search resets to an unfiltered view rather than
-	 * restoring the quick search.
+	 * Build a search from the quick search text, reproducing the quick search mode as
+	 * editable conditions
 	 *
 	 * @param {String} searchText
-	 * @param {String} [mode='fields'] - The quick search mode to reproduce
+	 * @param {String} mode - The quick search mode to reproduce
+	 * @return {Zotero.Search|null} - Null if the text contains no conditions or words
 	 */
-	this.openAdvancedSearchFromQuickSearch = async function (searchText, mode = 'fields') {
+	this._buildSearchFromQuickSearch = function (searchText, mode) {
 		// Conditions written in the query ("tag:foo") become conditions in the
 		// search; what's left is split into words (keeping quoted phrases
 		// intact), as the quick search does
 		let { tree, text } = Zotero.SearchQuery.parse(searchText);
 		let parts = Zotero.SearchConditions.parseSearchString(text);
 		if (!parts.length && !tree) {
-			await this.toggleAdvancedSearchState('open');
-			return;
+			return null;
 		}
 
-		let deck = document.getElementById('zotero-advanced-search-pane-deck');
 		let search = new Zotero.Search();
 		let libraryID = this.getSelectedLibraryIDs()[0];
 		if (libraryID) {
@@ -2409,6 +2472,28 @@ var ZoteroPane = new function () {
 				search.addCondition('anyField', 'contains', part.text);
 			}
 		}
+		return search;
+	};
+
+
+	/**
+	 * Open the Advanced Search pane seeded from the quick search text, reproducing
+	 * the current quick search mode as editable conditions.
+	 *
+	 * The quick search field is cleared, since its text now lives in the Advanced
+	 * Search. Closing the Advanced Search resets to an unfiltered view.
+	 *
+	 * @param {String} searchText
+	 * @param {String} [mode='fields'] - The quick search mode to reproduce
+	 */
+	this.openAdvancedSearchFromQuickSearch = async function (searchText, mode = 'fields') {
+		let search = this._buildSearchFromQuickSearch(searchText, mode);
+		if (!search) {
+			await this.toggleAdvancedSearchState('open');
+			return;
+		}
+
+		let deck = document.getElementById('zotero-advanced-search-pane-deck');
 
 		// Show the Advanced Search and seed it, without yet touching the items list,
 		// so that the quick search results stay visible until they're replaced below
@@ -2575,6 +2660,28 @@ var ZoteroPane = new function () {
 	 */
 	this.newWindow = function () {
 		return Zotero.openMainWindow({ libraryTabState: this._getSelectedCollectionsState() });
+	};
+
+
+	/**
+	 * Open a new main window showing this window's collection selection with the Advanced
+	 * Search pane open
+	 *
+	 * If searchText contains conditions or words, the new window's search is seeded from it,
+	 * reproducing the quick search mode as editable conditions, and run against the new
+	 * window's items list. This window's quick search is left in place.
+	 *
+	 * @param {String} [searchText]
+	 * @param {String} [mode='fields'] - The quick search mode to reproduce
+	 */
+	this.openAdvancedSearchInNewWindow = function (searchText, mode = 'fields') {
+		let state = this._getSelectedCollectionsState() || {};
+		let search = searchText ? this._buildSearchFromQuickSearch(searchText, mode) : null;
+		state.advancedSearch = {
+			search: search ? search.toJSON() : null,
+			libraryID: search ? search.libraryID : null
+		};
+		return Zotero.openMainWindow({ libraryTabState: state });
 	};
 
 

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -40,6 +40,8 @@ var ZoteroPane = new function () {
 	var _lastSelectedItems = [];
 	// [element, listener] for the collection tree focus listener added in initCollectionsTree()
 	var _collectionsTreeFocusListener = null;
+	var _libraryTabStateRestores = 0;
+	var _libraryTabStatePromise = Promise.resolve();
 	var lastFocusedElement = null;
 	this.lastKeyPress = null;
 	
@@ -1651,11 +1653,38 @@ var ZoteroPane = new function () {
 		}
 	}
 
+	/**
+	 * The library view state from the saved session
+	 *
+	 * @return {Object|null}
+	 */
+	function getSessionLibraryTabState() {
+		try {
+			let state = Zotero.Session.state.windows.find(x => x.type == 'pane');
+			let tab = (state?.tabs || []).find(x => x.type == 'library');
+			return tab?.data?.state || null;
+		}
+		catch (e) {
+			Zotero.logError(e);
+		}
+		return null;
+	}
+
+	/**
+	 * The collection to show at startup
+	 *
+	 * @return {String|null} - A collection tree row id
+	 */
+	function getSessionCollectionID() {
+		return getSessionLibraryTabState()?.collections?.[0] || null;
+	}
+
 	this.initCollectionsTree = async function () {
 		try {
 			const CollectionTree = require('zotero/collectionTree');
 			var collectionsTree = document.getElementById('zotero-collections-tree');
 			ZoteroPane.collectionsView = await CollectionTree.init(collectionsTree, {
+				initialFolder: getSessionCollectionID(),
 				onSelectionChange: prevSelection => ZoteroPane.onCollectionSelected(prevSelection),
 				onContextMenu: (...args) => ZoteroPane.onCollectionsContextMenuOpen(...args),
 				dragAndDrop: true,
@@ -1940,6 +1969,124 @@ var ZoteroPane = new function () {
 	};
 
 
+	/**
+	 * The library a collection tree row id belongs to
+	 *
+	 * @param {String} [rowID]
+	 * @return {Integer|null}
+	 */
+	function getLibraryIDFromRowID(rowID) {
+		if (!rowID) {
+			return null;
+		}
+		let objectID = parseInt(rowID.substr(1));
+		switch (rowID[0]) {
+			case 'L':
+			case 'T':
+			case 'D':
+			case 'U':
+			case 'Y':
+			case 'R':
+			case 'P':
+				return objectID;
+			
+			case 'C':
+				return Zotero.Collections.get(objectID)?.libraryID ?? null;
+			
+			case 'S':
+				return Zotero.Searches.get(objectID)?.libraryID ?? null;
+		}
+		return null;
+	}
+	
+	
+	/**
+	 * Capture the state of the library view, for the session
+	 *
+	 * @return {Object|null} - A JSON-serializable snapshot, or null if the view isn't ready
+	 */
+	this.captureLibraryTabState = function () {
+		if (_libraryTabStateRestores
+				|| !this.collectionsView
+				|| !this.itemsView?.collectionTreeRows?.length) {
+			return null;
+		}
+		let focusedRow = this.collectionsView.getRow(this.collectionsView.selection.focused);
+		return {
+			collections: this.getCollectionTreeRows().map(row => row.id),
+			focusedCollection: focusedRow ? focusedRow.id : null
+		};
+	};
+	
+	
+	/**
+	 * Show a library view captured by captureLibraryTabState()
+	 *
+	 * @param {Object} [state]
+	 * @return {Promise}
+	 */
+	this.restoreLibraryTabState = function (state) {
+		_libraryTabStateRestores++;
+		_libraryTabStatePromise = (async () => {
+			try {
+				await this._restoreLibraryTabState(state || {});
+			}
+			catch (e) {
+				Zotero.logError(e);
+			}
+			finally {
+				_libraryTabStateRestores--;
+			}
+		})();
+		return _libraryTabStatePromise;
+	};
+	
+	
+	/**
+	 * Wait for any in-progress restore of the library view
+	 *
+	 * @return {Promise}
+	 */
+	this.waitForLibraryTabState = function () {
+		return _libraryTabStatePromise;
+	};
+	
+	
+	this._restoreLibraryTabState = Zotero.serial(async function (state) {
+		if (!this.collectionsView) {
+			return;
+		}
+		await this.collectionsView.waitForLoad();
+		
+		// Show the loading message only if the collection selection is changing, so that a
+		// window that opens with the collection already selected keeps its loaded items
+		// list showing
+		let itemsPaneMessageShown = !Zotero.Utilities.arrayEquals(
+			this.getCollectionTreeRows().map(row => row.id).sort(),
+			(state.collections || []).slice().sort()
+		);
+		if (itemsPaneMessageShown) {
+			this.setItemsPaneMessage(Zotero.getString('pane.items.loading'));
+		}
+		
+		let selected = await this.collectionsView.restoreSelection(state.collections, {
+			focusedID: state.focusedCollection
+		});
+		if (!selected) {
+			let libraryID = getLibraryIDFromRowID(state.collections?.[0]);
+			if (!libraryID || !(await this.collectionsView.selectLibrary(libraryID))) {
+				await this.collectionsView.selectLibrary(Zotero.Libraries.userLibraryID);
+			}
+		}
+		// Let any queued collection selection finish
+		await this.onCollectionSelected();
+		await this.itemsView.waitForLoad();
+		if (itemsPaneMessageShown) {
+			this.clearItemsPaneMessage();
+		}
+	});
+	
+	
 	/**
 	 * Prompt to save changes in the open saved-search editor and close it
 	 *

--- a/chrome/content/zotero/zoteroPane.xhtml
+++ b/chrome/content/zotero/zoteroPane.xhtml
@@ -93,6 +93,7 @@
 		<!--FILE-->
 		<command id="cmd_quitApplication" oncommand="goQuitApplication(event);"/>
 		<command id="cmd_close" oncommand="ZoteroPane.handleClose(event)"/>
+		<command id="cmd_zotero_newWindow" oncommand="ZoteroPane.newWindow()"/>
 		
 		<!--EDIT-->
 		<command id="cmd_find"
@@ -151,6 +152,7 @@
 	</keyset>
 
 	<keyset id="mainKeyset">
+		<key id="key_newWindow" key="N" command="cmd_zotero_newWindow" modifiers="accel"/>
 		<key id="key_close" key="&closeCmd.key;" command="cmd_close" modifiers="accel"/>
 		<key id="key_quitApplication"
 			key="&quitApplicationCmdMac.key;"
@@ -237,6 +239,11 @@
 					<menu id="fileMenu" label="&fileMenu.label;" accesskey="&fileMenu.accesskey;">
 						<menupopup id="menu_FilePopup"
 									onpopupshowing="ZoteroStandalone.onFileMenuOpen(event)">
+							<menuitem id="menu_newWindow"
+									data-l10n-id="menu-new-window"
+									key="key_newWindow"
+									command="cmd_zotero_newWindow"/>
+							<menuseparator/>
 							<menu id="menu_newItem" class="menu-type-library" label="&zotero.toolbar.newItem.label;">
 								<menupopup id="menu_NewItemPopup"
 										onpopupshowing="ZoteroStandalone.buildNewItemMenu()"/>
@@ -932,6 +939,8 @@
 		<menupopup id="zotero-collectionmenu"
 				oncommand="ZoteroPane.onCollectionContextMenuSelect(event)">
 			<!-- Keep order in sync with buildCollectionContextMenu, which adds additional attributes -->
+			<menuitem data-l10n-id="collections-menu-open-in-new-window"/>
+			<menuseparator/>
 			<menuitem class="zotero-menuitem-sync"/>
 			<menuseparator/>
 			<menuitem class="zotero-menuitem-new-collection" data-l10n-id="menu-new-collection"/>

--- a/chrome/locale/en-US/zotero/zotero.ftl
+++ b/chrome/locale/en-US/zotero/zotero.ftl
@@ -167,6 +167,9 @@ menu-view-note-tab-font-size =
 menu-show-tabs-menu =
     .label = Show Tabs Menu
 
+menu-new-window =
+    .label = New Window
+
 menu-edit-copy-annotation =
     .label = { $count ->
         [one] Copy Annotation
@@ -242,6 +245,8 @@ items-section-library-sources =
     }
 items-section-library-recently-read = { $library } ({ recently-read })
 items-section-library = { $library }
+collections-menu-open-in-new-window =
+    .label = Open in New Window
 collections-menu-rename =
     .label = Rename
 edit-saved-search = Edit Saved Search

--- a/test/content/support.js
+++ b/test/content/support.js
@@ -468,7 +468,7 @@ async function waitForScrollToPane(itemDetails, paneID) {
 
 function clickOnItemsRow(win, itemsView, row) {
 	itemsView._treebox.scrollToRow(row);
-	let elem = win.document.querySelector(`#${itemsView.id}-row-${row}`);
+	let elem = itemsView.domEl.querySelector(`#${itemsView.id}-row-${row}`);
 	elem.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, button: 0 }));
 }
 

--- a/test/tests/collectionTreeRowTest.js
+++ b/test/tests/collectionTreeRowTest.js
@@ -142,7 +142,7 @@ describe("CollectionTreeRow", function () {
 			var attachment = await importPDFAttachment(item2);
 			var annotation = await createAnnotation('highlight', attachment);
 			
-			cv.selectByID("U" + userLibraryID);
+			await cv.selectByID("U" + userLibraryID);
 			await waitForItemsLoad(win);
 			var itemsView = zp.itemsView;
 			

--- a/test/tests/tabsTest.js
+++ b/test/tests/tabsTest.js
@@ -70,6 +70,197 @@ describe("Zotero_Tabs", function() {
 		});
 	});
 
+	describe("Multiple windows", function () {
+		var win2, zp2, collection, item, otherItem;
+		
+		before(async function () {
+			collection = await createDataObject('collection', { name: 'Second Window' });
+			item = await createDataObject('item', {
+				title: 'Second Window Item One',
+				collections: [collection.id]
+			});
+			otherItem = await createDataObject('item', {
+				title: 'Second Window Item Two',
+				collections: [collection.id]
+			});
+			win2 = await loadZoteroPane();
+			zp2 = win2.ZoteroPane;
+		});
+		
+		after(function () {
+			if (win2) {
+				win2.close();
+			}
+		});
+		
+		it("should open a reader tab in the window that requested it", async function () {
+			let attachment = await importPDFAttachment(item);
+			let reader = await Zotero.Reader.open(attachment.id, null, { window: win2 });
+			await reader._initPromise;
+			try {
+				assert.equal(reader._window, win2);
+				assert.include(win2.Zotero_Tabs._tabs.map(tab => tab.id), reader.tabID);
+				assert.notInclude(win.Zotero_Tabs._tabs.map(tab => tab.id), reader.tabID);
+				assert.equal(win2.Zotero_Tabs.selectedID, reader.tabID);
+				assert.equal(win.Zotero_Tabs.selectedType, 'library');
+			}
+			finally {
+				win2.Zotero_Tabs.close(reader.tabID);
+			}
+		});
+		
+		it("should leave another window's panes alone when a tab is selected", async function () {
+			await selectCollection(win2, collection);
+			await zp2.selectItem(item.id);
+			let splitter = win2.ZoteroContextPane.splitter;
+			assert.isTrue(splitter.hasAttribute('hidden'));
+			
+			let attachment = await importPDFAttachment(otherItem);
+			let reader = await Zotero.Reader.open(attachment.id, null, { window: win });
+			await reader._initPromise;
+			try {
+				// The other window's reader tab leaves this window showing its library
+				assert.isTrue(splitter.hasAttribute('hidden'));
+				
+				// The item pane keeps following this window's selection
+				await zp2.selectItem(otherItem.id);
+				let infoBox = zp2.itemPane._itemDetails.getPane('info');
+				await waitForCallback(
+					() => infoBox.querySelector('#itembox-field-value-title')?.value
+						=== 'Second Window Item Two',
+					100,
+					5
+				);
+			}
+			finally {
+				win.Zotero_Tabs.close(reader.tabID);
+			}
+		});
+		
+		it("should open the selected collections in a new window", async function () {
+			await selectCollection(win2, collection);
+			let newWin;
+			try {
+				newWin = zp2.openCollectionsInNewWindow();
+				await waitForCallback(
+					() => newWin.ZoteroPane
+						&& newWin.ZoteroPane.getCollectionTreeRows().map(row => row.id).join()
+							=== 'C' + collection.id,
+					100,
+					10
+				);
+				assert.notEqual(newWin.Zotero_Tabs.windowID, win2.Zotero_Tabs.windowID);
+			}
+			finally {
+				if (newWin) {
+					newWin.close();
+				}
+			}
+		});
+		
+		it("should show tags in a reinitialized tag selector while another window is open", async function () {
+			await item.addTag('second-window-tag');
+			await item.saveTx();
+			
+			// Hide the other window's tag selector so that this window's tag selector can't
+			// accidentally work against it
+			let otherShown = zp2.tagSelectorShown();
+			if (otherShown) {
+				await zp2.toggleTagSelector();
+			}
+			await selectCollection(win, collection);
+			await waitForItemsLoad(win);
+			try {
+				if (zp.tagSelectorShown()) {
+					await zp.toggleTagSelector();
+				}
+				await zp.toggleTagSelector();
+				await waitForCallback(
+					() => [...win.document.querySelectorAll('#zotero-tag-selector .tag-selector-item')]
+						.some(node => node.textContent === 'second-window-tag'),
+					100,
+					5
+				);
+			}
+			finally {
+				if (otherShown) {
+					await zp2.toggleTagSelector();
+				}
+			}
+		});
+		
+		it("should restore a saved window state into a window opened for it", async function () {
+			let sessionWindowID = 'win-' + Zotero.Utilities.randomString();
+			Zotero.Session.state.windows.push({
+				type: 'pane',
+				windowID: sessionWindowID,
+				geometry: { screenX: 60, screenY: 80, width: 980, height: 640, sizemode: 'normal' },
+				tabs: [
+					{
+						type: 'library',
+						title: collection.name,
+						selected: true,
+						data: { state: { collections: ['C' + collection.id] } }
+					}
+				]
+			});
+			let newWin;
+			try {
+				newWin = Zotero.openMainWindow({ sessionWindowID });
+				await waitForCallback(
+					() => newWin.ZoteroPane
+						&& newWin.ZoteroPane.getCollectionTreeRows().map(row => row.id).join()
+							=== 'C' + collection.id,
+					100,
+					10
+				);
+				assert.equal(newWin.ZoteroPane.getState().windowID, sessionWindowID);
+				assert.equal(newWin.screenX, 60);
+				assert.equal(newWin.screenY, 80);
+				assert.equal(newWin.outerWidth, 980);
+				assert.equal(newWin.outerHeight, 640);
+				assert.isEmpty(
+					Zotero.Session.getUnclaimedPaneStates()
+						.filter(x => x.windowID == sessionWindowID)
+				);
+				await waitForCallback(
+					() => newWin.ZoteroPane.itemsView?.rowCount === 2,
+					100,
+					10
+				);
+			}
+			finally {
+				if (newWin) {
+					newWin.close();
+				}
+				Zotero.Session.state.windows = Zotero.Session.state.windows
+					.filter(x => x.windowID != sessionWindowID);
+			}
+		});
+
+		it("should save a separate session state for each window", function () {
+			let states = Zotero.getZoteroPanes().map(pane => pane.getState());
+			let windowIDs = states.map(state => state.windowID);
+			assert.isAbove(states.length, 1);
+			assert.lengthOf(new Set(windowIDs), windowIDs.length);
+			for (let state of states) {
+				assert.equal(state.type, 'pane');
+				assert.isAbove(state.geometry.width, 0);
+				assert.isAbove(state.tabs.length, 0);
+			}
+		});
+
+		it("should save window states with the most recently activated window last", async function () {
+			let panes = Zotero.getZoteroPanes();
+			assert.isAbove(panes.length, 1);
+			// Mark the first-enumerated window as the last one activated
+			panes.forEach((pane, i) => pane.lastActivated = 1000 - i);
+			await Zotero.Session.save(true);
+			let states = Zotero.Session.state.windows.filter(x => x.type == 'pane');
+			assert.equal(states[states.length - 1].windowID, panes[0].getState().windowID);
+		});
+	});
+
 	describe("Window teardown", function () {
 		it("should not leave observers registered after a window is closed", async function () {
 			this.timeout(60000);
@@ -78,10 +269,15 @@ describe("Zotero_Tabs", function() {
 			let notifierBefore = new Set(Zotero.Notifier.getLeakedObserverIDs());
 			let prefsBefore = Zotero.Prefs.getLeakedObserverNames();
 			
-			// Render the library item pane in a second window
+			// Render the library item pane in a second window, and a per-tab item pane
+			// in its context pane
 			let win2 = await loadZoteroPane();
 			await selectCollection(win2, collection);
 			await win2.ZoteroPane.selectItem(item.id);
+			let otherItem = await createDataObject('item', { collections: [collection.id] });
+			let attachment = await importPDFAttachment(otherItem);
+			let reader = await Zotero.Reader.open(attachment.id, null, { window: win2 });
+			await reader._initPromise;
 			
 			// The window's observers are still registered while it tears down, and shouldn't be
 			// reported as leaked before it's actually gone

--- a/test/tests/tabsTest.js
+++ b/test/tests/tabsTest.js
@@ -41,6 +41,35 @@ describe("Zotero_Tabs", function() {
 		});
 	});
 
+	describe("Library view state", function () {
+		var collection, item;
+
+		before(async function () {
+			collection = await createDataObject('collection', { name: 'Library View State' });
+			item = await createDataObject('item', {
+				title: 'Library View State Item',
+				collections: [collection.id]
+			});
+			win.Zotero_Tabs.closeAll();
+		});
+
+		it("should round-trip the library view through getState() and restoreState()", async function () {
+			await selectCollection(win, collection);
+
+			let state = win.Zotero_Tabs.getState();
+			let libraryTab = state.find(tab => tab.type == 'library');
+			assert.deepEqual(libraryTab.data.state.collections, ['C' + collection.id]);
+
+			// Move away from the saved view before restoring it
+			await selectLibrary(win);
+
+			await win.Zotero_Tabs.restoreState(state);
+			await zp.waitForLibraryTabState();
+
+			assert.deepEqual(zp.getCollectionTreeRows().map(row => row.id), ['C' + collection.id]);
+		});
+	});
+
 	describe("Window teardown", function () {
 		it("should not leave observers registered after a window is closed", async function () {
 			this.timeout(60000);

--- a/test/tests/tabsTest.js
+++ b/test/tests/tabsTest.js
@@ -158,6 +158,37 @@ describe("Zotero_Tabs", function() {
 			}
 		});
 		
+		it("should open the Advanced Search in a new window", async function () {
+			let newWin;
+			try {
+				newWin = zp.openAdvancedSearchInNewWindow('foo');
+				await waitForCallback(
+					() => {
+						let deck = newWin.document
+							?.getElementById('zotero-advanced-search-pane-deck');
+						return deck?.state === 'open'
+							&& deck.pane.search
+							&& Object.values(deck.pane.search.getConditions())
+								.some(c => c.condition == 'anyField' && c.value == 'foo');
+					},
+					100,
+					10
+				);
+				// The search is focused, as it would be when opened within the window
+				let deck = newWin.document.getElementById('zotero-advanced-search-pane-deck');
+				await waitForCallback(
+					() => deck.pane.contains(newWin.document.activeElement),
+					100,
+					5
+				);
+			}
+			finally {
+				if (newWin) {
+					newWin.close();
+				}
+			}
+		});
+		
 		it("should show tags in a reinitialized tag selector while another window is open", async function () {
 			await item.addTag('second-window-tag');
 			await item.saveTx();


### PR DESCRIPTION
Other bugs found during this work, with fixes committed separately:

b3b6e7f33db06322e83e81b2771566d2af8c719d Reopen closed reader and note tabs at their original position
d0a32a3b4f1999b1191c9bd319d89385a8f37ba4 Poll for expected tag selector state in flaky tests
0e46a5356b955fa87b5de84298a53cd9a5e5ad07 Fix tag selector observer leaks on uninit
22a1b33a429ffb7042752977ad8ae5d5f937953f Remove library tree event listeners on teardown
53bcd30a5fac0aaef3f54298ab788ea9c22505f2 Don't report a window's observers as leaked while it's still closing
92dfac8c6445f19b2cb0343739fd0cfbd77cc663 Don't make an unloaded tab reopenable with Undo Close Tab